### PR TITLE
Fix the PodAutoscaler kind typo

### DIFF
--- a/pkg/controller/podautoscaler/hpa_resources.go
+++ b/pkg/controller/podautoscaler/hpa_resources.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podautoscaler
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -31,7 +32,7 @@ import (
 )
 
 var (
-	controllerKind = pav1.GroupVersion.WithKind("PodAutoScaler") // Define the resource type for the controller
+	controllerKind = pav1.GroupVersion.WithKind("PodAutoscaler") // Define the resource type for the controller
 )
 
 // MakeHPA creates an HPA resource from a PodAutoscaler resource.
@@ -43,12 +44,12 @@ func makeHPA(pa *pav1.PodAutoscaler) *autoscalingv2.HorizontalPodAutoscaler {
 	}
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        pa.Name,
+			Name:        fmt.Sprintf("%s-hpa", pa.Name),
 			Namespace:   pa.Namespace,
 			Labels:      pa.Labels,
 			Annotations: pa.Annotations,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(pa.GetObjectMeta(), controllerKind),
+				*metav1.NewControllerRef(pa, controllerKind),
 			},
 		},
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{


### PR DESCRIPTION
## Pull Request Description

Due to this typo,  hpa object can not be deleted by GC controller, it shows “unable to get REST mapping for autoscaling.aibrix.ai/v1alpha1/PodAutoScaler” error.  However, HPA does work well and we didn’t notice this earlier


## Related Issues
Resolves: https://github.com/aibrix/aibrix/issues/581

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>