### PR TITLE
[Docs] update development instructions to new make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,10 +208,10 @@ docker-push-kvcache-watcher: ## Push docker image with the kvcache-watcher.
 	$(call push_image,kvcache-watcher)
 
 # PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
-# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# architectures. (i.e. make docker-buildx AIBRIX_CONTAINER_REGISTRY_NAMESPACE=myregistry). To use this option you need to:
 # - be able to use docker buildx. More info: https://docs.docker.com/build/buildx/
 # - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-# - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
+# - be able to push the image to your registry (i.e. if you do not set a valid value via AIBRIX_CONTAINER_REGISTRY_NAMESPACE=<myregistry> then the export will fail)
 # To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx

--- a/benchmarks/scenarios/gateway/README.md
+++ b/benchmarks/scenarios/gateway/README.md
@@ -64,8 +64,8 @@ OUTPUT_FILE=throughput.jsonl ROUTING_STRATEGY=throughput locust -f benchmark.py 
 ## Local Testing
 
 ```bash
-make docker-build-plugins
-aibrix/plugins:9bd45a9915b71936ff0001a6fbfc32f10b65e480
+make docker-build-gateway-plugins
+aibrix/gateway-plugins:9bd45a9915b71936ff0001a6fbfc32f10b65e480
 
 k edit deployment aibrix-gateway-plugins
 

--- a/development/README.md
+++ b/development/README.md
@@ -47,10 +47,10 @@ Navigate to the cloned directory and run:
 make build
 ```
 
-Build and push your image to the location specified by `IMG`:
+Build and push your images to the registry location specified by `AIBRIX_CONTAINER_REGISTRY_NAMESPACE`:
 
 ```sh
-make docker-build docker-push IMG=<some-registry>/aibrix:tag
+make docker-build-all docker-push-all AIBRIX_CONTAINER_REGISTRY_NAMESPACE=<some-registry>
 ```
 
 > **NOTE:** This image ought to be published in the personal registry you specified.
@@ -67,16 +67,16 @@ make install
 
 ### Deploy the Manager to Kubernetes
 
-Deploy the Manager to your cluster using the `IMG` environment variable to specify the image:
+Deploy the Manager to your cluster using the `AIBRIX_CONTAINER_REGISTRY_NAMESPACE` environment variable to specify the image:
 
 ```sh
-make deploy IMG=<some-registry>/aibrix:tag
+make deploy AIBRIX_CONTAINER_REGISTRY_NAMESPACE=<some-registry>
 ```
 
 If you prefer local testing and do not want to push the image to a remote DockerHub, you can specify any name, such as:
 
 ```sh
-make deploy IMG=example.com/aibrix:v1
+make deploy AIBRIX_CONTAINER_REGISTRY_NAMESPACE=example.com
 ```
 
 > **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin privileges or be logged in as admin.
@@ -134,7 +134,7 @@ Following are the steps to build the installer and distribute this project to us
 1. Build the installer for the image built and published in the registry:
 
 ```sh
-make build-installer IMG=<some-registry>/aibrix:tag
+make build-installer AIBRIX_CONTAINER_REGISTRY_NAMESPACE=<some-registry>
 ```
 
 NOTE: The makefile target mentioned above generates an 'install.yaml' file in the dist directory. This file contains all the resources built with Kustomize, which are necessary to install this project without its dependencies.

--- a/development/tutorials/podautoscaler/README.md
+++ b/development/tutorials/podautoscaler/README.md
@@ -57,8 +57,8 @@ kubectl port-forward svc/llama2-70b 8000:8000 -n aibrix-system
 It's different from `make run`, since it may reveal the RBAC problem when manager what to watch HPA.
 
 ```shell
-make docker-build IMG=aibrix/aibrix-controller-manager:v0.1.1
-make deploy IMG=aibrix/aibrix-controller-manager:v0.1.1
+make docker-build-controller-manager AIBRIX_CONTAINER_REGISTRY_NAMESPACE=aibrix
+make deploy AIBRIX_CONTAINER_REGISTRY_NAMESPACE=aibrix
 ```
 
 check the deployed manager logs:


### PR DESCRIPTION
…guide

## Pull Request Description
It seems that the development instructions were using prvious `make` commands not reflecting the current state of the `Makefile`. In particular, all the commands related to the build/push of the components have been updated, as well as the way to pass a custom docker registry namespace

## Related Issues
Resolves: N/A
**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>