### PR TITLE
[Bug]: Fix legacy misconfigurations of autoscaling annotations.

### DIFF
--- a/config/samples/autoscaling_v1alpha1_mock_llama.yaml
+++ b/config/samples/autoscaling_v1alpha1_mock_llama.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aibrix
     app.kubernetes.io/managed-by: kustomize
+  annotations:
     autoscaling.aibrix.ai/max-scale-up-rate: "2"
     autoscaling.aibrix.ai/max-scale-down-rate: "2"
     kpa.autoscaling.aibrix.ai/stable-window: "60s"

--- a/development/app/config/heterogeneous/simulator_a40/patch_podautoscaler_a40.yaml
+++ b/development/app/config/heterogeneous/simulator_a40/patch_podautoscaler_a40.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling.aibrix.ai/v1alpha1
 kind: PodAutoscaler
 metadata:
   name: podautoscaler-simulator-llama2-7b-a40
-  labels:
+  annotations:
     kpa.autoscaling.aibrix.ai/scale-down-delay: 0s
 spec:
   scaleTargetRef:

--- a/development/app/config/simulator/patch_podautoscaler_a100.yaml
+++ b/development/app/config/simulator/patch_podautoscaler_a100.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling.aibrix.ai/v1alpha1
 kind: PodAutoscaler
 metadata:
   name: podautoscaler-simulator-llama2-7b-a100
-  labels:
+  annotations:
     kpa.autoscaling.aibrix.ai/scale-down-delay: 0s
 spec:
   scaleTargetRef:

--- a/development/app/config/templates/podautoscaler/podautoscaler_apa.yaml
+++ b/development/app/config/templates/podautoscaler/podautoscaler_apa.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aibrix
     app.kubernetes.io/managed-by: kustomize
+  annotations:
     autoscaling.aibrix.ai/up-fluctuation-tolerance: "0.1"
     autoscaling.aibrix.ai/down-fluctuation-tolerance: "0.2"
     apa.autoscaling.aibrix.ai/window: "30s"

--- a/development/app/config/templates/podautoscaler/podautoscaler_kpa.yaml
+++ b/development/app/config/templates/podautoscaler/podautoscaler_kpa.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aibrix
     app.kubernetes.io/managed-by: kustomize
+  annotations:
     kpa.autoscaling.aibrix.ai/scale-down-delay: 30s
   namespace: default
 spec:

--- a/samples/autoscaling/optimizer-kpa.yaml
+++ b/samples/autoscaling/optimizer-kpa.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aibrix
     app.kubernetes.io/managed-by: kustomize
+  annotations:
     kpa.autoscaling.aibrix.ai/scale-down-delay: 0s
 spec:
   scalingStrategy: KPA 

--- a/samples/heterogeneous/deepseek-coder-7b-l20-podautoscaler.yaml
+++ b/samples/heterogeneous/deepseek-coder-7b-l20-podautoscaler.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: aibrix
+  annotations:
     kpa.autoscaling.aibrix.ai/scale-down-delay: 0s
   name: podautoscaler-deepseek-coder-7b-l20
   namespace: default

--- a/samples/heterogeneous/deepseek-coder-7b-v100-podautoscaler.yaml
+++ b/samples/heterogeneous/deepseek-coder-7b-v100-podautoscaler.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: aibrix
+  annotations:
     kpa.autoscaling.aibrix.ai/scale-down-delay: 0s
   name: podautoscaler-deepseek-coder-7b-v100
   namespace: default


### PR DESCRIPTION
## Pull Request Description
Due to possible implementation changes, some autoscaling configuration examples used the legacy approach, which placed autoscaling parameters under the label section. This PR scans the whole repository and fixes misconfigurations.

## Related Issues
Resolves: #1159 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>