### PR TITLE
[Misc]: add more field for podautoscaler resource

### DIFF
--- a/api/autoscaling/v1alpha1/podautoscaler_types.go
+++ b/api/autoscaling/v1alpha1/podautoscaler_types.go
@@ -31,6 +31,11 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:printcolumn:name="MINPODS",type="integer",JSONPath=".spec.minReplicas"
+// +kubebuilder:printcolumn:name="MAXPODS",type="integer",JSONPath=".spec.maxReplicas"
+// +kubebuilder:printcolumn:name="REPLICAS",type="integer",JSONPath=".status.actualScale"
+// +kubebuilder:printcolumn:name="STRATEGY",type="string",JSONPath=".spec.scalingStrategy"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // PodAutoscaler is the Schema for the podautoscalers API, a resource to scale Kubernetes pods based on observed metrics.
 // The fields in the spec determine how the scaling behavior should be applied.

--- a/config/crd/autoscaling/autoscaling.aibrix.ai_podautoscalers.yaml
+++ b/config/crd/autoscaling/autoscaling.aibrix.ai_podautoscalers.yaml
@@ -14,7 +14,23 @@ spec:
     singular: podautoscaler
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.minReplicas
+      name: MINPODS
+      type: integer
+    - jsonPath: .spec.maxReplicas
+      name: MAXPODS
+      type: integer
+    - jsonPath: .status.actualScale
+      name: REPLICAS
+      type: integer
+    - jsonPath: .spec.scalingStrategy
+      name: STRATEGY
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:


### PR DESCRIPTION
## Pull Request Description
Add more field for podautoscaler resource
Now `podautoscaler` will provide more info:
```bash
ubuntu:~$ k get podautoscalers.autoscaling.aibrix.ai
NAME                               MINPODS   MAXPODS   REPLICAS   STRATEGY   AGE
deepseek-r1-distill-llama-8b-apa   1         8         8          APA        9m6s
```
## Related Issues
Resolves: #1609

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[x] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>