### PR TITLE
Assign tasks to client by keys

### DIFF
--- a/benchmarks/client/client.py
+++ b/benchmarks/client/client.py
@@ -14,13 +14,15 @@ from typing import List
 from utils import (load_workload, prepare_prompt, update_response)
 
 thread_pool_size = 8
-QUEUE_SIZE = thread_pool_size * 2
+QUEUE_SIZE = 2
 logging.basicConfig(level=logging.INFO)
-task_queue = Queue(maxsize=QUEUE_SIZE)
+task_queues = []
+for _ in range(thread_pool_size):
+    task_queues.append(Queue(maxsize=QUEUE_SIZE))
 session_history = {}
 lock = threading.Lock()
 
-def worker(thread_idx, client, model, send_request_func, output_file):
+def worker(thread_idx, task_queue, client, model, send_request_func, output_file):
     """Worker function to run an asyncio event loop in a separate thread."""
     asyncio.set_event_loop(asyncio.new_event_loop())
     loop = asyncio.get_event_loop()
@@ -34,9 +36,9 @@ def worker(thread_idx, client, model, send_request_func, output_file):
         task_queue.task_done()
 
 
-def start_worker_threads(thread_idx, client, model, send_request_func, output_file):
+def start_worker_threads(thread_idx, task_queue, client, model, send_request_func, output_file):
     """Start multiple threads, each running an event loop for handling tasks."""
-    thread = threading.Thread(target=worker, args=(thread_idx, client, model, send_request_func, output_file), daemon=True)
+    thread = threading.Thread(target=worker, args=(thread_idx, task_queue, client, model, send_request_func, output_file), daemon=True)
     thread.start()
     return thread
 
@@ -57,6 +59,8 @@ async def send_request_streaming(client: openai.AsyncOpenAI,
     try:
         cur_time = time.time()
         logging.warning(f"send_request_streaming: Prepare to launch task after {target_time - cur_time}")
+        if target_time > cur_time:
+            await asyncio.sleep(target_time - cur_time)
         response_stream = await client.chat.completions.create(
             model=model,
             messages=prompt,
@@ -167,7 +171,7 @@ async def benchmark_streaming(api_key: str,
     threads = []
     for thread_idx in range(0, thread_pool_size):
         client = create_client(api_key, endpoint, max_retries, timeout, routing_strategy)
-        threads.append(start_worker_threads(thread_idx, client, model, send_request_streaming, output_file))
+        threads.append(start_worker_threads(thread_idx, task_queues[thread_idx], client, model, send_request_streaming, output_file))
     for requests_dict in load_struct:
         ts = int(requests_dict["timestamp"])
         requests = requests_dict["requests"]
@@ -175,14 +179,16 @@ async def benchmark_streaming(api_key: str,
         formatted_prompts = [prepare_prompt(prompt = request["prompt"], lock = lock, session_id = request.get("session_id", None), history = session_history) for request in requests]
         for i in range(len(requests)):
             session_id = requests[i].get("session_id", None)
-            task_queue.put((formatted_prompts[i], output_file, request_id, session_id, target_time))
+            task_queue_id = session_id % len(task_queues)
+            task_queues[task_queue_id].put((formatted_prompts[i], output_file, request_id, session_id, target_time))
             request_id += 1
         num_requests += len(requests)
-    task_queue.join()
+    for task_queue in task_queues:
+        task_queue.join()
     # Stop all worker threads
     logging.warn("Producer completed ...")
-    for _ in threads:
-        task_queue.put(None)
+    for i, thread in enumerate(threads):
+        task_queues[i].put(None)
 
     for thread in threads:
         thread.join()
@@ -285,7 +291,7 @@ async def benchmark_batch(api_key: str,
     
     for thread_idx in range(0, thread_pool_size):
         client = create_client(api_key, endpoint, max_retries, timeout, routing_strategy)
-        threads.append(start_worker_threads(thread_idx, client, model, send_request_batch, output_file))
+        threads.append(start_worker_threads(thread_idx, task_queues[thread_idx], client, model, send_request_batch, output_file))
     for requests_dict in load_struct:
         ts = int(requests_dict["timestamp"])
         requests = requests_dict["requests"]
@@ -293,13 +299,15 @@ async def benchmark_batch(api_key: str,
         formatted_prompts = [prepare_prompt(prompt = request["prompt"], lock = lock, session_id = request.get("session_id", None), history = session_history) for request in requests]
         for i in range(len(requests)):
             session_id = requests[i].get("session_id", None)
-            task_queue.put((formatted_prompts[i], output_file, request_id, session_id, target_time))
+            task_queue_id = session_id % len(task_queues)
+            task_queues[task_queue_id].put((formatted_prompts[i], output_file, request_id, session_id, target_time))
             request_id += 1
         num_requests += len(requests)
-    task_queue.join()
+    for task_queue in task_queues:
+        task_queue.join()
     # Stop all worker threads
-    for _ in threads:
-        task_queue.put(None)
+    for i, _ in enumerate(threads):
+        task_queues[i].put(None)
 
     for thread in threads:
         thread.join()


### PR DESCRIPTION
## Pull Request Description
This PR fixes a task dispatch ordering issue by assiging requests from the same session to the same worker thread. This ensures requests from the same session are dispatched and processed in its intended order. 

## Related Issues
#903 

