### PR TITLE
Use better way to set up controller with Manager

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"github.com/aibrix/aibrix/pkg/controller/modeladapter"
+	"github.com/aibrix/aibrix/pkg/controller/podautoscaler"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// Borrowed logic from Kruise
+// Original source: https://github.com/openkruise/kruise/blob/master/pkg/controller/controllers.go
+// Reason: We have single controller-manager as well and use the controller-runtime libraries.
+// 		   Instead of registering every controller in the main.go, kruise's registration flow is much cleaner.
+
+var controllerAddFuncs []func(manager.Manager) error
+
+func init() {
+	controllerAddFuncs = append(controllerAddFuncs, podautoscaler.Add)
+	controllerAddFuncs = append(controllerAddFuncs, modeladapter.Add)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func SetupWithManager(m manager.Manager) error {
+	for _, f := range controllerAddFuncs {
+		if err := f(m); err != nil {
+			if kindMatchErr, ok := err.(*meta.NoKindMatchError); ok {
+				klog.InfoS("CRD is not installed, its controller will perform noops!", "CRD", kindMatchErr.GroupKind)
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/modeladapter/modeladapter_controller.go
+++ b/pkg/controller/modeladapter/modeladapter_controller.go
@@ -18,14 +18,54 @@ package modeladapter
 
 import (
 	"context"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	modelv1alpha1 "github.com/aibrix/aibrix/api/model/v1alpha1"
 )
+
+// Add creates a new ModelAdapter Controller and adds it to the Manager with default RBAC.
+// The Manager will set fields on the Controller and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	r, err := newReconciler(mgr)
+	if err != nil {
+		return err
+	}
+	return add(mgr, r)
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
+	reconciler := &ModelAdapterReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+	return reconciler, nil
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	_, err := controller.New("model-adapter-controller", mgr, controller.Options{
+		Reconciler: r})
+	if err != nil {
+		return err
+	}
+	//return ctrl.NewControllerManagedBy(mgr).
+	//	For(&modelv1alpha1.ModelAdapter{}).
+	//	Complete(r)
+
+	klog.V(4).InfoS("Finished to add model-adapter-controller")
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ModelAdapterReconciler{}
 
 // ModelAdapterReconciler reconciles a ModelAdapter object
 type ModelAdapterReconciler struct {
@@ -52,11 +92,4 @@ func (r *ModelAdapterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// TODO(user): your logic here
 
 	return ctrl.Result{}, nil
-}
-
-// SetupWithManager sets up the controller with the Manager.
-func (r *ModelAdapterReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&modelv1alpha1.ModelAdapter{}).
-		Complete(r)
 }


### PR DESCRIPTION
In traditional flow, any reconciler initialization logic needs to updated in `cmd/main.go` which is not that clean. Now, we borrow the similar way adopted in `kruise`.  There're few major changes

1. Add `Add` interface and registry the controller together at `pkg/controller/controller.go` and finish setup with manager
2. Create `newReconciler` method in every controller file.

After this change, whenever we need add a new controller or update controller initialization logic, we do not need to make the change here `cmd.go` and `controller.go`, most of the logics will be modified inside it's controller file.