### PR TITLE
[Misc] enhance headless service sync with update logic

### DIFF
--- a/pkg/controller/stormservice/utils.go
+++ b/pkg/controller/stormservice/utils.go
@@ -19,6 +19,8 @@ package stormservice
 import (
 	"sort"
 
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 
 	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
@@ -223,4 +225,11 @@ func sortRoleSetByRevision(roleSets []*orchestrationv1alpha1.RoleSet, updatedRev
 			return !utils.IsRoleSetReady(roleSets[i])
 		}
 	})
+}
+
+// isServiceEqual compares two Kubernetes Service objects for equality
+func isServiceEqual(a, b *corev1.Service) bool {
+	return a.Spec.Type == b.Spec.Type &&
+		apiequality.Semantic.DeepEqual(a.Spec.Selector, b.Spec.Selector) &&
+		a.Spec.ClusterIP == b.Spec.ClusterIP
 }


### PR DESCRIPTION
## Pull Request Description
While adding tests to `pkg/controller/stormservice/sync_test.go` I noticed that currently the headless service sync logic only handles creation of new services without properly updating existing ones. This PR enhances the sync logic to handle both creation and updates, ensuring service properties (Type, Selector, ClusterIP) stay properly synchronized. Added comprehensive unit tests to verify both scenarios.

## Related Issues
Resolves: NONE

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[ x Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[x] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>