### PR TITLE
Refactor Scaler: Resolve Issues with Metric Parameter Updates in Multiple KPAs

### DIFF
--- a/pkg/controller/podautoscaler/aggregation/window.go
+++ b/pkg/controller/podautoscaler/aggregation/window.go
@@ -34,6 +34,10 @@ type entry struct {
 	index int
 }
 
+func (e entry) String() string {
+	return fmt.Sprintf("{%d, %.2f}", e.index, e.value)
+}
+
 // window is a sliding window that keeps track of recent {size} values.
 type window struct {
 	valueList     []entry
@@ -125,7 +129,7 @@ func (w *window) String() string {
 
 	for i := 0; i < w.length; i++ {
 		idx := (w.first + i) % len(w.valueList)
-		sb.WriteString(fmt.Sprintf("%v", w.valueList[idx]))
+		sb.WriteString(fmt.Sprintf("%v", w.valueList[idx].String()))
 		if i < w.length-1 {
 			sb.WriteString(", ")
 		}

--- a/pkg/controller/podautoscaler/scaler/apa.go
+++ b/pkg/controller/podautoscaler/scaler/apa.go
@@ -51,6 +51,8 @@ type ApaScalingContext struct {
 	// UpFluctuationTolerance represents the threshold before scaling down,
 	// which means no scaling down will occur unless the currentMetricValue is less than the TargetValue by more than UpFluctuationTolerance
 	DownFluctuationTolerance float64
+	// metric window length
+	Window time.Duration
 }
 
 // NewApaScalingContext references KPA and sets up a default configuration.
@@ -59,7 +61,18 @@ func NewApaScalingContext() *ApaScalingContext {
 		BaseScalingContext:       *scalingcontext.NewBaseScalingContext(),
 		UpFluctuationTolerance:   0.1, // Tolerance for scaling up, set at 10%
 		DownFluctuationTolerance: 0.2, // Tolerance for scaling up, set at 10%
+		Window:                   time.Second * 60,
 	}
+}
+
+// NewApaScalingContextByPa initializes ApaScalingContext by passed-in PodAutoscaler description
+func NewApaScalingContextByPa(pa *autoscalingv1alpha1.PodAutoscaler) (*ApaScalingContext, error) {
+	res := NewApaScalingContext()
+	err := res.UpdateByPaTypes(pa)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 var _ common.ScalingContext = (*ApaScalingContext)(nil)
@@ -79,9 +92,14 @@ type ApaAutoscaler struct {
 var _ Scaler = (*ApaAutoscaler)(nil)
 
 // NewApaAutoscaler Initialize ApaAutoscaler
-func NewApaAutoscaler(readyPodsCount int, spec *ApaScalingContext) (*ApaAutoscaler, error) {
+func NewApaAutoscaler(readyPodsCount int, pa *autoscalingv1alpha1.PodAutoscaler) (*ApaAutoscaler, error) {
+	spec, err := NewApaScalingContextByPa(pa)
+	if err != nil {
+		return nil, err
+	}
+
 	metricsFetcher := &metrics.RestMetricsFetcher{}
-	metricsClient := metrics.NewAPAMetricsClient(metricsFetcher)
+	metricsClient := metrics.NewAPAMetricsClient(metricsFetcher, spec.Window)
 	scalingAlgorithm := algorithm.ApaScalingAlgorithm{}
 
 	return &ApaAutoscaler{
@@ -170,14 +188,19 @@ func (a *ApaAutoscaler) UpdateScalingContext(pa autoscalingv1alpha1.PodAutoscale
 	a.specMux.Lock()
 	defer a.specMux.Unlock()
 
-	targetValue, err := strconv.ParseFloat(pa.Spec.TargetValue, 64)
+	// update context and check configuration restraint.
+	// N.B. for now, we forbid update the config related to the stateful attribute, like window length.
+	updatedSpec, err := NewApaScalingContextByPa(&pa)
 	if err != nil {
-		klog.ErrorS(err, "Failed to parse target value", "targetValue", pa.Spec.TargetValue)
 		return err
 	}
-	a.scalingContext.TargetValue = targetValue
-	a.scalingContext.ScalingMetric = pa.Spec.TargetMetric
-
+	// check apa spec: panic window, stable window and delaywindow
+	rawSpec := a.scalingContext
+	if updatedSpec.Window != rawSpec.Window {
+		klog.Warningf("For APA, updating the Window (%v) is not allowed. Keep the original value (%v)", updatedSpec.Window, rawSpec.Window)
+		updatedSpec.Window = rawSpec.Window
+	}
+	a.scalingContext = updatedSpec
 	return nil
 }
 

--- a/pkg/controller/podautoscaler/scaler/scaler_factory.go
+++ b/pkg/controller/podautoscaler/scaler/scaler_factory.go
@@ -24,15 +24,17 @@ import (
 
 // NewAutoscalerFactory creates an Autoscaler based on the given ScalingStrategy
 func NewAutoscalerFactory(strategy autoscalingv1alpha1.ScalingStrategyType) (Scaler, error) {
+	// after update, the XpaAutoscaler must be associated with an instantiated PA, rather than an empty scaler that awaits filling.
+	// But NewAutoscalerFactory doesn't be used, so we temporarily pass into nil
 	switch strategy {
 	case autoscalingv1alpha1.KPA:
-		autoscaler, err := NewKpaAutoscaler(0, NewKpaScalingContext())
+		autoscaler, err := NewKpaAutoscaler(0, nil)
 		if err != nil {
 			return nil, err
 		}
 		return autoscaler, nil
 	case autoscalingv1alpha1.APA:
-		autoscaler, err := NewApaAutoscaler(0, NewApaScalingContext())
+		autoscaler, err := NewApaAutoscaler(0, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/podautoscaler/utils.go
+++ b/pkg/controller/podautoscaler/utils.go
@@ -19,6 +19,8 @@ package podautoscaler
 import (
 	"fmt"
 
+	autoscalingv1alpha1 "github.com/aibrix/aibrix/api/autoscaling/v1alpha1"
+	"github.com/aibrix/aibrix/pkg/controller/podautoscaler/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -49,4 +51,8 @@ func extractLabelSelector(scale *unstructured.Unstructured) (labels.Selector, er
 	}
 
 	return labelsSelector, nil
+}
+
+func NewNamespaceNameMetricByPa(pa autoscalingv1alpha1.PodAutoscaler) metrics.NamespaceNameMetric {
+	return metrics.NewNamespaceNameMetric(pa.Namespace, pa.Spec.ScaleTargetRef.Name, pa.Spec.TargetMetric)
 }


### PR DESCRIPTION
## Pull Request Description
[Please provide a clear and concise description of your changes here]

## Related Issues
Resolves: #410 #436 

## Description
When multiple KPAAutoScaler instances are created simultaneously, or when a same KPA is updated multiple times, there is a possibility that parameter values, particularly stateful metric parameters (like window length), may not update successfully. This PR addresses issue #406 and may also help resolve issue #436.

## Existing Issues

1. The `PodAutoscalerReconciler`'s `AutoscalerMap` is structured as `{KPA: KPAAutoScaler, APA: APAAutoScaler}`, meaning all KPAs share the same `KPAAutoScaler` object. During periodic calls to the `reconcile` function, the `PA` objects always update the same `Autoscaler`.
2. All KPA share the same `KpaMetricClient`, which maintains a dictionary mapping from `NamespaceNameMetric` to `PanicWindow` and `StableWindow`. The setting of `panicWindowDuration`(length of panic window) and `stableWindowDuration` does not take effect.

## Modification

1. The `PodAutoscalerReconciler`'s `autoscalerMap` is changed from `{KPA: KPAAutoScaler, APA: APAAutoScaler}` to `NamespaceNameMetric` -> `KPAAutoScaler`. Each `PA` has its own independent `Context` and `metricClient`.
2. We no longer create `KPAAutoScaler` instances in `newReconciler`., but waits until the `reconcile` function to create (if it does not exist) or update (if it already exists).
3. Each `KpaMetricClient` maintains only one `panicWindow` and one `stableWindow`, instead of maintaining metrics for multiple PAs.
4. Corrected the issue where settings for `panicWindowDuration` and `stableWindowDuration` were not taking effect.

## TODO:

1. Currently, updates to existing `panicWindowDuration` and `stableWindowDuration` are not allowed, as this involves the problem of how metric data in the old window can be transferred to the new window. We will design this carefully in the future.
2. How should we support the deletion of PAs?
---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>