### PR TITLE
[Misc] chore: remove unnecessary check for pod is zero

### DIFF
--- a/pkg/controller/modeladapter/scheduling/random.go
+++ b/pkg/controller/modeladapter/scheduling/random.go
@@ -18,7 +18,6 @@ package scheduling
 
 import (
 	"context"
-	"errors"
 	"math/rand"
 
 	"github.com/vllm-project/aibrix/pkg/cache"
@@ -37,10 +36,6 @@ func NewRandomScheduler(c cache.Cache) Scheduler {
 }
 
 func (r randomScheduler) SelectPod(ctx context.Context, model string, pods []v1.Pod) (*v1.Pod, error) {
-	if len(pods) == 0 {
-		return nil, errors.New("no pods to schedule model adapter")
-	}
-
 	idx := rand.Intn(len(pods))
 	selectedPod := pods[idx]
 


### PR DESCRIPTION
## Pull Request Description
[Please provide a clear and concise description of your changes here]

we already check in : 
https://github.com/vllm-project/aibrix/blob/d0973764a4e3234bb8b73d18092304909fa59e47/pkg/controller/modeladapter/modeladapter_controller.go#L385-L390


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>