### PR TITLE
Add graceful shutdown for gateway and add liveness/readiness probes

### DIFF
--- a/config/gateway/gateway-plugin/gateway-plugin.yaml
+++ b/config/gateway/gateway-plugin/gateway-plugin.yaml
@@ -76,6 +76,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          livenessProbe:
+            grpc:
+              port: 50052
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            grpc:
+              port: 50052
+            initialDelaySeconds: 5
+            periodSeconds: 10
       serviceAccountName: aibrix-gateway-plugins
 ---
 # this is a dummy route for incoming request to list models registered to aibrix-control-plane

--- a/config/overlays/release/default_patch.yaml
+++ b/config/overlays/release/default_patch.yaml
@@ -4,6 +4,7 @@ metadata:
   name: gateway-plugins
   namespace: aibrix-system
 spec:
+  replicas: 1
   template:
     spec:
       containers:

--- a/pkg/cache/cache_init.go
+++ b/pkg/cache/cache_init.go
@@ -148,6 +148,7 @@ func InitForMetadata(config *rest.Config, stopCh <-chan struct{}, redisClient *r
 
 func InitForGateway(config *rest.Config, stopCh <-chan struct{}, redisClient *redis.Client) *Store {
 	once.Do(func() {
+		klog.Info("initialize cache for gateway")
 		store = New(redisClient, initPrometheusAPI())
 
 		// Initialize cache components


### PR DESCRIPTION
## Pull Request Description
Add graceful shutdown for gateway pod and adds liveness/readiness probes.

On termination of gateway pod, no new requests will be accepted and just existing requests will complete.
<img width="1196" alt="Screenshot 2025-04-09 at 2 49 19 PM" src="https://github.com/user-attachments/assets/77eea900-1a19-4dba-baf5-15306c0cf824" />


## Related Issues
Resolves: #760  #906 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>