### PR TITLE
Misc: add support to metricsSources property of podautoscaler

### DIFF
--- a/pkg/controller/podautoscaler/metrics/fetcher.go
+++ b/pkg/controller/podautoscaler/metrics/fetcher.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,7 +44,10 @@ const (
 
 // MetricFetcher defines an interface for fetching metrics. it could be Kubernetes metrics or Pod prometheus metrics.
 type MetricFetcher interface {
+	// Obseleted: Call FetchMetric instead.
 	FetchPodMetrics(ctx context.Context, pod v1.Pod, metricsPort int, metricName string) (float64, error)
+
+	FetchMetric(ctx context.Context, endpoint string, path string, metricName string) (float64, error)
 }
 
 // RestMetricsFetcher implements MetricFetcher to fetch metrics from Pod's /metrics endpoint.
@@ -51,40 +55,42 @@ type RestMetricsFetcher struct{}
 
 func (f *RestMetricsFetcher) FetchPodMetrics(ctx context.Context, pod v1.Pod, metricsPort int, metricName string) (float64, error) {
 	// Use http to fetch pod's /metrics endpoint and parse the value
-	url := fmt.Sprintf("http://%s:%d/metrics", pod.Status.PodIP, metricsPort)
+	return f.FetchMetric(ctx, fmt.Sprintf("http://%s:%d", pod.Status.PodIP, metricsPort), "/metrics", metricName)
+}
 
-	key := "DEBUG_MODE"
-	value, exists := getEnvKey(key)
+func (f *RestMetricsFetcher) FetchMetric(ctx context.Context, endpoint string, path string, metricName string) (float64, error) {
 
-	if exists && value == "on" {
-		// 30080 is the nodePort of the base model service.
-		url = fmt.Sprintf("http://%s:8000/metrics", "localhost")
-	}
+	// We should use the primary container port. In future, we can decide whether to use sidecar container's port
+	url := fmt.Sprintf("http://%s/%s", strings.TrimRight(endpoint, "/"), strings.TrimLeft(path, "/"))
 
-	// TODO a temp for debugging
-	//url := fmt.Sprintf("http://%s:%d/metrics", "127.0.0.1", metricsPort)
-	resp, err := http.Get(url)
+	// Create request with context, so that the request will be canceled if the context is canceled
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return 0, fmt.Errorf("failed to fetch metrics from pod %s %s %d: %v", pod.Name, pod.Status.PodIP, metricsPort, err)
+		return 0.0, fmt.Errorf("failed to create request to source %s: %v", url, err)
 	}
 
+	// Send the request using the default client
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0.0, fmt.Errorf("failed to fetch metrics from source %s: %v", url, err)
+	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			klog.ErrorS(err, "Error closing response body")
+			// Handle the error here. For example, log it or take appropriate corrective action.
+			klog.InfoS("Error closing response body:", err)
 		}
 	}()
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read response from pod %s %s %d: %v", pod.Name, pod.Status.PodIP, metricsPort, err)
+		return 0.0, fmt.Errorf("failed to read response from source %s: %v", url, err)
 	}
 
 	metricValue, err := ParseMetricFromBody(body, metricName)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse metrics from pod %s %s %d: %v", pod.Name, pod.Status.PodIP, metricsPort, err)
+		return 0.0, fmt.Errorf("failed to parse metrics from source %s: %v", url, err)
 	}
 
-	klog.InfoS("Successfully parsed metrics", "metric", metricName, "PodIP", pod.Status.PodIP, "Port", metricsPort, "metricValue", metricValue)
+	klog.InfoS("Successfully parsed metrics", "metric", metricName, "source", url, "metricValue", metricValue)
 
 	return metricValue, nil
 }

--- a/pkg/controller/podautoscaler/metrics/interface.go
+++ b/pkg/controller/podautoscaler/metrics/interface.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "k8s.io/api/core/v1"
+
+	autoscalingv1alpha1 "github.com/aibrix/aibrix/api/autoscaling/v1alpha1"
 )
 
 // NamespaceNameMetric contains the namespace, name and the metric name
@@ -60,5 +62,10 @@ type MetricClient interface {
 
 	GetMetricsFromPods(ctx context.Context, pods []v1.Pod, metricName string, metricPort int) ([]float64, error)
 
+	GetMetricFromSource(ctx context.Context, source autoscalingv1alpha1.MetricSource) (float64, error)
+
+	// Obsoleted, please use UpdateMetrics
 	UpdatePodListMetric(metricValues []float64, metricKey NamespaceNameMetric, now time.Time) error
+
+	UpdateMetrics(now time.Time, metricKey NamespaceNameMetric, metricValues ...float64) error
 }

--- a/pkg/controller/podautoscaler/scaler/apa.go
+++ b/pkg/controller/podautoscaler/scaler/apa.go
@@ -127,6 +127,15 @@ func (a *ApaAutoscaler) UpdateScaleTargetMetrics(ctx context.Context, metricKey 
 	return nil
 }
 
+func (a *ApaAutoscaler) UpdateSourceMetrics(ctx context.Context, metricKey metrics.NamespaceNameMetric, source autoscalingv1alpha1.MetricSource, now time.Time) error {
+	metricValue, err := a.metricClient.GetMetricFromSource(ctx, source)
+	if err != nil {
+		return err
+	}
+
+	return a.metricClient.UpdateMetrics(now, metricKey, metricValue)
+}
+
 func (a *ApaAutoscaler) UpdateScalingContext(pa autoscalingv1alpha1.PodAutoscaler) error {
 	a.specMux.Lock()
 	defer a.specMux.Unlock()

--- a/pkg/controller/podautoscaler/scaler/interface.go
+++ b/pkg/controller/podautoscaler/scaler/interface.go
@@ -56,6 +56,21 @@ type Scaler interface {
 	// This method ensures that the autoscaler has up-to-date metrics before making any scaling decisions.
 	UpdateScaleTargetMetrics(ctx context.Context, metricKey metrics.NamespaceNameMetric, pods []corev1.Pod, now time.Time) error
 
+	// UpdateSourceMetrics updates the current state of metrics used to determine scaling actions.
+	// It processes the latest metrics for a metrics source and stores
+	// these values for later use during scaling decisions.
+	//
+	// Parameters:
+	// - ctx: The context used for managing request-scoped values, cancellation, and deadlines.
+	// - metricKey: A unique identifier for the scaling target's metrics (e.g., CPU, memory, or QPS) that
+	//   is used to correlate metrics with the appropriate scaling logic.
+	// - source: The MetricSource object containing the desired scaling configuration and current state.
+	// - now: The current time at which the metrics are being processed. This timestamp helps track
+	//   when the last metric update occurred and can be used to calculate time-based scaling actions.
+	//
+	// This method ensures that the autoscaler has up-to-date metrics before making any scaling decisions.
+	UpdateSourceMetrics(ctx context.Context, metricKey metrics.NamespaceNameMetric, source autoscalingv1alpha1.MetricSource, now time.Time) error
+
 	// Scale calculates the necessary scaling action based on observed metrics
 	// and the current time. This is the core logic of the autoscaler.
 	//

--- a/pkg/controller/podautoscaler/scaler/kpa.go
+++ b/pkg/controller/podautoscaler/scaler/kpa.go
@@ -307,6 +307,15 @@ func (k *KpaAutoscaler) UpdateScaleTargetMetrics(ctx context.Context, metricKey 
 	return nil
 }
 
+func (k *KpaAutoscaler) UpdateSourceMetrics(ctx context.Context, metricKey metrics.NamespaceNameMetric, source autoscalingv1alpha1.MetricSource, now time.Time) error {
+	metricValue, err := k.metricClient.GetMetricFromSource(ctx, source)
+	if err != nil {
+		return err
+	}
+
+	return k.metricClient.UpdateMetrics(now, metricKey, metricValue)
+}
+
 func (k *KpaAutoscaler) UpdateScalingContext(pa autoscalingv1alpha1.PodAutoscaler) error {
 	k.specMux.Lock()
 	defer k.specMux.Unlock()


### PR DESCRIPTION
## Pull Request Description
Currently, the metricsSources property in podAutoScaler is not considered. This pull request adds support to metricsSources, which will override the default KPA behavior that reads metrics from the model pods. In this pull request, only one metricsSource is supported. Extra metricsSources will be ignored.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>