### PR TITLE
Make stream include usage as optional

### DIFF
--- a/development/vllm/config/deployment.yaml
+++ b/development/vllm/config/deployment.yaml
@@ -27,8 +27,29 @@ spec:
           image: aibrix/vllm-cpu-env:macos
           ports:
             - containerPort: 8000
-          command: ["/bin/sh", "-c"]
-          args: ["vllm serve facebook/opt-125m --served-model-name facebook-opt-125m --chat-template /etc/chat-template-config/chat-template.j2 --trust-remote-code --device cpu --disable_async_output_proc --enforce-eager --dtype float16"]
+          command:
+            - python3
+            - -m
+            - vllm.entrypoints.openai.api_server
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "8000"
+            - --uvicorn-log-level
+            - warning
+            - --model
+            - facebook/opt-125m 
+            - --served-model-name 
+            - facebook-opt-125m 
+            - --chat-template 
+            - /etc/chat-template-config/chat-template.j2 
+            - --trust-remote-code 
+            - --device 
+            - cpu 
+            - --disable_async_output_proc 
+            - --enforce-eager 
+            - --dtype 
+            - float16
           env:
             - name: DEPLOYMENT_NAME
               valueFrom:

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -115,7 +115,7 @@ func TestGetRoutingStrategy(t *testing.T) {
 			_ = os.Unsetenv("ROUTING_ALGORITHM")
 		}
 
-		routingStrategy, enabled := GetRoutingStrategy(tt.headers)
+		routingStrategy, enabled := getRoutingStrategy(tt.headers)
 		assert.Equal(t, tt.expectedStrategy, routingStrategy, tt.message)
 		assert.Equal(t, tt.expectedEnabled, enabled, tt.message)
 

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package gateway
 
 import (

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -1,0 +1,122 @@
+package gateway
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+
+	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/vllm-project/aibrix/pkg/utils"
+	"k8s.io/klog/v2"
+)
+
+// validateStreamOptions validates whether stream options to include usage is set for user request
+func validateStreamOptions(requestID string, user utils.User, jsonMap map[string]interface{}) *extProcPb.ProcessingResponse {
+	if user.Tpm != 0 {
+		streamOptions, ok := jsonMap["stream_options"].(map[string]interface{})
+		if !ok {
+			klog.ErrorS(nil, "no stream option available", "requestID", requestID, "jsonMap", jsonMap)
+			return generateErrorResponse(envoyTypePb.StatusCode_InternalServerError,
+				[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
+					Key: HeaderErrorNoStreamOptions, RawValue: []byte("stream options not set")}}},
+				"no stream option available")
+		}
+		includeUsage, ok := streamOptions["include_usage"].(bool)
+		if !includeUsage || !ok {
+			klog.ErrorS(nil, "no stream with usage option available", "requestID", requestID, "jsonMap", jsonMap)
+			return generateErrorResponse(envoyTypePb.StatusCode_InternalServerError,
+				[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
+					Key: HeaderErrorStreamOptionsIncludeUsage, RawValue: []byte("include usage for stream options not set")}}},
+				"no stream with usage option available")
+		}
+	}
+	return nil
+}
+
+// getRoutingStrategy retrieves the routing strategy from the headers or environment variable
+// It returns the routing strategy value and whether custom routing strategy is enabled.
+func getRoutingStrategy(headers []*configPb.HeaderValue) (string, bool) {
+	var routingStrategy string
+	routingStrategyEnabled := false
+
+	// Check headers for routing strategy
+	for _, header := range headers {
+		if strings.ToLower(header.Key) == HeaderRoutingStrategy {
+			routingStrategy = string(header.RawValue)
+			routingStrategyEnabled = true
+			break // Prioritize header value over environment variable
+		}
+	}
+
+	// If header not set, check environment variable
+	if !routingStrategyEnabled {
+		if value, exists := utils.CheckEnvExists(EnvRoutingAlgorithm); exists {
+			routingStrategy = value
+			routingStrategyEnabled = true
+		}
+	}
+
+	return routingStrategy, routingStrategyEnabled
+}
+
+// validateRoutingStrategy validates if user provided routing strategy is supported by gateway
+func validateRoutingStrategy(routingStrategy string) bool {
+	routingStrategy = strings.TrimSpace(routingStrategy)
+	return slices.Contains(routingStrategies, routingStrategy)
+}
+
+// getRequestMessage returns input request message field which has user prompt
+func getRequestMessage(jsonMap map[string]interface{}) (string, *extProcPb.ProcessingResponse) {
+	messages, ok := jsonMap["messages"]
+	if !ok {
+		return "", generateErrorResponse(envoyTypePb.StatusCode_InternalServerError,
+			[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{Key: HeaderErrorRequestBodyProcessing, RawValue: []byte("true")}}},
+			"no messages in the request body")
+	}
+	messagesJSON, err := json.Marshal(messages)
+	if err != nil {
+		return "", generateErrorResponse(envoyTypePb.StatusCode_InternalServerError,
+			[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{Key: HeaderErrorRequestBodyProcessing, RawValue: []byte("true")}}},
+			"unable to marshal messages from request body")
+	}
+	return string(messagesJSON), nil
+}
+
+// generateErrorResponse construct envoy proxy error response
+func generateErrorResponse(statusCode envoyTypePb.StatusCode, headers []*configPb.HeaderValueOption, body string) *extProcPb.ProcessingResponse {
+	// Set the Content-Type header to application/json
+	headers = append(headers, &configPb.HeaderValueOption{
+		Header: &configPb.HeaderValue{
+			Key:   "Content-Type",
+			Value: "application/json",
+		},
+	})
+
+	return &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_ImmediateResponse{
+			ImmediateResponse: &extProcPb.ImmediateResponse{
+				Status: &envoyTypePb.HttpStatus{
+					Code: statusCode,
+				},
+				Headers: &extProcPb.HeaderMutation{
+					SetHeaders: headers,
+				},
+				Body: generateErrorMessage(body, int(statusCode)),
+			},
+		},
+	}
+}
+
+// generateErrorMessage constructs a JSON error message
+func generateErrorMessage(message string, code int) string {
+	errorStruct := map[string]interface{}{
+		"error": map[string]interface{}{
+			"message": message,
+			"code":    code,
+		},
+	}
+	jsonData, _ := json.Marshal(errorStruct)
+	return string(jsonData)
+}


### PR DESCRIPTION
## Pull Request Description
Make stream include usage as optional parameter. If request is for a user (user has default tpm limit, if not configured) then stream's include usage is mandatory.

Heterogeneous GPU use case is not supported with stream option right now. Once the support is added, include_usage need to be enabled as well.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>