### PR TITLE
Bump AIBrix version to v0.2.1 for standalone distributed inference

### DIFF
--- a/config/standalone/distributed-inference-controller/kustomization.yaml
+++ b/config/standalone/distributed-inference-controller/kustomization.yaml
@@ -21,7 +21,10 @@ namePrefix: aibrix-orchestration-
 images:
   - name: controller
     newName: aibrix/controller-manager
-    newTag: nightly
+    newTag: v0.2.1
+  - name: quay.io/kuberay/operator
+    newName: aibrix/kuberay-operator
+    newTag: v1.2.1-patch
 
 patches:
   - path: patch.yaml


### PR DESCRIPTION
## Pull Request Description
We are trying to install the distributed inference by the standalone way "kubectl apply -k config/standalone/distributed-inference-controller/", and currently we should use the v0.2.1 and the special kuberay version to make it work.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>