### PR TITLE
[Misc] Heterogeneous GPU Optimizer Logging Clean Up

### DIFF
--- a/python/aibrix/aibrix/gpu_optimizer/app.py
+++ b/python/aibrix/aibrix/gpu_optimizer/app.py
@@ -94,7 +94,7 @@ def start_serving_thread(watch_ver, deployment, watch_event: bool) -> bool:
             watch_ver, deployment_name, namespace, lambda: new_deployment(deployment)
         )
         logger.info(
-            f'Deployment "{deployment_name}" added to the model monitor for "{model_name}"'
+            f'Deployment "{deployment_name}" found in watch version {watch_ver}, added to the model monitor for "{model_name}"'
         )
         return False
 
@@ -335,7 +335,7 @@ if __name__ == "__main__":
         logging.ERROR
     )  # Suppress kubenetes logs
     logging.getLogger("pulp.apis.core").setLevel(logging.INFO)  # Suppress pulp logs
-    logger = logging.getLogger("aibrix.gpuoptimizer")
+    logger = logging.getLogger("aibrix.gpu_optimizer")
 
     timeout = 600
     try:
@@ -356,10 +356,14 @@ if __name__ == "__main__":
         app,
         host="0.0.0.0",
         port=8080,
+        log_level="info",
         log_config={
             "version": 1,
             "disable_existing_loggers": False,
-            "loggers": {"uvicorn.access": {"filters": ["dash_update_filter"]}},
+            "loggers": {
+                "uvicorn.access": {"filters": ["dash_update_filter"]},
+                "uvicorn.error": {"level": "INFO", "propagate": False},
+            },
             "filters": {
                 "dash_update_filter": {
                     "()": ExcludePathsFilter,

--- a/python/aibrix/aibrix/gpu_optimizer/load_monitor/monitor.py
+++ b/python/aibrix/aibrix/gpu_optimizer/load_monitor/monitor.py
@@ -32,7 +32,7 @@ from .profile_reader import ProfileReader
 
 Empty_Array: Iterable = []
 
-logger = logging.getLogger("aibrix.gpuoptimizer.loadmonitor")
+logger = logging.getLogger("aibrix.gpu_optimizer.load_monitor")
 
 debug_gpu_profile = GPUProfile(
     gpu="default", cost=1.0, tputs=[[100]], indexes=[[10], [10]]
@@ -53,7 +53,9 @@ class DeploymentStates:
 
     @property
     def cost(self):
-        return 0.0 if self.profile is None else self.profile.cost * self.replicas
+        return (
+            float("inf") if self.profile is None else self.profile.cost * self.replicas
+        )
 
     def minimize(self):
         """Set replica to minimum mode."""
@@ -464,7 +466,7 @@ class ModelMonitor:
         self._cost = cost
         self._lock.release()
         logger.info(
-            f"{self.model_name} scaled to minimum, cost ${self._cost}: {list(self.deployments.values())}"
+            f"{self.model_name} scaled to minimum, total cost ${self._cost}. Detailed Configuration:{list(self.deployments.values())}"
         )
 
     @property

--- a/python/aibrix/aibrix/gpu_optimizer/load_monitor/profile_reader.py
+++ b/python/aibrix/aibrix/gpu_optimizer/load_monitor/profile_reader.py
@@ -17,7 +17,7 @@ from typing import List, Protocol
 
 from aibrix.gpu_optimizer.optimizer import GPUProfile
 
-logger = logging.getLogger("aibrix.gpuoptimizer.profile_reader")
+logger = logging.getLogger("aibrix.gpu_optimizer.profile_reader")
 
 
 class ProfileReader(Protocol):

--- a/python/aibrix/aibrix/gpu_optimizer/load_monitor/visualizer.py
+++ b/python/aibrix/aibrix/gpu_optimizer/load_monitor/visualizer.py
@@ -83,7 +83,7 @@ figure.__dict__ = {
     "lock": threading.Lock(),
 }
 
-logger = logging.getLogger("aibrix.gpuoptimizer.loadmonitor.visualizer")
+logger = logging.getLogger("aibrix.gpu_optimizer.load_monitor.visualizer")
 
 
 def get_debug_model_montior(


### PR DESCRIPTION
## Pull Request Description

In this PR, we clean up the GPU optimizer's logging information.

(1) using snake case format
(2) Removed uvicorn.error, which is confusing
(3) modified the default GPU cost from 0 to inf, In this case, the OPU optimizer will never use a GPU type without profiling.

## Related Issues
Resolves: https://github.com/aibrix/aibrix/issues/502

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>