### PR TITLE
[Bug] Fix image replacements in Kustomize files to support installation

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -72,6 +72,15 @@ images:
   - name: metadata-service
     newName: aibrix/metadata-service
     newTag: nightly
+  - name: aibrix/runtime
+    newName: aibrix/runtime
+    newTag: nightly
+  - name: redis
+    newName: redis
+    newTag: latest
+  - name: busybox
+    newName: busybox
+    newTag: stable
 
 labels:
   - pairs:

--- a/config/dependency/kuberay-operator/kustomization.yaml
+++ b/config/dependency/kuberay-operator/kustomization.yaml
@@ -15,3 +15,8 @@ resources:
 - templates/rolebinding.yaml
 - templates/service.yaml
 - templates/serviceaccount.yaml
+
+images:
+  - name: quay.io/kuberay/operator
+    newName: quay.io/kuberay/operator
+    newTag: v1.2.1


### PR DESCRIPTION
## Pull Request Description

This PR ensures all container images are explicitly specified in the Kustomize manifests. 

When deploying AIBrix, it’s important to note that the AIBrix mirror is mainly hosted on Dockerhub, and deploying it in environments has Dockerhub access limitation can be challenging. This PR is necessary due to the current lack of proxy support in Helm (to be supported in 0.4.0). 

By fully qualifying all image names, developers can more easily replace or mirror images as needed for local deployment.

## Related Issues
Resolves: #1164