### PR TITLE
[Bug] add Tolerations for kvcache pod to fix Pending and CrashLoopBackOff on GKE

### DIFF
--- a/pkg/controller/kvcache/kvcache_controller.go
+++ b/pkg/controller/kvcache/kvcache_controller.go
@@ -561,6 +561,13 @@ func (r *KVCacheReconciler) reconcileDeployment(ctx context.Context, kvCache *or
 						},
 					},
 					Affinity: &affinity,
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "nvidia.com/gpu",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
 					Volumes: []corev1.Volume{
 						{
 							Name: "vineyard-socket",


### PR DESCRIPTION

## Pull Request Description

When follow the [example](https://aibrix.readthedocs.io/latest/features/distributed-kv-cache.html) to deploy a kvcache on GKE, I saw deepseek pod keeps crashing with error "not found /var/run/vineyard.sock", while the kvcache pod is always pending.
```code
$ kubectl get pod
NAME                                            READY   STATUS             RESTARTS       AGE
deepseek-coder-7b-instruct-688778dd76-wzwmg     0/1     CrashLoopBackOff   13 (68s ago)   65m
deepseek-coder-7b-kvcache-7c984cdff8-xq5pk      0/1     Pending            0              65m
deepseek-coder-7b-kvcache-etcd-0                1/1     Running            0              65m
```

The root cause is 
1.  When creating a GPU node in node pool, GKE automatically adds the nvidia.com/gpu=present:NoSchedule taint to the new nodes. ([reference](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms#spot-vms-gpus))
2. GKE automatically adds this toleration to Pods that request GPUs. 
3. But when aibrix kvcache controller create kvcache pod, it **DOES NOT** have this toleration. 

kubectl describe kvcache pod also show the error
```code
FailedScheduling   2m21s (x42 over 60m)  default-scheduler  1 node(s) had untolerated taint {nvidia.com/gpu: present}
```

After apply the fix,  kvcache and deepseek pod can run successfully 
```code
$ kubectl get pod 
NAME                                            READY   STATUS    RESTARTS       AGE  
deepseek-coder-7b-instruct-688778dd76-wzwmg     1/1     Running   18 (35m ago)   125m   
deepseek-coder-7b-kvcache-65f5fc46bc-92fxl      1/1     Running   0              35m
```
