### PR TITLE
Improve the runtime downloader quality

### DIFF
--- a/python/aibrix/aibrix/downloader/__main__.py
+++ b/python/aibrix/aibrix/downloader/__main__.py
@@ -15,12 +15,13 @@ def str_to_dict(s) -> Optional[Dict]:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Download model from HuggingFace")
+    parser = argparse.ArgumentParser(
+        description="Download model from HuggingFace, AWS S3, or TOS"
+    )
     parser.add_argument(
         "--model-uri",
         type=str,
         default="deepseek-ai/deepseek-coder-6.7b-instruct",
-        required=True,
         help="model uri from different source, support HuggingFace, AWS S3, TOS",
     )
     parser.add_argument(
@@ -48,13 +49,16 @@ def main():
         help="Extra config for download, like auth config, parallel config, etc.",
     )
     args = parser.parse_args()
-    download_model(
+    model_path = download_model(
         args.model_uri,
         args.local_dir,
         args.model_name,
         args.download_extra_config,
         args.enable_progress_bar,
     )
+    # Print the resolved model path for easier scripting
+    if model_path is not None:
+        print(str(model_path))
 
 
 if __name__ == "__main__":

--- a/python/aibrix/aibrix/downloader/huggingface.py
+++ b/python/aibrix/aibrix/downloader/huggingface.py
@@ -79,7 +79,7 @@ class HuggingFaceDownloader(BaseDownloader):
         logger.debug(
             f"Downloader {self.__class__.__name__} initialized."
             f"HF Settings are followed: \n"
-            f"hf_token={self.hf_token}, \n"
+            f"hf_token={'<redacted>' if self.hf_token else None}, \n"
             f"hf_endpoint={self.hf_endpoint}"
         )
 

--- a/python/aibrix/aibrix/downloader/s3.py
+++ b/python/aibrix/aibrix/downloader/s3.py
@@ -291,7 +291,9 @@ class S3BaseDownloader(BaseDownloader):
         try:
             self.client.head_object(Bucket=self.bucket_name, Key=self.bucket_path)
             key_exists = True
-        except Exception:
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") not in ("404", "NoSuchKey"):
+                raise
             key_exists = False
 
         # Check for any child under prefix + '/'
@@ -304,7 +306,7 @@ class S3BaseDownloader(BaseDownloader):
                 return True
             break
 
-        return not key_exists and True or False
+        return not key_exists
 
     def _directory_list(self, path: str) -> List[str]:
         # Recursively list all objects under the prefix using paginator

--- a/python/aibrix/aibrix/downloader/tos.py
+++ b/python/aibrix/aibrix/downloader/tos.py
@@ -125,16 +125,14 @@ class TOSDownloaderV1(BaseDownloader):
         keys: List[str] = []
         continuation_token: Optional[str] = None
         while True:
-            kwargs = {"prefix": prefix, "delimiter": "/"}
+            kwargs = {"prefix": prefix}
             if continuation_token:
                 kwargs["continuation_token"] = continuation_token
             try:
                 resp = self.client.list_objects_type2(self.bucket_name, **kwargs)
             except TypeError:
                 # SDK may not support continuation; fall back to single call
-                resp = self.client.list_objects_type2(
-                    self.bucket_name, prefix=prefix, delimiter="/"
-                )
+                resp = self.client.list_objects_type2(self.bucket_name, prefix=prefix)
                 keys.extend([obj.key for obj in getattr(resp, "contents", [])])
                 break
 


### PR DESCRIPTION
## Pull Request Description

- S3 listing now uses paginator and returns all keys under the prefix recursively.
-Threadpool path now raises worker errors by calling future.result() after wait.
- HF token never logged; token shows as <redacted> if present.
- TOS v2 no longer sets empty aws_access_key_id/aws_secret_access_key, preserving default credential chain/IRSA.


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>