### PR TITLE
[Bug] add the return value check to pass linter

### DIFF
--- a/test/integration/controller/suit_test.go
+++ b/test/integration/controller/suit_test.go
@@ -83,9 +83,9 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	// Initialize klog flags and set verbosity to 0 (suppress all info logs)
 	klog.InitFlags(nil)
-	flag.Set("v", "0")
-	flag.Set("logtostderr", "false")
-	flag.Set("alsologtostderr", "false")
+	_ = flag.Set("v", "0")
+	_ = flag.Set("logtostderr", "false")
+	_ = flag.Set("alsologtostderr", "false")
 
 	// Configure controller-runtime logger to only show errors
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(false)))


### PR DESCRIPTION
## Pull Request Description
<img width="1842" height="638" alt="image" src="https://github.com/user-attachments/assets/02f4e92a-b195-4eb7-b87b-38a02e78c60d" />

it's my bad. I want to rebase a change and merge this one without waiting for test pass

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>