### PR TITLE
[Bug] Routers that require cache failed on Register

### DIFF
--- a/pkg/cache/cache_init.go
+++ b/pkg/cache/cache_init.go
@@ -98,6 +98,14 @@ func New(redisClient *redis.Client, prometheusApi prometheusv1.API) *Store {
 	}
 }
 
+// InitForTest initializes the cache store for testing purposes
+func InitForTest() *Store {
+	once.Do(func() {
+		store = New(nil, nil)
+	})
+	return store
+}
+
 // Init initializes the cache store (singleton pattern)
 // Parameters:
 //

--- a/pkg/plugins/gateway/algorithms/least_busy_time.go
+++ b/pkg/plugins/gateway/algorithms/least_busy_time.go
@@ -32,8 +32,7 @@ var (
 )
 
 func init() {
-	router, err := NewLeastBusyTimeRouter()
-	Register(RouterLeastBusyTime, func() (Router, error) { return router, err })
+	RegisterDelayedConstructor(RouterLeastBusyTime, NewLeastBusyTimeRouter)
 }
 
 type leastBusyTimeRouter struct {
@@ -51,7 +50,7 @@ func NewLeastBusyTimeRouter() (Router, error) {
 	}, nil
 }
 
-func (r leastBusyTimeRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx RoutingContext) (string, error) {
+func (r leastBusyTimeRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx *RoutingContext) (string, error) {
 	var targetPodIP string
 	minBusyTimeRatio := math.MaxFloat64 // <= 1 in general
 

--- a/pkg/plugins/gateway/algorithms/least_kv_cache.go
+++ b/pkg/plugins/gateway/algorithms/least_kv_cache.go
@@ -33,8 +33,7 @@ var (
 )
 
 func init() {
-	router, err := NewLeastKvCacheRouter()
-	Register(RouterLeastKvCache, func() (Router, error) { return router, err })
+	RegisterDelayedConstructor(RouterLeastKvCache, NewLeastKvCacheRouter)
 }
 
 type leastKvCacheRouter struct {
@@ -52,7 +51,7 @@ func NewLeastKvCacheRouter() (Router, error) {
 	}, nil
 }
 
-func (r leastKvCacheRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx RoutingContext) (string, error) {
+func (r leastKvCacheRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx *RoutingContext) (string, error) {
 	var targetPodIP string
 	minKvCache := math.MaxFloat64
 

--- a/pkg/plugins/gateway/algorithms/least_latency.go
+++ b/pkg/plugins/gateway/algorithms/least_latency.go
@@ -33,8 +33,7 @@ var (
 )
 
 func init() {
-	router, err := NewLeastExpectedLatencyRouter()
-	Register(RouterLeastLatency, func() (Router, error) { return router, err })
+	RegisterDelayedConstructor(RouterLeastLatency, NewLeastExpectedLatencyRouter)
 }
 
 type leastExpectedLatencyRouter struct {
@@ -52,7 +51,7 @@ func NewLeastExpectedLatencyRouter() (Router, error) {
 	}, nil
 }
 
-func (r leastExpectedLatencyRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx RoutingContext) (string, error) {
+func (r leastExpectedLatencyRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx *RoutingContext) (string, error) {
 	var targetPodIP string
 	minExpectedLatency := math.MaxFloat64
 

--- a/pkg/plugins/gateway/algorithms/least_request.go
+++ b/pkg/plugins/gateway/algorithms/least_request.go
@@ -34,8 +34,7 @@ var (
 )
 
 func init() {
-	router, err := NewLeastRequestRouter()
-	Register(RouterLeastRequest, func() (Router, error) { return router, err })
+	RegisterDelayedConstructor(RouterLeastRequest, NewLeastRequestRouter)
 }
 
 type leastRequestRouter struct {
@@ -53,7 +52,7 @@ func NewLeastRequestRouter() (Router, error) {
 	}, nil
 }
 
-func (r leastRequestRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx RoutingContext) (string, error) {
+func (r leastRequestRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx *RoutingContext) (string, error) {
 	var targetPodIP string
 	minCount := math.MaxFloat64
 

--- a/pkg/plugins/gateway/algorithms/prefix_cache.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache.go
@@ -34,8 +34,7 @@ var (
 )
 
 func init() {
-	router, err := NewPrefixCacheRouter()
-	Register(RouterPrefixCache, func() (Router, error) { return router, err })
+	RegisterDelayedConstructor(RouterPrefixCache, NewPrefixCacheRouter)
 }
 
 const (
@@ -83,7 +82,7 @@ func NewPrefixCacheRouter() (Router, error) {
 	}, nil
 }
 
-func (p prefixCacheRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx RoutingContext) (string, error) {
+func (p prefixCacheRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx *RoutingContext) (string, error) {
 	readyPods := utils.FilterReadyPods(pods)
 	if len(readyPods) == 0 {
 		return "", fmt.Errorf("no pods to forward request")

--- a/pkg/plugins/gateway/algorithms/prefix_cache_and_load.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_and_load.go
@@ -35,8 +35,7 @@ var (
 )
 
 func init() {
-	router, err := NewPrefixCacheAndLoadRouter()
-	Register(RouterPrefixCacheAndLoad, func() (Router, error) { return router, err })
+	RegisterDelayedConstructor(RouterPrefixCacheAndLoad, NewPrefixCacheAndLoadRouter)
 }
 
 const (
@@ -438,7 +437,7 @@ func (p *prefixCacheAndLoadRouter) updatePodSet(readyPods []*v1.Pod) {
 	}
 }
 
-func (p *prefixCacheAndLoadRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx RoutingContext) (string, error) {
+func (p *prefixCacheAndLoadRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx *RoutingContext) (string, error) {
 	readyPods := utils.FilterReadyPods(pods)
 	if len(readyPods) == 0 {
 		return "", fmt.Errorf("no pods to forward request")

--- a/pkg/plugins/gateway/algorithms/prefix_cache_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_test.go
@@ -53,10 +53,10 @@ func Test_PrefixCache(t *testing.T) {
 			}},
 	}
 
-	targetPod, err := prefixCacheRouter.Route(context.Background(), pods, RoutingContext{Model: "m1", Message: "this is first message"})
+	targetPod, err := prefixCacheRouter.Route(context.Background(), pods, &RoutingContext{Model: "m1", Message: "this is first message"})
 	assert.NoError(t, err)
 
-	targetPod2, err := prefixCacheRouter.Route(context.Background(), pods, RoutingContext{Model: "m1", Message: "this is first message"})
+	targetPod2, err := prefixCacheRouter.Route(context.Background(), pods, &RoutingContext{Model: "m1", Message: "this is first message"})
 	assert.NoError(t, err)
 
 	assert.Equal(t, targetPod, targetPod2)

--- a/pkg/plugins/gateway/algorithms/random.go
+++ b/pkg/plugins/gateway/algorithms/random.go
@@ -29,8 +29,7 @@ var (
 )
 
 func init() {
-	router, err := NewRandomRouter()
-	Register(RouterRandom, func() (Router, error) { return router, err })
+	RegisterDelayedConstructor(RouterRandom, NewRandomRouter)
 }
 
 type randomRouter struct {
@@ -40,7 +39,7 @@ func NewRandomRouter() (Router, error) {
 	return randomRouter{}, nil
 }
 
-func (r randomRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx RoutingContext) (string, error) {
+func (r randomRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx *RoutingContext) (string, error) {
 	var targetPodIP string
 	if len(pods) == 0 {
 		return "", fmt.Errorf("no pods to forward request")

--- a/pkg/plugins/gateway/algorithms/router_test.go
+++ b/pkg/plugins/gateway/algorithms/router_test.go
@@ -33,21 +33,21 @@ func TestNoPods(t *testing.T) {
 	c := cache.Store{}
 	r1 := randomRouter{}
 	model := ""
-	targetPodIP, err := r1.Route(context.TODO(), c.Pods, RoutingContext{Model: model, Message: ""})
+	targetPodIP, err := r1.Route(context.TODO(), c.Pods, &RoutingContext{Model: model, Message: ""})
 	assert.Empty(t, targetPodIP, "targetPodIP must be empty")
 	assert.Error(t, err, "no pod has IP")
 
 	r2 := leastRequestRouter{
 		cache: &c,
 	}
-	targetPodIP, err = r2.Route(context.TODO(), c.Pods, RoutingContext{Model: model, Message: ""})
+	targetPodIP, err = r2.Route(context.TODO(), c.Pods, &RoutingContext{Model: model, Message: ""})
 	assert.Empty(t, targetPodIP, "targetPodIP must be empty")
 	assert.Error(t, err, "no pod has IP")
 
 	r3 := throughputRouter{
 		cache: &c,
 	}
-	targetPodIP, err = r3.Route(context.TODO(), c.Pods, RoutingContext{Model: model, Message: ""})
+	targetPodIP, err = r3.Route(context.TODO(), c.Pods, &RoutingContext{Model: model, Message: ""})
 	assert.Empty(t, targetPodIP, "targetPodIP must be empty")
 	assert.Error(t, err, "no pod has IP")
 }
@@ -70,21 +70,21 @@ func TestWithNoIPPods(t *testing.T) {
 	model := ""
 
 	r1 := randomRouter{}
-	targetPodIP, err := r1.Route(context.TODO(), c.Pods, RoutingContext{Model: model, Message: ""})
+	targetPodIP, err := r1.Route(context.TODO(), c.Pods, &RoutingContext{Model: model, Message: ""})
 	assert.Empty(t, targetPodIP, "targetPodIP must be empty")
 	assert.Error(t, err, "no pod has IP")
 
 	r2 := leastRequestRouter{
 		cache: &c,
 	}
-	targetPodIP, err = r2.Route(context.TODO(), c.Pods, RoutingContext{Model: model, Message: ""})
+	targetPodIP, err = r2.Route(context.TODO(), c.Pods, &RoutingContext{Model: model, Message: ""})
 	assert.Empty(t, targetPodIP, "targetPodIP must be empty")
 	assert.Error(t, err, "no pod has IP")
 
 	r3 := throughputRouter{
 		cache: &c,
 	}
-	targetPodIP, err = r3.Route(context.TODO(), c.Pods, RoutingContext{Model: model, Message: ""})
+	targetPodIP, err = r3.Route(context.TODO(), c.Pods, &RoutingContext{Model: model, Message: ""})
 	assert.Empty(t, targetPodIP, "targetPodIP must be empty")
 	assert.Error(t, err, "no pod has IP")
 }
@@ -145,21 +145,21 @@ func TestWithIPPods(t *testing.T) {
 	model := ""
 
 	r1 := randomRouter{}
-	targetPodIP, err := r1.Route(context.TODO(), c.Pods, RoutingContext{Model: model, Message: ""})
+	targetPodIP, err := r1.Route(context.TODO(), c.Pods, &RoutingContext{Model: model, Message: ""})
 	assert.NotEmpty(t, targetPodIP, "targetPodIP is not empty")
 	assert.NoError(t, err)
 
 	r2 := leastRequestRouter{
 		cache: &c,
 	}
-	targetPodIP, err = r2.Route(context.TODO(), c.Pods, RoutingContext{Model: model, Message: ""})
+	targetPodIP, err = r2.Route(context.TODO(), c.Pods, &RoutingContext{Model: model, Message: ""})
 	assert.NotEmpty(t, targetPodIP, "targetPodIP is not empty")
 	assert.NoError(t, err)
 
 	r3 := throughputRouter{
 		cache: &c,
 	}
-	targetPodIP, err = r3.Route(context.TODO(), c.Pods, RoutingContext{Model: model, Message: ""})
+	targetPodIP, err = r3.Route(context.TODO(), c.Pods, &RoutingContext{Model: model, Message: ""})
 	assert.NotEmpty(t, targetPodIP, "targetPodIP is not empty")
 	assert.NoError(t, err)
 }

--- a/pkg/plugins/gateway/algorithms/throughput.go
+++ b/pkg/plugins/gateway/algorithms/throughput.go
@@ -34,8 +34,7 @@ var (
 )
 
 func init() {
-	router, err := NewThroughputRouter()
-	Register(RouterThroughput, func() (Router, error) { return router, err })
+	RegisterDelayedConstructor(RouterThroughput, NewThroughputRouter)
 }
 
 type throughputRouter struct {
@@ -53,7 +52,7 @@ func NewThroughputRouter() (Router, error) {
 	}, nil
 }
 
-func (r throughputRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx RoutingContext) (string, error) {
+func (r throughputRouter) Route(ctx context.Context, pods map[string]*v1.Pod, routingCtx *RoutingContext) (string, error) {
 	var targetPodIP string
 	minCount := math.MaxFloat64
 

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -69,6 +69,9 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface) *Server {
 	}
 	r := ratelimiter.NewRedisAccountRateLimiter("aibrix", redisClient, 1*time.Minute)
 
+	// Initialize the routers
+	routing.Init()
+
 	return &Server{
 		redisClient:         redisClient,
 		ratelimiter:         r,
@@ -135,8 +138,8 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 	}
 }
 
-func (s *Server) selectTargetPod(ctx context.Context, routingStrategy routing.Algorithms, pods map[string]*v1.Pod, routingCtx routing.RoutingContext) (string, error) {
-	router, err := routing.Select(routingStrategy)()
+func (s *Server) selectTargetPod(ctx context.Context, routingStrategy routing.Algorithms, pods map[string]*v1.Pod, routingCtx *routing.RoutingContext) (string, error) {
+	router, err := routing.Select(routingStrategy)(routingCtx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -95,7 +95,7 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 		if extErr != nil {
 			return extErr, model, targetPodIP, stream, term
 		}
-		routingCtx := routing.RoutingContext{Model: model, Message: message}
+		routingCtx := &routing.RoutingContext{Model: model, Message: message}
 		targetPodIP, err = s.selectTargetPod(ctx, routing.Algorithms(routingStrategy), pods, routingCtx)
 		if targetPodIP == "" || err != nil {
 			klog.ErrorS(err, "failed to select target pod", "requestID", requestID, "routingStrategy", routingStrategy, "model", model)

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -22,6 +22,7 @@ import (
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/vllm-project/aibrix/pkg/cache"
 	routing "github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms"
 )
 
@@ -57,7 +58,8 @@ func Test_ValidateRoutingStrategy(t *testing.T) {
 			expectedValidation: false,
 		},
 	}
-
+	cache.InitForTest()
+	routing.Init()
 	for _, tt := range tests {
 		currentValidation := routing.Validate(routing.Algorithms(tt.routingStrategy))
 		assert.Equal(t, tt.expectedValidation, currentValidation, tt.message)


### PR DESCRIPTION
## Pull Request Description

Introduced two router Register functions to delay the initialization of routers.
1. RegisterDelayed: this is a more generic function to delay the initialization of routers.
2. RegisterDelayedConstructor: Pass the router constructor and expect the initialization of routers to get delayed until the cache is initialized.

## Related Issues
Resolves: #912


**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>