### PR TITLE
[Misc] Use domain-qualified finalizer name

### DIFF
--- a/pkg/controller/roleset/roleset_controller.go
+++ b/pkg/controller/roleset/roleset_controller.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	ControllerName            = "roleset-controller"
-	RoleSetFinalizer          = "roleset-finalizer"
+	RoleSetFinalizer          = "orchestration.aibrix.ai/roleset-finalizer"
 	DefaultRequeueAfter       = 15 * time.Second
 	PodBurst                  = 500
 	PodOperationInitBatchSize = 16

--- a/pkg/controller/stormservice/stormservice_controller.go
+++ b/pkg/controller/stormservice/stormservice_controller.go
@@ -40,7 +40,7 @@ const (
 	ControllerName              = "stormservice-controller"
 	DefaultRequeueAfter         = 15 * time.Second
 	DefaultRevisionHistoryLimit = 10
-	StormServiceFinalizer       = "stormservice-finalizer"
+	StormServiceFinalizer       = "orchestration.aibrix.ai/stormservice-finalizer"
 )
 
 // controllerKind contains the schema.GroupVersionKind for this controller type.


### PR DESCRIPTION
## Pull Request Description
Use domain-qualified finalizer name to avoid potential conflicts.

```
I0706 07:33:29.414963       1 warning_handler.go:65] "msg"="metadata.finalizers: \"stormservice-finalizer\": prefer a domain-qualified finalizer name to avoid accidental conflicts with other finalizer writers" "logger"="KubeAPIWarningLogger"
```


## Related Issues
Resolves: https://github.com/vllm-project/aibrix/issues/1254

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>