### PR TITLE
[Bug] Add read lock for h.histogram

### DIFF
--- a/pkg/plugins/gateway/algorithms/prefix_cache_and_load.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_and_load.go
@@ -348,6 +348,9 @@ func (h *SlidingWindowHistogram) getNodeCost(node *prefixcacheindexer.TreeNode, 
 }
 
 func (h *SlidingWindowHistogram) getCurrentAllocationCostPerPod() map[string]float64 {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
 	costs := make(map[string]float64)
 	for node := range h.histogram {
 		// Iterate through all models and their pods for this node


### PR DESCRIPTION
Based on the crash backtrace of the last comment in issue https://github.com/vllm-project/aibrix/issues/1131 , looks like we should add the Read Lock to protect the h.histogram

