### PR TITLE
Support watcher pod rbac in kvcache controller

### DIFF
--- a/cmd/kvcache-watcher/main.go
+++ b/cmd/kvcache-watcher/main.go
@@ -56,7 +56,7 @@ import (
 const KVCacheLabelKeyIdentifier = "kvcache.orchestration.aibrix.ai/name"
 const KVCacheLabelKeyRole = "kvcache.orchestration.aibrix.ai/role"
 const KVCacheLabelValueRoleCache = "cache"
-const HPKVRedisNodeMemberKey = "hpkv_nodes"
+const HPKVRedisNodeMemberKey = "hpkv_cluster_metadata"
 const InfiniStoreRedisNodeMemberKey = "kvcache_nodes"
 
 const networkStatusAnnotation = "k8s.volcengine.com/network-status"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -67,6 +67,10 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: aibrix
     app.kubernetes.io/managed-by: kustomize
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
+    prometheus.io/path: "/metrics"
   name: controller-manager-metrics-service
   namespace: system
 spec:

--- a/config/rbac/controller-manager/role.yaml
+++ b/config/rbac/controller-manager/role.yaml
@@ -13,9 +13,36 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+- apiGroups:
   - apps
   resources:
   - deployments
+  - statefulsets
   verbs:
   - create
   - delete
@@ -28,30 +55,11 @@ rules:
   - apps
   resources:
   - deployments/status
+  - statefulsets/status
   verbs:
   - get
   - patch
   - update
-- apiGroups:
-    - apps
-  resources:
-    - statefulsets
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - apps
-  resources:
-    - statefulsets/status
-  verbs:
-    - get
-    - patch
-    - update
 - apiGroups:
   - autoscaling
   resources:
@@ -107,6 +115,7 @@ rules:
   - ""
   resources:
   - pods/status
+  - services
   verbs:
   - create
   - delete
@@ -118,14 +127,12 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - services
+  - serviceaccounts
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""
@@ -159,17 +166,6 @@ rules:
   - gateway.networking.k8s.io
   resources:
   - httproutes
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
   - referencegrants
   verbs:
   - create
@@ -209,57 +205,7 @@ rules:
   - orchestration.aibrix.ai
   resources:
   - kvcaches
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - orchestration.aibrix.ai
-  resources:
-  - kvcaches/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - orchestration.aibrix.ai
-  resources:
-  - kvcaches/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - orchestration.aibrix.ai
-  resources:
   - rayclusterfleets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - orchestration.aibrix.ai
-  resources:
-  - rayclusterfleets/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - orchestration.aibrix.ai
-  resources:
-  - rayclusterfleets/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - orchestration.aibrix.ai
-  resources:
   - rayclusterreplicasets
   verbs:
   - create
@@ -272,12 +218,16 @@ rules:
 - apiGroups:
   - orchestration.aibrix.ai
   resources:
+  - kvcaches/finalizers
+  - rayclusterfleets/finalizers
   - rayclusterreplicasets/finalizers
   verbs:
   - update
 - apiGroups:
   - orchestration.aibrix.ai
   resources:
+  - kvcaches/status
+  - rayclusterfleets/status
   - rayclusterreplicasets/status
   verbs:
   - get
@@ -310,28 +260,23 @@ rules:
   - patch
   - update
 - apiGroups:
-  - ""
+  - rbac.authorization.k8s.io
   resources:
-  - secrets
+  - rolebindings
   verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
   - get
   - list
   - update
   - watch
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list

--- a/config/rbac/controller-manager/role.yaml
+++ b/config/rbac/controller-manager/role.yaml
@@ -114,6 +114,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/exec
   - pods/status
   - services
   verbs:

--- a/config/standalone/kv-cache-controller/patch.yaml
+++ b/config/standalone/kv-cache-controller/patch.yaml
@@ -12,6 +12,6 @@ spec:
             - --leader-elect
             - --leader-election-id=aibrix-kv-cache-controller
             - --health-probe-bind-address=:8081
-            - --metrics-bind-address=0
+            - --metrics-bind-address=:8080
             - --controllers=kv-cache-controller
             - --disable-webhook

--- a/pkg/controller/kvcache/backends/distributed.go
+++ b/pkg/controller/kvcache/backends/distributed.go
@@ -60,6 +60,18 @@ func (r *DistributedReconciler) Reconcile(ctx context.Context, kvCache *orchestr
 		return reconcile.Result{}, err
 	}
 
+	if err := r.reconcileWatcherPodServiceAccount(ctx, r.Backend.BuildWatcherPodServiceAccount(kvCache)); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.reconcileWatcherPodRole(ctx, r.Backend.BuildWatcherPodRole(kvCache)); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.reconcileWatcherPodRoleBinding(ctx, r.Backend.BuildWatcherPodRoleBinding(kvCache)); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Handle infinistore kvCache Deployment
 	if err := r.ReconcileStatefulsetObject(ctx, r.Backend.BuildCacheStatefulSet(kvCache)); err != nil {
 		return ctrl.Result{}, err

--- a/pkg/controller/kvcache/backends/distributed_test.go
+++ b/pkg/controller/kvcache/backends/distributed_test.go
@@ -22,6 +22,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
@@ -181,6 +182,9 @@ type mockBackend struct {
 	watcher *corev1.Pod
 	svc     *corev1.Service
 	sts     *appsv1.StatefulSet
+	sa      *corev1.ServiceAccount
+	role    *rbacv1.Role
+	rb      *rbacv1.RoleBinding
 }
 
 func (m mockBackend) Name() string {
@@ -197,6 +201,18 @@ func (m mockBackend) BuildMetadataPod(*v1alpha1.KVCache) *corev1.Pod {
 
 func (m mockBackend) BuildMetadataService(*v1alpha1.KVCache) *corev1.Service {
 	return m.svc
+}
+
+func (m mockBackend) BuildWatcherPodServiceAccount(*v1alpha1.KVCache) *corev1.ServiceAccount {
+	return m.sa
+}
+
+func (m mockBackend) BuildWatcherPodRole(*v1alpha1.KVCache) *rbacv1.Role {
+	return m.role
+}
+
+func (m mockBackend) BuildWatcherPodRoleBinding(*v1alpha1.KVCache) *rbacv1.RoleBinding {
+	return m.rb
 }
 
 func (m mockBackend) BuildWatcherPod(*v1alpha1.KVCache) *corev1.Pod {

--- a/pkg/controller/kvcache/backends/hpkv.go
+++ b/pkg/controller/kvcache/backends/hpkv.go
@@ -144,6 +144,11 @@ func buildKVCacheWatcherPod(kvCache *orchestrationv1alpha1.KVCache) *corev1.Pod 
 				constants.KVCacheLabelKeyIdentifier: kvCache.Name,
 				constants.KVCacheLabelKeyRole:       constants.KVCacheLabelValueRoleKVWatcher,
 			},
+			Annotations: map[string]string{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/port":   "8000",
+				"prometheus.io/path":   "/metrics",
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(kvCache, orchestrationv1alpha1.GroupVersion.WithKind("KVCache")),
 			},
@@ -215,7 +220,11 @@ func buildCacheStatefulSet(kvCache *orchestrationv1alpha1.KVCache) *appsv1.State
 		envs = append(envs, kvCache.Spec.Cache.Env...)
 	}
 
-	annotations := map[string]string{}
+	annotations := map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   strconv.Itoa(params.AdminPort),
+		"prometheus.io/path":   "/metrics",
+	}
 	rdmaKey := corev1.ResourceName("vke.volcengine.com/rdma")
 	if _, ok := kvCache.Spec.Cache.Resources.Limits[rdmaKey]; ok {
 		annotations["k8s.volcengine.com/pod-networks"] = `

--- a/pkg/controller/kvcache/backends/infinistore.go
+++ b/pkg/controller/kvcache/backends/infinistore.go
@@ -138,6 +138,11 @@ func buildKVCacheWatcherPodForInfiniStore(kvCache *orchestrationv1alpha1.KVCache
 				constants.KVCacheLabelKeyIdentifier: kvCache.Name,
 				constants.KVCacheLabelKeyRole:       constants.KVCacheLabelValueRoleKVWatcher,
 			},
+			Annotations: map[string]string{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/port":   "8000",
+				"prometheus.io/path":   "/metrics",
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(kvCache, orchestrationv1alpha1.GroupVersion.WithKind("KVCache")),
 			},
@@ -206,7 +211,11 @@ func buildCacheStatefulSetForInfiniStore(kvCache *orchestrationv1alpha1.KVCache)
 		envs = append(envs, kvCache.Spec.Cache.Env...)
 	}
 
-	annotations := map[string]string{}
+	annotations := map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   strconv.Itoa(params.AdminPort),
+		"prometheus.io/path":   "/metrics",
+	}
 	rdmaKey := corev1.ResourceName("vke.volcengine.com/rdma")
 	if _, ok := kvCache.Spec.Cache.Resources.Limits[rdmaKey]; ok {
 		annotations["k8s.volcengine.com/pod-networks"] = `

--- a/pkg/controller/kvcache/backends/infinistore.go
+++ b/pkg/controller/kvcache/backends/infinistore.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vllm-project/aibrix/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -70,6 +71,18 @@ func (InfiniStoreBackend) ValidateObject(kvCache *orchestrationv1alpha1.KVCache)
 		return errors.New("either etcd or redis configuration is required")
 	}
 	return nil
+}
+
+func (b InfiniStoreBackend) BuildWatcherPodServiceAccount(kvCache *orchestrationv1alpha1.KVCache) *corev1.ServiceAccount {
+	return buildServiceAccount(kvCache)
+}
+
+func (b InfiniStoreBackend) BuildWatcherPodRole(kvCache *orchestrationv1alpha1.KVCache) *rbacv1.Role {
+	return buildRole(kvCache)
+}
+
+func (b InfiniStoreBackend) BuildWatcherPodRoleBinding(kvCache *orchestrationv1alpha1.KVCache) *rbacv1.RoleBinding {
+	return buildRoleBinding(kvCache)
 }
 
 func (InfiniStoreBackend) BuildWatcherPod(kvCache *orchestrationv1alpha1.KVCache) *corev1.Pod {
@@ -157,8 +170,7 @@ func buildKVCacheWatcherPodForInfiniStore(kvCache *orchestrationv1alpha1.KVCache
 					Resources: kvCache.Spec.Watcher.Resources,
 				},
 			},
-			// TODO: refactor the permission management here.
-			ServiceAccountName: "kvcache-watcher-sa",
+			ServiceAccountName: kvCache.Name,
 		},
 	}
 
@@ -192,6 +204,20 @@ func buildCacheStatefulSetForInfiniStore(kvCache *orchestrationv1alpha1.KVCache)
 	envs = append(envs, kvCacheServerEnvVars...)
 	if len(kvCache.Spec.Cache.Env) == 0 {
 		envs = append(envs, kvCache.Spec.Cache.Env...)
+	}
+
+	annotations := map[string]string{}
+	rdmaKey := corev1.ResourceName("vke.volcengine.com/rdma")
+	if _, ok := kvCache.Spec.Cache.Resources.Limits[rdmaKey]; ok {
+		annotations["k8s.volcengine.com/pod-networks"] = `
+[
+  {
+    "cniConf": {
+      "name": "rdma"
+    }
+  }
+]
+`
 	}
 
 	kvCacheServerArgs := []string{
@@ -230,19 +256,7 @@ func buildCacheStatefulSetForInfiniStore(kvCache *orchestrationv1alpha1.KVCache)
 						constants.KVCacheLabelKeyIdentifier: kvCache.Name,
 						constants.KVCacheLabelKeyRole:       constants.KVCacheLabelValueRoleCache,
 					},
-					// TODO: if there's rdma enabled, then we should attach resources.
-					// use an annotation to control it? enable RDMA
-					Annotations: map[string]string{
-						"k8s.volcengine.com/pod-networks": `
-[
-  {
-    "cniConf": {
-      "name": "rdma"
-    }
-  }
-]
-`,
-					},
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					//HostNetwork: true, // CNI doesn't need hostNetwork:true. in that case, RDMA ip won't be injected.

--- a/pkg/controller/kvcache/kvcache_controller.go
+++ b/pkg/controller/kvcache/kvcache_controller.go
@@ -133,6 +133,10 @@ type KVCacheReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;delete;update
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list
 
 // Reconcile reconciles a KVCache to desired state.
 func (r *KVCacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/controller/kvcache/kvcache_controller.go
+++ b/pkg/controller/kvcache/kvcache_controller.go
@@ -127,6 +127,7 @@ type KVCacheReconciler struct {
 // +kubebuilder:rbac:groups=orchestration.aibrix.ai,resources=kvcaches/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
## Pull Request Description
1. Update key from `hpkv_nodes` to `hpkv_cluster_metadata` based on internal sync up result
2. Support sa/role/rolebinding for watcher pod. We used to specific a fixed service account name and require user to create it and use it. Now, service account is fully managed by controllers. 
3. `make manifest` to generate latest role. I notice customresource is to kubebuilder market in last PR https://github.com/vllm-project/aibrix/pull/922, I added this back.
4. remove fixed `k8s.volcengine.com/pod-networks` setting. Only if user specific volcano engine rdma devices, we will attach this annotation



## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>