### PR TITLE
[MISC]: add vtc_bucket_size_active metric gauge for vtc-basic 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/moby/spdystream v0.4.0 // indirect

--- a/pkg/metrics/custom_metrics.go
+++ b/pkg/metrics/custom_metrics.go
@@ -28,7 +28,7 @@ var (
 	customGaugesMu   sync.RWMutex
 	customCounters   = make(map[string]*prometheus.CounterVec)
 	customCountersMu sync.RWMutex
-	
+
 	// Function variable that can be overridden for testing
 	SetGaugeMetricFnForTest = defaultSetGaugeMetric
 )
@@ -41,7 +41,7 @@ func defaultSetGaugeMetric(name string, help string, value float64, labelNames [
 	customGaugesMu.RLock()
 	gauge, ok := customGauges[name]
 	customGaugesMu.RUnlock()
-	
+
 	if !ok {
 		customGaugesMu.Lock()
 		gauge, ok = customGauges[name]
@@ -62,7 +62,7 @@ func IncrementCounterMetric(name string, help string, value float64, labelNames 
 	customCountersMu.RLock()
 	counter, ok := customCounters[name]
 	customCountersMu.RUnlock()
-	
+
 	if !ok {
 		customCountersMu.Lock()
 		counter, ok = customCounters[name]
@@ -101,13 +101,13 @@ func SetupMetricsForTest(metricName string, labelNames []string) (*prometheus.Ga
 		labelNames,
 	)
 	testRegistry.MustRegister(testGauge)
-	
+
 	originalFn := SetGaugeMetricFnForTest
 	SetGaugeMetricFnForTest = func(name string, help string, value float64, labels []string, labelValues ...string) {
 		if name == metricName {
 			testGauge.WithLabelValues(labelValues...).Set(value)
 		}
 	}
-	
+
 	return testGauge, func() { SetGaugeMetricFnForTest = originalFn }
 }

--- a/pkg/metrics/custom_metrics.go
+++ b/pkg/metrics/custom_metrics.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	customGauges     = make(map[string]*prometheus.GaugeVec)
+	customGaugesMu   sync.RWMutex
+	customCounters   = make(map[string]*prometheus.CounterVec)
+	customCountersMu sync.RWMutex
+	
+	// Function variable that can be overridden for testing
+	SetGaugeMetricFnForTest = defaultSetGaugeMetric
+)
+
+func SetGaugeMetric(name string, help string, value float64, labelNames []string, labelValues ...string) {
+	SetGaugeMetricFnForTest(name, help, value, labelNames, labelValues...)
+}
+
+func defaultSetGaugeMetric(name string, help string, value float64, labelNames []string, labelValues ...string) {
+	customGaugesMu.RLock()
+	gauge, ok := customGauges[name]
+	customGaugesMu.RUnlock()
+	
+	if !ok {
+		customGaugesMu.Lock()
+		gauge, ok = customGauges[name]
+		if !ok {
+			gauge = promauto.NewGaugeVec(
+				prometheus.GaugeOpts{Name: name, Help: help},
+				labelNames,
+			)
+			customGauges[name] = gauge
+		}
+		customGaugesMu.Unlock()
+	}
+
+	gauge.WithLabelValues(labelValues...).Set(value)
+}
+
+func IncrementCounterMetric(name string, help string, value float64, labelNames []string, labelValues ...string) {
+	customCountersMu.RLock()
+	counter, ok := customCounters[name]
+	customCountersMu.RUnlock()
+	
+	if !ok {
+		customCountersMu.Lock()
+		counter, ok = customCounters[name]
+		if !ok {
+			counter = promauto.NewCounterVec(
+				prometheus.CounterOpts{Name: name, Help: help},
+				labelNames,
+			)
+			customCounters[name] = counter
+		}
+		customCountersMu.Unlock()
+	}
+
+	counter.WithLabelValues(labelValues...).Add(value)
+}
+
+func GetMetricHelp(metricName string) string {
+	metric, ok := Metrics[metricName]
+	if !ok {
+		return ""
+	}
+	return metric.Description
+}
+
+func GetGaugeValueForTest(name string, labelValues ...string) float64 {
+	customGaugesMu.RLock()
+	defer customGaugesMu.RUnlock()
+	// Tests should use their own registry
+	return 0
+}
+
+func SetupMetricsForTest(metricName string, labelNames []string) (*prometheus.GaugeVec, func()) {
+	testRegistry := prometheus.NewRegistry()
+	testGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: metricName},
+		labelNames,
+	)
+	testRegistry.MustRegister(testGauge)
+	
+	originalFn := SetGaugeMetricFnForTest
+	SetGaugeMetricFnForTest = func(name string, help string, value float64, labels []string, labelValues ...string) {
+		if name == metricName {
+			testGauge.WithLabelValues(labelValues...).Set(value)
+		}
+	}
+	
+	return testGauge, func() { SetGaugeMetricFnForTest = originalFn }
+}

--- a/pkg/metrics/custom_metrics_test.go
+++ b/pkg/metrics/custom_metrics_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testMetricName  = "test_metric"
+	testMetricHelp  = "Test metric for unit tests"
+	testLabelName   = "test_label"
+	testLabelValue  = "test_value"
+	testLabelName2  = "test_label2"
+	testLabelValue2 = "test_value2"
+)
+
+func TestSetGaugeMetric(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	
+	registry := prometheus.NewRegistry()
+	gauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: testMetricName, Help: testMetricHelp},
+		[]string{testLabelName},
+	)
+	registry.MustRegister(gauge)
+	
+	originalFn := SetGaugeMetricFnForTest
+	defer func() { SetGaugeMetricFnForTest = originalFn }()
+	
+	SetGaugeMetricFnForTest = func(name string, help string, value float64, labelNames []string, labelValues ...string) {
+		if name == testMetricName {
+			gauge.WithLabelValues(labelValues...).Set(value)
+		}
+	}
+	
+	testValue := 42.0
+	SetGaugeMetric(testMetricName, testMetricHelp, testValue, []string{testLabelName}, testLabelValue)
+	
+	value := testutil.ToFloat64(gauge.WithLabelValues(testLabelValue))
+	assert.Equal(t, testValue, value, "Metric value should match what was set")
+}
+
+func TestSetupMetricsForTest(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	
+	testGauge, cleanup := SetupMetricsForTest(testMetricName, []string{testLabelName})
+	defer cleanup()
+	
+	testValue := 42.0
+	SetGaugeMetric(testMetricName, testMetricHelp, testValue, []string{testLabelName}, testLabelValue)
+	
+	value := testutil.ToFloat64(testGauge.WithLabelValues(testLabelValue))
+	assert.Equal(t, testValue, value, "Metric value should match what was set")
+	
+	cleanup()
+	SetGaugeMetric(testMetricName, testMetricHelp, 99.0, []string{testLabelName}, testLabelValue)
+	
+	value = testutil.ToFloat64(testGauge.WithLabelValues(testLabelValue))
+	assert.Equal(t, testValue, value, "Metric value should not change after cleanup")
+}
+
+func TestMetricRegistrationOnlyOnce(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	customGauges = make(map[string]*prometheus.GaugeVec)
+	
+	for i := 0; i < 5; i++ {
+		SetGaugeMetric(testMetricName, testMetricHelp, float64(i), []string{testLabelName}, testLabelValue)
+	}
+	
+	customGaugesMu.RLock()
+	count := len(customGauges)
+	customGaugesMu.RUnlock()
+	
+	assert.Equal(t, 1, count, "Should only register the metric once")
+}
+
+func TestConcurrentMetricUpdates(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	customGauges = make(map[string]*prometheus.GaugeVec)
+	
+	numGoroutines := 10
+	numUpdatesPerGoroutine := 100
+	
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < numUpdatesPerGoroutine; j++ {
+				labelValue := testLabelValue + "_" + string(rune('A'+id))
+				SetGaugeMetric(testMetricName, testMetricHelp, float64(j), []string{testLabelName}, labelValue)
+			}
+		}(i)
+	}
+	
+	wg.Wait()
+	
+	customGaugesMu.RLock()
+	count := len(customGauges)
+	gauge := customGauges[testMetricName]
+	customGaugesMu.RUnlock()
+	
+	assert.Equal(t, 1, count, "Should only register the metric once even with concurrent updates")
+	
+	ch := make(chan *prometheus.Desc, 1)
+	gauge.Describe(ch)
+	desc := <-ch
+	assert.Contains(t, desc.String(), testMetricName, "Metric description should contain the metric name")
+}
+
+func TestMultipleLabels(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	customGauges = make(map[string]*prometheus.GaugeVec)
+	
+	registry := prometheus.NewRegistry()
+	gauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: testMetricName, Help: testMetricHelp},
+		[]string{testLabelName, testLabelName2},
+	)
+	registry.MustRegister(gauge)
+	
+	originalFn := SetGaugeMetricFnForTest
+	defer func() { SetGaugeMetricFnForTest = originalFn }()
+	
+	SetGaugeMetricFnForTest = func(name string, help string, value float64, labelNames []string, labelValues ...string) {
+		if name == testMetricName {
+			gauge.WithLabelValues(labelValues...).Set(value)
+		}
+	}
+	
+	testValue := 42.0
+	SetGaugeMetric(testMetricName, testMetricHelp, testValue, 
+		[]string{testLabelName, testLabelName2}, 
+		testLabelValue, testLabelValue2)
+	
+	value := testutil.ToFloat64(gauge.WithLabelValues(testLabelValue, testLabelValue2))
+	assert.Equal(t, testValue, value, "Metric value with multiple labels should match what was set")
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -46,7 +46,7 @@ const (
 	MaxLora                              = "max_lora"
 	WaitingLoraAdapters                  = "waiting_lora_adapters"
 	RunningLoraAdapters                  = "running_lora_adapters"
-	// Realtime metrics
+	VTCBucketSizeActive                  = "vtc_bucket_size_active"
 	RealtimeNumRequestsRunning = "realtime_num_requests_running"
 )
 
@@ -302,6 +302,14 @@ var (
 			},
 			RawMetricName: "lora_requests_info",
 			Description:   "Count of waiting Lora Adapters",
+		},
+		VTCBucketSizeActive: {
+			MetricScope:  PodModelMetricScope,
+			MetricSource: PodRawMetrics,
+			MetricType: MetricType{
+				Raw: Gauge,
+			},
+			Description: "Current adaptive bucket size used by VTC algorithm for token normalization",
 		},
 	}
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -47,7 +47,7 @@ const (
 	WaitingLoraAdapters                  = "waiting_lora_adapters"
 	RunningLoraAdapters                  = "running_lora_adapters"
 	VTCBucketSizeActive                  = "vtc_bucket_size_active"
-	RealtimeNumRequestsRunning = "realtime_num_requests_running"
+	RealtimeNumRequestsRunning           = "realtime_num_requests_running"
 )
 
 var (

--- a/pkg/plugins/gateway/algorithms/vtc/vtc_basic_test.go
+++ b/pkg/plugins/gateway/algorithms/vtc/vtc_basic_test.go
@@ -609,7 +609,8 @@ func TestVTCBucketSizePatterns(t *testing.T) {
 				continue
 			}
 
-			metricValue := testutil.ToFloat64(testGauge.WithLabelValues("pod1", "model1"))
+			podName := fmt.Sprintf("pod-metrics-%c", 'a'+i)
+			metricValue := testutil.ToFloat64(testGauge.WithLabelValues(podName, "model1"))
 			sizes = append(sizes, metricValue)
 		}
 


### PR DESCRIPTION
## Pull Request Description
This change adds:
- `vtc_bucket_size_active` custom metric gauge to see if any config change is needed in `vtc-basic`
-  centralized metrics utility for custom metrics like the above in this project


## Related Issues
https://github.com/vllm-project/aibrix/pull/1011#issuecomment-2845795519


## Submission Checklist
- [x] PR title includes appropriate prefix(es)
- [x] Changes are clearly explained in the PR description
- [x] New and existing tests pass successfully
- [x] Code adheres to project style and best practices
- [x] Documentation updated to reflect changes (if applicable)
- [x] Thorough testing completed, no regressions introduced
