### PR TITLE
[Misc] Cleanup deprecated function intstr.FromInt

### DIFF
--- a/pkg/controller/kvcache/kvcache_controller.go
+++ b/pkg/controller/kvcache/kvcache_controller.go
@@ -264,8 +264,8 @@ func (r *KVCacheReconciler) reconcileMetadataService(ctx context.Context, kvCach
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{
-					{Name: "client", Port: 2379, TargetPort: intstr.FromInt(2379), Protocol: corev1.ProtocolTCP},
-					{Name: "server", Port: 2380, TargetPort: intstr.FromInt(2380), Protocol: corev1.ProtocolTCP},
+					{Name: "client", Port: 2379, TargetPort: intstr.FromInt32(2379), Protocol: corev1.ProtocolTCP},
+					{Name: "server", Port: 2380, TargetPort: intstr.FromInt32(2380), Protocol: corev1.ProtocolTCP},
 				},
 				Selector: map[string]string{
 					KVCacheLabelKeyIdentifier:    kvCache.Name,
@@ -296,7 +296,7 @@ func (r *KVCacheReconciler) reconcileMetadataService(ctx context.Context, kvCach
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
-				{Name: "etcd-for-vineyard-port", Port: 2379, TargetPort: intstr.FromInt(2379), Protocol: corev1.ProtocolTCP},
+				{Name: "etcd-for-vineyard-port", Port: 2379, TargetPort: intstr.FromInt32(2379), Protocol: corev1.ProtocolTCP},
 			},
 			Selector: map[string]string{
 				KVCacheLabelKeyIdentifier: kvCache.Name,
@@ -358,7 +358,7 @@ func (r *KVCacheReconciler) reconcileServices(ctx context.Context, kvCache *orch
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
-				{Name: "vineyard-rpc", Port: 9600, TargetPort: intstr.FromInt(9600), Protocol: corev1.ProtocolTCP},
+				{Name: "vineyard-rpc", Port: 9600, TargetPort: intstr.FromInt32(9600), Protocol: corev1.ProtocolTCP},
 			},
 			Selector: map[string]string{
 				KVCacheLabelKeyIdentifier: kvCache.Name,
@@ -549,7 +549,7 @@ func (r *KVCacheReconciler) reconcileDeployment(ctx context.Context, kvCache *or
 								TimeoutSeconds:   1,
 								ProbeHandler: corev1.ProbeHandler{
 									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt(9600),
+										Port: intstr.FromInt32(9600),
 									},
 								},
 							},

--- a/pkg/controller/modeladapter/resources_test.go
+++ b/pkg/controller/modeladapter/resources_test.go
@@ -94,7 +94,7 @@ func TestBuildModelAdapterService(t *testing.T) {
 	// Check ports
 	assert.Len(t, service.Spec.Ports, 1)
 	assert.Equal(t, int32(8000), service.Spec.Ports[0].Port)
-	assert.Equal(t, intstr.FromInt(8000), service.Spec.Ports[0].TargetPort)
+	assert.Equal(t, intstr.FromInt32(8000), service.Spec.Ports[0].TargetPort)
 	assert.Equal(t, corev1.ProtocolTCP, service.Spec.Ports[0].Protocol)
 
 	// Check owner references


### PR DESCRIPTION
## Pull Request Description
[Please provide a clear and concise description of your changes here]

```go
// FromInt creates an IntOrString object with an int32 value. It is
// your responsibility not to call this method with a value greater
// than int32.
// Deprecated: use FromInt32 instead.
```


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>