### PR TITLE
Bug: remove duplicate labels that prevent flux helm-controller from deploying the aibrix chart

### DIFF
--- a/dist/chart/templates/gateway-instance/gateway.yaml
+++ b/dist/chart/templates/gateway-instance/gateway.yaml
@@ -78,7 +78,6 @@ spec:
               template:
                 metadata:
                   labels:
-                    {{- include "chart.selectorLabels" . | nindent 20 }}
                     app.kubernetes.io/name: envoy
                     app.kubernetes.io/component: proxy
                 spec:

--- a/dist/chart/templates/metadata-service/redis.yaml
+++ b/dist/chart/templates/metadata-service/redis.yaml
@@ -17,7 +17,6 @@ spec:
     metadata:
       labels:
         {{- include "chart.labels" . | nindent 8 }}
-        {{- include "chart.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: aibrix-metadata-redis
     spec:
       {{- include "chart.imagePullSecrets" (dict "componentSecrets" .Values.metadata.redis.imagePullSecrets "globalSecrets" .Values.global.imagePullSecrets) | nindent 6 }}


### PR DESCRIPTION
## Pull Request Description

Deduplicates labels in the Helm chart templates that are currently preventing the flux helm-controller from successfully installing the aibrix chart.

You can verify the duplication by issuing `helm template aibrix dist/chart -f dist/chart/values.yaml --namespace aibrix-system --debug > verify.yaml` and inspecting the relevant sections of `verify.yaml`.

### Before

```yaml
# Source: aibrix/templates/metadata-service/redis.yaml
...
spec:
  template:
    metadata:
      labels:
        app.kubernetes.io/version: "0.4.1"
        helm.sh/chart: "0.4.1"
        app.kubernetes.io/name: aibrix
        app.kubernetes.io/instance: aibrix
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: aibrix <-- dupe
        app.kubernetes.io/instance: aibrix <-- dupe
        app.kubernetes.io/component: aibrix-metadata-redis

# Source: aibrix/templates/gateway-instance/gateway.yaml
...
        patch:
          type: StrategicMerge
          value:
            spec:
              template:
                metadata:
                  labels:
                    app.kubernetes.io/name: aibrix <-- dupe
                    app.kubernetes.io/instance: aibrix <-- not a dupe, but questionable
                    app.kubernetes.io/name: envoy
                    app.kubernetes.io/component: proxy
```

### After

```yaml
# Source: aibrix/templates/metadata-service/redis.yaml
...
spec:
  template:
    metadata:
      labels:
        app.kubernetes.io/version: "0.4.1"
        helm.sh/chart: "0.4.1"
        app.kubernetes.io/name: aibrix
        app.kubernetes.io/instance: aibrix
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: aibrix-metadata-redis

# Source: aibrix/templates/gateway-instance/gateway.yaml
...
        patch:
          type: StrategicMerge
          value:
            spec:
              template:
                metadata:
                  labels:
                    app.kubernetes.io/name: envoy
                    app.kubernetes.io/component: proxy
```

### Flux Error

Flux fails for the same underlying reason as described in https://github.com/fluxcd/helm-controller/issues/283. The exact error for this particular chart is as follows:

```
message: |-                                                                                                                                                         
       Helm install failed for release aibrix-system/aibrix with chart aibrix@0.4.1: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:                                                                                                                                                            
         line 32: mapping key "app.kubernetes.io/name" already defined at line 29                                                                                        
         line 33: mapping key "app.kubernetes.io/instance" already defined at line 30
```

## Related Issues

N/A
---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[x] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>