### PR TITLE
Configure autoscaler http client to skip certificate check

### DIFF
--- a/pkg/controller/podautoscaler/scaler/apa.go
+++ b/pkg/controller/podautoscaler/scaler/apa.go
@@ -98,7 +98,7 @@ func NewApaAutoscaler(readyPodsCount int, pa *autoscalingv1alpha1.PodAutoscaler)
 		return nil, err
 	}
 
-	metricsFetcher := &metrics.RestMetricsFetcher{}
+	metricsFetcher := metrics.NewRestMetricsFetcher()
 	metricsClient := metrics.NewAPAMetricsClient(metricsFetcher, spec.Window)
 	scalingAlgorithm := algorithm.ApaScalingAlgorithm{}
 

--- a/pkg/controller/podautoscaler/scaler/apa_test.go
+++ b/pkg/controller/podautoscaler/scaler/apa_test.go
@@ -37,7 +37,7 @@ func TestAPAScale(t *testing.T) {
 
 	readyPodCount := 5
 	spec := NewApaScalingContext()
-	metricsFetcher := &metrics.RestMetricsFetcher{}
+	metricsFetcher := metrics.NewRestMetricsFetcher()
 	apaMetricsClient := metrics.NewAPAMetricsClient(metricsFetcher, spec.Window)
 	now := time.Now()
 

--- a/pkg/controller/podautoscaler/scaler/kpa.go
+++ b/pkg/controller/podautoscaler/scaler/kpa.go
@@ -220,7 +220,7 @@ func NewKpaAutoscaler(readyPodsCount int, pa *autoscalingv1alpha1.PodAutoscaler,
 	}
 
 	// TODO missing MetricClient
-	metricsFetcher := &metrics.RestMetricsFetcher{}
+	metricsFetcher := metrics.NewRestMetricsFetcher()
 	metricsClient := metrics.NewKPAMetricsClient(metricsFetcher, spec.StableWindow, spec.PanicWindow)
 
 	scalingAlgorithm := algorithm.KpaScalingAlgorithm{}

--- a/pkg/controller/podautoscaler/scaler/kpa_test.go
+++ b/pkg/controller/podautoscaler/scaler/kpa_test.go
@@ -56,7 +56,7 @@ func TestKpaScale(t *testing.T) {
 		PanicWindow:         10 * time.Second,
 		ScaleDownDelay:      30 * time.Minute,
 	}
-	metricsFetcher := &metrics.RestMetricsFetcher{}
+	metricsFetcher := metrics.NewRestMetricsFetcher()
 	kpaMetricsClient := metrics.NewKPAMetricsClient(metricsFetcher, spec.StableWindow, spec.PanicWindow)
 	now := time.Now()
 	_ = kpaMetricsClient.UpdateMetricIntoWindow(now.Add(-60*time.Second), 10.0)

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -268,7 +268,9 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 				fmt.Sprintf("error on getting pods for model %s", model)), targetPodIP, stream
 		}
 
+		klog.InfoS("debug", "pods", pods)
 		targetPodIP, err = s.selectTargetPod(ctx, routingStrategy, pods, model)
+		klog.InfoS("debug", "targetPodIP", targetPodIP)
 		if err != nil {
 			return generateErrorResponse(
 				envoyTypePb.StatusCode_InternalServerError,


### PR DESCRIPTION
## Pull Request Description
Configure autoscaler http client to skip certificate check

## Related Issues
Resolves: https://github.com/aibrix/aibrix/issues/528

![img_v3_02hk_4ec705a1-4725-4c61-9520-9373f1c4b71h](https://github.com/user-attachments/assets/799f5046-7814-4ea5-b764-c901eec2ad56)


**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>