### PR TITLE
[Bug]fix: add scale subresource to rayclusterfleet

### DIFF
--- a/api/orchestration/v1alpha1/rayclusterfleet_types.go
+++ b/api/orchestration/v1alpha1/rayclusterfleet_types.go
@@ -113,6 +113,10 @@ type RayClusterFleetStatus struct {
 	// newest ReplicaSet.
 	// +optional
 	CollisionCount *int32 `json:"collisionCount,omitempty" protobuf:"varint,8,opt,name=collisionCount"`
+
+	// HPAPodSelector for pods that belong to the RayClusterFleet object, this is
+	// needed for HPA to know what pods belong to the RayClusterFleet object.
+	HPAPodSelector string `json:"hpaPodSelector,omitempty"`
 }
 
 // DeploymentCondition describes the state of a deployment at a certain point.
@@ -151,6 +155,7 @@ const (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.hpaPodSelector
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RayClusterFleet is the Schema for the rayclusterfleets API

--- a/api/orchestration/v1alpha1/rayclusterfleet_types.go
+++ b/api/orchestration/v1alpha1/rayclusterfleet_types.go
@@ -114,9 +114,8 @@ type RayClusterFleetStatus struct {
 	// +optional
 	CollisionCount *int32 `json:"collisionCount,omitempty" protobuf:"varint,8,opt,name=collisionCount"`
 
-	// HPAPodSelector for pods that belong to the RayClusterFleet object, this is
-	// needed for HPA to know what pods belong to the RayClusterFleet object.
-	HPAPodSelector string `json:"hpaPodSelector,omitempty"`
+	// The label selector information of the pods belonging to the RayClusterFleet object.
+	ScalingTargetSelector string `json:"scalingTargetSelector,omitempty"`
 }
 
 // DeploymentCondition describes the state of a deployment at a certain point.
@@ -155,7 +154,7 @@ const (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.hpaPodSelector
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.scalingTargetSelector
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RayClusterFleet is the Schema for the rayclusterfleets API

--- a/pkg/client/applyconfiguration/orchestration/v1alpha1/rayclusterfleetstatus.go
+++ b/pkg/client/applyconfiguration/orchestration/v1alpha1/rayclusterfleetstatus.go
@@ -20,15 +20,15 @@ package v1alpha1
 // RayClusterFleetStatusApplyConfiguration represents a declarative configuration of the RayClusterFleetStatus type for use
 // with apply.
 type RayClusterFleetStatusApplyConfiguration struct {
-	ObservedGeneration  *int64                                       `json:"observedGeneration,omitempty"`
-	Replicas            *int32                                       `json:"replicas,omitempty"`
-	UpdatedReplicas     *int32                                       `json:"updatedReplicas,omitempty"`
-	ReadyReplicas       *int32                                       `json:"readyReplicas,omitempty"`
-	AvailableReplicas   *int32                                       `json:"availableReplicas,omitempty"`
-	UnavailableReplicas *int32                                       `json:"unavailableReplicas,omitempty"`
-	Conditions          []RayClusterFleetConditionApplyConfiguration `json:"conditions,omitempty"`
-	CollisionCount      *int32                                       `json:"collisionCount,omitempty"`
-	HPAPodSelector      *string                                      `json:"hpaPodSelector,omitempty"`
+	ObservedGeneration    *int64                                       `json:"observedGeneration,omitempty"`
+	Replicas              *int32                                       `json:"replicas,omitempty"`
+	UpdatedReplicas       *int32                                       `json:"updatedReplicas,omitempty"`
+	ReadyReplicas         *int32                                       `json:"readyReplicas,omitempty"`
+	AvailableReplicas     *int32                                       `json:"availableReplicas,omitempty"`
+	UnavailableReplicas   *int32                                       `json:"unavailableReplicas,omitempty"`
+	Conditions            []RayClusterFleetConditionApplyConfiguration `json:"conditions,omitempty"`
+	CollisionCount        *int32                                       `json:"collisionCount,omitempty"`
+	ScalingTargetSelector *string                                      `json:"scalingTargetSelector,omitempty"`
 }
 
 // RayClusterFleetStatusApplyConfiguration constructs a declarative configuration of the RayClusterFleetStatus type for use with
@@ -106,10 +106,10 @@ func (b *RayClusterFleetStatusApplyConfiguration) WithCollisionCount(value int32
 	return b
 }
 
-// WithHPAPodSelector sets the HPAPodSelector field in the declarative configuration to the given value
+// WithScalingTargetSelector sets the ScalingTargetSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the HPAPodSelector field is set to the value of the last call.
-func (b *RayClusterFleetStatusApplyConfiguration) WithHPAPodSelector(value string) *RayClusterFleetStatusApplyConfiguration {
-	b.HPAPodSelector = &value
+// If called multiple times, the ScalingTargetSelector field is set to the value of the last call.
+func (b *RayClusterFleetStatusApplyConfiguration) WithScalingTargetSelector(value string) *RayClusterFleetStatusApplyConfiguration {
+	b.ScalingTargetSelector = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/orchestration/v1alpha1/rayclusterfleetstatus.go
+++ b/pkg/client/applyconfiguration/orchestration/v1alpha1/rayclusterfleetstatus.go
@@ -28,6 +28,7 @@ type RayClusterFleetStatusApplyConfiguration struct {
 	UnavailableReplicas *int32                                       `json:"unavailableReplicas,omitempty"`
 	Conditions          []RayClusterFleetConditionApplyConfiguration `json:"conditions,omitempty"`
 	CollisionCount      *int32                                       `json:"collisionCount,omitempty"`
+	HPAPodSelector      *string                                      `json:"hpaPodSelector,omitempty"`
 }
 
 // RayClusterFleetStatusApplyConfiguration constructs a declarative configuration of the RayClusterFleetStatus type for use with
@@ -102,5 +103,13 @@ func (b *RayClusterFleetStatusApplyConfiguration) WithConditions(values ...*RayC
 // If called multiple times, the CollisionCount field is set to the value of the last call.
 func (b *RayClusterFleetStatusApplyConfiguration) WithCollisionCount(value int32) *RayClusterFleetStatusApplyConfiguration {
 	b.CollisionCount = &value
+	return b
+}
+
+// WithHPAPodSelector sets the HPAPodSelector field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the HPAPodSelector field is set to the value of the last call.
+func (b *RayClusterFleetStatusApplyConfiguration) WithHPAPodSelector(value string) *RayClusterFleetStatusApplyConfiguration {
+	b.HPAPodSelector = &value
 	return b
 }

--- a/pkg/controller/rayclusterfleet/rollback.go
+++ b/pkg/controller/rayclusterfleet/rollback.go
@@ -77,7 +77,7 @@ func (r *RayClusterFleetReconciler) rollback(ctx context.Context, d *orchestrati
 func (r *RayClusterFleetReconciler) rollbackToTemplate(ctx context.Context, d *orchestrationv1alpha1.RayClusterFleet, rs *orchestrationv1alpha1.RayClusterReplicaSet) (bool, error) {
 	logger := klog.FromContext(ctx)
 	performedRollback := false
-	if !util.EqualIgnoreHash(&d.Spec.Template, &rs.Spec.Template) {
+	if !util.EqualIgnoreLabels(&d.Spec.Template, &rs.Spec.Template) {
 		logger.V(4).Info("Rolling back deployment to old template spec", "deployment", klog.KObj(d), "templateSpec", rs.Spec.Template)
 		util.SetFromReplicaSetTemplate(d, rs.Spec.Template)
 		// set RS (the old RS we'll rolling back to) annotations back to the deployment;

--- a/pkg/controller/rayclusterfleet/sync.go
+++ b/pkg/controller/rayclusterfleet/sync.go
@@ -515,6 +515,7 @@ func calculateStatus(allRSs []*orchestrationv1alpha1.RayClusterReplicaSet, newRS
 	labelSelector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			util.SetNameLabelKey: deployment.Name,
+			"ray.io/node-type":   "head",
 		},
 	}
 	selector, _ := metav1.LabelSelectorAsSelector(labelSelector)

--- a/pkg/controller/rayclusterfleet/sync.go
+++ b/pkg/controller/rayclusterfleet/sync.go
@@ -192,6 +192,13 @@ func (r *RayClusterFleetReconciler) getNewReplicaSet(ctx context.Context, d *orc
 
 	// new ReplicaSet does not exist, create one.
 	newRSTemplate := *d.Spec.Template.DeepCopy()
+
+	// Add rayclusterfleet name to all pod label
+	newRSTemplate.Spec.HeadGroupSpec.Template.Labels = labelsutil.CloneAndAddLabel(d.Spec.Template.Spec.HeadGroupSpec.Template.Labels, util.SetNameLabelKey, d.Name)
+	for i := range d.Spec.Template.Spec.WorkerGroupSpecs {
+		newRSTemplate.Spec.WorkerGroupSpecs[i].Template.Labels = labelsutil.CloneAndAddLabel(d.Spec.Template.Spec.WorkerGroupSpecs[i].Template.Labels, util.SetNameLabelKey, d.Name)
+	}
+
 	podTemplateSpecHash := util.ComputeHash(&newRSTemplate, d.Status.CollisionCount)
 	newRSTemplate.Labels = labelsutil.CloneAndAddLabel(d.Spec.Template.Labels, appsv1.DefaultDeploymentUniqueLabelKey, podTemplateSpecHash)
 	// Add podTemplateHash label to selector.
@@ -245,7 +252,7 @@ func (r *RayClusterFleetReconciler) getNewReplicaSet(ctx context.Context, d *orc
 		// Otherwise, this is a hash collision and we need to increment the collisionCount field in
 		// the status of the Deployment and requeue to try the creation in the next sync.
 		controllerRef := metav1.GetControllerOf(rs)
-		if controllerRef != nil && controllerRef.UID == d.UID && util.EqualIgnoreHash(&d.Spec.Template, &rs.Spec.Template) {
+		if controllerRef != nil && controllerRef.UID == d.UID && util.EqualIgnoreLabels(&d.Spec.Template, &rs.Spec.Template) {
 			createdRS = rs
 			err = nil
 			break
@@ -505,6 +512,13 @@ func calculateStatus(allRSs []*orchestrationv1alpha1.RayClusterReplicaSet, newRS
 		unavailableReplicas = 0
 	}
 
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			util.SetNameLabelKey: deployment.Name,
+		},
+	}
+	selector, _ := metav1.LabelSelectorAsSelector(labelSelector)
+
 	status := orchestrationv1alpha1.RayClusterFleetStatus{
 		// TODO: Ensure that if we start retrying status updates, we won't pick up a new Generation value.
 		ObservedGeneration:  deployment.Generation,
@@ -514,6 +528,7 @@ func calculateStatus(allRSs []*orchestrationv1alpha1.RayClusterReplicaSet, newRS
 		AvailableReplicas:   availableReplicas,
 		UnavailableReplicas: unavailableReplicas,
 		CollisionCount:      deployment.Status.CollisionCount,
+		HPAPodSelector:      selector.String(),
 	}
 
 	// Copy conditions one by one so we won't mutate the original object.

--- a/pkg/controller/rayclusterfleet/sync.go
+++ b/pkg/controller/rayclusterfleet/sync.go
@@ -522,14 +522,14 @@ func calculateStatus(allRSs []*orchestrationv1alpha1.RayClusterReplicaSet, newRS
 
 	status := orchestrationv1alpha1.RayClusterFleetStatus{
 		// TODO: Ensure that if we start retrying status updates, we won't pick up a new Generation value.
-		ObservedGeneration:  deployment.Generation,
-		Replicas:            util.GetActualReplicaCountForReplicaSets(allRSs),
-		UpdatedReplicas:     util.GetActualReplicaCountForReplicaSets([]*orchestrationv1alpha1.RayClusterReplicaSet{newRS}),
-		ReadyReplicas:       util.GetReadyReplicaCountForReplicaSets(allRSs),
-		AvailableReplicas:   availableReplicas,
-		UnavailableReplicas: unavailableReplicas,
-		CollisionCount:      deployment.Status.CollisionCount,
-		HPAPodSelector:      selector.String(),
+		ObservedGeneration:    deployment.Generation,
+		Replicas:              util.GetActualReplicaCountForReplicaSets(allRSs),
+		UpdatedReplicas:       util.GetActualReplicaCountForReplicaSets([]*orchestrationv1alpha1.RayClusterReplicaSet{newRS}),
+		ReadyReplicas:         util.GetReadyReplicaCountForReplicaSets(allRSs),
+		AvailableReplicas:     availableReplicas,
+		UnavailableReplicas:   unavailableReplicas,
+		CollisionCount:        deployment.Status.CollisionCount,
+		ScalingTargetSelector: selector.String(),
 	}
 
 	// Copy conditions one by one so we won't mutate the original object.

--- a/pkg/controller/rayclusterfleet/util/fleet.go
+++ b/pkg/controller/rayclusterfleet/util/fleet.go
@@ -105,7 +105,7 @@ const (
 	MinimumReplicasUnavailable = "MinimumReplicasUnavailable"
 
 	// Set name label will record the rayclusterfleet name that those Pods belong to.
-	SetNameLabelKey string = "aibrix.ai/raycluster-fleet-name"
+	SetNameLabelKey string = "orchestration.aibrix.ai/raycluster-fleet-name"
 )
 
 // NewDeploymentCondition creates a new deployment condition.

--- a/pkg/controller/rayclusterfleet/util/fleet.go
+++ b/pkg/controller/rayclusterfleet/util/fleet.go
@@ -605,15 +605,15 @@ func ListPods(deployment *orchestrationv1alpha1.RayClusterFleet, rsList []*orche
 	return owned, nil
 }
 
-// EqualIgnoreLabels returns true if two given podTemplateSpec are equal, ignoring the diff in value of Labels[pod-template-hash]
-// We ignore pod-template-hash and aibrix.ai/raycluster-fleet-name, because:
+// EqualIgnoreLabels returns true if two given podTemplateSpec are equal, ignoring the diff in value of Labels[pod-template-hash] and Labels[orchestration.aibrix.ai/raycluster-fleet-name].
+// We ignore pod-template-hash and orchestration.aibrix.ai/raycluster-fleet-name, because:
 //  1. The hash result would be different upon podTemplateSpec API changes
 //     (e.g. the addition of a new field will cause the hash code to change)
-//  2. The deployment template won't have hash and aibrix.ai/raycluster-fleet-name labels
+//  2. The deployment template won't have hash and fleet name labels
 func EqualIgnoreLabels(template1, template2 *orchestrationv1alpha1.RayClusterTemplateSpec) bool {
 	t1Copy := template1.DeepCopy()
 	t2Copy := template2.DeepCopy()
-	// Remove hash and aibrix.ai/raycluster-fleet-name labels from template.Labels before comparing
+	// Remove hash and fleet name labels from template.Labels before comparing
 	// Note: only head and worker templates has the pod templates.
 	for _, key := range []string{appsv1.DefaultDeploymentUniqueLabelKey, SetNameLabelKey} {
 		delete(t1Copy.Labels, key)

--- a/pkg/controller/rayclusterfleet/util/fleet.go
+++ b/pkg/controller/rayclusterfleet/util/fleet.go
@@ -103,6 +103,9 @@ const (
 	// MinimumReplicasUnavailable is added in a deployment when it doesn't have the minimum required replicas
 	// available.
 	MinimumReplicasUnavailable = "MinimumReplicasUnavailable"
+
+	// Set name label will record the rayclusterfleet name that those Pods belong to.
+	SetNameLabelKey string = "aibrix.ai/raycluster-fleet-name"
 )
 
 // NewDeploymentCondition creates a new deployment condition.
@@ -602,26 +605,28 @@ func ListPods(deployment *orchestrationv1alpha1.RayClusterFleet, rsList []*orche
 	return owned, nil
 }
 
-// EqualIgnoreHash returns true if two given podTemplateSpec are equal, ignoring the diff in value of Labels[pod-template-hash]
-// We ignore pod-template-hash because:
+// EqualIgnoreLabels returns true if two given podTemplateSpec are equal, ignoring the diff in value of Labels[pod-template-hash]
+// We ignore pod-template-hash and aibrix.ai/raycluster-fleet-name, because:
 //  1. The hash result would be different upon podTemplateSpec API changes
 //     (e.g. the addition of a new field will cause the hash code to change)
-//  2. The deployment template won't have hash labels
-func EqualIgnoreHash(template1, template2 *orchestrationv1alpha1.RayClusterTemplateSpec) bool {
+//  2. The deployment template won't have hash and aibrix.ai/raycluster-fleet-name labels
+func EqualIgnoreLabels(template1, template2 *orchestrationv1alpha1.RayClusterTemplateSpec) bool {
 	t1Copy := template1.DeepCopy()
 	t2Copy := template2.DeepCopy()
-	// Remove hash labels from template.Labels before comparing
+	// Remove hash and aibrix.ai/raycluster-fleet-name labels from template.Labels before comparing
 	// Note: only head and worker templates has the pod templates.
-	delete(t1Copy.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
-	delete(t2Copy.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
+	for _, key := range []string{appsv1.DefaultDeploymentUniqueLabelKey, SetNameLabelKey} {
+		delete(t1Copy.Labels, key)
+		delete(t2Copy.Labels, key)
+		delete(t1Copy.Spec.HeadGroupSpec.Template.Labels, key)
+		delete(t2Copy.Spec.HeadGroupSpec.Template.Labels, key)
+		for i := range t1Copy.Spec.WorkerGroupSpecs {
+			delete(t1Copy.Spec.WorkerGroupSpecs[i].Template.Labels, key)
 
-	delete(t1Copy.Spec.HeadGroupSpec.Template.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
-	delete(t2Copy.Spec.HeadGroupSpec.Template.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
-	for i := range t1Copy.Spec.WorkerGroupSpecs {
-		delete(t1Copy.Spec.WorkerGroupSpecs[i].Template.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
-	}
-	for i := range t2Copy.Spec.WorkerGroupSpecs {
-		delete(t2Copy.Spec.WorkerGroupSpecs[i].Template.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
+		}
+		for i := range t2Copy.Spec.WorkerGroupSpecs {
+			delete(t2Copy.Spec.WorkerGroupSpecs[i].Template.Labels, key)
+		}
 	}
 	return apiequality.Semantic.DeepEqual(t1Copy, t2Copy)
 }
@@ -630,7 +635,7 @@ func EqualIgnoreHash(template1, template2 *orchestrationv1alpha1.RayClusterTempl
 func FindNewReplicaSet(fleet *orchestrationv1alpha1.RayClusterFleet, rsList []*orchestrationv1alpha1.RayClusterReplicaSet) *orchestrationv1alpha1.RayClusterReplicaSet {
 	sort.Sort(ReplicaSetsByCreationTimestamp(rsList))
 	for i := range rsList {
-		if EqualIgnoreHash(&rsList[i].Spec.Template, &fleet.Spec.Template) {
+		if EqualIgnoreLabels(&rsList[i].Spec.Template, &fleet.Spec.Template) {
 			// In rare cases, such as after cluster upgrades, Deployment may end up with
 			// having more than one new ReplicaSets that have the same template as its template,
 			// see https://github.com/kubernetes/kubernetes/issues/40415


### PR DESCRIPTION
## Pull Request Description
1. add +kubebuilder:subresource:scale above RayClusterFleet definition
2. add HPAPodSelector field in RayClusterFleetStatus to specify which pods belong to this RayClusterFleet
3. add "aibrix.ai/raycluster-fleet-name" in pod labels

## Related Issues
Resolves: #986 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>