### PR TITLE
Fix the ticker interval by removing unnecessary ms

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -78,11 +78,16 @@ var (
 func getPodMetricRefreshInterval() time.Duration {
 	value, exists := os.LookupEnv("AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS")
 	if exists {
-		if intValue, err := strconv.Atoi(value); err == nil {
-			return time.Duration(intValue) * time.Millisecond
+		intValue, err := strconv.Atoi(value)
+		if err != nil {
+			klog.V(4).Infof("Invalid AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS: %s, falling back to default", value)
+		} else {
+			klog.V(4).Infof("Using env value for refresh interval: %d ms", intValue)
+			return time.Duration(intValue)
 		}
 	}
-	return time.Duration(defaultPodMetricRefreshIntervalInMS) * time.Millisecond
+	klog.V(4).Infof("Using default refresh interval: %d ms", defaultPodMetricRefreshIntervalInMS)
+	return time.Duration(defaultPodMetricRefreshIntervalInMS)
 }
 
 func GetCache() (*Cache, error) {


### PR DESCRIPTION
## Pull Request Description
Correct the ticker interval setting and just return raw duration from `getPodMetricRefreshInterval` without `* time.Millisecond`

## Related Issues
Resolves: https://github.com/aibrix/aibrix/issues/414

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>