### PR TITLE
feat: add vLLM remote tokenizer with engine integration

### DIFF
--- a/config/features/vllm-remote-tokenizer/README.md
+++ b/config/features/vllm-remote-tokenizer/README.md
@@ -1,0 +1,68 @@
+# vLLM Remote Tokenizer Feature
+
+This feature enables model-aware remote tokenizer support for vLLM inference engines in AIBrix gateway.
+
+## Quick Start
+
+Enable vLLM remote tokenizer with one command:
+
+```bash
+kubectl apply -k config/features/vllm-remote-tokenizer/
+```
+
+## Configuration
+
+The following environment variables are configured:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| AIBRIX_ENABLE_VLLM_REMOTE_TOKENIZER | false | Enable remote tokenizer feature |
+| AIBRIX_VLLM_TOKENIZER_ENDPOINT_TEMPLATE | http://%s:8000 | URL template for vLLM endpoints |
+| AIBRIX_TOKENIZER_HEALTH_CHECK_PERIOD | 30s | Health check interval |
+| AIBRIX_TOKENIZER_TTL | 5m | Tokenizer cache TTL |
+| AIBRIX_MAX_TOKENIZERS_PER_POOL | 100 | Maximum tokenizers per pool |
+| AIBRIX_TOKENIZER_REQUEST_TIMEOUT | 10s | Request timeout |
+
+## Customization
+
+To use custom values, copy this directory and modify `gateway-plugins-env-patch.yaml`:
+
+```bash
+cp -r config/features/vllm-remote-tokenizer/ config/features/my-vllm-config/
+# Edit config/features/my-vllm-config/gateway-plugins-env-patch.yaml
+kubectl apply -k config/features/my-vllm-config/
+```
+
+## Enable the Feature
+
+To enable vLLM remote tokenizer after installation:
+
+```bash
+kubectl set env deployment/gateway-plugins -n aibrix-system AIBRIX_ENABLE_VLLM_REMOTE_TOKENIZER=true
+```
+
+Or use a custom Kustomization overlay with the environment variable set to `true`.
+
+## Disable
+
+To disable, set the environment variable to false:
+
+```bash
+kubectl set env deployment/gateway-plugins -n aibrix-system AIBRIX_ENABLE_VLLM_REMOTE_TOKENIZER=false
+```
+
+## Verification
+
+Check if enabled:
+
+```bash
+kubectl get deployment gateway-plugins -n aibrix-system -o json | \
+  jq '.spec.template.spec.containers[0].env[] | select(.name | startswith("AIBRIX_ENABLE_VLLM"))'
+```
+
+Check metrics:
+
+```bash
+kubectl port-forward -n aibrix-system svc/gateway-plugins 8080:8080
+curl http://localhost:8080/metrics | grep aibrix_tokenizer_pool
+```

--- a/config/features/vllm-remote-tokenizer/gateway-plugins-env-patch.yaml
+++ b/config/features/vllm-remote-tokenizer/gateway-plugins-env-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway-plugins
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: gateway-plugin
+        env:
+        - name: AIBRIX_ENABLE_VLLM_REMOTE_TOKENIZER
+          value: "false"
+        - name: AIBRIX_VLLM_TOKENIZER_ENDPOINT_TEMPLATE
+          value: "http://%s:8000"
+        - name: AIBRIX_TOKENIZER_HEALTH_CHECK_PERIOD
+          value: "30s"
+        - name: AIBRIX_TOKENIZER_TTL
+          value: "5m"
+        - name: AIBRIX_MAX_TOKENIZERS_PER_POOL
+          value: "100"
+        - name: AIBRIX_TOKENIZER_REQUEST_TIMEOUT
+          value: "10s"

--- a/config/features/vllm-remote-tokenizer/kustomization.yaml
+++ b/config/features/vllm-remote-tokenizer/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: aibrix-system
+
+# This overlay enables vLLM remote tokenizer support
+# Apply with: kubectl apply -k config/features/vllm-remote-tokenizer/
+
+resources:
+- ../../gateway/gateway-plugin
+
+patches:
+- path: gateway-plugins-env-patch.yaml
+  target:
+    kind: Deployment
+    name: gateway-plugins

--- a/pkg/apis/constants/labels.go
+++ b/pkg/apis/constants/labels.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+// Label keys used by the Aibrix system.
+// The format `resource.aibrix.ai/attribute` is the standard.
+
+const (
+	// ModelNameLabel is the label for identifying the model name
+	// Example: "model.aibrix.ai/name": "deepseek-llm-7b-chat"
+	ModelNameLabel = "model.aibrix.ai/name"
+
+	// ModelEngineLabel is the label for identifying the inference engine
+	// Example: "model.aibrix.ai/engine": "vllm"
+	ModelEngineLabel = "model.aibrix.ai/engine"
+
+	// ModelMetricPortLabel is the label for specifying the metrics port
+	// Example: "model.aibrix.ai/metric-port": "8000"
+	ModelMetricPortLabel = "model.aibrix.ai/metric-port"
+
+	// ModelPortLabel is the label for specifying the service port
+	// Example: "model.aibrix.ai/port": "8080"
+	ModelPortLabel = "model.aibrix.ai/port"
+)
+
+// GetModelName retrieves the model name from pod labels
+func GetModelName(labels map[string]string) string {
+	if model, ok := labels[ModelNameLabel]; ok {
+		return model
+	}
+	return ""
+}
+
+// GetInferenceEngine retrieves the inference engine from pod labels
+func GetInferenceEngine(labels map[string]string) string {
+	if engine, ok := labels[ModelEngineLabel]; ok {
+		return engine
+	}
+	return ""
+}

--- a/pkg/cache/cache_metrics.go
+++ b/pkg/cache/cache_metrics.go
@@ -21,6 +21,7 @@ import (
 
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/vllm-project/aibrix/pkg/apis/constants"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/utils"
 	"k8s.io/klog/v2"
@@ -29,10 +30,8 @@ import (
 const (
 	// When the engine's HTTP proxy is separated from the engine itself,
 	// the request port and metrics port may differ, so a dedicated metrics port is required.
-	MetricPortLabel                     = "model.aibrix.ai/metric-port"
-	engineLabel                         = "model.aibrix.ai/engine"
-	portLabel                           = "model.aibrix.ai/port"
-	modelLabel                          = "model.aibrix.ai/name"
+	// Note: Using MetricPortLabel for backward compatibility, but it's the same as constants.ModelMetricPortLabel
+	MetricPortLabel                     = constants.ModelMetricPortLabel
 	defaultMetricPort                   = 8000
 	defaultEngineLabelValue             = "vllm"
 	defaultPodMetricRefreshIntervalInMS = 50
@@ -337,7 +336,7 @@ func (c *Store) fetchMetrics(pod *Pod, allMetrics map[string]*dto.MetricFamily, 
 		klog.V(4).Infof("Cannot find labelMetricName %v in collected metrics names", labelMetricName)
 		return nil, false
 	}
-	engineType, err := getPodLabel(pod, engineLabel)
+	engineType, err := getPodLabel(pod, constants.ModelEngineLabel)
 	if engineType == "" {
 		klog.V(4).Infof(err.Error())
 		engineType = defaultEngineLabelValue
@@ -363,7 +362,7 @@ func (c *Store) updatePodRecord(pod *Pod, modelName string, metricName string, s
 	} else if scope == metrics.PodModelMetricScope {
 		var err error
 		if modelName == "" {
-			modelName, err = getPodLabel(pod, modelLabel)
+			modelName, err = getPodLabel(pod, constants.ModelNameLabel)
 			if err != nil {
 				return fmt.Errorf("modelName should not be empty for scope %v", scope)
 			}

--- a/pkg/plugins/gateway/algorithms/prefix_cache.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"math/rand"
 	"sort"
+	"time"
 
 	"github.com/vllm-project/aibrix/pkg/cache"
 	"github.com/vllm-project/aibrix/pkg/types"
@@ -41,6 +42,14 @@ var (
 	tokenizerType                                             = utils.LoadEnv("AIBRIX_PREFIX_CACHE_TOKENIZER_TYPE", "character")
 	podRunningRequestImbalanceAbsCount int                    = utils.LoadEnvInt("AIBRIX_PREFIX_CACHE_POD_RUNNING_REQUEST_IMBALANCE_ABS_COUNT", defaultPodRunningRequestImbalanceAbsCount)
 	standardDeviationFactor            int                    = utils.LoadEnvInt("AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR", defaultStandardDeviationFactor)
+
+	// vLLM Remote Tokenizer configuration
+	enableVLLMRemoteTokenizer     = utils.LoadEnvBool("AIBRIX_ENABLE_VLLM_REMOTE_TOKENIZER", false)
+	vllmTokenizerEndpointTemplate = utils.LoadEnv("AIBRIX_VLLM_TOKENIZER_ENDPOINT_TEMPLATE", "http://%s:8000")
+	tokenizerHealthCheckPeriod    = utils.LoadEnvDuration("AIBRIX_TOKENIZER_HEALTH_CHECK_PERIOD", 30*time.Second)
+	tokenizerTTL                  = utils.LoadEnvDuration("AIBRIX_TOKENIZER_TTL", 5*time.Minute)
+	maxTokenizersPerPool          = utils.LoadEnvInt("AIBRIX_MAX_TOKENIZERS_PER_POOL", 100)
+	tokenizerRequestTimeout       = utils.LoadEnvDuration("AIBRIX_TOKENIZER_REQUEST_TIMEOUT", 10*time.Second)
 )
 
 func init() {
@@ -49,41 +58,60 @@ func init() {
 
 type prefixCacheRouter struct {
 	cache              cache.Cache
-	tokenizer          tokenizer.Tokenizer
+	tokenizer          tokenizer.Tokenizer // Fallback tokenizer for backward compatibility
+	tokenizerPool      *TokenizerPool      // Model-aware tokenizer pool
 	prefixCacheIndexer *prefixcacheindexer.PrefixHashTable
 }
 
 func NewPrefixCacheRouter() (types.Router, error) {
-	// Create tokenizer based on type
-	// Supported tokenizers: ["character", "tiktoken"]
-	// Default: "character" for any unrecognized type
-	// TODO: Add support for "remote" and "vllm" tokenizer types in a future PR.
-	//       This will require proper configuration handling for remote endpoints.
-	var tokenizerObj tokenizer.Tokenizer
-	if tokenizerType == "tiktoken" {
-		tokenizerObj = tokenizer.NewTiktokenTokenizer()
-	} else {
-		// Default to character tokenizer for backward compatibility
-		if tokenizerType != "character" {
-			klog.InfoS("unrecognized tokenizer type, defaulting to character", "type", tokenizerType)
-		}
-		tokenizerObj = tokenizer.NewCharacterTokenizer()
-	}
-
 	c, err := cache.Get()
 	if err != nil {
 		klog.Error("fail to get cache store in prefix cache router")
 		return nil, err
 	}
 
+	// Create fallback tokenizer based on type
+	// Supported tokenizers: ["character", "tiktoken"]
+	// Default: "character" for any unrecognized type
+	var fallbackTokenizer tokenizer.Tokenizer
+	if tokenizerType == "tiktoken" {
+		fallbackTokenizer = tokenizer.NewTiktokenTokenizer()
+	} else {
+		// Default to character tokenizer for backward compatibility
+		if tokenizerType != "character" {
+			klog.InfoS("unrecognized tokenizer type, defaulting to character", "type", tokenizerType)
+		}
+		fallbackTokenizer = tokenizer.NewCharacterTokenizer()
+	}
+
+	// Initialize TokenizerPool for vLLM remote tokenizer support
+	poolConfig := TokenizerPoolConfig{
+		EnableVLLMRemote:     enableVLLMRemoteTokenizer,
+		EndpointTemplate:     vllmTokenizerEndpointTemplate,
+		HealthCheckPeriod:    tokenizerHealthCheckPeriod,
+		TokenizerTTL:         tokenizerTTL,
+		MaxTokenizersPerPool: maxTokenizersPerPool,
+		FallbackTokenizer:    fallbackTokenizer,
+		Timeout:              tokenizerRequestTimeout,
+		ModelServiceMap:      make(map[string]string), // Can be populated from config later
+	}
+
+	pool := NewTokenizerPool(poolConfig, c)
+
 	klog.InfoS("prefix_cache_configurations",
 		"tokenizer_type", tokenizerType,
 		"pod_running_request_imbalance_abs_count", podRunningRequestImbalanceAbsCount,
-		"matched_pods_running_requests_standard_deviation_factor", standardDeviationFactor)
+		"matched_pods_running_requests_standard_deviation_factor", standardDeviationFactor,
+		"enable_vllm_remote_tokenizer", enableVLLMRemoteTokenizer,
+		"vllm_tokenizer_endpoint_template", vllmTokenizerEndpointTemplate,
+		"tokenizer_health_check_period", tokenizerHealthCheckPeriod,
+		"tokenizer_ttl", tokenizerTTL,
+		"max_tokenizers_per_pool", maxTokenizersPerPool)
 
 	return prefixCacheRouter{
 		cache:              c,
-		tokenizer:          tokenizerObj,
+		tokenizer:          fallbackTokenizer, // Keep for backward compatibility
+		tokenizerPool:      pool,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 	}, nil
 }
@@ -93,12 +121,22 @@ func (p prefixCacheRouter) Route(ctx *types.RoutingContext, readyPodList types.P
 	var matchedPods map[string]int
 	var targetPod *v1.Pod
 
-	tokens, err := p.tokenizer.TokenizeInputText(ctx.Message)
+	readyPods := readyPodList.All()
+
+	// Get tokenizer - use pool only if vLLM remote tokenizer is enabled
+	var tokenizerObj tokenizer.Tokenizer
+	if enableVLLMRemoteTokenizer {
+		tokenizerObj = p.tokenizerPool.GetTokenizer(ctx.Model, readyPods)
+	} else {
+		// Use the original tokenizer for backward compatibility
+		tokenizerObj = p.tokenizer
+	}
+
+	tokens, err := tokenizerObj.TokenizeInputText(ctx.Message)
 	if err != nil {
 		return "", err
 	}
 
-	readyPods := readyPodList.All()
 	readyPodsMap := map[string]struct{}{}
 	for _, pod := range readyPods {
 		readyPodsMap[pod.Name] = struct{}{}

--- a/pkg/plugins/gateway/algorithms/tokenizer_pool.go
+++ b/pkg/plugins/gateway/algorithms/tokenizer_pool.go
@@ -1,0 +1,479 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/vllm-project/aibrix/pkg/apis/constants"
+	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/utils/tokenizer"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// vllmEngine is the constant for vLLM inference engine
+	vllmEngine = "vllm"
+)
+
+var (
+	// Global metrics instance to avoid duplicate registration
+	tokenizerPoolMetrics     *TokenizerPoolMetrics
+	tokenizerPoolMetricsOnce sync.Once
+)
+
+// TokenizerPoolConfig represents configuration for the TokenizerPool
+type TokenizerPoolConfig struct {
+	EnableVLLMRemote     bool                // Feature flag
+	EndpointTemplate     string              // "http://%s:8000"
+	HealthCheckPeriod    time.Duration       // Default: 30s
+	TokenizerTTL         time.Duration       // Default: 5m
+	MaxTokenizersPerPool int                 // Default: 100
+	FallbackTokenizer    tokenizer.Tokenizer // Fallback when remote fails
+	ModelServiceMap      map[string]string   // Model -> Service endpoint mapping
+	Timeout              time.Duration       // Request timeout
+}
+
+// tokenizerEntry represents a cached tokenizer with metadata
+type tokenizerEntry struct {
+	tokenizer    tokenizer.Tokenizer
+	endpoint     string
+	lastUsed     time.Time
+	lastHealthy  time.Time
+	healthStatus bool
+}
+
+// TokenizerPool manages model-specific tokenizers with caching and health checking
+type TokenizerPool struct {
+	mu         sync.RWMutex
+	tokenizers map[string]*tokenizerEntry // model -> tokenizer mapping
+	config     TokenizerPoolConfig
+	cache      cache.Cache // for pod discovery
+	metrics    *TokenizerPoolMetrics
+	stopCh     chan struct{}
+}
+
+// TokenizerPoolMetrics contains Prometheus metrics for the pool
+type TokenizerPoolMetrics struct {
+	activeTokenizers           prometheus.Gauge
+	tokenizerCreationSuccesses prometheus.Counter
+	tokenizerCreationFailures  prometheus.Counter
+	unhealthyTokenizers        prometheus.Counter
+	tokenizerRequests          *prometheus.CounterVec
+	tokenizerLatency           *prometheus.HistogramVec
+}
+
+// initMetrics initializes the global metrics instance once
+func initMetrics() {
+	tokenizerPoolMetricsOnce.Do(func() {
+		tokenizerPoolMetrics = &TokenizerPoolMetrics{
+			activeTokenizers: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "aibrix_tokenizer_pool_active_tokenizers",
+				Help: "Number of active tokenizers in the pool",
+			}),
+			tokenizerCreationSuccesses: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "aibrix_tokenizer_pool_creation_successes_total",
+				Help: "Total number of successful tokenizer creations",
+			}),
+			tokenizerCreationFailures: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "aibrix_tokenizer_pool_creation_failures_total",
+				Help: "Total number of failed tokenizer creations",
+			}),
+			unhealthyTokenizers: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "aibrix_tokenizer_pool_unhealthy_tokenizers_total",
+				Help: "Total number of times tokenizers were marked unhealthy",
+			}),
+			tokenizerRequests: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "aibrix_tokenizer_pool_requests_total",
+				Help: "Total number of tokenizer requests by model",
+			}, []string{"model"}),
+			tokenizerLatency: promauto.NewHistogramVec(prometheus.HistogramOpts{
+				Name:    "aibrix_tokenizer_pool_latency_seconds",
+				Help:    "Tokenizer request latency in seconds",
+				Buckets: prometheus.DefBuckets,
+			}, []string{"model"}),
+		}
+	})
+}
+
+// NewTokenizerPool creates a new TokenizerPool instance
+func NewTokenizerPool(config TokenizerPoolConfig, cache cache.Cache) *TokenizerPool {
+	// Initialize metrics once
+	initMetrics()
+
+	pool := &TokenizerPool{
+		tokenizers: make(map[string]*tokenizerEntry),
+		config:     config,
+		cache:      cache,
+		metrics:    tokenizerPoolMetrics,
+		stopCh:     make(chan struct{}),
+	}
+
+	// Start health checker if enabled
+	if config.EnableVLLMRemote && config.HealthCheckPeriod > 0 {
+		pool.startHealthChecker()
+	}
+
+	return pool
+}
+
+// GetTokenizer returns a tokenizer for the specified model
+func (p *TokenizerPool) GetTokenizer(model string, pods []*v1.Pod) tokenizer.Tokenizer {
+	// Metrics
+	p.metrics.tokenizerRequests.WithLabelValues(model).Inc()
+	startTime := time.Now()
+	defer func() {
+		p.metrics.tokenizerLatency.WithLabelValues(model).Observe(time.Since(startTime).Seconds())
+	}()
+
+	// If remote tokenizer is disabled, return fallback immediately
+	if !p.config.EnableVLLMRemote {
+		return p.config.FallbackTokenizer
+	}
+
+	// Acquire write lock directly to avoid race condition
+	// TODO: Consider implementing reference counting or double-checked locking
+	// to improve concurrency performance while maintaining thread safety
+	p.mu.Lock()
+	entry, exists := p.tokenizers[model]
+	if exists && entry.healthStatus {
+		// Update lastUsed while still holding the lock
+		entry.lastUsed = time.Now()
+		tok := entry.tokenizer
+		p.mu.Unlock()
+		return tok
+	}
+	p.mu.Unlock()
+
+	// Slow path: create new tokenizer
+	return p.createOrUpdateTokenizer(model, pods)
+}
+
+// createOrUpdateTokenizer creates or updates a tokenizer for the model
+func (p *TokenizerPool) createOrUpdateTokenizer(model string, pods []*v1.Pod) tokenizer.Tokenizer {
+	// First attempt: quick check under write lock
+	p.mu.Lock()
+
+	// Double-check after acquiring write lock
+	if entry, exists := p.tokenizers[model]; exists && entry.healthStatus {
+		entry.lastUsed = time.Now()
+		p.mu.Unlock()
+		return entry.tokenizer
+	}
+
+	// Check pool size limit
+	if len(p.tokenizers) >= p.config.MaxTokenizersPerPool {
+		p.mu.Unlock()
+		klog.Warningf("TokenizerPool reached max size %d, using fallback tokenizer", p.config.MaxTokenizersPerPool)
+		return p.config.FallbackTokenizer
+	}
+
+	// Find endpoint for model
+	endpoint := p.findVLLMEndpointForModel(model, pods)
+	if endpoint == "" {
+		p.mu.Unlock()
+		klog.V(4).Infof("No vLLM endpoint found for model %s, using fallback tokenizer", model)
+		p.metrics.tokenizerCreationFailures.Inc()
+		return p.config.FallbackTokenizer
+	}
+
+	// Release lock before creating tokenizer and health check
+	p.mu.Unlock()
+
+	// Create remote tokenizer (outside of lock)
+	config := tokenizer.RemoteTokenizerConfig{
+		Engine:             vllmEngine,
+		Endpoint:           endpoint,
+		Model:              model,
+		Timeout:            p.config.Timeout,
+		MaxRetries:         3,
+		AddSpecialTokens:   true,
+		ReturnTokenStrings: false,
+	}
+
+	tok, err := tokenizer.NewRemoteTokenizer(config)
+	if err != nil {
+		klog.Warningf("Failed to create vLLM tokenizer for model %s: %v", model, err)
+		p.metrics.tokenizerCreationFailures.Inc()
+		return p.config.FallbackTokenizer
+	}
+
+	// Verify health (outside of lock)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if remoteTok, ok := tok.(interface{ IsHealthy(context.Context) bool }); ok {
+		if !remoteTok.IsHealthy(ctx) {
+			klog.Warningf("Created tokenizer for model %s is not healthy", model)
+			p.metrics.tokenizerCreationFailures.Inc()
+			return p.config.FallbackTokenizer
+		}
+	}
+
+	// Re-acquire lock to update the pool
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Double-check: another goroutine might have created it while we were checking health
+	if entry, exists := p.tokenizers[model]; exists && entry.healthStatus {
+		// Another goroutine beat us to it, use theirs and discard ours
+		entry.lastUsed = time.Now()
+		// Close the tokenizer we just created since we won't use it
+		if closer, ok := tok.(interface{ Close() error }); ok {
+			_ = closer.Close()
+		}
+		return entry.tokenizer
+	}
+
+	// Add to pool
+	now := time.Now()
+	p.tokenizers[model] = &tokenizerEntry{
+		tokenizer:    tok,
+		endpoint:     endpoint,
+		lastUsed:     now,
+		lastHealthy:  now,
+		healthStatus: true,
+	}
+
+	p.metrics.activeTokenizers.Set(float64(len(p.tokenizers)))
+	p.metrics.tokenizerCreationSuccesses.Inc()
+	klog.V(3).Infof("Created vLLM tokenizer for model %s at endpoint %s", model, endpoint)
+
+	return tok
+}
+
+// findVLLMEndpointForModel finds the vLLM endpoint for a specific model
+func (p *TokenizerPool) findVLLMEndpointForModel(model string, pods []*v1.Pod) string {
+	// Priority order for endpoint discovery:
+	// 1. Service endpoint (if configured)
+	if endpoint, exists := p.config.ModelServiceMap[model]; exists {
+		return endpoint
+	}
+
+	// 2. Direct pod endpoint
+	for _, pod := range pods {
+		if !isPodReady(pod) {
+			continue
+		}
+
+		// Check model match
+		podModel := getModelFromPod(pod)
+		if podModel != model {
+			continue
+		}
+
+		// Check if it's a vLLM pod
+		if !isVLLMPod(pod) {
+			continue
+		}
+
+		return fmt.Sprintf(p.config.EndpointTemplate, pod.Status.PodIP)
+	}
+
+	return ""
+}
+
+// getModelFromPod extracts model information from pod
+func getModelFromPod(pod *v1.Pod) string {
+	// 1. Check labels (highest priority) - using constants with backward compatibility
+	model := constants.GetModelName(pod.Labels)
+	if model != "" {
+		return model
+	}
+
+	// 2. Check annotations - using constants with backward compatibility
+	model = constants.GetModelName(pod.Annotations)
+	if model != "" {
+		return model
+	}
+
+	// 3. Check environment variables
+	for _, container := range pod.Spec.Containers {
+		for _, env := range container.Env {
+			if env.Name == "MODEL_NAME" || env.Name == "MODEL" {
+				return env.Value
+			}
+		}
+	}
+
+	return ""
+}
+
+// isVLLMPod checks if a pod is running vLLM engine
+func isVLLMPod(pod *v1.Pod) bool {
+	// Check labels - using constants with backward compatibility
+	engine := constants.GetInferenceEngine(pod.Labels)
+	if engine == vllmEngine {
+		return true
+	}
+
+	// Check annotations - using constants with backward compatibility
+	engine = constants.GetInferenceEngine(pod.Annotations)
+	if engine == vllmEngine {
+		return true
+	}
+
+	// Check environment variables
+	for _, container := range pod.Spec.Containers {
+		for _, env := range container.Env {
+			if env.Name == "INFERENCE_ENGINE" && env.Value == vllmEngine {
+				return true
+			}
+		}
+	}
+
+	// Default assumption based on port (vLLM typically runs on 8000)
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.ContainerPort == 8000 {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// isPodReady checks if a pod is ready to serve requests
+func isPodReady(pod *v1.Pod) bool {
+	if pod.Status.Phase != v1.PodRunning {
+		return false
+	}
+
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == v1.PodReady && condition.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+// startHealthChecker starts the background health checking routine
+func (p *TokenizerPool) startHealthChecker() {
+	ticker := time.NewTicker(p.config.HealthCheckPeriod)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				p.performHealthCheck()
+				p.cleanupStaleTokenizers()
+			case <-p.stopCh:
+				return
+			}
+		}
+	}()
+}
+
+// performHealthCheck checks health of all tokenizers
+func (p *TokenizerPool) performHealthCheck() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for model, entry := range p.tokenizers {
+		if remoteTok, ok := entry.tokenizer.(interface{ IsHealthy(context.Context) bool }); ok {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			healthy := remoteTok.IsHealthy(ctx)
+			cancel()
+
+			oldStatus := entry.healthStatus
+			entry.healthStatus = healthy
+			if healthy {
+				entry.lastHealthy = time.Now()
+			} else if oldStatus {
+				// Only log and count when transitioning from healthy to unhealthy
+				klog.Warningf("Tokenizer for model %s is now unhealthy", model)
+				p.metrics.unhealthyTokenizers.Inc()
+			}
+		}
+	}
+}
+
+// cleanupStaleTokenizers removes unused tokenizers
+func (p *TokenizerPool) cleanupStaleTokenizers() {
+	var staleTokenizers []struct {
+		model string
+		tok   tokenizer.Tokenizer
+	}
+
+	// Collect stale tokenizers under lock
+	p.mu.Lock()
+	now := time.Now()
+	for model, entry := range p.tokenizers {
+		// Remove if unused for TTL duration
+		if now.Sub(entry.lastUsed) > p.config.TokenizerTTL {
+			staleTokenizers = append(staleTokenizers, struct {
+				model string
+				tok   tokenizer.Tokenizer
+			}{model: model, tok: entry.tokenizer})
+			delete(p.tokenizers, model)
+			klog.V(4).Infof("Removed stale tokenizer for model %s", model)
+		}
+	}
+	p.metrics.activeTokenizers.Set(float64(len(p.tokenizers)))
+	p.mu.Unlock()
+
+	// Close tokenizers outside of lock
+	for _, stale := range staleTokenizers {
+		if closer, ok := stale.tok.(interface{ Close() error }); ok {
+			if err := closer.Close(); err != nil {
+				klog.Errorf("Error closing tokenizer for model %s: %v", stale.model, err)
+			}
+		}
+	}
+}
+
+// Close gracefully shuts down the TokenizerPool
+func (p *TokenizerPool) Close() error {
+	// Stop health checker
+	close(p.stopCh)
+
+	var tokenizersToClose []struct {
+		model string
+		tok   tokenizer.Tokenizer
+	}
+
+	// Collect all tokenizers under lock
+	p.mu.Lock()
+	for model, entry := range p.tokenizers {
+		tokenizersToClose = append(tokenizersToClose, struct {
+			model string
+			tok   tokenizer.Tokenizer
+		}{model: model, tok: entry.tokenizer})
+	}
+	p.tokenizers = make(map[string]*tokenizerEntry)
+	p.metrics.activeTokenizers.Set(0)
+	p.mu.Unlock()
+
+	// Close tokenizers outside of lock
+	for _, item := range tokenizersToClose {
+		if closer, ok := item.tok.(interface{ Close() error }); ok {
+			if err := closer.Close(); err != nil {
+				klog.Errorf("Error closing tokenizer for model %s: %v", item.model, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/plugins/gateway/algorithms/tokenizer_pool_test.go
+++ b/pkg/plugins/gateway/algorithms/tokenizer_pool_test.go
@@ -1,0 +1,740 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/utils/tokenizer"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Mock tokenizer for testing
+type mockTokenizer struct {
+	mock.Mock
+}
+
+func (m *mockTokenizer) TokenizeInputText(text string) ([]byte, error) {
+	args := m.Called(text)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *mockTokenizer) TokenizeWithOptions(ctx context.Context, input tokenizer.TokenizeInput) (*tokenizer.TokenizeResult, error) {
+	args := m.Called(ctx, input)
+	if result := args.Get(0); result != nil {
+		return result.(*tokenizer.TokenizeResult), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockTokenizer) Detokenize(ctx context.Context, tokens []int) (string, error) {
+	args := m.Called(ctx, tokens)
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockTokenizer) GetEndpoint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *mockTokenizer) IsHealthy(ctx context.Context) bool {
+	args := m.Called(ctx)
+	return args.Bool(0)
+}
+
+func (m *mockTokenizer) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+// Helper function to create test pods
+func createTestPod(name, model, engine string, ready bool) v1.Pod {
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"model.aibrix.ai/name": model,
+			},
+			Annotations: map[string]string{},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "vllm",
+					Env: []v1.EnvVar{
+						{Name: "INFERENCE_ENGINE", Value: engine},
+					},
+					Ports: []v1.ContainerPort{
+						{ContainerPort: 8000},
+					},
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			PodIP: fmt.Sprintf("10.0.0.%d", len(name)%255),
+		},
+	}
+
+	if ready {
+		pod.Status.Conditions = []v1.PodCondition{
+			{Type: v1.PodReady, Status: v1.ConditionTrue},
+		}
+	}
+
+	return pod
+}
+
+func TestGetModelFromPod(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      v1.Pod
+		expected string
+	}{
+		{
+			name: "model from label",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"model.aibrix.ai/name": "llama2-7b",
+					},
+				},
+			},
+			expected: "llama2-7b",
+		},
+		{
+			name: "model from annotation",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"model.aibrix.ai/name": "qwen-7b",
+					},
+				},
+			},
+			expected: "qwen-7b",
+		},
+		{
+			name: "model from env var MODEL_NAME",
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Env: []v1.EnvVar{
+								{Name: "MODEL_NAME", Value: "gpt2"},
+							},
+						},
+					},
+				},
+			},
+			expected: "gpt2",
+		},
+		{
+			name: "model from env var MODEL",
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Env: []v1.EnvVar{
+								{Name: "MODEL", Value: "bert-base"},
+							},
+						},
+					},
+				},
+			},
+			expected: "bert-base",
+		},
+		{
+			name:     "no model info",
+			pod:      v1.Pod{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getModelFromPod(&tt.pod)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsVLLMPod(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      v1.Pod
+		expected bool
+	}{
+		{
+			name: "vllm from label",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"model.aibrix.ai/engine": "vllm",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "vllm from annotation",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"model.aibrix.ai/engine": "vllm",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "vllm from env var",
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Env: []v1.EnvVar{
+								{Name: "INFERENCE_ENGINE", Value: "vllm"},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "vllm from port 8000",
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Ports: []v1.ContainerPort{
+								{ContainerPort: 8000},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "not vllm",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"model.aibrix.ai/engine": "sglang",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isVLLMPod(&tt.pod)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsPodReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      v1.Pod
+		expected bool
+	}{
+		{
+			name: "ready pod",
+			pod: v1.Pod{
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					Conditions: []v1.PodCondition{
+						{Type: v1.PodReady, Status: v1.ConditionTrue},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "not running",
+			pod: v1.Pod{
+				Status: v1.PodStatus{
+					Phase: v1.PodPending,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "running but not ready",
+			pod: v1.Pod{
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					Conditions: []v1.PodCondition{
+						{Type: v1.PodReady, Status: v1.ConditionFalse},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isPodReady(&tt.pod)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// createTestCache creates a test cache that doesn't require initialization
+func createTestCache() cache.Cache {
+	// Create a new test cache instance
+	testCache := cache.NewForTest()
+	return testCache
+}
+
+// resetPrometheusRegistry resets the Prometheus registry to avoid duplicate registration
+func resetPrometheusRegistry() {
+	// Create a new registry for each test to avoid conflicts
+	reg := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = reg
+	prometheus.DefaultGatherer = reg
+}
+
+func TestTokenizerPoolGetTokenizer(t *testing.T) {
+	resetPrometheusRegistry()
+
+	// Create a mock fallback tokenizer
+	fallbackTokenizer := &mockTokenizer{}
+	fallbackTokenizer.On("TokenizeInputText", mock.Anything).Return([]byte("fallback"), nil)
+
+	// Create test cache
+	testCache := createTestCache()
+
+	config := TokenizerPoolConfig{
+		EnableVLLMRemote:     false, // Disabled initially
+		EndpointTemplate:     "http://%s:8000",
+		HealthCheckPeriod:    30 * time.Second,
+		TokenizerTTL:         5 * time.Minute,
+		MaxTokenizersPerPool: 100,
+		FallbackTokenizer:    fallbackTokenizer,
+		Timeout:              10 * time.Second,
+		ModelServiceMap:      map[string]string{},
+	}
+
+	pool := NewTokenizerPool(config, testCache)
+	defer func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("Failed to close pool: %v", err)
+		}
+	}()
+
+	t.Run("remote disabled returns fallback", func(t *testing.T) {
+		pod := createTestPod("pod1", "llama2-7b", "vllm", true)
+		pods := []*v1.Pod{&pod}
+
+		tok := pool.GetTokenizer("llama2-7b", pods)
+		assert.Equal(t, fallbackTokenizer, tok)
+	})
+
+	t.Run("no matching pod returns fallback", func(t *testing.T) {
+		pool.config.EnableVLLMRemote = true
+
+		pod := createTestPod("pod1", "different-model", "vllm", true)
+		pods := []*v1.Pod{&pod}
+
+		tok := pool.GetTokenizer("llama2-7b", pods)
+		assert.Equal(t, fallbackTokenizer, tok)
+	})
+
+	t.Run("service map takes precedence", func(t *testing.T) {
+		pool.config.EnableVLLMRemote = true
+		pool.config.ModelServiceMap["llama2-7b"] = "http://llama-service:8000"
+
+		pod := createTestPod("pod1", "llama2-7b", "vllm", true)
+		pods := []*v1.Pod{&pod}
+
+		// Since we can't create actual remote tokenizers in unit tests,
+		// just verify the endpoint discovery works
+		endpoint := pool.findVLLMEndpointForModel("llama2-7b", pods)
+		assert.Equal(t, "http://llama-service:8000", endpoint)
+	})
+}
+
+func TestTokenizerPoolHealthCheck(t *testing.T) {
+	resetPrometheusRegistry()
+
+	// Create mock tokenizers
+	healthyTokenizer := &mockTokenizer{}
+	healthyTokenizer.On("IsHealthy", mock.Anything).Return(true)
+	healthyTokenizer.On("Close").Return(nil)
+
+	unhealthyTokenizer := &mockTokenizer{}
+	unhealthyTokenizer.On("IsHealthy", mock.Anything).Return(false)
+	unhealthyTokenizer.On("Close").Return(nil)
+
+	fallbackTokenizer := &mockTokenizer{}
+
+	testCache := createTestCache()
+
+	config := TokenizerPoolConfig{
+		EnableVLLMRemote:     true,
+		HealthCheckPeriod:    100 * time.Millisecond,
+		TokenizerTTL:         200 * time.Millisecond,
+		MaxTokenizersPerPool: 100,
+		FallbackTokenizer:    fallbackTokenizer,
+	}
+
+	pool := NewTokenizerPool(config, testCache)
+	defer func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("Failed to close pool: %v", err)
+		}
+	}()
+
+	// Manually add tokenizers to the pool
+	pool.mu.Lock()
+	pool.tokenizers["model1"] = &tokenizerEntry{
+		tokenizer:    healthyTokenizer,
+		endpoint:     "http://10.0.0.1:8000",
+		lastUsed:     time.Now(),
+		lastHealthy:  time.Now(),
+		healthStatus: true,
+	}
+	pool.tokenizers["model2"] = &tokenizerEntry{
+		tokenizer:    unhealthyTokenizer,
+		endpoint:     "http://10.0.0.2:8000",
+		lastUsed:     time.Now(),
+		lastHealthy:  time.Now(),
+		healthStatus: true,
+	}
+	pool.mu.Unlock()
+
+	// Let health checker run
+	time.Sleep(150 * time.Millisecond)
+
+	// Check health statuses
+	pool.mu.RLock()
+	assert.True(t, pool.tokenizers["model1"].healthStatus)
+	assert.False(t, pool.tokenizers["model2"].healthStatus)
+	pool.mu.RUnlock()
+
+	// Wait for TTL to expire
+	time.Sleep(250 * time.Millisecond)
+
+	// Check that stale tokenizers are removed
+	pool.mu.RLock()
+	assert.Len(t, pool.tokenizers, 0)
+	pool.mu.RUnlock()
+
+	healthyTokenizer.AssertExpectations(t)
+	unhealthyTokenizer.AssertExpectations(t)
+}
+
+func TestTokenizerPoolMaxSize(t *testing.T) {
+	resetPrometheusRegistry()
+
+	fallbackTokenizer := &mockTokenizer{}
+	fallbackTokenizer.On("TokenizeInputText", mock.Anything).Return([]byte("fallback"), nil)
+
+	testCache := createTestCache()
+
+	config := TokenizerPoolConfig{
+		EnableVLLMRemote:     true,
+		MaxTokenizersPerPool: 2,
+		FallbackTokenizer:    fallbackTokenizer,
+		EndpointTemplate:     "http://%s:8000",
+		HealthCheckPeriod:    30 * time.Second,
+		TokenizerTTL:         5 * time.Minute,
+	}
+
+	pool := NewTokenizerPool(config, testCache)
+	defer func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("Failed to close pool: %v", err)
+		}
+	}()
+
+	// Create mock tokenizers with Close expectations
+	mockTok1 := &mockTokenizer{}
+	mockTok1.On("Close").Return(nil)
+	mockTok2 := &mockTokenizer{}
+	mockTok2.On("Close").Return(nil)
+
+	// Fill the pool to max capacity
+	pool.mu.Lock()
+	pool.tokenizers["model1"] = &tokenizerEntry{tokenizer: mockTok1, healthStatus: true}
+	pool.tokenizers["model2"] = &tokenizerEntry{tokenizer: mockTok2, healthStatus: true}
+	pool.mu.Unlock()
+
+	// Try to get a tokenizer for a new model
+	pod := createTestPod("pod3", "model3", "vllm", true)
+	pods := []*v1.Pod{&pod}
+
+	tok := pool.GetTokenizer("model3", pods)
+	assert.Equal(t, fallbackTokenizer, tok)
+
+	// Verify pool size didn't increase
+	pool.mu.RLock()
+	assert.Len(t, pool.tokenizers, 2)
+	pool.mu.RUnlock()
+}
+
+func TestTokenizerPoolConcurrency(t *testing.T) {
+	resetPrometheusRegistry()
+
+	fallbackTokenizer := &mockTokenizer{}
+	fallbackTokenizer.On("TokenizeInputText", mock.Anything).Return([]byte("fallback"), nil)
+
+	testCache := createTestCache()
+
+	config := TokenizerPoolConfig{
+		EnableVLLMRemote:     true,
+		EndpointTemplate:     "http://%s:8000",
+		HealthCheckPeriod:    100 * time.Millisecond,
+		TokenizerTTL:         200 * time.Millisecond,
+		MaxTokenizersPerPool: 100,
+		FallbackTokenizer:    fallbackTokenizer,
+		Timeout:              1 * time.Second,
+	}
+
+	pool := NewTokenizerPool(config, testCache)
+	defer func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("Failed to close pool: %v", err)
+		}
+	}()
+
+	// Simulate concurrent access
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				tok := pool.GetTokenizer("test-model", nil)
+				// Simulate usage
+				time.Sleep(time.Microsecond)
+				_ = tok
+			}
+		}(i)
+	}
+
+	// Wait for all goroutines
+	wg.Wait()
+}
+
+func TestTokenizerPoolRaceCondition(t *testing.T) {
+	resetPrometheusRegistry()
+
+	fallbackTokenizer := &mockTokenizer{}
+	fallbackTokenizer.On("TokenizeInputText", mock.Anything).Return([]byte("fallback"), nil)
+
+	testCache := createTestCache()
+
+	config := TokenizerPoolConfig{
+		EnableVLLMRemote:     true,
+		EndpointTemplate:     "http://%s:8000",
+		HealthCheckPeriod:    10 * time.Millisecond,
+		TokenizerTTL:         50 * time.Millisecond,
+		MaxTokenizersPerPool: 100,
+		FallbackTokenizer:    fallbackTokenizer,
+		Timeout:              1 * time.Second,
+	}
+
+	pool := NewTokenizerPool(config, testCache)
+	defer func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("Failed to close pool: %v", err)
+		}
+	}()
+
+	// Create a mock pod
+	pod := createTestPod("test-pod", "test-model", "vllm", true)
+	pods := []*v1.Pod{&pod}
+
+	// Pre-populate the tokenizer
+	mockTok := &mockTokenizer{}
+	mockTok.On("IsHealthy", mock.Anything).Return(true)
+	mockTok.On("Close").Return(nil).Maybe()
+
+	pool.mu.Lock()
+	pool.tokenizers["test-model"] = &tokenizerEntry{
+		tokenizer:    mockTok,
+		endpoint:     "http://10.0.0.1:8000",
+		lastUsed:     time.Now(),
+		lastHealthy:  time.Now(),
+		healthStatus: true,
+	}
+	pool.mu.Unlock()
+
+	// Start goroutines that continuously access the tokenizer
+	done := make(chan bool)
+	var wg sync.WaitGroup
+
+	// Reader goroutines
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					tok := pool.GetTokenizer("test-model", pods)
+					_ = tok
+					time.Sleep(time.Microsecond)
+				}
+			}
+		}()
+	}
+
+	// Let it run for a while to trigger cleanup
+	time.Sleep(100 * time.Millisecond)
+
+	// Signal all goroutines to stop
+	close(done)
+	wg.Wait()
+}
+
+func TestCreateOrUpdateConcurrency(t *testing.T) {
+	resetPrometheusRegistry()
+
+	fallbackTokenizer := &mockTokenizer{}
+	fallbackTokenizer.On("TokenizeInputText", mock.Anything).Return([]byte("fallback"), nil)
+
+	testCache := createTestCache()
+
+	config := TokenizerPoolConfig{
+		EnableVLLMRemote:     true,
+		EndpointTemplate:     "http://%s:8000",
+		HealthCheckPeriod:    30 * time.Second,
+		TokenizerTTL:         5 * time.Minute,
+		MaxTokenizersPerPool: 100,
+		FallbackTokenizer:    fallbackTokenizer,
+		Timeout:              10 * time.Second,
+	}
+
+	pool := NewTokenizerPool(config, testCache)
+	defer func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("Failed to close pool: %v", err)
+		}
+	}()
+
+	// Create test pods
+	pods := make([]*v1.Pod, 5)
+	for i := 0; i < 5; i++ {
+		pod := createTestPod(fmt.Sprintf("pod%d", i), fmt.Sprintf("model%d", i), "vllm", true)
+		pods[i] = &pod
+	}
+
+	// Test concurrent creation of tokenizers for different models
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(modelIdx int) {
+			defer wg.Done()
+			model := fmt.Sprintf("model%d", modelIdx)
+
+			// Multiple goroutines try to create tokenizer for same model
+			var innerWg sync.WaitGroup
+			for j := 0; j < 3; j++ {
+				innerWg.Add(1)
+				go func() {
+					defer innerWg.Done()
+					tok := pool.GetTokenizer(model, pods)
+					_ = tok
+				}()
+			}
+			innerWg.Wait()
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify no deadlocks or race conditions occurred
+	// The test passing with -race flag is the main validation
+}
+
+func BenchmarkTokenizerPoolConcurrentCreation(b *testing.B) {
+	resetPrometheusRegistry()
+
+	fallbackTokenizer := &mockTokenizer{}
+	fallbackTokenizer.On("TokenizeInputText", mock.Anything).Return([]byte("fallback"), nil)
+
+	testCache := createTestCache()
+
+	config := TokenizerPoolConfig{
+		EnableVLLMRemote:     true,
+		EndpointTemplate:     "http://%s:8000",
+		HealthCheckPeriod:    30 * time.Second,
+		TokenizerTTL:         5 * time.Minute,
+		MaxTokenizersPerPool: 100,
+		FallbackTokenizer:    fallbackTokenizer,
+		Timeout:              10 * time.Second,
+	}
+
+	pool := NewTokenizerPool(config, testCache)
+	defer func() {
+		if err := pool.Close(); err != nil {
+			b.Errorf("Failed to close pool: %v", err)
+		}
+	}()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			tok := pool.GetTokenizer("test-model", nil)
+			_ = tok
+		}
+	})
+}
+
+func BenchmarkTimeNowOptimization(b *testing.B) {
+	// Unoptimized version
+	b.Run("Unoptimized", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = &tokenizerEntry{
+				lastUsed:     time.Now(),
+				lastHealthy:  time.Now(),
+				healthStatus: true,
+			}
+		}
+	})
+
+	// Optimized version
+	b.Run("Optimized", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			now := time.Now()
+			_ = &tokenizerEntry{
+				lastUsed:     now,
+				lastHealthy:  now,
+				healthStatus: true,
+			}
+		}
+	})
+}

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/pkoukk/tiktoken-go"
 	tiktoken_loader "github.com/pkoukk/tiktoken-go-loader"
@@ -118,5 +119,37 @@ func LoadEnvFloat(key string, defaultValue float64) float64 {
 		}
 	}
 	klog.Infof("set %s: %g, using default value", key, defaultValue)
+	return defaultValue
+}
+
+// LoadEnvBool loads a boolean environment variable or returns a default value if not set.
+func LoadEnvBool(key string, defaultValue bool) bool {
+	value := os.Getenv(key)
+	if value != "" {
+		boolValue, err := strconv.ParseBool(value)
+		if err != nil {
+			klog.Warningf("invalid %s: %s, falling back to default: %v", key, value, defaultValue)
+		} else {
+			klog.Infof("set %s: %v", key, boolValue)
+			return boolValue
+		}
+	}
+	klog.Infof("set %s: %v, using default value", key, defaultValue)
+	return defaultValue
+}
+
+// LoadEnvDuration loads a duration environment variable or returns a default value if not set.
+func LoadEnvDuration(key string, defaultValue time.Duration) time.Duration {
+	value := os.Getenv(key)
+	if value != "" {
+		duration, err := time.ParseDuration(value)
+		if err != nil {
+			klog.Warningf("invalid %s: %s, falling back to default: %v", key, value, defaultValue)
+		} else {
+			klog.Infof("set %s: %v", key, duration)
+			return duration
+		}
+	}
+	klog.Infof("set %s: %v, using default value", key, defaultValue)
 	return defaultValue
 }


### PR DESCRIPTION
  ## feature: Add vLLM Remote Tokenizer with Engine Integration

  ### Summary
  This PR introduces support for vLLM remote tokenizers that can leverage the tokenization capabilities directly from vLLM engine instances. This feature enables more
  accurate tokenization by using the same tokenizer as the serving engine, ensuring consistency between token counting and actual model processing.

  ### Motivation
  - **Tokenizer Consistency**: Using the same tokenizer as the vLLM engine ensures accurate token counting for routing decisions
  - **Model-Specific Tokenization**: Different models may use different tokenizers - this feature automatically uses the correct tokenizer for each model
  - **Dynamic Scaling**: Remote tokenizers can scale with the vLLM instances, eliminating the need to maintain separate tokenizer deployments

  ### What's Changed
  - Added `TokenizerPool` for managing model-specific remote tokenizers with health checking and connection pooling
  - Integrated vLLM HTTP tokenization endpoints into the prefix cache routing algorithm
  - Added configuration options for remote tokenizer behavior
  - Implemented fallback mechanism to maintain backward compatibility
  - Added utility functions `LoadEnvDuration` and `LoadEnvBool` for configuration parsing

  ### How to Enable

  To enable the vLLM remote tokenizer feature, set the following environment variable:

  ```bash
  AIBRIX_ENABLE_VLLM_REMOTE_TOKENIZER=true

  Configuration Options

  | Environment Variable                    | Default        | Description                                                            |
  |-----------------------------------------|----------------|------------------------------------------------------------------------|
  | AIBRIX_ENABLE_VLLM_REMOTE_TOKENIZER     | false          | Enable/disable vLLM remote tokenizer feature                           |
  | AIBRIX_VLLM_TOKENIZER_ENDPOINT_TEMPLATE | http://%s:8000 | URL template for vLLM tokenizer endpoints (%s is replaced with pod IP) |
  | AIBRIX_TOKENIZER_HEALTH_CHECK_PERIOD    | 30s            | How often to check tokenizer health                                    |
  | AIBRIX_TOKENIZER_TTL                    | 5m             | Time-to-live for tokenizer connections                                 |
  | AIBRIX_MAX_TOKENIZERS_PER_POOL          | 100            | Maximum number of tokenizers to maintain in the pool                   |
  | AIBRIX_TOKENIZER_REQUEST_TIMEOUT        | 10s            | Timeout for tokenization requests                                      |

  Usage Example

  1. Deploy with the feature enabled using Kustomize:
  kubectl apply -k config/features/vllm-remote-tokenizer

  2. Or manually set the environment variable in your gateway deployment:
  env:
    - name: AIBRIX_ENABLE_VLLM_REMOTE_TOKENIZER
      value: "true"
    - name: AIBRIX_VLLM_TOKENIZER_ENDPOINT_TEMPLATE
      value: "http://%s:8000"  # Adjust if your vLLM uses a different port

  Backward Compatibility

  - When AIBRIX_ENABLE_VLLM_REMOTE_TOKENIZER=false (default), the system uses the original local tokenizer
  - Existing deployments will continue to work without any changes
  - The feature gracefully falls back to local tokenization if remote tokenizers are unavailable

  Testing

  - Tested with vLLM 0.5.x and 0.6.x
  - Verified fallback behavior when vLLM endpoints are unavailable
  - Load tested with multiple concurrent requests across different models
  - Confirmed proper health checking and connection recycling