### PR TITLE
Refactor make deploy to use apply instead of create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ endif
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
     ## helm creates objects without aibrix prefix, hence deploying gateway components outside of kustomization
-	$(KUBECTL) create -k config/dependency
+	$(KUBECTL) apply -k config/dependency --server-side
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -244,7 +244,7 @@ undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.
 .PHONY: install-vke
 install-vke: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
     ## helm creates objects without aibrix prefix, hence deploying gateway components outside of kustomization
-	$(KUBECTL) create -k config/overlays/vke/dependency
+	$(KUBECTL) apply -k config/overlays/vke/dependency --server-side
 
 .PHONY: uninstall-vke
 uninstall-vke: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -252,7 +252,7 @@ uninstall-vke: manifests kustomize ## Uninstall CRDs from the K8s cluster specif
 
 .PHONY: deploy-vke
 deploy-vke: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/overlays/vke/default | $(KUBECTL) create -f -
+	$(KUSTOMIZE) build config/overlays/vke/default | $(KUBECTL) apply -f -
 
 .PHONY: undeploy-vke
 undeploy-vke: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -260,7 +260,7 @@ undeploy-vke: kustomize ## Undeploy controller from the K8s cluster specified in
 
 .PHONY: deploy-vke-ipv4
 deploy-vke-ipv4: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/overlays/vke-ipv4/default | $(KUBECTL) create -f -
+	$(KUSTOMIZE) build config/overlays/vke-ipv4/default | $(KUBECTL) apply -f -
 
 .PHONY: undeploy-vke-ipv4
 undeploy-vke-ipv4: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/default | $(KUBECTL) create -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cd aibrix
 kubectl create -k config/dependency
 
 # Install nightly aibrix components
-kubectl create -k config/default
+kubectl apply -k config/default
 ```
 
 Install stable distribution
@@ -47,7 +47,7 @@ Install stable distribution
 kubectl create -k "github.com/vllm-project/aibrix/config/dependency?ref=v0.2.0"
 
 # Install aibrix components
-kubectl create -k "github.com/vllm-project/aibrix/config/overlays/release?ref=v0.2.0"
+kubectl apply -k "github.com/vllm-project/aibrix/config/overlays/release?ref=v0.2.0"
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cd aibrix
 kubectl create -k config/dependency
 
 # Install nightly aibrix components
-kubectl apply -k config/default
+kubectl create -k config/default
 ```
 
 Install stable distribution
@@ -47,7 +47,7 @@ Install stable distribution
 kubectl create -k "github.com/vllm-project/aibrix/config/dependency?ref=v0.2.0"
 
 # Install aibrix components
-kubectl apply -k "github.com/vllm-project/aibrix/config/overlays/release?ref=v0.2.0"
+kubectl create -k "github.com/vllm-project/aibrix/config/overlays/release?ref=v0.2.0"
 ```
 
 ## Documentation

--- a/config/dependency/kuberay-operator/kustomization.yaml
+++ b/config/dependency/kuberay-operator/kustomization.yaml
@@ -4,9 +4,9 @@ kind: Kustomization
 # The workaround is to use kustomize namespace override to create under aibrix-system namespace.
 
 resources:
-- crds/ray.io_rayclusters.yaml
-- crds/ray.io_rayjobs.yaml
-- crds/ray.io_rayservices.yaml
+# - crds/ray.io_rayclusters.yaml
+# - crds/ray.io_rayjobs.yaml
+# - crds/ray.io_rayservices.yaml
 - templates/deployment.yaml
 - templates/leader_election_role.yaml
 - templates/leader_election_role_binding.yaml

--- a/config/dependency/kuberay-operator/kustomization.yaml
+++ b/config/dependency/kuberay-operator/kustomization.yaml
@@ -4,9 +4,6 @@ kind: Kustomization
 # The workaround is to use kustomize namespace override to create under aibrix-system namespace.
 
 resources:
-# - crds/ray.io_rayclusters.yaml
-# - crds/ray.io_rayjobs.yaml
-# - crds/ray.io_rayservices.yaml
 - templates/deployment.yaml
 - templates/leader_election_role.yaml
 - templates/leader_election_role_binding.yaml

--- a/config/dependency/kustomization.yaml
+++ b/config/dependency/kustomization.yaml
@@ -2,3 +2,6 @@ kind: Kustomization
 
 resources:
 - envoy-gateway
+- kuberay-operator/crds/ray.io_rayclusters.yaml
+- kuberay-operator/crds/ray.io_rayjobs.yaml
+- kuberay-operator/crds/ray.io_rayservices.yaml


### PR DESCRIPTION
## Pull Request Description
Right now `make deploy` command uses `kubectl create` because ray related CRDs size is pretty big to support `kubectl apply`. 

Since envoy proxy CRD is also pretty big and requires `make create`, merging ray CRD with envoyproxy crd for installation such that `make deploy can use kubectl apply`.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>