### PR TITLE
[Bug] handle metricKey creation with MetricsSources 

### DIFF
--- a/pkg/controller/podautoscaler/metrics/interface.go
+++ b/pkg/controller/podautoscaler/metrics/interface.go
@@ -33,7 +33,7 @@ type NamespaceNameMetric struct {
 	MetricName string
 }
 
-func NewNamespaceNameMetric(namespace, name string, pa *autoscalingv1alpha1.PodAutoscaler) NamespaceNameMetric {
+func NewNamespaceNameMetric(pa *autoscalingv1alpha1.PodAutoscaler) NamespaceNameMetric {
 	metricName := pa.Spec.TargetMetric
 	if len(pa.Spec.MetricsSources) > 0 {
 		metricName = pa.Spec.MetricsSources[0].Name
@@ -41,8 +41,8 @@ func NewNamespaceNameMetric(namespace, name string, pa *autoscalingv1alpha1.PodA
 
 	return NamespaceNameMetric{
 		NamespacedName: types.NamespacedName{
-			Namespace: namespace,
-			Name:      name,
+			Namespace: pa.Namespace,
+			Name:      pa.Spec.ScaleTargetRef.Name,
 		},
 		MetricName: metricName,
 	}

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -284,7 +284,7 @@ func (r *PodAutoscalerReconciler) reconcileCustomPA(ctx context.Context, pa auto
 	paStatusOriginal := pa.Status.DeepCopy()
 	paType := pa.Spec.ScalingStrategy
 	scaleReference := fmt.Sprintf("%s/%s/%s", pa.Spec.ScaleTargetRef.Kind, pa.Namespace, pa.Spec.ScaleTargetRef.Name)
-	metricKey := metrics.NewNamespaceNameMetric(pa.Namespace, pa.Spec.ScaleTargetRef.Name, &pa)
+	metricKey := metrics.NewNamespaceNameMetric(&pa)
 
 	targetGV, err := schema.ParseGroupVersion(pa.Spec.ScaleTargetRef.APIVersion)
 	if err != nil {

--- a/pkg/controller/podautoscaler/scaler/apa_test.go
+++ b/pkg/controller/podautoscaler/scaler/apa_test.go
@@ -52,7 +52,7 @@ func TestAPAScale(t *testing.T) {
 		},
 	}
 
-	metricKey := metrics.NewNamespaceNameMetric(pa.Namespace, pa.Spec.ScaleTargetRef.Name, &pa)
+	metricKey := metrics.NewNamespaceNameMetric(&pa)
 	_ = apaMetricsClient.UpdateMetricIntoWindow(now.Add(-60*time.Second), 10.0)
 	_ = apaMetricsClient.UpdateMetricIntoWindow(now.Add(-50*time.Second), 11.0)
 	_ = apaMetricsClient.UpdateMetricIntoWindow(now.Add(-40*time.Second), 12.0)

--- a/pkg/controller/podautoscaler/scaler/kpa_test.go
+++ b/pkg/controller/podautoscaler/scaler/kpa_test.go
@@ -92,8 +92,7 @@ func TestKpaScale(t *testing.T) {
 		},
 	}
 
-	// metricKey := metrics.NewNamespaceNameMetric("test_ns", "llama-70b", spec.ScalingMetric)
-	metricKey := metrics.NewNamespaceNameMetric("test_ns", "llama-70b", &pa)
+	metricKey := metrics.NewNamespaceNameMetric(&pa)
 
 	result := kpaScaler.Scale(readyPodCount, metricKey, now)
 	// recent rapid rising metric value make scaler adapt turn on panic mode

--- a/pkg/controller/podautoscaler/utils.go
+++ b/pkg/controller/podautoscaler/utils.go
@@ -54,5 +54,5 @@ func extractLabelSelector(scale *unstructured.Unstructured) (labels.Selector, er
 }
 
 func NewNamespaceNameMetricByPa(pa autoscalingv1alpha1.PodAutoscaler) metrics.NamespaceNameMetric {
-	return metrics.NewNamespaceNameMetric(pa.Namespace, pa.Spec.ScaleTargetRef.Name, &pa)
+	return metrics.NewNamespaceNameMetric(&pa)
 }


### PR DESCRIPTION
## Pull Request Description

This PR solves the issue that KPA cannot fetch metrics collected from this metricSource endpoint to scale pods. The reason is that the current code doesn't configure metricKey correctly.



## Related Issues
Resolves: https://github.com/aibrix/aibrix/issues/485

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>