### PR TITLE
[BUG] Use more accurate chi-squared test for randomness validation in e2e test.

### DIFF
--- a/test/e2e/vtc_routing_test.go
+++ b/test/e2e/vtc_routing_test.go
@@ -188,7 +188,7 @@ func TestVTCBasicRouting(t *testing.T) {
 
 		podHistogram := make(map[string]int)
 
-		for range 5 {
+		for i := 0; i < 5; i++ {
 			for _, user := range users {
 				pod := getTargetPodFromChatCompletionWithUser(t, msgMap[user], "vtc-basic", user)
 				podHistogram[pod]++


### PR DESCRIPTION
## Pull Request Description
Now we use a more formal way to validate the randomness of the random routing result in the e2e test. The chi-squared test is used. A non-random distribution will reject the null hypothesis.  We use a low significance level to be more error tolerant and keep a small (100) repeats.


## Related Issues
Resolves: #1021 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>