### PR TITLE
[fix] Correct the headless service ownerReference UID in tests

### DIFF
--- a/pkg/controller/stormservice/sync_test.go
+++ b/pkg/controller/stormservice/sync_test.go
@@ -144,6 +144,7 @@ func TestSyncHeadlessService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-storm",
 					Namespace: "default",
+					UID:       "test-stormservice-uid",
 					Labels: map[string]string{
 						"app": "test",
 					},
@@ -158,12 +159,20 @@ func TestSyncHeadlessService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-storm",
 					Namespace: "default",
+					UID:       "test-stormservice-uid",
 				},
 			},
 			existingService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-storm",
 					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "StormService",
+							APIVersion: "orchestration.aibrix.org/v1alpha1",
+							UID:        "test-stormservice-uid",
+						},
+					},
 				},
 				Spec: corev1.ServiceSpec{
 					Type:      corev1.ServiceTypeClusterIP,
@@ -179,12 +188,20 @@ func TestSyncHeadlessService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-storm",
 					Namespace: "default",
+					UID:       "test-stormservice-uid",
 				},
 			},
 			existingService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-storm",
 					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "StormService",
+							APIVersion: "orchestration.aibrix.org/v1alpha1",
+							UID:        "test-stormservice-uid",
+						},
+					},
 				},
 				Spec: corev1.ServiceSpec{
 					Type:                     corev1.ServiceTypeClusterIP,
@@ -238,14 +255,12 @@ func TestSyncHeadlessService(t *testing.T) {
 				t.Errorf("Expected ClusterIP to be None, got %s", service.Spec.ClusterIP)
 			}
 
-			if tt.existingService == nil {
-				if len(service.OwnerReferences) == 0 {
-					t.Error("Expected service to have an owner reference")
-				} else {
-					ownerRef := service.OwnerReferences[0]
-					if ownerRef.Kind != orchestrationv1alpha1.StormServiceKind || ownerRef.UID != service.UID {
-						t.Errorf("Expected owner reference to be %s %s, got %s %s", orchestrationv1alpha1.StormServiceKind, service.UID, ownerRef.Kind, ownerRef.UID)
-					}
+			if len(service.OwnerReferences) == 0 {
+				t.Error("Expected service to have an owner reference")
+			} else {
+				ownerRef := service.OwnerReferences[0]
+				if ownerRef.Kind != orchestrationv1alpha1.StormServiceKind || ownerRef.UID != tt.stormService.UID {
+					t.Errorf("Expected owner reference to be %s %s, got %s %s", orchestrationv1alpha1.StormServiceKind, tt.stormService.UID, ownerRef.Kind, ownerRef.UID)
 				}
 			}
 


### PR DESCRIPTION
## Pull Request Description
I found an issue in #1442, the test validation logic is incorrect. however, since the original UID is "", so it doesn't throw any issues. 

/cc @bigerous

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>