### PR TITLE
Use AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS=50 in base configs

### DIFF
--- a/config/gateway/gateway-plugin/gateway-plugin.yaml
+++ b/config/gateway/gateway-plugin/gateway-plugin.yaml
@@ -42,7 +42,7 @@ spec:
             - name: REDIS_PORT
               value: "6379" 
             - name: AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS
-              value: "10000" # 10 seconds, only local testing
+              value: "50"
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Pull Request Description
change `AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS` in default setting is kind of risky. Some overlay refer the kustomization config without overriding the configs. I consider to override in overlay but notice `10000` is just for testing, then I decide to change back to 50 so people who work on testing can manually update it or create a separate dev overlay. Default should be used by most of the production setups.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>