### PR TITLE
[Fix] Unify all workload generator output file names

### DIFF
--- a/benchmarks/generator/workload-generator/README.md
+++ b/benchmarks/generator/workload-generator/README.md
@@ -1,7 +1,5 @@
 # Using Workload Generator
 
-## Generate workload file
-
 ### Prerequisite
 
 Our workload generator expects prompt collection files that follow one of the two data schema:
@@ -19,6 +17,10 @@ Our workload generator expects prompt collection files that follow one of the tw
 ...
 ```
 Please refer to [this](../dataset-generator/README.md) to create synthetic prompts or convert existing dataset to one of these formats before generating workloads. 
+
+## Generate workload file
+
+The workload generator currently supports the following workload types: static workload that supports static workload (QPS, input/output lengths), synthetic dynamic workload, grafana exported statistics, and actual LLM serving trace (Azure LLM trace). The output workload will be stored as a `workload.jsonl` under the output directory under `--output-dir`. 
 
 ### Generate a workload file based with constant target QPS (synthetic patterns)
 
@@ -45,7 +47,7 @@ Here `--interval-ms` specifies the granularity of concurrent dispatched requests
 
 The file would be stored under `output` folder based on the name of different patterns. And the plot illustrates the workload pattern will be under the `plot` directory. 
 
-## Generate a workload file based on internal load summary .csv file
+### Generate a workload file based on Grafana exported .csv statistics files.
 
 ```shell
 export TRAFFIC_FILE=${PATH_TO_TRAFFIC_FILE}
@@ -57,7 +59,7 @@ python workload_generator.py --prompt-file $PROMPT_FILE --interval-ms 1000 --dur
 
 The scaling factor here (e.g., `qps-scale`) scale down rate from the original trace to the desired rate, i.e., if the peak rate in the original file is 80 and the desired peak rate is 8, the scale is set to 10.0. 
 
-### `maas` trace type 
+#### `maas` trace type 
 - With `maas` trace type, the generator assumes the `$TRAFFIC_FILE` to be in the following format
 ```
 "Time","Total","Success","4xx Error"
@@ -74,7 +76,7 @@ The scaling factor here (e.g., `qps-scale`) scale down rate from the original tr
 "Time","P50","P70","P95","P99"
 ```
 
-### `cloudide` trace type 
+#### `cloudide` trace type 
 - With `cloudide` trace type, the generator assumes the `$TRAFFIC_FILE` to be in the following format -- `"Rate"` column could have arbitrary names. 
 ```
 "Time","Rate"
@@ -90,7 +92,7 @@ The scaling factor here (e.g., `qps-scale`) scale down rate from the original tr
 "Time","recv_bytes","sent_bytes"
 ```
 
-### Indicate the length of prompt/completion
+#### Indicate the length of prompt/completion
 In this case, you can also indicate the request's prompt length by the `--prompt-len-file` config, or the output length by the `--completion-len-file`,
 based on the parameters, the generator will select the proper length in the prompt_file to simulate the length of the real flow's load.
 
@@ -114,7 +116,7 @@ This generator generate workload file (in .json format) under `output` folder. T
 And the plot illustrates the workload pattern will be under the `plot` directory. 
 
 
-## Generate a workload file based on Azure LLM Trace
+### Generate a workload file based on Azure LLM Trace
 
 To produce a workload based on [Azure LLM Trace](https://github.com/Azure/AzurePublicDataset/tree/master/data), use the following commands:
 

--- a/benchmarks/generator/workload-generator/utils.py
+++ b/benchmarks/generator/workload-generator/utils.py
@@ -165,8 +165,7 @@ def get_tokenizer(
     return AutoTokenizer.from_pretrained(pretrained_model_name_or_path,
                                          trust_remote_code=trust_remote_code)
 
-def plot_workload(workload_name: str, 
-                  workload: list,
+def plot_workload(workload: list,
                   bin_size_sec: int = 1,
                   output_dir: str = None):
     """
@@ -174,7 +173,6 @@ def plot_workload(workload_name: str,
     Also plots a session timeline as a scatter plot.
 
     Args:
-        workload_name (str): Name of the workload.
         workload (list of dict): Workload entries with timestamps and request details.
         bin_size_sec (int): Size of each bin in seconds for aggregation.
         output_dir (str, optional): Directory path to save the plot.
@@ -256,8 +254,8 @@ def plot_workload(workload_name: str,
     # Save or show the plot
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
-        plt.savefig(f"{output_dir}/{workload_name}.pdf")
-        logging.info(f'Saved workload plot to {output_dir}/{workload_name}.pdf')
+        plt.savefig(f"{output_dir}/workload.pdf")
+        logging.info(f'Saved workload plot to {output_dir}/workload.pdf')
     else:
         plt.show()
 

--- a/benchmarks/generator/workload-generator/workload_generator.py
+++ b/benchmarks/generator/workload-generator/workload_generator.py
@@ -448,7 +448,7 @@ if __name__ == '__main__':
                                                 duration_ms=args.duration_ms,
                                                 interval_ms=args.interval_ms,
                                                 max_concurrent_sessions=args.max_concurrent_sessions,
-                                                output_file=f"{args.output_dir}/{comp_pattern_type}",
+                                                output_file=f"{args.output_dir}/workload",
                                                 to_jsonl=(args.output_format == "jsonl"),
                                             )
         workload_dict[comp_pattern_type] = generated_workload
@@ -462,7 +462,7 @@ if __name__ == '__main__':
                                                     duration_ms=args.duration_ms, 
                                                     interval_ms=args.interval_ms,
                                                     max_concurrent_sessions=args.max_concurrent_sessions,
-                                                    output_file=f"{args.output_dir}/{args.trace_type}",
+                                                    output_file=f"{args.output_dir}/workload",
                                                     to_jsonl=(args.output_format == "jsonl"),
                                                 )
         elif args.trace_type == "internal":
@@ -477,7 +477,7 @@ if __name__ == '__main__':
                                                             output_scale=args.output_scale,
                                                             internal_trace_type=args.internal_trace_type,
                                                             max_concurrent_sessions=args.max_concurrent_sessions,
-                                                            output_file=f"{args.output_dir}/{args.trace_type}",
+                                                            output_file=f"{args.output_dir}/workload",
                                                             to_jsonl=(args.output_format == "jsonl"),
                                                             )
 
@@ -487,7 +487,7 @@ if __name__ == '__main__':
                                                          duration_ms=args.duration_ms, 
                                                          tokenizer=tokenizer,
                                                          interval_ms=args.interval_ms, 
-                                                         output_file=f"{args.output_dir}/{args.trace_type}",
+                                                         output_file=f"{args.output_dir}/workload",
                                                          to_jsonl=(args.output_format == "jsonl"),
                                                          )
 
@@ -497,7 +497,6 @@ if __name__ == '__main__':
         # Plot the workloads
         for workload_name, workload in workload_dict.items():
             plot_workload(
-                workload_name = workload_name, 
                 workload = workload, 
                 bin_size_sec = int(args.interval_ms/1000), 
                 output_dir = f"{args.output_dir}")


### PR DESCRIPTION
## Pull Request Description
Change all output file names to workload (workload.jsonl and workload.pdf) for easy adoption in benchmark script. 

## Related Issues
Related: #903