### PR TITLE
[fix] deep copy template to avoid hash mutation issue

### DIFF
--- a/pkg/controller/roleset/podset_rollsyncer.go
+++ b/pkg/controller/roleset/podset_rollsyncer.go
@@ -357,7 +357,9 @@ func (p *PodSetRoleSyncer) podSetSlotForRole(role *orchestrationv1alpha1.RoleSpe
 }
 
 func (p *PodSetRoleSyncer) createPodSetForRole(roleSet *orchestrationv1alpha1.RoleSet, role *orchestrationv1alpha1.RoleSpec, roleIndex *int) *orchestrationv1alpha1.PodSet {
-	templateHash := p.computeHashFunc(&role.Template, nil)
+	// Make a deep copy of the template first to avoid mutation issues
+	podTemplate := *role.Template.DeepCopy()
+	templateHash := p.computeHashFunc(&podTemplate, nil)
 	podSet := &orchestrationv1alpha1.PodSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: roleSet.Namespace,
@@ -377,7 +379,7 @@ func (p *PodSetRoleSyncer) createPodSetForRole(roleSet *orchestrationv1alpha1.Ro
 		},
 		Spec: orchestrationv1alpha1.PodSetSpec{
 			PodGroupSize: *role.PodGroupSize,
-			Template:     role.Template,
+			Template:     podTemplate,
 			Stateful:     role.Stateful,
 		},
 	}


### PR DESCRIPTION
## Pull Request Description
Fix the mismatch issue

<img width="1382" height="910" alt="image" src="https://github.com/user-attachments/assets/2a03ae35-d751-474c-87fb-137a69b52878" />

The issue was template mutation caused by shared object references:
1. Multiple PodSets were sharing the same `role.Template` object reference
2. When `injectContainerEnvVars` modified containers in one PodSet, it was mutating the shared template
3. This caused subsequent PodSets to compute hashes from the already-modified template
4. Result: PodSet labels used the original hash, but environment variables used hashes from modified templates

```
kubectl get podsets -o json | jq -r '
  .items[] |
  .metadata.name as $name |
  .metadata.labels["role-template-hash"] as $label |
  (.spec.template.spec.containers[]?.env[]? | select(.name=="ROLE_TEMPLATE_HASH") | .value) as $env |
  "\($name): label=\($label), env=\($env)"'


## results

llm-xpyd-roleset-8plg2-decode-76647b8d65-0: label=76647b8d65, env=76647b8d65
llm-xpyd-roleset-8plg2-decode-76647b8d65-1: label=76647b8d65, env=76647b8d65
llm-xpyd-roleset-8plg2-decode-76647b8d65-2: label=76647b8d65, env=76647b8d65
llm-xpyd-roleset-8plg2-prefill-586944488f-0: label=586944488f, env=586944488f
llm-xpyd-roleset-8plg2-prefill-586944488f-1: label=586944488f, env=586944488f
llm-xpyd-roleset-8plg2-prefill-586944488f-2: label=586944488f, env=586944488f

```



## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>