### PR TITLE
clean memory scaler object when pa crd is deleted

### DIFF
--- a/pkg/controller/podautoscaler/metrics/interface.go
+++ b/pkg/controller/podautoscaler/metrics/interface.go
@@ -30,8 +30,10 @@ import (
 
 // NamespaceNameMetric contains the namespace, name and the metric name
 type NamespaceNameMetric struct {
-	types.NamespacedName
-	MetricName string
+	types.NamespacedName // target deployment namespace and name
+	MetricName           string
+	PaNamespace          string
+	PaName               string
 }
 
 // NewNamespaceNameMetric creates a NamespaceNameMetric based on the PodAutoscaler's metrics source.
@@ -47,7 +49,9 @@ func NewNamespaceNameMetric(pa *autoscalingv1alpha1.PodAutoscaler) (NamespaceNam
 			Namespace: pa.Namespace,
 			Name:      pa.Spec.ScaleTargetRef.Name,
 		},
-		MetricName: metricSource.TargetMetric,
+		MetricName:  metricSource.TargetMetric,
+		PaNamespace: pa.Namespace,
+		PaName:      pa.Name,
 	}, metricSource, nil
 }
 


### PR DESCRIPTION
## Pull Request Description
[Please provide a clear and concise description of your changes here]

This PR addresses an issue where deleting a PA object does not remove the associated scaler object from memory, potentially leading to increased memory usage and bugs upon PA recreation.

### Changes Introduced:
- Added cleaning logic that triggers when a PA is detected as deleted.
- Enhanced the NamespaceMetric structure to include PA information. Previously, it only contained TargetRef details. Now, it also records the PA's namespace and name, which are accessible post-deletion.


logs when creating pa:
```
I1211 16:07:48.072607   55435 podautoscaler_controller.go:658] "New scaler added to AutoscalerMap" metricKey="default/mock-llama2-7b" type="KPA" spec={"scaleTargetRef":{"kind":"Deployment","name":"mock-llama2-7b","apiVersion":"apps/v1"},"minReplicas":0,"maxReplicas":10,"metricsSources":[{"metricSourceType":"pod","protocolType":"http","path":"metrics","port":"8000","targetMetric":"avg_prompt_throughput_toks_per_s","targetValue":"60"}],"scalingStrategy":"KPA"}
```

logs when deleting pa:
```
I1211 16:08:02.635597   55435 podautoscaler_controller.go:135] "Delete scaler" PaName="podautoscaler-mock-llama2-7b" PaNamespace="default" TargetRefNamespace="default" TargetRefName="podautoscaler-mock-llama2-7b"
I1211 16:08:03.391976   55435 podautoscaler_controller.go:167] PodAutoscaler resource not found. Clean scaler object in memory since object default/podautoscaler-mock-llama2-7b must have been deleted
```
---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>