### PR TITLE
Fix repeated initialization of gateway routers and add unit test for prefix cache

### DIFF
--- a/pkg/plugins/gateway/algorithms/least_busy_time.go
+++ b/pkg/plugins/gateway/algorithms/least_busy_time.go
@@ -32,7 +32,8 @@ var (
 )
 
 func init() {
-	Register(RouterLeastBusyTime, func() (Router, error) { return NewLeastBusyTimeRouter() })
+	router, err := NewLeastBusyTimeRouter()
+	Register(RouterLeastBusyTime, func() (Router, error) { return router, err })
 }
 
 type leastBusyTimeRouter struct {

--- a/pkg/plugins/gateway/algorithms/least_kv_cache.go
+++ b/pkg/plugins/gateway/algorithms/least_kv_cache.go
@@ -33,7 +33,8 @@ var (
 )
 
 func init() {
-	Register(RouterLeastKvCache, func() (Router, error) { return NewLeastKvCacheRouter() })
+	router, err := NewLeastKvCacheRouter()
+	Register(RouterLeastKvCache, func() (Router, error) { return router, err })
 }
 
 type leastKvCacheRouter struct {

--- a/pkg/plugins/gateway/algorithms/least_latency.go
+++ b/pkg/plugins/gateway/algorithms/least_latency.go
@@ -33,7 +33,8 @@ var (
 )
 
 func init() {
-	Register(RouterLeastLatency, func() (Router, error) { return NewLeastExpectedLatencyRouter() })
+	router, err := NewLeastExpectedLatencyRouter()
+	Register(RouterLeastLatency, func() (Router, error) { return router, err })
 }
 
 type leastExpectedLatencyRouter struct {

--- a/pkg/plugins/gateway/algorithms/least_request.go
+++ b/pkg/plugins/gateway/algorithms/least_request.go
@@ -34,7 +34,8 @@ var (
 )
 
 func init() {
-	Register(RouterLeastRequest, func() (Router, error) { return NewLeastRequestRouter() })
+	router, err := NewLeastRequestRouter()
+	Register(RouterLeastRequest, func() (Router, error) { return router, err })
 }
 
 type leastRequestRouter struct {

--- a/pkg/plugins/gateway/algorithms/prefix_cache.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache.go
@@ -33,7 +33,8 @@ var (
 )
 
 func init() {
-	Register(RouterPrefixCache, func() (Router, error) { return NewPrefixCacheRouter() })
+	router, err := NewPrefixCacheRouter()
+	Register(RouterPrefixCache, func() (Router, error) { return router, err })
 }
 
 const (
@@ -105,8 +106,6 @@ func (p prefixCacheRouter) Route(ctx context.Context, pods map[string]*v1.Pod, m
 		readyPodNames = append(readyPodNames, p.Status.PodIP)
 	}
 	klog.InfoS("prefix cache route",
-		"message", message,
-		"tokens", tokens,
 		"matched_tokens", matchedTokens,
 		"unmatched_tokens", unMatchedTokens,
 		"matched_pods", matchedPodNames,

--- a/pkg/plugins/gateway/algorithms/prefix_cache_and_load.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_and_load.go
@@ -35,7 +35,8 @@ var (
 )
 
 func init() {
-	Register(RouterPrefixCacheAndLoad, func() (Router, error) { return NewPrefixCacheAndLoadRouter() })
+	router, err := NewPrefixCacheAndLoadRouter()
+	Register(RouterPrefixCacheAndLoad, func() (Router, error) { return router, err })
 }
 
 const (

--- a/pkg/plugins/gateway/algorithms/prefix_cache_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package routingalgorithms
 
 import (

--- a/pkg/plugins/gateway/algorithms/prefix_cache_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_test.go
@@ -1,0 +1,47 @@
+package routingalgorithms
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_PrefixCache(t *testing.T) {
+	prefixCacheRouter, _ := NewPrefixCacheRouter()
+
+	pods := map[string]*v1.Pod{
+		"p1": {
+			ObjectMeta: metav1.ObjectMeta{Name: "p1"},
+			Status: v1.PodStatus{
+				PodIP: "1.1.1.1",
+				Conditions: []v1.PodCondition{
+					{
+						Type:   v1.PodReady,
+						Status: v1.ConditionTrue,
+					},
+				},
+			}},
+		"p2": {
+			ObjectMeta: metav1.ObjectMeta{Name: "p2"},
+			Status: v1.PodStatus{
+				PodIP: "2.2.2.2",
+				Conditions: []v1.PodCondition{
+					{
+						Type:   v1.PodReady,
+						Status: v1.ConditionTrue,
+					},
+				},
+			}},
+	}
+
+	targetPod, err := prefixCacheRouter.Route(context.Background(), pods, "m1", "this is first message")
+	assert.NoError(t, err)
+
+	targetPod2, err := prefixCacheRouter.Route(context.Background(), pods, "m1", "this is first message")
+	assert.NoError(t, err)
+
+	assert.Equal(t, targetPod, targetPod2)
+}

--- a/pkg/plugins/gateway/algorithms/random.go
+++ b/pkg/plugins/gateway/algorithms/random.go
@@ -29,7 +29,8 @@ var (
 )
 
 func init() {
-	Register(RouterRandom, func() (Router, error) { return NewRandomRouter() })
+	router, err := NewRandomRouter()
+	Register(RouterRandom, func() (Router, error) { return router, err })
 }
 
 type randomRouter struct {

--- a/pkg/plugins/gateway/algorithms/throughput.go
+++ b/pkg/plugins/gateway/algorithms/throughput.go
@@ -34,7 +34,8 @@ var (
 )
 
 func init() {
-	Register(RouterThroughput, func() (Router, error) { return NewThroughputRouter() })
+	router, err := NewThroughputRouter()
+	Register(RouterThroughput, func() (Router, error) { return router, err })
 }
 
 type throughputRouter struct {

--- a/test/e2e/routing_strategy_test.go
+++ b/test/e2e/routing_strategy_test.go
@@ -31,12 +31,13 @@ import (
 
 func TestPrefixCacheModelInference(t *testing.T) {
 	// #1 request - cache first time request
-	targetPod := getTargetPodFromChatCompletion(t, "this is first message")
-	fmt.Printf("target pod from #1 request: %v\n", targetPod)
+	req := "this is first message"
+	targetPod := getTargetPodFromChatCompletion(t, req)
+	fmt.Printf("req: %s, target pod: %v\n", req, targetPod)
 
 	// #2 request - reuse target pod from first time
-	targetPod2 := getTargetPodFromChatCompletion(t, "this is first message")
-	fmt.Printf("target pod from #2 request: %v\n", targetPod2)
+	targetPod2 := getTargetPodFromChatCompletion(t, req)
+	fmt.Printf("req: %s, target pod: %v\n", req, targetPod2)
 	assert.Equal(t, targetPod, targetPod2)
 
 	// #3 request - new request, match to random pod


### PR DESCRIPTION
## Pull Request Description
In this PR: https://github.com/vllm-project/aibrix/pull/810, gateway's router initialization was refactored recently which introduced a bug where routers were re-initialized on each request. Due to re-initialization of prefix cache router was loosing in-memory state and e2e tests were failing.

## Related Issues
Resolves: #816

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>