### PR TITLE
[Bug] fix: update metaPods cache to use namespace/name as the key

### DIFF
--- a/pkg/cache/cache_api.go
+++ b/pkg/cache/cache_api.go
@@ -35,10 +35,11 @@ type PodCache interface {
 	// GetPod retrieves a Pod object by name
 	// Parameters:
 	//   podName: Name of the pod
+	//   podNamespace: Namespace of the pod
 	// Returns:
 	//   *v1.Pod: Found pod object
 	//   error: Error information if operation fails
-	GetPod(podName string) (*v1.Pod, error)
+	GetPod(podName, podNamespace string) (*v1.Pod, error)
 
 	// ListPodsByModel gets pods associated with a model
 	// Parameters:
@@ -66,10 +67,11 @@ type ModelCache interface {
 	// ListModelsByPod gets models associated with a pod
 	// Parameters:
 	//   podName: Name of the pod
+	//   podNamespace: Namespace of the pod
 	// Returns:
 	//   map[string]struct{}: Set of model names
 	//   error: Error information if operation fails
-	ListModelsByPod(podName string) ([]string, error)
+	ListModelsByPod(podName, podNamespace string) ([]string, error)
 }
 
 // MetricCache defines operations for metric data caching
@@ -77,22 +79,24 @@ type MetricCache interface {
 	// GetMetricValueByPod gets metric value for a pod
 	// Parameters:
 	//   podName: Name of the pod
+	//   podNamespace: Namespace of the pod
 	//   metricName: Name of the metric
 	// Returns:
 	//   metrics.MetricValue: Retrieved metric value
 	//   error: Error information if operation fails
-	GetMetricValueByPod(podName, metricName string) (metrics.MetricValue, error)
+	GetMetricValueByPod(podName, podNamespace, metricName string) (metrics.MetricValue, error)
 
 	// GetMetricValueByPodModel gets metric value for pod-model pair
 	// Parameters:
 	//   ctx: Routing context
 	//   podName: Name of the pod
+	//   podNamespace: Namespace of the pod
 	//   modelName: Name of the model
 	//   metricName: Name of the metric
 	// Returns:
 	//   metrics.MetricValue: Retrieved metric value
 	//   error: Error information if operation fails
-	GetMetricValueByPodModel(podName, modelName string, metricName string) (metrics.MetricValue, error)
+	GetMetricValueByPodModel(podName, podNamespace, modelName string, metricName string) (metrics.MetricValue, error)
 
 	// AddSubscriber adds a metric subscriber
 	// Parameters:

--- a/pkg/cache/cache_impl.go
+++ b/pkg/cache/cache_impl.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -30,15 +32,17 @@ import (
 // Parameters:
 //
 //	podName: Name of the pod to retrieve
+//	podNamespace: Namespace of the pod to retrieve
 //
 // Returns:
 //
 //	*v1.Pod: The found Pod object
 //	error: Error if pod doesn't exist
-func (c *Store) GetPod(podName string) (*v1.Pod, error) {
-	metaPod, ok := c.metaPods.Load(podName)
+func (c *Store) GetPod(podName, podNamespace string) (*v1.Pod, error) {
+	key := utils.GeneratePodKey(podNamespace, podName)
+	metaPod, ok := c.metaPods.Load(key)
 	if !ok {
-		return nil, fmt.Errorf("pod does not exist in the cache: %s", podName)
+		return nil, fmt.Errorf("key does not exist in the cache: %s", key)
 	}
 
 	return metaPod.Pod, nil
@@ -102,15 +106,17 @@ func (c *Store) HasModel(modelName string) bool {
 // Parameters:
 //
 //	podName: Name of the Pod to query
+//	podNamespace: Namespace of the Pod to query
 //
 // Returns:
 //
 //	[]string: Slice of model names
 //	error: Error if Pod doesn't exist
-func (c *Store) ListModelsByPod(podName string) ([]string, error) {
-	metaPod, ok := c.metaPods.Load(podName)
+func (c *Store) ListModelsByPod(podName, podNamespace string) ([]string, error) {
+	key := utils.GeneratePodKey(podNamespace, podName)
+	metaPod, ok := c.metaPods.Load(key)
 	if !ok {
-		return nil, fmt.Errorf("pod does not exist in the cache: %s", podName)
+		return nil, fmt.Errorf("key does not exist in the cache: %s", key)
 	}
 
 	return metaPod.Models.Array(), nil
@@ -120,16 +126,18 @@ func (c *Store) ListModelsByPod(podName string) ([]string, error) {
 // Parameters:
 //
 //	podName: Name of the Pod
+//	podNamespace: Namespace of the Pod
 //	metricName: Name of the metric
 //
 // Returns:
 //
 //	metrics.MetricValue: The metric value
 //	error: Error if Pod or metric doesn't exist
-func (c *Store) GetMetricValueByPod(podName, metricName string) (metrics.MetricValue, error) {
-	metaPod, ok := c.metaPods.Load(podName)
+func (c *Store) GetMetricValueByPod(podName, podNamespace, metricName string) (metrics.MetricValue, error) {
+	key := utils.GeneratePodKey(podNamespace, podName)
+	metaPod, ok := c.metaPods.Load(key)
 	if !ok {
-		return nil, fmt.Errorf("pod does not exist in the cache: %s", podName)
+		return nil, fmt.Errorf("key does not exist in the cache: %s", key)
 	}
 
 	return c.getPodMetricImpl(podName, &metaPod.Metrics, metricName)
@@ -139,6 +147,7 @@ func (c *Store) GetMetricValueByPod(podName, metricName string) (metrics.MetricV
 // Parameters:
 //
 //	podName: Name of the Pod
+//	podNamespace: Namespace of the Pod
 //	modelName: Name of the model
 //	metricName: Name of the metric
 //
@@ -146,10 +155,11 @@ func (c *Store) GetMetricValueByPod(podName, metricName string) (metrics.MetricV
 //
 //	metrics.MetricValue: The metric value
 //	error: Error if Pod, model or metric doesn't exist
-func (c *Store) GetMetricValueByPodModel(podName, modelName string, metricName string) (metrics.MetricValue, error) {
-	metaPod, ok := c.metaPods.Load(podName)
+func (c *Store) GetMetricValueByPodModel(podName, podNamespace, modelName string, metricName string) (metrics.MetricValue, error) {
+	key := utils.GeneratePodKey(podNamespace, podName)
+	metaPod, ok := c.metaPods.Load(key)
 	if !ok {
-		return nil, fmt.Errorf("pod does not exist in the cache: %s", podName)
+		return nil, fmt.Errorf("key does not exist in the cache: %s", key)
 	}
 
 	return c.getPodMetricImpl(podName, &metaPod.ModelMetrics, c.getPodModelMetricName(modelName, metricName))

--- a/pkg/cache/cache_init.go
+++ b/pkg/cache/cache_init.go
@@ -51,7 +51,7 @@ type Store struct {
 	numRequestsTraces int32                                 // Request trace counter
 
 	// Pod related storage
-	metaPods utils.SyncMap[string, *Pod] // pod_name -> *Pod
+	metaPods utils.SyncMap[string, *Pod] // pod_namespace/pod_name -> *Pod
 
 	// Mapping relationships
 	metaModels utils.SyncMap[string, *Model] // model_name -> *Model
@@ -103,7 +103,11 @@ func NewTestCacheWithPods(pods []*v1.Pod, model string) *Store {
 
 func NewTestCacheWithPodsMetrics(pods []*v1.Pod, model string, podMetrics map[string]map[string]metrics.MetricValue) *Store {
 	c := NewTestCacheWithPods(pods, model)
-	c.metaPods.Range(func(podName string, metaPod *Pod) bool {
+	c.metaPods.Range(func(key string, metaPod *Pod) bool {
+		_, podName, ok := utils.ParsePodKey(key)
+		if !ok {
+			return true
+		}
 		if podmetrics, ok := podMetrics[podName]; ok {
 			for metricName, metric := range podmetrics {
 				if err := c.updatePodRecord(metaPod, model, metricName, metrics.PodMetricScope, metric); err != nil {

--- a/pkg/cache/cache_log.go
+++ b/pkg/cache/cache_log.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/vllm-project/aibrix/pkg/metrics"
+	"github.com/vllm-project/aibrix/pkg/utils"
 	"k8s.io/klog/v2"
 )
 
@@ -28,7 +29,11 @@ func (c *Store) debugInfo() {
 		return
 	}
 
-	c.metaPods.Range(func(podName string, pod *Pod) bool {
+	c.metaPods.Range(func(key string, pod *Pod) bool {
+		_, podName, ok := utils.ParsePodKey(key)
+		if !ok {
+			return true
+		}
 		klog.V(4).Infof("pod: %s, podIP: %v, models: %s", podName, pod.Status.PodIP, strings.Join(pod.Models.Array(), " "))
 		pod.Metrics.Range(func(metricName string, metricVal metrics.MetricValue) bool {
 			klog.V(5).Infof("%v_%v_%v", podName, metricName, metricVal)

--- a/pkg/cache/cache_metrics.go
+++ b/pkg/cache/cache_metrics.go
@@ -111,7 +111,7 @@ func (c *Store) getPodModelMetricName(modelName string, metricName string) strin
 }
 
 func (c *Store) updatePodMetrics() {
-	c.metaPods.Range(func(podName string, metaPod *Pod) bool {
+	c.metaPods.Range(func(key string, metaPod *Pod) bool {
 		if !utils.FilterReadyPod(metaPod.Pod) {
 			// Skip unready pod
 			return true

--- a/pkg/cache/cache_trace.go
+++ b/pkg/cache/cache_trace.go
@@ -49,8 +49,8 @@ func (c *Store) addPodStats(ctx *types.RoutingContext, requestID string) {
 		return
 	}
 	pod := ctx.TargetPod()
-
-	metaPod, ok := c.metaPods.Load(pod.Name)
+	key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+	metaPod, ok := c.metaPods.Load(key)
 	if !ok {
 		klog.Warningf("can't find routing pod: %s, requestID: %s", pod.Name, requestID)
 		return
@@ -69,7 +69,8 @@ func (c *Store) donePodStats(ctx *types.RoutingContext, requestID string) {
 	pod := ctx.TargetPod()
 
 	// Now that pendingLoadProvider must be set.
-	metaPod, ok := c.metaPods.Load(pod.Name)
+	key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+	metaPod, ok := c.metaPods.Load(key)
 	if !ok {
 		klog.Warningf("can't find routing pod: %s, requestID: %s", pod.Name, requestID)
 		return

--- a/pkg/cache/model.go
+++ b/pkg/cache/model.go
@@ -21,6 +21,9 @@ import (
 )
 
 type Model struct {
+	// Pods is a CustomizedRegistry that stores *v1.Pod objects.
+	// The internal map uses `namespace/name` as the key and `*v1.Pod` as the value.
+	// This allows efficient lookups and caching of Pod objects by their unique identifier.
 	Pods *utils.CustomizedRegistry[*v1.Pod, *utils.PodArray]
 	// Metrics utils.SyncMap[string, metrics.MetricValue] // reserved
 

--- a/pkg/controller/modeladapter/scheduling/bin_pack.go
+++ b/pkg/controller/modeladapter/scheduling/bin_pack.go
@@ -42,7 +42,7 @@ func (r binPackScheduler) SelectPod(ctx context.Context, model string, pods []v1
 	podRemainCapMin := math.MaxInt
 
 	for _, pod := range pods {
-		models, err := r.cache.ListModelsByPod(pod.Name)
+		models, err := r.cache.ListModelsByPod(pod.Name, pod.Namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/modeladapter/scheduling/least_adapters.go
+++ b/pkg/controller/modeladapter/scheduling/least_adapters.go
@@ -40,7 +40,7 @@ func (r leastAdapters) SelectPod(ctx context.Context, model string, pods []v1.Po
 	modelAdapterCountMin := math.MaxInt
 
 	for _, pod := range pods {
-		models, err := r.cache.ListModelsByPod(pod.Name)
+		models, err := r.cache.ListModelsByPod(pod.Name, pod.Namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/modeladapter/scheduling/least_latency.go
+++ b/pkg/controller/modeladapter/scheduling/least_latency.go
@@ -41,11 +41,11 @@ func (r leastLatencyScheduler) SelectPod(ctx context.Context, model string, pods
 	podLatencyMin := math.MaxFloat64
 
 	for _, pod := range pods {
-		queueTime, err := r.cache.GetMetricValueByPodModel(pod.Name, model, metrics.RequestQueueTimeSeconds)
+		queueTime, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, model, metrics.RequestQueueTimeSeconds)
 		if err != nil {
 			return nil, err
 		}
-		inferenceTime, err := r.cache.GetMetricValueByPodModel(pod.Name, model, metrics.RequestInferenceTimeSeconds)
+		inferenceTime, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, model, metrics.RequestInferenceTimeSeconds)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/modeladapter/scheduling/least_throughput.go
+++ b/pkg/controller/modeladapter/scheduling/least_throughput.go
@@ -41,11 +41,11 @@ func (r leastThroughputScheduler) SelectPod(ctx context.Context, model string, p
 	podThroughputMin := math.MaxFloat64
 
 	for _, pod := range pods {
-		promptThroughput, err := r.cache.GetMetricValueByPodModel(pod.Name, model, metrics.AvgPromptThroughputToksPerMinPod)
+		promptThroughput, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, model, metrics.AvgPromptThroughputToksPerMinPod)
 		if err != nil {
 			return nil, err
 		}
-		generationThroughput, err := r.cache.GetMetricValueByPodModel(pod.Name, model, metrics.AvgGenerationThroughputToksPerMinPod)
+		generationThroughput, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, model, metrics.AvgGenerationThroughputToksPerMinPod)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/plugins/gateway/algorithms/least_busy_time.go
+++ b/pkg/plugins/gateway/algorithms/least_busy_time.go
@@ -64,7 +64,7 @@ func (r leastBusyTimeRouter) Route(ctx *types.RoutingContext, pods types.PodList
 			continue
 		}
 
-		busyTimeRatio, err := r.cache.GetMetricValueByPod(pod.Name, "gpu_busy_time_ratio") // todo: replace mock
+		busyTimeRatio, err := r.cache.GetMetricValueByPod(pod.Name, pod.Namespace, "gpu_busy_time_ratio") // todo: replace mock
 		if err != nil {
 			klog.Error(err)
 			continue

--- a/pkg/plugins/gateway/algorithms/least_kv_cache.go
+++ b/pkg/plugins/gateway/algorithms/least_kv_cache.go
@@ -68,12 +68,12 @@ func (r leastKvCacheRouter) Route(ctx *types.RoutingContext, pods types.PodList)
 		// Due to metric refactor (pull/543) to better support lora and multi models,
 		// we change to use PodModelMetrics instead of PodMetrics in some scenarios.
 		// This works but doesn't look very promising, we can revisit this part later.
-		gpuCache, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.GPUCacheUsagePerc)
+		gpuCache, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.GPUCacheUsagePerc)
 		if err != nil {
 			klog.Error(err)
 			continue
 		}
-		cpuCache, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.CPUCacheUsagePerc)
+		cpuCache, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.CPUCacheUsagePerc)
 		if err != nil {
 			klog.Error(err)
 			continue

--- a/pkg/plugins/gateway/algorithms/least_latency.go
+++ b/pkg/plugins/gateway/algorithms/least_latency.go
@@ -65,12 +65,12 @@ func (r leastExpectedLatencyRouter) Route(ctx *types.RoutingContext, pods types.
 	cntPromt := 0
 	cntGeneration := 0
 	for _, pod := range pods.All() {
-		avgPromptTokens, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.AvgPromptToksPerReq)
+		avgPromptTokens, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.AvgPromptToksPerReq)
 		if err != nil {
 			klog.Error(err)
 			continue
 		}
-		avgGenerationTokens, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.AvgGenerationToksPerReq)
+		avgGenerationTokens, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.AvgGenerationToksPerReq)
 		if err != nil {
 			klog.Error(err)
 			continue
@@ -99,19 +99,19 @@ func (r leastExpectedLatencyRouter) Route(ctx *types.RoutingContext, pods types.
 		}
 
 		// expected queuing latency
-		queuingLatency, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.RequestQueueTimeSeconds)
+		queuingLatency, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.RequestQueueTimeSeconds)
 		if err != nil {
 			klog.Error(err)
 			continue
 		}
 
 		// expected prefill latency
-		avgPromptTokens, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.AvgPromptToksPerReq)
+		avgPromptTokens, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.AvgPromptToksPerReq)
 		if err != nil {
 			klog.Error(err)
 			continue
 		}
-		PrefillTime, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.RequestPrefillTimeSeconds)
+		PrefillTime, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.RequestPrefillTimeSeconds)
 		if err != nil {
 			klog.Error(err)
 			continue
@@ -119,12 +119,12 @@ func (r leastExpectedLatencyRouter) Route(ctx *types.RoutingContext, pods types.
 		prefillLatency := PrefillTime.GetHistogramValue().GetMean() / avgPromptTokens.GetSimpleValue() * guessPromptTokens
 
 		// expected decode latency
-		avgGenerationTokens, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.AvgGenerationToksPerReq)
+		avgGenerationTokens, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.AvgGenerationToksPerReq)
 		if err != nil {
 			klog.Error(err)
 			continue
 		}
-		DecodeTime, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.RequestDecodeTimeSeconds)
+		DecodeTime, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.RequestDecodeTimeSeconds)
 		if err != nil {
 			klog.Error(err)
 			continue

--- a/pkg/plugins/gateway/algorithms/least_request.go
+++ b/pkg/plugins/gateway/algorithms/least_request.go
@@ -110,7 +110,7 @@ func selectTargetPodWithLeastRequestCount(cache cache.Cache, readyPods []*v1.Pod
 func getRequestCounts(cache cache.Cache, readyPods []*v1.Pod) map[string]int {
 	podRequestCount := map[string]int{}
 	for _, pod := range readyPods {
-		runningReq, err := cache.GetMetricValueByPod(pod.Name, metrics.RealtimeNumRequestsRunning)
+		runningReq, err := cache.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
 		if err != nil {
 			runningReq = &metrics.SimpleMetricValue{Value: 0}
 		}

--- a/pkg/plugins/gateway/algorithms/throughput.go
+++ b/pkg/plugins/gateway/algorithms/throughput.go
@@ -66,12 +66,12 @@ func (r throughputRouter) Route(ctx *types.RoutingContext, pods types.PodList) (
 	}
 
 	for _, pod := range readyPods {
-		promptThroughput, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.AvgPromptThroughputToksPerS)
+		promptThroughput, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.AvgPromptThroughputToksPerS)
 		if err != nil {
 			klog.Error(err)
 			continue
 		}
-		generationThroughput, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.AvgGenerationThroughputToksPerS)
+		generationThroughput, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.AvgGenerationThroughputToksPerS)
 		if err != nil {
 			klog.Error(err)
 			continue

--- a/pkg/plugins/gateway/algorithms/vtc/vtc_basic.go
+++ b/pkg/plugins/gateway/algorithms/vtc/vtc_basic.go
@@ -130,7 +130,7 @@ func (r *BasicVTCRouter) Route(ctx *types.RoutingContext, pods types.PodList) (s
 		// 2. Get pod load for utilization score
 		var podLoad float64
 		if r.cache != nil {
-			reqCount, err := r.cache.GetMetricValueByPodModel(pod.Name, ctx.Model, metrics.NumRequestsRunning)
+			reqCount, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.NumRequestsRunning)
 			if err != nil {
 				klog.ErrorS(err, "failed to get pod metrics, using default value", "pod", pod.Name)
 				podLoad = 0

--- a/pkg/plugins/gateway/algorithms/vtc/vtc_test.go
+++ b/pkg/plugins/gateway/algorithms/vtc/vtc_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -55,14 +56,15 @@ func (c *SimpleCache) GetPodMetric(ctx context.Context, podIP, model, metricName
 	return 0, nil
 }
 
-func (c *SimpleCache) GetMetricValueByPodModel(podName, modelName, metricName string) (metrics.MetricValue, error) {
-	if _, ok := c.metrics[podName]; !ok {
+func (c *SimpleCache) GetMetricValueByPodModel(podName, podNamespace, modelName, metricName string) (metrics.MetricValue, error) {
+	key := utils.GeneratePodKey(podNamespace, podName)
+	if _, ok := c.metrics[key]; !ok {
 		return &metrics.SimpleMetricValue{Value: 0}, nil
 	}
-	if _, ok := c.metrics[podName][modelName]; !ok {
+	if _, ok := c.metrics[key][modelName]; !ok {
 		return &metrics.SimpleMetricValue{Value: 0}, nil
 	}
-	if value, ok := c.metrics[podName][modelName][metricName]; ok {
+	if value, ok := c.metrics[key][modelName][metricName]; ok {
 		return &metrics.SimpleMetricValue{Value: value}, nil
 	}
 	return &metrics.SimpleMetricValue{Value: 0}, nil
@@ -78,7 +80,7 @@ func (c *SimpleCache) DoneRequestCount(ctx *types.RoutingContext, requestID stri
 func (c *SimpleCache) DoneRequestTrace(ctx *types.RoutingContext, requestID string, modelName string, traceTerm int64, inputTokens int64, outputTokens int64) {
 }
 
-func (c *SimpleCache) GetPod(podName string) (*v1.Pod, error) {
+func (c *SimpleCache) GetPod(podName, podNamespace string) (*v1.Pod, error) {
 	return nil, nil
 }
 
@@ -94,11 +96,11 @@ func (c *SimpleCache) ListModels() []string {
 	return []string{}
 }
 
-func (c *SimpleCache) ListModelsByPod(podName string) ([]string, error) {
+func (c *SimpleCache) ListModelsByPod(podName, podNamespace string) ([]string, error) {
 	return []string{}, nil
 }
 
-func (c *SimpleCache) GetMetricValueByPod(podName, metricName string) (metrics.MetricValue, error) {
+func (c *SimpleCache) GetMetricValueByPod(podName, podNamespace, metricName string) (metrics.MetricValue, error) {
 	return nil, nil
 }
 

--- a/pkg/utils/pod.go
+++ b/pkg/utils/pod.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/klog/v2"
 
@@ -31,6 +32,22 @@ import (
 const (
 	NAMESPACE = "aibrix-system"
 )
+
+// GeneratePodKey generates a key in the format "namespace/name" for a given pod.
+func GeneratePodKey(podNamespace, podName string) string {
+	return fmt.Sprintf("%s/%s", podNamespace, podName)
+}
+
+// ParsePodKey parses a key in the format "namespace/podName".
+// Returns (namespace, podName, success).
+func ParsePodKey(key string) (string, string, bool) {
+	parts := strings.Split(key, "/")
+	if len(parts) != 2 {
+		klog.V(4).Infof("Invalid key format: %q. Expected format: namespace/name", key)
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
 
 // IsPodTerminating check if pod is in terminating status via whether the deletion timestamp is set
 func IsPodTerminating(pod *v1.Pod) bool {


### PR DESCRIPTION
## Pull Request Description
[Please provide a clear and concise description of your changes here]

Previously, the metaPods cache used only the `name` as the key, which could lead to 
key collisions when Pods with the same name existed in different namespaces. 

This pr updates cache to use `namespace/name` as the key, ensuring uniqueness 
and avoiding potential conflicts. This aligns with Kubernetes' common practice of 
using `namespace/name` to uniquely identify resources.

## Related Issues
Resolves: https://github.com/vllm-project/aibrix/issues/1008

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>