### PR TITLE
[Bug] Remove compulsory `include_usage` when `stream=true` in gateway

### DIFF
--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -338,24 +338,6 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 	}
 
 	stream, ok = jsonMap["stream"].(bool)
-	if stream && ok {
-		streamOptions, ok := jsonMap["stream_options"].(map[string]interface{})
-		if !ok {
-			klog.ErrorS(nil, "no stream option available", "requestID", requestID, "jsonMap", jsonMap)
-			return generateErrorResponse(envoyTypePb.StatusCode_InternalServerError,
-				[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
-					Key: HeaderErrorNoStreamOptions, RawValue: []byte("stream options not set")}}},
-				"no stream option available"), model, targetPodIP, stream, term
-		}
-		includeUsage, ok := streamOptions["include_usage"].(bool)
-		if !includeUsage || !ok {
-			klog.ErrorS(nil, "no stream with usage option available", "requestID", requestID, "jsonMap", jsonMap)
-			return generateErrorResponse(envoyTypePb.StatusCode_InternalServerError,
-				[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
-					Key: HeaderErrorStreamOptionsIncludeUsage, RawValue: []byte("include usage for stream options not set")}}},
-				"no stream with usage option available"), model, targetPodIP, stream, term
-		}
-	}
 
 	headers := []*configPb.HeaderValueOption{}
 	if routingStrategy == "" {


### PR DESCRIPTION
## Pull Request Description

When `stream=true`, OpenAI API does not require `stream_options` to be specified. This will work

```
curl https://api.openai.com/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
  "model": "gpt-4o",
  "stream": true,
  "messages": [{"role": "user", "content": "help me write a random generator in python"}]
}'
```

However, currently when `stream=true`, AIBrix gateway specifically checks for `stream_options={"include_usage":true}`. This PR simply removes the check.

Note from @Jeffwan 

> Some features like heterogenous feature relies on the usage to be reported. We probably need some docs changes in the feature page to claim that include_usage is needed.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>