### PR TITLE
[Bug] Fixed the yaml of deployments in heterogenous GPU settings to make KPA scaling work as expected.

### DIFF
--- a/development/app/config/heterogeneous/simulator_a40/patch_deployment_a40.yaml
+++ b/development/app/config/heterogeneous/simulator_a40/patch_deployment_a40.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       model.aibrix.ai/name: "llama2-7b"
+      app: "simulator-llama2-7b-a40"
   template:
     metadata:
       labels:

--- a/development/app/config/simulator/patch_deployment_a100.yaml
+++ b/development/app/config/simulator/patch_deployment_a100.yaml
@@ -10,6 +10,7 @@ spec:
   selector:
     matchLabels:
       model.aibrix.ai/name: "llama2-7b"
+      app: "simulator-llama2-7b-a100"
   template:
     metadata:
       labels:

--- a/development/app/config/templates/deployment/deployment.yaml
+++ b/development/app/config/templates/deployment/deployment.yaml
@@ -13,6 +13,7 @@ spec:
     matchLabels:
       adapter.model.aibrix.ai/enabled: "true"
       model.aibrix.ai/name: "llama2-7b"
+      app: "mock-llama2-7b"
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Pull Request Description
The root cause of #507 is due to the previous spec.selector of mock app deployment configuration identifying model only and missing the label that identifies the deployment. After a fix of mock app deployment, KPA scaling now works as expected

## Related Issues
Resolves: #507

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>