### PR TITLE
Fix P/D disaggregation router to follow Nixl kv_transfer_params

### DIFF
--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -205,14 +205,26 @@ func (r *pdRouter) doPrefillRequest(routingCtx *types.RoutingContext, prefillPod
 
 	if llmEngine == SGLangEngine {
 		go func() {
-			if err := r.executeHTTPRequest(apiURL, routingCtx, payload); err != nil {
+			if _, err := r.executeHTTPRequest(apiURL, routingCtx, payload); err != nil {
 				klog.ErrorS(err, "prefill request for sglang failed", "request_id", routingCtx.RequestID)
 				return
 			}
 			klog.InfoS("prefill_request_complete", "request_id", routingCtx.RequestID)
 		}()
+	} else if llmEngine == VLLMEngine {
+		responseData, err := r.executeHTTPRequest(apiURL, routingCtx, payload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute prefill request: %w", err)
+		}
+
+		// Update routing context with KV transfer params from prefill response for vLLM
+		if err := r.updateRoutingContextWithKVTransferParams(routingCtx, responseData, prefillPod); err != nil {
+			return nil, fmt.Errorf("failed to update routing context with KV transfer params: %w", err)
+		}
+
+		klog.InfoS("prefill_request_complete", "request_id", routingCtx.RequestID, "prefill_pod_ip", prefillPod.Status.PodIP)
 	} else {
-		if err := r.executeHTTPRequest(apiURL, routingCtx, payload); err != nil {
+		if _, err := r.executeHTTPRequest(apiURL, routingCtx, payload); err != nil {
 			return nil, fmt.Errorf("failed to execute prefill request: %w", err)
 		}
 		klog.InfoS("prefill_request_complete", "request_id", routingCtx.RequestID, "prefill_pod_ip", prefillPod.Status.PodIP)
@@ -243,6 +255,18 @@ func (r *pdRouter) preparePrefillPayload(routingCtx *types.RoutingContext, pod *
 		routingCtx.ReqBody = bodyCopy
 	}
 
+	// Add nixl-specific kv_transfer_params for vLLM prefill requests only
+	if llmEngine == VLLMEngine {
+		completionRequest["kv_transfer_params"] = map[string]any{
+			"do_remote_decode":  true,
+			"do_remote_prefill": false,
+			"remote_engine_id":  nil,
+			"remote_block_ids":  nil,
+			"remote_host":       nil,
+			"remote_port":       nil,
+		}
+	}
+
 	// Set prefill-specific parameters
 	completionRequest["max_tokens"] = 1
 	completionRequest["max_completion_tokens"] = 1
@@ -252,11 +276,11 @@ func (r *pdRouter) preparePrefillPayload(routingCtx *types.RoutingContext, pod *
 	return json.Marshal(completionRequest)
 }
 
-func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingContext, payload []byte) error {
+func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingContext, payload []byte) (map[string]any, error) {
 	// Create request with context
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
 	if err != nil {
-		return fmt.Errorf("failed to create http prefill request: %w", err)
+		return nil, fmt.Errorf("failed to create http prefill request: %w", err)
 	}
 
 	// Set headers
@@ -264,24 +288,71 @@ func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingConte
 		req.Header.Set(key, value)
 	}
 	req.Header.Set("content-type", "application/json")
-	req.Header.Set("content-length", strconv.Itoa(len(payload)))
+	req.Header.Set("X-Request-Id", routingCtx.RequestID)
 
-	// Execute with timeout
-	client := &http.Client{Timeout: time.Duration(prefillRequestTimeout) * time.Second}
+	client := &http.Client{
+		Timeout: time.Duration(prefillRequestTimeout) * time.Second,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to execute http prefill request: %w", err)
+		return nil, fmt.Errorf("failed to execute http prefill request: %w", err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
 
-	// Check response status
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("http prefill request failed with status %d: %s", resp.StatusCode, string(body))
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read prefill response body: %w", err)
 	}
 
+	// Check response status
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http prefill request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse response JSON
+	var responseData map[string]any
+	if err := json.Unmarshal(body, &responseData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal prefill response: %w", err)
+	}
+
+	return responseData, nil
+}
+
+func (r *pdRouter) updateRoutingContextWithKVTransferParams(routingCtx *types.RoutingContext, responseData map[string]any, prefillPod *v1.Pod) error {
+	// Extract kv_transfer_params from prefill response
+	kvTransferParams, exists := responseData["kv_transfer_params"]
+	if !exists {
+		klog.InfoS("no kv_transfer_params in prefill response", "request_id", routingCtx.RequestID)
+		return nil
+	}
+
+	// Parse the original request body
+	var originalRequest map[string]any
+	if err := json.Unmarshal(routingCtx.ReqBody, &originalRequest); err != nil {
+		return fmt.Errorf("failed to unmarshal original request body: %w", err)
+	}
+
+	// Update request body with KV transfer params from prefill response
+	originalRequest["kv_transfer_params"] = kvTransferParams
+
+	// Add prefill host information following the Python pattern
+	if kvTransferParamsMap, ok := kvTransferParams.(map[string]any); ok {
+		kvTransferParamsMap["remote_host"] = prefillPod.Status.PodIP
+	}
+
+	// Marshal the updated request body
+	updatedReqBody, err := json.Marshal(originalRequest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated request body: %w", err)
+	}
+
+	// Update routing context with new request body
+	routingCtx.ReqBody = updatedReqBody
+
+	klog.InfoS("updated routing context with kv_transfer_params", "request_id", routingCtx.RequestID, "prefill_host", prefillPod.Status.PodIP)
 	return nil
 }
 

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -55,7 +55,6 @@ func TestPDRouter_Route(t *testing.T) {
 					Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}}},
 			},
 			serverCode:  http.StatusOK,
-			serverResp:  "success",
 			llmEngine:   "vllm",
 			expectError: false,
 			expectMsg:   "127.0.0.2:8000",
@@ -84,7 +83,7 @@ func TestPDRouter_Route(t *testing.T) {
 			ts := setupTestServer(t, tt.serverCode, tt.serverResp, tt.llmEngine)
 			defer ts.Close()
 
-			ctx := types.NewRoutingContext(context.Background(), "test", "model", "message", "request", "user")
+			ctx := types.NewRoutingContext(context.Background(), "test", "model", "message", "test-request", "user")
 			ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
 
 			result, err := r.Route(ctx, &utils.PodArray{Pods: tt.readyPods})
@@ -235,6 +234,268 @@ func TestDoPrefillRequest(t *testing.T) {
 	}
 }
 
+func TestPreparePrefillPayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		llmEngine string
+		reqBody   string
+		checkKV   bool
+	}{
+		{
+			name:      "vllm engine adds kv_transfer_params",
+			llmEngine: VLLMEngine,
+			reqBody:   `{"messages":[{"role":"user","content":"test"}],"stream":true}`,
+			checkKV:   true,
+		},
+		{
+			name:      "sglang engine no kv_transfer_params",
+			llmEngine: SGLangEngine,
+			reqBody:   `{"messages":[{"role":"user","content":"test"}],"stream":true}`,
+			checkKV:   false,
+		},
+		{
+			name:      "other engine no kv_transfer_params",
+			llmEngine: "other",
+			reqBody:   `{"messages":[{"role":"user","content":"test"}],"stream":true}`,
+			checkKV:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := &pdRouter{}
+			pod := &v1.Pod{
+				Status: v1.PodStatus{PodIP: "127.0.0.1"},
+			}
+			routingCtx := &types.RoutingContext{
+				ReqBody: []byte(tt.reqBody),
+			}
+
+			payload, err := router.preparePrefillPayload(routingCtx, pod, tt.llmEngine)
+			assert.NoError(t, err)
+
+			var result map[string]any
+			err = json.Unmarshal(payload, &result)
+			assert.NoError(t, err)
+
+			// Check basic prefill parameters
+			assert.Equal(t, float64(1), result["max_tokens"])
+			assert.Equal(t, float64(1), result["max_completion_tokens"])
+			assert.Equal(t, false, result["stream"])
+			_, exists := result["stream_options"]
+			assert.False(t, exists)
+
+			// Check KV transfer params
+			kvParams, hasKV := result["kv_transfer_params"]
+			if tt.checkKV {
+				assert.True(t, hasKV, "vLLM should have kv_transfer_params")
+				kvMap := kvParams.(map[string]any)
+				assert.Equal(t, true, kvMap["do_remote_decode"])
+				assert.Equal(t, false, kvMap["do_remote_prefill"])
+			} else {
+				assert.False(t, hasKV, "non-vLLM engines should not have kv_transfer_params")
+			}
+		})
+	}
+}
+
+func TestUpdateRoutingContextWithKVTransferParams(t *testing.T) {
+	tests := []struct {
+		name         string
+		responseData map[string]any
+		originalBody string
+		expectError  bool
+		expectKV     bool
+	}{
+		{
+			name: "successful kv params update",
+			responseData: map[string]any{
+				"kv_transfer_params": map[string]any{
+					"remote_engine_id": "engine123",
+					"remote_block_ids": []string{"block1", "block2"},
+				},
+			},
+			originalBody: `{"messages":[{"role":"user","content":"test"}]}`,
+			expectError:  false,
+			expectKV:     true,
+		},
+		{
+			name:         "no kv params in response",
+			responseData: map[string]any{"other": "data"},
+			originalBody: `{"messages":[{"role":"user","content":"test"}]}`,
+			expectError:  false,
+			expectKV:     false,
+		},
+		{
+			name:         "invalid json body",
+			responseData: map[string]any{"kv_transfer_params": map[string]any{}},
+			originalBody: `invalid json`,
+			expectError:  true,
+			expectKV:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := &pdRouter{}
+			pod := &v1.Pod{
+				Status: v1.PodStatus{PodIP: "192.168.1.100"},
+			}
+			routingCtx := &types.RoutingContext{
+				RequestID: "test-request",
+				ReqBody:   []byte(tt.originalBody),
+			}
+
+			err := router.updateRoutingContextWithKVTransferParams(routingCtx, tt.responseData, pod)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if tt.expectKV {
+				// Parse updated request body
+				var updatedRequest map[string]any
+				err = json.Unmarshal(routingCtx.ReqBody, &updatedRequest)
+				assert.NoError(t, err)
+
+				// Check KV transfer params were added
+				kvParams, exists := updatedRequest["kv_transfer_params"]
+				assert.True(t, exists)
+
+				// Check remote_host was added
+				kvMap := kvParams.(map[string]any)
+				assert.Equal(t, "192.168.1.100", kvMap["remote_host"])
+			}
+		})
+	}
+}
+
+func TestVLLMIntegrationWithTestServer(t *testing.T) {
+	// Integration test: verify vLLM prefill request extracts KV params from test server
+	ts := setupTestServer(t, http.StatusOK, "", VLLMEngine) // Empty resp means use default vLLM response
+	defer ts.Close()
+
+	prefillPods := []*v1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-test",
+			Labels: map[string]string{
+				LLMEngineIdentifier: VLLMEngine,
+				PDRoleIdentifier:    "prefill",
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP: "127.0.0.1",
+			Conditions: []v1.PodCondition{{
+				Type:   v1.PodReady,
+				Status: v1.ConditionTrue,
+			}},
+		},
+	}}
+
+	routingCtx := &types.RoutingContext{
+		RequestID:  "integration-test",
+		Model:      "test-model",
+		ReqPath:    "/v1/chat/completions",
+		ReqBody:    []byte(`{"messages":[{"role":"user","content":"test"}]}`),
+		ReqHeaders: map[string]string{"Authorization": "Bearer test"},
+	}
+
+	router := &pdRouter{
+		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
+		cache:              cache.NewWithPodsForTest(prefillPods, "test-model"),
+		tokenizer:          tokenizer.NewCharacterTokenizer(),
+	}
+
+	_, err := router.doPrefillRequest(routingCtx, prefillPods, VLLMEngine)
+	assert.NoError(t, err)
+
+	// Verify that routing context was updated with KV transfer params from test server
+	var updatedRequest map[string]any
+	err = json.Unmarshal(routingCtx.ReqBody, &updatedRequest)
+	assert.NoError(t, err)
+
+	kvParams, exists := updatedRequest["kv_transfer_params"]
+	assert.True(t, exists, "KV transfer params should be extracted from test server response")
+
+	kvMap := kvParams.(map[string]any)
+	assert.Equal(t, "127.0.0.1", kvMap["remote_host"], "remote_host should be set to prefill pod IP")
+	assert.Equal(t, "test-engine-123", kvMap["remote_engine_id"], "remote_engine_id should match test server response")
+	assert.Equal(t, true, kvMap["do_remote_decode"], "do_remote_decode should be true from test server")
+	assert.Equal(t, false, kvMap["do_remote_prefill"], "do_remote_prefill should be false from test server")
+
+	// Verify remote_block_ids is present
+	blockIds, ok := kvMap["remote_block_ids"].([]any)
+	assert.True(t, ok, "remote_block_ids should be an array")
+	assert.Len(t, blockIds, 2, "should have 2 block IDs from test server")
+	assert.Equal(t, "block1", blockIds[0])
+	assert.Equal(t, "block2", blockIds[1])
+}
+
+func TestVLLMKVTransferProcessing(t *testing.T) {
+	// Test that updateRoutingContextWithKVTransferParams works correctly for vLLM
+	tests := []struct {
+		name     string
+		response map[string]any
+		checkKV  bool
+	}{
+		{
+			name: "vllm with kv_transfer_params",
+			response: map[string]any{
+				"kv_transfer_params": map[string]any{
+					"remote_engine_id": "test-engine",
+				},
+			},
+			checkKV: true,
+		},
+		{
+			name: "vllm without kv_transfer_params",
+			response: map[string]any{
+				"other_data": "value",
+			},
+			checkKV: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := &pdRouter{}
+			pod := &v1.Pod{Status: v1.PodStatus{PodIP: "192.168.1.1"}}
+			routingCtx := &types.RoutingContext{
+				RequestID: "test-req",
+				ReqBody:   []byte(`{"messages":[{"role":"user","content":"hello"}]}`),
+			}
+
+			// Call the update function (this is only called for vLLM in real flow)
+			err := router.updateRoutingContextWithKVTransferParams(routingCtx, tt.response, pod)
+			assert.NoError(t, err)
+
+			if tt.checkKV {
+				// Body should be updated when KV params are present
+				var updatedRequest map[string]any
+				err = json.Unmarshal(routingCtx.ReqBody, &updatedRequest)
+				assert.NoError(t, err)
+
+				kvParams, exists := updatedRequest["kv_transfer_params"]
+				assert.True(t, exists)
+				if kvMap, ok := kvParams.(map[string]any); ok {
+					assert.Equal(t, "192.168.1.1", kvMap["remote_host"])
+					assert.Equal(t, "test-engine", kvMap["remote_engine_id"])
+				}
+			} else {
+				// Body should remain unchanged when no KV params are present
+				var updatedRequest map[string]any
+				err = json.Unmarshal(routingCtx.ReqBody, &updatedRequest)
+				assert.NoError(t, err)
+				_, exists := updatedRequest["kv_transfer_params"]
+				assert.False(t, exists, "KV params should not be added when not in response")
+			}
+		})
+	}
+}
+
 // Common test utilities
 func setupTestServer(t *testing.T, code int, resp string, llmEngine string) *httptest.Server {
 	l, err := net.Listen("tcp", "127.0.0.1:8000")
@@ -264,9 +525,49 @@ func setupTestServer(t *testing.T, code int, resp string, llmEngine string) *htt
 			assert.Equal(t, float64(8998), completionRequest["bootstrap_port"])
 		}
 
+		// Check KV transfer params only for vLLM
+		kvParams, hasKV := completionRequest["kv_transfer_params"]
+		if llmEngine == VLLMEngine {
+			assert.True(t, hasKV, "vLLM should have kv_transfer_params")
+			kvMap := kvParams.(map[string]any)
+			assert.Equal(t, true, kvMap["do_remote_decode"])
+			assert.Equal(t, false, kvMap["do_remote_prefill"])
+		} else {
+			assert.False(t, hasKV, "non-vLLM engines should not have kv_transfer_params")
+		}
+
+		// Check X-Request-Id header is set (should match the request ID from routing context)
+		xRequestId := r.Header.Get("X-Request-Id")
+		assert.NotEmpty(t, xRequestId, "X-Request-Id header should be set")
+		// For most tests it's "test-request", but integration tests use different IDs
+		assert.True(t, xRequestId == "test-request" || xRequestId == "integration-test", "X-Request-Id should be valid request ID")
+
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(code)
 		if resp != "" {
 			_, _ = w.Write([]byte(resp))
+		} else {
+			if llmEngine == VLLMEngine {
+				response := map[string]any{
+					"choices": []map[string]any{{
+						"message": map[string]any{"content": "test response"},
+					}},
+					"kv_transfer_params": map[string]any{
+						"do_remote_decode":  true,
+						"do_remote_prefill": false,
+						"remote_engine_id":  "test-engine-123",
+						"remote_block_ids":  []string{"block1", "block2"},
+						"remote_host":       "127.0.0.1", // please use this ip for testing.
+						"remote_port":       "8080",
+					},
+				}
+				respBytes, _ := json.Marshal(response)
+				_, _ = w.Write(respBytes)
+			} else {
+				// For other engines, return simple success
+				respBytes, _ := json.Marshal(map[string]any{"choices": []map[string]any{{"message": map[string]any{"content": "test response"}}}})
+				_, _ = w.Write(respBytes)
+			}
 		}
 	}))
 

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -86,7 +86,8 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 		headers = buildEnvoyProxyHeaders(headers,
 			HeaderRoutingStrategy, string(routingAlgorithm),
 			HeaderTargetPod, targetPodIP,
-			"content-length", strconv.Itoa(len(routingCtx.ReqBody)))
+			"content-length", strconv.Itoa(len(routingCtx.ReqBody)),
+			"X-Request-Id", routingCtx.RequestID)
 		klog.InfoS("request start", "requestID", requestID, "requestPath", requestPath, "model", model, "stream", stream, "routingAlgorithm", routingAlgorithm, "targetPodIP", targetPodIP, "routingDuration", routingCtx.GetRoutingDelay())
 	}
 

--- a/pkg/plugins/gateway/gateway_req_body_test.go
+++ b/pkg/plugins/gateway/gateway_req_body_test.go
@@ -230,11 +230,17 @@ func Test_handleRequestBody(t *testing.T) {
 							RawValue: []byte("74"),
 						},
 					},
+					{
+						Header: &configPb.HeaderValue{
+							Key:      "X-Request-Id",
+							RawValue: []byte("test-request-id"),
+						},
+					},
 				},
 				model:      "test-model",
 				stream:     false,
 				term:       1,
-				routingCtx: &types.RoutingContext{},
+				routingCtx: &types.RoutingContext{RequestID: "test-request-id"},
 			},
 			validate: func(t *testing.T, tt *testCase, resp *extProcPb.ProcessingResponse, model string, routingCtx *types.RoutingContext, stream bool, term int64) {
 				assert.Equal(t, tt.expected.statusCode, envoyTypePb.StatusCode_OK)


### PR DESCRIPTION
- Add kv_transfer_params configuration to prefill requests and decode requests

## Pull Request Description
this is a follow up PR of #1425, to address the problems in https://github.com/vllm-project/aibrix/issues/1407

## Related Issues

```
python3 benchmark_serving.py --port 8000 --host 192.168.0.138  --seed $(date +%s) \
>       --model qwen3-8B \
>       --tokenizer /models/Qwen3-8B \
>       --dataset-name random --random-input-len 8000 --random-output-len 200 \
>       --num-prompts 200 --burstiness 100 --request-rate 1 --metric-percentiles 95 \
>       --backend openai-chat --endpoint /v1/chat/completions --ignore-eos
```

1st try - without the change - aibrix router
```
Traffic request rate: 1.0 RPS.
Burstiness factor: 100.0 (Gamma distribution)
Maximum request concurrency: None
100%|██████████████████████████████████████████████████████████████████████████████████████████| 200/200 [03:56<00:00,  1.18s/it]
============ Serving Benchmark Result ============
Successful requests:                     200
Benchmark duration (s):                  236.22
Total input tokens:                      1599488
Total generated tokens:                  40000
Request throughput (req/s):              0.85
Output token throughput (tok/s):         169.33
Total Token throughput (tok/s):          6940.49
---------------Time to First Token----------------
Mean TTFT (ms):                          14193.76
Median TTFT (ms):                        12422.17
P95 TTFT (ms):                           33107.99
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          301.22
Median TPOT (ms):                        349.75
P95 TPOT (ms):                           353.99
---------------Inter-token Latency----------------
Mean ITL (ms):                           299.71
Median ITL (ms):                         54.00
P95 ITL (ms):                            1053.71
==================================================
```

2nd try - aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/gateway-plugins:012f7dd20d281df36c4964eb5d455d40ce0abc7e 

```
Traffic request rate: 1.0 RPS.
Burstiness factor: 100.0 (Gamma distribution)
Maximum request concurrency: None
100%|██████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [03:20<00:00,  1.00s/it]
============ Serving Benchmark Result ============
Successful requests:                     200
Benchmark duration (s):                  200.21
Total input tokens:                      1599642
Total generated tokens:                  40000
Request throughput (req/s):              1.00
Output token throughput (tok/s):         199.79
Total Token throughput (tok/s):          8189.69
---------------Time to First Token----------------
Mean TTFT (ms):                          1256.15
Median TTFT (ms):                        1211.70
P95 TTFT (ms):                           1568.65
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.00
Median TPOT (ms):                        9.01
P95 TPOT (ms):                           9.36
---------------Inter-token Latency----------------
Mean ITL (ms):                           8.96
Median ITL (ms):                         8.98
P95 ITL (ms):                            10.09
==================================================
```



another sample - python router version

```
============ Serving Benchmark Result ============
Successful requests:                     200
Benchmark duration (s):                  201.63
Total input tokens:                      1599434
Total generated tokens:                  40000
Request throughput (req/s):              0.99
Output token throughput (tok/s):         198.38
Total Token throughput (tok/s):          8130.74
---------------Time to First Token----------------
Mean TTFT (ms):                          1232.50
Median TTFT (ms):                        1185.72
P95 TTFT (ms):                           1515.11
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.10
Median TPOT (ms):                        9.05
P95 TPOT (ms):                           10.13
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.06
Median ITL (ms):                         9.06
P95 ITL (ms):                            10.26
==================================================
```


**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>