### PR TITLE
[CLI] Add —disableWebhook in controller 

### DIFF
--- a/cmd/controllers/main.go
+++ b/cmd/controllers/main.go
@@ -247,7 +247,7 @@ func main() {
 	certsReady := make(chan struct{})
 
 	if disableWebhook {
-		setupLog.Error(err, "Close the certsReady channel if webhook is disabled, this is to avoid blocking setupControllers")
+		setupLog.Info("Closing the certsReady channel because the webhook is disabled, this is to avoid blocking setupControllers")
 		close(certsReady)
 	} else {
 		if err = cert.CertsManager(mgr, leaderElectionNamespace, certsReady); err != nil {

--- a/config/standalone/autoscaler-controller/patch.yaml
+++ b/config/standalone/autoscaler-controller/patch.yaml
@@ -14,3 +14,4 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=0
             - --controllers=pod-autoscaler-controller
+            - --disable-webhook

--- a/config/standalone/distributed-inference-controller/patch.yaml
+++ b/config/standalone/distributed-inference-controller/patch.yaml
@@ -14,3 +14,4 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=0
             - --controllers=distributed-inference-controller
+            - --disable-webhook

--- a/config/standalone/model-adapter-controller/kustomization.yaml
+++ b/config/standalone/model-adapter-controller/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
   - ../../rbac/model
   - ../../rbac/controller-manager
   - ../../manager
+  # lora needs webhook manifest
+  - ../../webhook
+  - ../../internalcert
 
 # Adds namespace to all resources.
 namespace: aibrix-system

--- a/config/standalone/model-adapter-controller/patch.yaml
+++ b/config/standalone/model-adapter-controller/patch.yaml
@@ -14,3 +14,17 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=0
             - --controllers=model-adapter-controller
+          # following patch is from config/default/manager_webhook_patch.yaml
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: webhook-server-cert


### PR DESCRIPTION
## Pull Request Description

Add an option for standalone components installation. After this change, all standalone controller deployment manifest beside lora will have `--disable-webhook`. #930 is one example. 

## Related Issues
Resolves: https://github.com/vllm-project/aibrix/issues/932

![image](https://github.com/user-attachments/assets/f35bf649-7ea0-43c0-8b9a-82945964c530)


**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>