### PR TITLE
Modernize logger interface

### DIFF
--- a/benchmarks/client/client.py
+++ b/benchmarks/client/client.py
@@ -28,7 +28,7 @@ def worker(thread_idx, task_queue, client, model, max_output, send_request_func,
         task = task_queue.get()
         logging.debug(f"Worker {thread_idx} receive task...")
         if task is None:  # Stop signal
-            logging.warn(f"Worker {thread_idx} exit.")
+            logging.warning(f"Worker {thread_idx} exit.")
             break
         else:
             loop.run_until_complete(send_request_func(client, model, max_output, *task))
@@ -198,13 +198,13 @@ async def benchmark_streaming(api_key: str,
     for task_queue in task_queues:
         task_queue.join()
     # Stop all worker threads
-    logging.warn("Producer completed ...")
+    logging.warning("Producer completed ...")
     for i, thread in enumerate(threads):
         task_queues[i].put(None)
 
     for thread in threads:
         thread.join()
-        logging.warn(f"Worker thread {thread} completed ...")
+        logging.warning(f"Worker thread {thread} completed ...")
     logging.warning(f"All {num_requests} requests completed for deployment.")
 
 # Asynchronous request handler
@@ -339,7 +339,7 @@ async def benchmark_batch(api_key: str,
 
     for thread in threads:
         thread.join()
-        logging.warn(f"Worker thread {thread} completed ...")
+        logging.warning(f"Worker thread {thread} completed ...")
     logging.warning(f"All {num_requests} requests completed for deployment.")
 
 def create_client(api_key: str,

--- a/benchmarks/generator/dataset_generator/multiturn_prefix_sharing_dataset.py
+++ b/benchmarks/generator/dataset_generator/multiturn_prefix_sharing_dataset.py
@@ -86,7 +86,7 @@ def main(args):
         })
     save_dataset_jsonl(sessioned_prompts, args.output)
     analyze_dataset(sessioned_prompts, tokenizer)
-    logging.warn(f"...Finished saving dataset {args.output}.")
+    logging.warning(f"...Finished saving dataset {args.output}.")
         
 
 if __name__ == "__main__":

--- a/benchmarks/generator/workload_generator/sample_request.py
+++ b/benchmarks/generator/workload_generator/sample_request.py
@@ -68,7 +68,7 @@ def _load_plain_dataset(
         }
         for entry in dataset if entry['prompt'] is not None
     )
-    logging.warn(f"...Complete sessioned dataframe transformation")
+    logging.warning(f"...Complete sessioned dataframe transformation")
     return df
 
 class RequestFinder:
@@ -197,7 +197,7 @@ class RequestFinder:
                     if not repeating:
                         self.df.drop(index=sample_idx, inplace=True)  # Remove the selected row
                         self.df.reset_index(drop=True, inplace=True)  # Reset index to avoid issues
-                    logging.warn(f"No exact match found for request {i + 1}, target input/output lengths {input_len}/{output_len}, use closest QA pair input {closest_input} output {closest_output}.")
+                    logging.warning(f"No exact match found for request {i + 1}, target input/output lengths {input_len}/{output_len}, use closest QA pair input {closest_input} output {closest_output}.")
 
         return filtered_results
 
@@ -265,7 +265,7 @@ class RequestFinder:
                 if len(sample_session["prompts"] == 0):
                     self.df.drop(index=sample_idx, inplace=True)  # Remove the selected row
                     self.df.reset_index(drop=True, inplace=True)  # Reset index to avoid issues
-                logging.warn(f"No exact match found for request {i + 1}, target input/output lengths {input_len}/{output_len}, use closest QA pair input {closest_input} output {closest_output}.")
+                logging.warning(f"No exact match found for request {i + 1}, target input/output lengths {input_len}/{output_len}, use closest QA pair input {closest_input} output {closest_output}.")
         return filtered_results
   
     def sample_requests_all(

--- a/benchmarks/generator/workload_generator/utils.py
+++ b/benchmarks/generator/workload_generator/utils.py
@@ -289,11 +289,11 @@ def save_workload(load_struct: List[Any],
             for row in load_struct:
                 json_line = json.dumps(row)  # Convert list to JSON string
                 file.write(json_line + "\n")
-            logging.warn(f'Saved workload file to {output_path + ".jsonl"}')
+            logging.warning(f'Saved workload file to {output_path + ".jsonl"}')
     else:
         with open(output_path + ".json", 'w') as file:
             json.dump(load_struct, file, indent=4)
-        logging.warn(f'Saved workload file to {output_path + ".json"}')
+        logging.warning(f'Saved workload file to {output_path + ".json"}')
 
 def load_config(config_path: str) -> Dict[str, Any]:
     with open(config_path, "r") as file:


### PR DESCRIPTION
## Pull Request Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
