### PR TITLE
[DO NOT MERGE] Support PodGroupSize at the role level

### DIFF
--- a/api/orchestration/v1alpha1/roleset_types.go
+++ b/api/orchestration/v1alpha1/roleset_types.go
@@ -64,6 +64,10 @@ type RoleSpec struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
+	// PodGroupSize is the number of pods to form a minimum role instance.
+	// +optional
+	PodGroupSize *int32 `json:"podGroupSize,omitempty"`
+
 	// +optional
 	// +patchStrategy=retainKeys
 	UpdateStrategy RoleUpdateStrategy `json:"updateStrategy,omitempty"`

--- a/api/orchestration/v1alpha1/zz_generated.deepcopy.go
+++ b/api/orchestration/v1alpha1/zz_generated.deepcopy.go
@@ -671,6 +671,11 @@ func (in *RoleSpec) DeepCopyInto(out *RoleSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.PodGroupSize != nil {
+		in, out := &in.PodGroupSize, &out.PodGroupSize
+		*out = new(int32)
+		**out = **in
+	}
 	in.UpdateStrategy.DeepCopyInto(&out.UpdateStrategy)
 	in.Template.DeepCopyInto(&out.Template)
 	in.DisruptionTolerance.DeepCopyInto(&out.DisruptionTolerance)

--- a/config/crd/orchestration/orchestration.aibrix.ai_rolesets.yaml
+++ b/config/crd/orchestration/orchestration.aibrix.ai_rolesets.yaml
@@ -39,6 +39,9 @@ spec:
                       type: object
                     name:
                       type: string
+                    podGroupSize:
+                      format: int32
+                      type: integer
                     replicas:
                       format: int32
                       type: integer

--- a/config/crd/orchestration/orchestration.aibrix.ai_stormservices.yaml
+++ b/config/crd/orchestration/orchestration.aibrix.ai_stormservices.yaml
@@ -106,6 +106,9 @@ spec:
                               type: object
                             name:
                               type: string
+                            podGroupSize:
+                              format: int32
+                              type: integer
                             replicas:
                               format: int32
                               type: integer

--- a/pkg/controller/constants/stormservice.go
+++ b/pkg/controller/constants/stormservice.go
@@ -25,16 +25,18 @@ const (
 	RoleNameLabelKey             = "role-name"
 	RoleTemplateHashLabelKey     = "role-template-hash"
 	RoleReplicaIndexLabelKey     = "stormservice.orchestration.aibrix.ai/role-replica-index"
+	RolePodGroupIndexLabelKey    = "stormservice.orchestration.aibrix.ai/pod-group-index"
 
 	RoleSetIndexAnnotationKey    = "stormservice.orchestration.aibrix.ai/roleset-index"
 	RoleSetRevisionAnnotationKey = "stormservice.orchestration.aibrix.ai/revision"
 	// RoleReplicaIndexAnnotationKey is originally used, to support label filter rank 0 pod, we add label support but keep this annotation for backward compatibility.
 	RoleReplicaIndexAnnotationKey = "stormservice.orchestration.aibrix.ai/role-replica-index"
 
-	StormServiceNameEnvKey = "STORM_SERVICE_NAME"
-	RoleSetNameEnvKey      = "ROLESET_NAME"
-	RoleSetIndexEnvKey     = "ROLESET_INDEX"
-	RoleNameEnvKey         = "ROLE_NAME"
-	RoleReplicaIndexEnvKey = "ROLE_REPLICA_INDEX"
-	RoleTemplateHashEnvKey = "ROLE_TEMPLATE_HASH"
+	StormServiceNameEnvKey  = "STORM_SERVICE_NAME"
+	RoleSetNameEnvKey       = "ROLESET_NAME"
+	RoleSetIndexEnvKey      = "ROLESET_INDEX"
+	RoleNameEnvKey          = "ROLE_NAME"
+	RoleReplicaIndexEnvKey  = "ROLE_REPLICA_INDEX"
+	RolePodGroupIndexEnvKey = "POD_GROUP_INDEX"
+	RoleTemplateHashEnvKey  = "ROLE_TEMPLATE_HASH"
 )

--- a/pkg/controller/roleset/sync.go
+++ b/pkg/controller/roleset/sync.go
@@ -144,11 +144,12 @@ func (r *RoleSetReconciler) calculateStatusForRole(ctx context.Context, rs *orch
 	}
 	pods = filterRolePods(role, pods)
 	pods, _ = filterActivePods(pods)
-	readyReplicas := GetReadyReplicaCountForRole(pods)
+	podGroupSize := getRolePodGroupSize(role)
+	readyReplicas := GetReadyReplicaCountForRole(pods) / int32(podGroupSize)
 	updated, _ := filterUpdatedPods(pods, ctrlutil.ComputeHash(&role.Template, nil))
-	updatedReplicas := len(updated)
-	updatedReadyReplicas := GetReadyReplicaCountForRole(updated)
-	totalReplicas := len(pods)
+	updatedReplicas := len(updated) / podGroupSize
+	updatedReadyReplicas := GetReadyReplicaCountForRole(updated) / int32(podGroupSize)
+	totalReplicas := len(pods) / podGroupSize
 	notReadyReplicas := totalReplicas - int(readyReplicas)
 	return &orchestrationv1alpha1.RoleStatus{
 		Name:                 role.Name,

--- a/pkg/controller/roleset/utils_test.go
+++ b/pkg/controller/roleset/utils_test.go
@@ -113,7 +113,7 @@ func TestRenderStormServicePod_WithRoleIndex(t *testing.T) {
 		Spec: *roleSet.Spec.Roles[0].Template.Spec.DeepCopy(),
 	}
 
-	renderStormServicePod(roleSet, &roleSet.Spec.Roles[0], pod, &roleIndex)
+	renderStormServicePod(roleSet, &roleSet.Spec.Roles[0], pod, &roleIndex, nil)
 
 	// Verify labels
 	assert.Equal(t, "test-role-set", pod.Labels[constants.RoleSetNameLabelKey])
@@ -160,7 +160,7 @@ func TestRenderStormServicePod_WithoutRoleIndex(t *testing.T) {
 	pod := &corev1.Pod{
 		Spec: *roleSet.Spec.Roles[0].Template.Spec.DeepCopy(),
 	}
-	renderStormServicePod(roleSet, &roleSet.Spec.Roles[0], pod, nil)
+	renderStormServicePod(roleSet, &roleSet.Spec.Roles[0], pod, nil, nil)
 
 	// Verify replica index is not set
 	assert.NotContains(t, pod.Labels, constants.RoleReplicaIndexLabelKey)
@@ -200,7 +200,7 @@ func TestRenderStormServicePod_WithPodGroup(t *testing.T) {
 	pod := &corev1.Pod{
 		Spec: *roleSet.Spec.Roles[0].Template.Spec.DeepCopy(),
 	}
-	renderStormServicePod(roleSet, &roleSet.Spec.Roles[0], pod, &roleIndex)
+	renderStormServicePod(roleSet, &roleSet.Spec.Roles[0], pod, &roleIndex, nil)
 
 	// Verify pod group labels and annotations
 	assert.Equal(t, "test-role-set", pod.Labels[constants.GodelPodGroupNameAnnotationKey])
@@ -229,7 +229,7 @@ func TestRenderStormServicePod_EmptyLabelsAndAnnotations(t *testing.T) {
 	}
 
 	pod := &corev1.Pod{}
-	renderStormServicePod(roleSet, &roleSet.Spec.Roles[0], pod, nil)
+	renderStormServicePod(roleSet, &roleSet.Spec.Roles[0], pod, nil, nil)
 
 	// Verify basic labels are set even when roleSet has no labels
 	assert.Equal(t, "test-role-set", pod.Labels[constants.RoleSetNameLabelKey])
@@ -266,7 +266,7 @@ func TestRenderStormServicePod_MultipleContainers(t *testing.T) {
 	pod := &corev1.Pod{
 		Spec: *roleSet.Spec.Roles[0].Template.Spec.DeepCopy(),
 	}
-	renderStormServicePod(roleSet, &roleSet.Spec.Roles[0], pod, nil)
+	renderStormServicePod(roleSet, &roleSet.Spec.Roles[0], pod, nil, nil)
 
 	// Verify all containers get env vars injected
 	assert.Len(t, pod.Spec.Containers, 2)


### PR DESCRIPTION
## Pull Request Description
Support parallelism of single worker 

In large EP mode or with full-parameter models (e.g., DeepSeek-R1 or Kimi K2), single-instance cross-node xPyD support is required. Although the current StormService technically supports cross-node deployment through `role.replicas`, it is limited to the 1P1D pattern. This approach has several limitations. Firstly, replicas was not originally designed to represent parallelism, making it a workaround that complicates other processes such as upgrades. Secondly, the semantic clarity is compromised, leading to potential confusion and operational fragility.

```
type RoleSpec struct {
    Name string `json:"name,omitempty"`

    // Replicas is the number of desired replicas.
    // +optional
    Replicas *int32 `json:"replicas,omitempty"`

   + // PodGroupSize is the number of pods to form a minimum role instance.
   + // +optional
   + PodGroupSize *int32 `json:"podGroupSize,omitempty"`
```

Previous names
```
llm-xpyd-roleset-gdkvq-decode-7dcf585456-0    1/1     Running   0          46s
llm-xpyd-roleset-gdkvq-decode-7dcf585456-1    1/1     Running   0          46s
llm-xpyd-roleset-gdkvq-prefill-5c8fd867f6-0   1/1     Running   0          46s
llm-xpyd-roleset-gdkvq-prefill-5c8fd867f6-1   1/1     Running   0          46s
llm-xpyd-roleset-gdkvq-prefill-5c8fd867f6-2   1/1     Running   0          46s
llm-xpyd-roleset-gdkvq-prefill-5c8fd867f6-3   1/1     Running   0          7s
```

new names, with new dimension `pod-group-index`

```
NAME                                            READY   STATUS        RESTARTS   AGE
llm-xpyd-roleset-v42l6-decode-7dcf585456-0-0    1/1     Running       0          2m49s
llm-xpyd-roleset-v42l6-decode-7dcf585456-0-1    1/1     Running       0          2m49s
llm-xpyd-roleset-v42l6-decode-7dcf585456-0-2    1/1     Running       0          2m49s
llm-xpyd-roleset-v42l6-decode-7dcf585456-0-3    1/1     Running       0          2m49s
llm-xpyd-roleset-v42l6-prefill-5c8fd867f6-0-0   1/1     Running       0          2m49s
llm-xpyd-roleset-v42l6-prefill-5c8fd867f6-0-1   1/1     Running       0          2m49s
llm-xpyd-roleset-v42l6-prefill-5c8fd867f6-1-0   1/1     Terminating   0          2m49s
llm-xpyd-roleset-v42l6-prefill-5c8fd867f6-1-1   1/1     Terminating   0          2m49s
```


after the change we should use following way for communication

```
    python3 ....
        --disaggregation-mode prefill \
        --trust-remote-code \
        --dist-init-addr "${ROLESET_NAME}-${ROLE_NAME}-${ROLE_TEMPLATE_HASH}-${ROLE_REPLICA_INDEX}-0.${STORM_SERVICE_NAME}.default.svc.cluster.local:5000" \
        --nnodes 2 \
        --node-rank $POD_GROUP_INDEX \
        --tp-size 2 \
        --log-level debug
```

```
    Environment:
      POD_GROUP_INDEX:     0
      ROLESET_INDEX:
      ROLESET_NAME:        llm-xpyd-roleset-dc8bz
      ROLE_NAME:           prefill
      ROLE_REPLICA_INDEX:  2
      ROLE_TEMPLATE_HASH:  5c8fd867f6
      STORM_SERVICE_NAME:  llm-xpyd
```



## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>