### PR TITLE
[Fix] Fix L2Cache's register descriptor container

### DIFF
--- a/python/aibrix_kvcache/aibrix_kvcache/l2/l2_cache.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/l2/l2_cache.py
@@ -15,7 +15,7 @@
 import asyncio
 import logging
 from concurrent.futures import Executor
-from typing import Any, Iterator, Sequence, Set, Tuple
+from typing import Any, Iterator, List, Sequence, Tuple
 
 import torch
 from more_itertools import batched
@@ -106,7 +106,7 @@ class L2Cache(MeasurableBase):
             )
             self._backend = Placement.create(placement_config)
 
-        self._register_descs: Set[ConnectorRegisterDescriptor] = set()
+        self._register_descs: List[ConnectorRegisterDescriptor] = []
 
         logger.info(
             "%s is initialized. Using partition_id=%s.", str(self), partition_id
@@ -141,7 +141,7 @@ class L2Cache(MeasurableBase):
         status = self._backend.register_mr(addr, length)
         if not status.is_ok():
             return status
-        self._register_descs.add(status.get())
+        self._register_descs.append(status.get())
         return status
 
     @nvtx_range("prefetch", "kv_cache_ol.L2Cache")


### PR DESCRIPTION


## Pull Request Description
Change L2Cache's register descriptor container to list to support unhashable descriptors.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>