### PR TITLE
E2E CI fix to ensure all pods are ready

### DIFF
--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Check pod status
         run: |
-          sleep 10s
+          sleep 30s
           kubectl get pods --all-namespaces
           kubectl wait pod --all --for=condition=ready --all-namespaces --timeout=300s
 

--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Check pod status
         run: |
-          sleep 30s
+          sleep 10s
           kubectl get pods --all-namespaces
           kubectl wait pod --all --for=condition=ready --all-namespaces --timeout=300s
 

--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -6,6 +6,7 @@ on:
     branches: [ "main", "release-*" ]
     paths:
       - 'pkg/**'
+      - 'test/**'
       - 'cmd/**'
       - 'api/**'
       - 'go.mod'
@@ -15,6 +16,7 @@ on:
     branches: [ "main" ]
     paths:
       - 'pkg/**'
+      - 'test/**'
       - 'cmd/**'
       - 'api/**'
       - 'go.mod'

--- a/development/app/config/templates/deployment/deployment.yaml
+++ b/development/app/config/templates/deployment/deployment.yaml
@@ -62,11 +62,11 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
-            initialDelaySeconds: 3
-            periodSeconds: 2
+            initialDelaySeconds: 1
+            periodSeconds: 1
           readinessProbe:
             httpGet:
               path: /ready
               port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: 1
+            periodSeconds: 1

--- a/test/e2e/model_adapter_test.go
+++ b/test/e2e/model_adapter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	modelv1alpha1 "github.com/vllm-project/aibrix/api/model/v1alpha1"
 	v1alpha1 "github.com/vllm-project/aibrix/pkg/client/clientset/versioned"
+	"github.com/vllm-project/aibrix/pkg/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -49,7 +50,18 @@ func TestModelAdapter(t *testing.T) {
 				}
 				return false, nil
 			}))
-
+		allPodsReady := false
+		for i := 0; i < 3; i++ {
+			podlist, err := k8sClient.CoreV1().Pods("default").List(context.Background(), v1.ListOptions{})
+			if err != nil {
+				continue
+			}
+			assert.Equal(t, 3, len(utils.FilterActivePods(podlist.Items)))
+			fmt.Println("all pods are ready", len(utils.FilterActivePods(podlist.Items)))
+			allPodsReady = true
+			break
+		}
+		assert.True(t, allPodsReady, "ensure all pods are ready")
 	})
 
 	// create model adapter

--- a/test/e2e/model_adapter_test.go
+++ b/test/e2e/model_adapter_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	modelv1alpha1 "github.com/vllm-project/aibrix/api/model/v1alpha1"
 	v1alpha1 "github.com/vllm-project/aibrix/pkg/client/clientset/versioned"
-	"github.com/vllm-project/aibrix/pkg/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -50,18 +49,7 @@ func TestModelAdapter(t *testing.T) {
 				}
 				return false, nil
 			}))
-		allPodsReady := false
-		for i := 0; i < 3; i++ {
-			podlist, err := k8sClient.CoreV1().Pods("default").List(context.Background(), v1.ListOptions{})
-			if err != nil {
-				continue
-			}
-			assert.Equal(t, 3, len(utils.FilterActivePods(podlist.Items)))
-			fmt.Println("all pods are ready", len(utils.FilterActivePods(podlist.Items)))
-			allPodsReady = true
-			break
-		}
-		assert.True(t, allPodsReady, "ensure all pods are ready")
+		validateAllPodsAreReady(t, k8sClient, 3)
 	})
 
 	// create model adapter

--- a/test/e2e/model_adapter_test.go
+++ b/test/e2e/model_adapter_test.go
@@ -49,7 +49,6 @@ func TestModelAdapter(t *testing.T) {
 				}
 				return false, nil
 			}))
-		validateAllPodsAreReady(t, k8sClient, 3)
 	})
 
 	// create model adapter
@@ -63,6 +62,7 @@ func TestModelAdapter(t *testing.T) {
 	// delete pod and ensure model adapter is rescheduled
 	t.Log("deleting pod instance to force model adapter rescheduling")
 	assert.NoError(t, k8sClient.CoreV1().Pods("default").Delete(context.Background(), oldPod, v1.DeleteOptions{}))
+	validateAllPodsAreReady(t, k8sClient, 3)
 	time.Sleep(3 * time.Second)
 	adapter = validateModelAdapter(t, v1alpha1Client, adapter.Name)
 	newPod := adapter.Status.Instances[0]

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -143,9 +143,9 @@ func validateInferenceWithClient(t *testing.T, client *openai.Client, modelName 
 
 func validateAllPodsAreReady(t *testing.T, client *kubernetes.Clientset, expectedPodCount int) {
 	allPodsReady := false
-	for i := 0; i < 3; i++ {
+	for i := 0; i <= 3; i++ {
 		podlist, err := client.CoreV1().Pods("default").List(context.Background(), v1.ListOptions{})
-		if err != nil && expectedPodCount == len(utils.FilterActivePods(podlist.Items)) {
+		if err == nil && expectedPodCount == len(utils.FilterActivePods(podlist.Items)) {
 			allPodsReady = true
 			fmt.Println("all pods are ready", len(utils.FilterActivePods(podlist.Items)))
 			break

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"testing"
@@ -147,7 +146,7 @@ func validateAllPodsAreReady(t *testing.T, client *kubernetes.Clientset, expecte
 		podlist, err := client.CoreV1().Pods("default").List(context.Background(), v1.ListOptions{})
 		if err == nil && expectedPodCount == len(utils.FilterActivePods(podlist.Items)) {
 			allPodsReady = true
-			fmt.Println("all pods are ready", len(utils.FilterActivePods(podlist.Items)))
+			t.Log("all pods are ready", len(utils.FilterActivePods(podlist.Items)))
 			break
 		}
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
## Pull Request Description
In model adapter e2e test, one pod is deleted to validate lora adapter is rescheduled. In mock app deployment config, readiness probe interval was 10s and before pod could be running other tests run which can affect them negatively (one of them is prefix cache validation).

This change
- reduces the readiness probe for mock app.
- add validation in model adapter test to ensure all pods are running in post test.

## Related Issues
Resolves: #951 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>