### PR TITLE
[Feature] KVCache: support external cache handle

### DIFF
--- a/python/aibrix_kvcache/aibrix_kvcache/__init__.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/__init__.py
@@ -27,6 +27,7 @@ from .cache_manager import (
     KVCacheManager,
 )
 from .config import KVCacheConfig
+from .memory import ExternalMemoryRegion, MemoryRegion
 from .metrics import KVCacheMetrics
 from .spec import *
 from .status import Status, StatusCodes
@@ -35,6 +36,8 @@ __all__ = [
     "__version__",
     "__version_tuple__",
     "KVCacheHandle",
+    "ExternalMemoryRegion",
+    "MemoryRegion",
     "MemoryRegionKVCacheHandle",
     "GDRKVCacheHandle",
     "TokenListView",

--- a/python/aibrix_kvcache/aibrix_kvcache/cache_handle.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/cache_handle.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import List, Sequence, Tuple
+from typing import Callable, List, Sequence, Tuple
 
 import torch
 
@@ -27,7 +27,14 @@ class KVCacheHandle(ABC):
 
     @property
     @abstractmethod
-    def memory_regions(self) -> Sequence[MemoryRegion | Sequence[MemoryRegion]]:
+    def memory_regions(
+        self,
+    ) -> Sequence[MemoryRegion] | Sequence[Sequence[MemoryRegion]]:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def memory_region_type(self) -> type[MemoryRegion]:
         raise NotImplementedError
 
     @abstractmethod
@@ -58,9 +65,19 @@ class MemoryRegionKVCacheHandle(KVCacheHandle):
         self._block_shape = block_shape
         self._mrs = mrs
 
+        assert len(mrs) > 0, "mrs should not be empty"
+        self._mr_type = type(self._mrs[0])
+
+        for mr in self._mrs[1:]:
+            assert type(mr) is self._mr_type
+
     @property
     def memory_regions(self) -> Sequence[MemoryRegion]:
         return self._mrs
+
+    @property
+    def memory_region_type(self) -> type[MemoryRegion]:
+        return self._mr_type
 
     def to_tensors(self) -> Sequence[torch.Tensor]:
         return MemoryRegion.to_tensors(
@@ -79,6 +96,66 @@ class MemoryRegionKVCacheHandle(KVCacheHandle):
     def __len__(self) -> int:
         return len(self._mrs)
 
+    @staticmethod
+    def create(
+        blocks: Sequence[torch.Tensor],
+        block_spec: KVCacheBlockSpec,
+        slot_mapping: Sequence[int] | torch.Tensor,
+        on_mr_release: Callable[[torch.Tensor, int, int], None] | None = None,
+    ) -> KVCacheHandle:
+        """
+        Create a external MR backed MemoryRegionKVCacheHandle for the given
+        token list.
+
+        Args:
+            blocks: Blocks that have been registered via register_kvcache.
+            block_spec: KVCache block spec.
+            slot_mapping: Mapping from tokens to blocks.
+            on_mr_release: Callback function when memory region is released.
+
+        Returns:
+            KVCacheHandle.
+        """
+        block_ntokens = block_spec.block_ntokens
+        block_nbytes = block_spec.block_nbytes
+        block_dtype = block_spec.block_dtype
+        block_shape = block_spec.block_shape
+        kvcache_block_layout = block_spec.block_layout
+
+        if block_ntokens != block_spec.engine_block_ntokens:
+            assert kvcache_block_layout == KVCacheBlockLayout.NCLD, (
+                "Need to use NCLD layout to support using different block "
+                "sizes for engine's kvcache and AIBrix kvcache"
+            )
+
+        total_blocks = len(blocks)
+        assert total_blocks > 0, "blocks must not be empty"
+
+        ntokens = (
+            len(slot_mapping)
+            if isinstance(slot_mapping, Sequence)
+            else slot_mapping.shape[0]
+        )
+
+        num_blocks = ntokens // block_ntokens
+        mrs: List[ExternalMemoryRegion] = [None for _ in range(num_blocks)]  # type: ignore
+        for i in range(0, ntokens, block_ntokens):
+            block_id = slot_mapping[i] // block_ntokens
+            block_off = slot_mapping[i] % block_ntokens
+            slab = blocks[block_id].flatten().view(torch.uint8)
+            mr = ExternalMemoryRegion(
+                slab=slab,
+                addr=int(
+                    blocks[block_id][block_off].data_ptr() - slab.data_ptr()
+                ),
+                length=block_nbytes,
+                on_release=on_mr_release,
+            )
+
+            mrs[i // block_ntokens] = mr
+
+        return MemoryRegionKVCacheHandle(block_dtype, block_shape, mrs)
+
 
 class GDRKVCacheHandle(KVCacheHandle):
     def __init__(
@@ -91,9 +168,17 @@ class GDRKVCacheHandle(KVCacheHandle):
         self._mr_shape = mr_shape
         self._mrs = mrs
 
+        assert len(mrs) > 0, "mrs should not be empty"
+        assert len(mrs[0]) > 0, "mrs[0] should not be empty"
+        self._mr_type = type(mrs[0][0])
+
     @property
     def memory_regions(self) -> Sequence[Sequence[MemoryRegion]]:
         return self._mrs
+
+    @property
+    def memory_region_type(self) -> type[MemoryRegion]:
+        return self._mr_type
 
     def to_tensors(self) -> Sequence[Sequence[torch.Tensor]]:
         return [
@@ -120,6 +205,7 @@ class GDRKVCacheHandle(KVCacheHandle):
         blocks: Sequence[torch.Tensor],
         block_spec: KVCacheBlockSpec,
         slot_mapping: Sequence[int] | torch.Tensor,
+        on_mr_release: Callable[[torch.Tensor, int, int], None] | None = None,
     ) -> KVCacheHandle:
         """
         Create a KVCacheHandle for the given token list.
@@ -129,6 +215,7 @@ class GDRKVCacheHandle(KVCacheHandle):
                     num_blocks, block_size, num_kv_heads, head_size)
             block_spec: KVCache block spec.
             slot_mapping: Mapping from tokens to blocks.
+            on_mr_release: Callback function when memory region is released.
 
         Returns:
             KVCacheHandle.
@@ -174,7 +261,8 @@ class GDRKVCacheHandle(KVCacheHandle):
                         addr=int(
                             blocks[i][0][block_id].data_ptr() - slab.data_ptr()
                         ),
-                        len=layer_nbytes_per_cache_type,
+                        length=layer_nbytes_per_cache_type,
+                        on_release=on_mr_release,
                     )
 
                     vmr = ExternalMemoryRegion(
@@ -182,7 +270,8 @@ class GDRKVCacheHandle(KVCacheHandle):
                         addr=int(
                             blocks[i][1][block_id].data_ptr() - slab.data_ptr()
                         ),
-                        len=layer_nbytes_per_cache_type,
+                        length=layer_nbytes_per_cache_type,
+                        on_release=on_mr_release,
                     )
                     mrs[j // block_ntokens][i * 2] = kmr
                     mrs[j // block_ntokens][i * 2 + 1] = vmr

--- a/python/aibrix_kvcache/aibrix_kvcache/memory/allocator.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/memory/allocator.py
@@ -110,9 +110,9 @@ class ManagedMemoryRegion(MemoryRegion):
         allocator: "TensorPoolAllocator",
         slab: torch.Tensor,
         addr: int,
-        len: int,
+        length: int,
     ) -> None:
-        super().__init__(slab=slab, addr=addr, len=len)
+        super().__init__(slab=slab, addr=addr, length=length)
         assert allocator is not None
         self.allocator = allocator
         self._init_meta()

--- a/python/aibrix_kvcache/aibrix_kvcache/memory/external_memory_region.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/memory/external_memory_region.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Callable
 
 import torch
 
@@ -26,9 +27,11 @@ class ExternalMemoryRegion(MemoryRegion):
         self,
         slab: torch.Tensor,
         addr: int,
-        len: int,
+        length: int,
+        on_release: Callable[[torch.Tensor, int, int], None] | None = None,
     ) -> None:
-        super().__init__(slab, addr, len)
+        super().__init__(slab, addr, length)
+        self._on_release = on_release
 
     def __repr__(self) -> str:
         return (
@@ -37,4 +40,5 @@ class ExternalMemoryRegion(MemoryRegion):
         )
 
     def destroy_unsafe(self):
-        pass
+        if self._on_release is not None:
+            self._on_release(self.slab, self.addr, self.length)

--- a/python/aibrix_kvcache/aibrix_kvcache/memory/memory_region.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/memory/memory_region.py
@@ -29,13 +29,13 @@ class MemoryRegion(RefCountedObj):
         self,
         slab: torch.Tensor,
         addr: int,
-        len: int,
+        length: int,
     ) -> None:
         super().__init__()
         self.slab = slab
         self.addr = addr
-        self.length = len
-        self.capacity = len
+        self.length = length
+        self.capacity = length
         self._cached_tensor_view: torch.Tensor | None = None
 
     def __len__(self) -> int:
@@ -73,6 +73,13 @@ class MemoryRegion(RefCountedObj):
         self.slab[self.addr : self.addr + len(data)].copy_(
             torch.frombuffer(data, dtype=torch.uint8)
         )
+
+    def copy(self, mr: "MemoryRegion") -> None:
+        assert self.capacity >= mr.length
+        self.slab[self.addr : self.addr + mr.length].copy_(
+            mr.slab[mr.addr : mr.addr + mr.length]
+        )
+        self.length = mr.length
 
     def to_tensor(
         self,

--- a/python/aibrix_kvcache/requirements/test.txt
+++ b/python/aibrix_kvcache/requirements/test.txt
@@ -9,6 +9,6 @@ pytest-rerunfailures
 pytest-benchmark
 pytest-forked
 
-fakeredis >= 2.28.1
+fakeredis==2.30.1
 
 vllm


### PR DESCRIPTION
## Pull Request Description
- ExternalMemoryRegion supports customized callback which will be invoked on MR release
- Enable external cache handle support on both L1 and L2 caches
- NOTE: Need to use NCLD layout if using different block sizes for engine kvcache and AIBrix kvcache

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>