### PR TITLE
[CI] improve the ci efficiency by parallelizing the build tasks

### DIFF
--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -7,14 +7,42 @@ on:
     branches: [ "main" ]
 
 jobs:
-  installation-test:
+  build-images:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [controller-manager, plugins, runtime, users]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Build ${{ matrix.image }}
+        run: |
+          GIT_COMMIT_HASH=${{ github.sha }} make docker-build-${{ matrix.image }}
+
+      - name: Save image
+        run: |
+          docker save aibrix/${{ matrix.image }}:${{ github.sha }} > ${{ matrix.image }}.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.image }}-image
+          path: ${{ matrix.image }}.tar
+          retention-days: 1
+
+  installation-test:
+    needs: build-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Download all image artifacts
+        uses: actions/download-artifact@v3
 
       - name: Install kind
         run: |
@@ -34,17 +62,13 @@ jobs:
           kind create cluster --name installation-test
           kubectl cluster-info --context kind-installation-test
 
-      - name: Build container images
-        run: |
-          GIT_COMMIT_HASH=${{ github.sha }} make docker-build-all
-
       - name: Load image into Kind
         run: |
-          kind load docker-image aibrix/controller-manager:${{ github.sha }} --name installation-test
-          kind load docker-image aibrix/plugins:${{ github.sha }} --name installation-test
-          kind load docker-image aibrix/runtime:${{ github.sha }} --name installation-test
-          kind load docker-image aibrix/users:${{ github.sha }} --name installation-test
-
+          for image in controller-manager plugins runtime users; do
+            docker load < ${image}-image/${image}.tar
+            kind load docker-image aibrix/${image}:${{ github.sha }} --name installation-test
+          done
+          
       - name: Deploy controller with the built image
         run: |
           kubectl create -k config/dependency


### PR DESCRIPTION
## Pull Request Description

In the initial version, we do not care the efficiency that much and we use single runner to build the images one by one. 

In this PR, we create four runners to build images in parallel and then use another runner to conduct tests.

## Related Issues
Resolves: #[128]

