### PR TITLE
[BUG] return directly when error occurs while adding the controller

### DIFF
--- a/pkg/controller/kvcache/kvcache_controller.go
+++ b/pkg/controller/kvcache/kvcache_controller.go
@@ -122,9 +122,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		Owns(&appsv1.Deployment{}).
 		Watches(&corev1.Pod{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(podWithLabelFilter(KVCacheLabelKeyIdentifier))).
 		Complete(r)
+	if err != nil {
+		return err
+	}
 
 	klog.InfoS("Finished to add kv-cache-controller")
-	return err
+	return nil
 }
 
 // KVCacheReconciler reconciles a KVCache object

--- a/pkg/controller/modeladapter/modeladapter_controller.go
+++ b/pkg/controller/modeladapter/modeladapter_controller.go
@@ -230,9 +230,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(lookupLinkedModelAdapterInNamespace(mgr.GetClient())),
 			builder.WithPredicates(podWithLabelFilter(ModelAdapterPodTemplateLabelKey, ModelAdapterPodTemplateLabelValue, ModelIdentifierKey))).
 		Complete(r)
+	if err != nil {
+		return err
+	}
 
 	klog.V(4).InfoS("Finished to add model-adapter-controller")
-	return err
+	return nil
 }
 
 var _ reconcile.Reconciler = &ModelAdapterReconciler{}

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -126,6 +126,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		Watches(&autoscalingv2.HorizontalPodAutoscaler{}, handler.EnqueueRequestsFromMapFunc(filterHPAObject)).
 		WatchesRawSource(src).
 		Complete(r)
+	if err != nil {
+		return err
+	}
 
 	klog.InfoS("Added AIBrix pod-autoscaler-controller successfully")
 
@@ -139,7 +142,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		}
 	}()
 
-	return err
+	return nil
 }
 
 var _ reconcile.Reconciler = &PodAutoscalerReconciler{}

--- a/pkg/controller/rayclusterfleet/rayclusterfleet_controller.go
+++ b/pkg/controller/rayclusterfleet/rayclusterfleet_controller.go
@@ -80,9 +80,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		Owns(&orchestrationv1alpha1.RayClusterReplicaSet{}).
 		Owns(&rayclusterv1.RayCluster{}).
 		Complete(r)
+	if err != nil {
+		return err
+	}
 
 	klog.V(4).InfoS("Finished to add model-adapter-controller")
-	return err
+	return nil
 }
 
 var _ reconcile.Reconciler = &RayClusterFleetReconciler{}

--- a/pkg/controller/rayclusterreplicaset/rayclusterreplicaset_controller.go
+++ b/pkg/controller/rayclusterreplicaset/rayclusterreplicaset_controller.go
@@ -77,9 +77,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		For(&orchestrationv1alpha1.RayClusterReplicaSet{}).
 		Owns(&rayclusterv1.RayCluster{}).
 		Complete(r)
+	if err != nil {
+		return err
+	}
 
 	klog.V(4).InfoS("Finished to add raycluster-replicaset-controller")
-	return err
+	return nil
 }
 
 var _ reconcile.Reconciler = &RayClusterReplicaSetReconciler{}


### PR DESCRIPTION
## Pull Request Description
[Please provide a clear and concise description of your changes here]
Return errors promptly to prevent incorrect log messages and avoid triggering inappropriate goroutine start within the podautoscaler controller.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>