### PR TITLE
Update request message processing for /v1/completion input

### DIFF
--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -86,10 +86,14 @@ func validateRoutingStrategy(routingStrategy string) bool {
 // getRequestMessage returns input request message field which has user prompt
 func getRequestMessage(jsonMap map[string]interface{}) (string, *extProcPb.ProcessingResponse) {
 	messages, ok := jsonMap["messages"]
+	if !ok || messages == "" {
+		messages, ok = jsonMap["prompt"]
+	}
+
 	if !ok {
 		return "", generateErrorResponse(envoyTypePb.StatusCode_InternalServerError,
 			[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{Key: HeaderErrorRequestBodyProcessing, RawValue: []byte("true")}}},
-			"no messages in the request body")
+			"no messages/prompt in the request body")
 	}
 	messagesJSON, err := json.Marshal(messages)
 	if err != nil {


### PR DESCRIPTION
## Pull Request Description
Right now if routing strategy is enabled, then gateway processes request message for prefix cache aware routing. In this case, add "prompt" request input along with "messages". This is patch fix, detailed fix will be done in next iteration.

## Related Issues
Resolves: #783

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>