### PR TITLE
Increase gateway request timeout from 120s to 1800s

### DIFF
--- a/config/gateway/gateway.yaml
+++ b/config/gateway/gateway.yaml
@@ -83,7 +83,7 @@ spec:
                 regex: .*
         route:  
           cluster: original_destination_cluster
-          timeout: 120s  # Increase route timeout
+          timeout: 1800s  # Increase route timeout
         typed_per_filter_config:
           "envoy.filters.http.ext_proc/envoyextensionpolicy/aibrix-system/aibrix-gateway-plugins-extension-policy/extproc/0":
             "@type": "type.googleapis.com/envoy.config.route.v3.FilterConfig"

--- a/pkg/controller/modelrouter/modelrouter_controller.go
+++ b/pkg/controller/modelrouter/modelrouter_controller.go
@@ -211,7 +211,7 @@ func (m *ModelRouter) createHTTPRoute(namespace string, labels map[string]string
 						},
 					},
 					Timeouts: &gatewayv1.HTTPRouteTimeouts{
-						Request: ptr.To(gatewayv1.Duration("120s")),
+						Request: ptr.To(gatewayv1.Duration("1800s")),
 					},
 				},
 			},


### PR DESCRIPTION
## Pull Request Description
while running benchmark tests I came across scenario where if token length is more than 4k and QPS > 100, I was connection timeout errors. Increasing the timeout from 120s to 1800s. In future we will make these values configurable and users can set per their requirement.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>