### PR TITLE
[Fix] 401 errors in gateway should be returned as immediate response 

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -97,6 +97,8 @@ func TestBaseModelInferenceFailures(t *testing.T) {
 			var apiErr *openai.Error
 			if !errors.As(err, &apiErr) {
 				t.Fatalf("Error is not an APIError: %+v", err)
+			} else {
+				t.Logf("API Error code: %d, message: %s", apiErr.StatusCode, apiErr.Message)
 			}
 			if assert.ErrorAs(t, err, &apiErr) {
 				assert.Equal(t, tc.expectErrCode, apiErr.StatusCode, t.Name())

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -84,9 +84,16 @@ func initializeClient(ctx context.Context, t *testing.T) (*kubernetes.Clientset,
 }
 
 func createOpenAIClient(baseURL, apiKey string) *openai.Client {
+	// For strict testing, use a custom http.Transport with disabled keep-alives and caching to avoid flaky tests.
+	transport := &http.Transport{
+		DisableKeepAlives: true,
+		MaxIdleConns:      0,
+	}
+
 	return openai.NewClient(
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey(apiKey),
+		option.WithHTTPClient(&http.Client{Transport: transport}),
 		option.WithMiddleware(func(r *http.Request, mn option.MiddlewareNext) (*http.Response, error) {
 			r.URL.Path = "/v1" + r.URL.Path
 			return mn(r)


### PR DESCRIPTION
## Pull Request Description

  - Use a custom transport with disabled keep-alives and caching
  - Add protection for for context.canceld and EOF case
  - Early return the 401 resposne
  - Update e2e SDK with timeout

## Related Issues
Resolves: https://github.com/vllm-project/aibrix/issues/1004

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>