### PR TITLE
[Bug] stormservice's headless service not set ownerRef

### DIFF
--- a/pkg/controller/stormservice/sync.go
+++ b/pkg/controller/stormservice/sync.go
@@ -76,6 +76,9 @@ func (r *StormServiceReconciler) syncHeadlessService(ctx context.Context, servic
 			Name:      service.Name,
 			Namespace: service.Namespace,
 			Labels:    service.Labels,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(service, orchestrationv1alpha1.SchemeGroupVersion.WithKind(orchestrationv1alpha1.StormServiceKind)),
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			Type:      corev1.ServiceTypeClusterIP,

--- a/pkg/controller/stormservice/sync_test.go
+++ b/pkg/controller/stormservice/sync_test.go
@@ -216,6 +216,17 @@ func TestSyncHeadlessService(t *testing.T) {
 				t.Errorf("Expected ClusterIP to be None, got %s", service.Spec.ClusterIP)
 			}
 
+			if tt.existingService == nil {
+				if len(service.OwnerReferences) == 0 {
+					t.Error("Expected service to have an owner reference")
+				} else {
+					ownerRef := service.OwnerReferences[0]
+					if ownerRef.Kind != orchestrationv1alpha1.StormServiceKind || ownerRef.UID != service.UID {
+						t.Errorf("Expected owner reference to be %s %s, got %s %s", orchestrationv1alpha1.StormServiceKind, service.UID, ownerRef.Kind, ownerRef.UID)
+					}
+				}
+			}
+
 			expectedSelector := map[string]string{constants.StormServiceNameLabelKey: tt.stormService.Name}
 			if !reflect.DeepEqual(service.Spec.Selector, expectedSelector) {
 				t.Errorf("Expected selector %v, got %v", expectedSelector, service.Spec.Selector)


### PR DESCRIPTION
## Pull Request Description
The StormService controller currently creates a headless Service without setting its ownerReference.
As a result, when a StormService resource is deleted, the associated headless Service is not automatically cleaned up and remains in the cluster.

This change ensures that the created headless Service has the correct ownerReference so it will be garbage-collected when the StormService is deleted.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>