### PR TITLE
Support pod autoscaler periodically check

### DIFF
--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -198,13 +198,14 @@ func (r *PodAutoscalerReconciler) Run(ctx context.Context, errChan chan<- error)
 	for {
 		select {
 		case <-ticker.C:
+			klog.Info("enqueue all autoscalers")
 			// periodically sync all autoscaling objects
 			if err := r.enqueuePodAutoscalers(ctx); err != nil {
 				klog.ErrorS(err, "Failed to enqueue pod autoscalers")
 				errChan <- err
-				return
 			}
 		case <-ctx.Done():
+			klog.Info("context done, stopping running the loop")
 			errChan <- ctx.Err()
 			return
 		}


### PR DESCRIPTION
## Pull Request Description
Pod Autoscaler used to be event triggered, this PR supports periodically reconcile.

![image](https://github.com/user-attachments/assets/a454da91-b66f-439f-8001-b1ab57fd3d85)
Please ignore the error message, it's due to the mocked app. It already start to reconcile the object every 30s, which is the default resyncInterval


## Related Issues
Resolves: https://github.com/aibrix/aibrix/issues/204

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>