### PR TITLE
Resolve the UpdateConfiguration race issue in autoscaler

### DIFF
--- a/pkg/controller/podautoscaler/algorithm/apa.go
+++ b/pkg/controller/podautoscaler/algorithm/apa.go
@@ -25,16 +25,8 @@ import (
 )
 
 // APAAlgorithm implements Application-specific Pod Autoscaling
-type APAAlgorithm struct {
-	config AlgorithmConfig
-}
-
-// NewAPAAlgorithm creates a new APA algorithm instance
-func NewAPAAlgorithm(config AlgorithmConfig) *APAAlgorithm {
-	return &APAAlgorithm{
-		config: config,
-	}
-}
+// This is a stateless struct that can be safely reused across goroutines
+type APAAlgorithm struct{}
 
 var _ ScalingAlgorithm = (*APAAlgorithm)(nil)
 
@@ -67,12 +59,6 @@ func (a *APAAlgorithm) ComputeRecommendation(ctx context.Context, request Scalin
 // GetAlgorithmType returns the algorithm type
 func (a *APAAlgorithm) GetAlgorithmType() string {
 	return "apa"
-}
-
-// UpdateConfiguration updates the algorithm configuration
-func (a *APAAlgorithm) UpdateConfiguration(config AlgorithmConfig) error {
-	a.config = config
-	return nil
 }
 
 // computeTargetReplicas - APA's algorithm references and enhances the algorithm in the following paper:

--- a/pkg/controller/podautoscaler/algorithm/hpa.go
+++ b/pkg/controller/podautoscaler/algorithm/hpa.go
@@ -21,16 +21,8 @@ import (
 )
 
 // HPAAlgorithm is a placeholder for HPA strategy (actual HPA is handled by K8s HPA resources)
-type HPAAlgorithm struct {
-	config AlgorithmConfig
-}
-
-// NewHPAAlgorithm creates a new HPA algorithm instance
-func NewHPAAlgorithm(config AlgorithmConfig) *HPAAlgorithm {
-	return &HPAAlgorithm{
-		config: config,
-	}
-}
+// This is a stateless struct that can be safely reused across goroutines
+type HPAAlgorithm struct{}
 
 var _ ScalingAlgorithm = (*HPAAlgorithm)(nil)
 
@@ -51,10 +43,4 @@ func (a *HPAAlgorithm) ComputeRecommendation(ctx context.Context, request Scalin
 // GetAlgorithmType returns the algorithm type
 func (a *HPAAlgorithm) GetAlgorithmType() string {
 	return "hpa"
-}
-
-// UpdateConfiguration updates the algorithm configuration
-func (a *HPAAlgorithm) UpdateConfiguration(config AlgorithmConfig) error {
-	a.config = config
-	return nil
 }

--- a/pkg/controller/podautoscaler/autoscaler.go
+++ b/pkg/controller/podautoscaler/autoscaler.go
@@ -19,7 +19,7 @@ package podautoscaler
 import (
 	"context"
 	"fmt"
-	"hash/fnv"
+	"sync"
 	"time"
 
 	autoscalingv1alpha1 "github.com/vllm-project/aibrix/api/autoscaling/v1alpha1"
@@ -36,18 +36,13 @@ import (
 
 // AutoScaler provides scaling decision capabilities based on metrics and algorithms.
 // This interface focuses purely on scaling logic without actual resource manipulation.
+// All implementations are stateless and thread-safe, supporting concurrent reconciliation.
 type AutoScaler interface {
 	// ComputeDesiredReplicas performs metric-based scaling calculation.
 	// This is the primary method for scaling decisions and returns only the recommendation.
 	// It does NOT perform any actual scaling operations.
+	// All per-PA configuration is extracted from the PodAutoscaler spec on each call.
 	ComputeDesiredReplicas(ctx context.Context, request ReplicaComputeRequest) (*ReplicaComputeResult, error)
-
-	// UpdateConfiguration updates the autoscaler's strategy and parameters.
-	// This method optimizes performance by only recreating components when strategy changes.
-	UpdateConfiguration(pa autoscalingv1alpha1.PodAutoscaler) error
-
-	// GetStrategy returns the currently configured scaling strategy.
-	GetStrategy() autoscalingv1alpha1.ScalingStrategyType
 }
 
 // ReplicaComputeRequest represents a request for replica calculation.
@@ -68,20 +63,18 @@ type ReplicaComputeResult struct {
 }
 
 // DefaultAutoScaler implements the complete scaling pipeline
+// All components are stateless or thread-safe, allowing concurrent reconciliation
 type DefaultAutoScaler struct {
+	// Immutable shared components (all thread-safe)
 	factory         metrics.MetricFetcherFactory
 	client          client.Client
 	configExtractor *config.ConfigExtractor
 	metricsClient   *metrics.MetricsClient
+	aggregator      aggregation.MetricAggregator
 
-	// Current configuration (updated per request)
-	strategy               autoscalingv1alpha1.ScalingStrategyType
-	lastConfiguredStrategy autoscalingv1alpha1.ScalingStrategyType
-	aggregator             aggregation.MetricAggregator
-	algorithm              algorithm.ScalingAlgorithm
-	metricKey              types.MetricKey
-	metricSource           autoscalingv1alpha1.MetricSource
-	lastConfigHash         uint64 // Track configuration changes
+	// Algorithm cache (algorithms are stateless structs, can be safely reused)
+	mu             sync.RWMutex
+	algorithmCache map[autoscalingv1alpha1.ScalingStrategyType]algorithm.ScalingAlgorithm
 }
 
 // NewDefaultAutoScaler creates a new default autoscaler
@@ -93,13 +86,8 @@ func NewDefaultAutoScaler(
 	// Windows auto-initialize on first use based on the PodAutoscaler config
 	metricsClient := metrics.NewMetricsClient(time.Second)
 
-	// Create single aggregator for all strategies (doesn't depend on strategy)
-	aggregator := aggregation.NewMetricAggregator(metricsClient, aggregation.AggregationConfig{
-		StableWindow: 120 * time.Second,
-		PanicWindow:  15 * time.Second,
-		Window:       120 * time.Second,
-		Granularity:  time.Second,
-	})
+	// Create single aggregator for all strategies (stateless, just delegates to client)
+	aggregator := aggregation.NewMetricAggregator(metricsClient)
 
 	return &DefaultAutoScaler{
 		factory:         factory,
@@ -107,35 +95,54 @@ func NewDefaultAutoScaler(
 		configExtractor: config.NewConfigExtractor(),
 		metricsClient:   metricsClient,
 		aggregator:      aggregator,
+		algorithmCache:  make(map[autoscalingv1alpha1.ScalingStrategyType]algorithm.ScalingAlgorithm),
 	}
 }
 
-// configureForStrategy configures the autoscaler for a specific strategy
-func (a *DefaultAutoScaler) configureForStrategy(strategy autoscalingv1alpha1.ScalingStrategyType, source autoscalingv1alpha1.MetricSource) {
-	// MetricsClient and aggregator are already created and stable
-	// Windows are auto-initialized on first metric update with default durations
+// getOrCreateAlgorithm retrieves or creates a stateless algorithm for the given strategy
+// The algorithm struct is stateless and can be safely cached and reused
+func (a *DefaultAutoScaler) getOrCreateAlgorithm(strategy autoscalingv1alpha1.ScalingStrategyType) algorithm.ScalingAlgorithm {
+	// Try read lock first (common case)
+	a.mu.RLock()
+	algo, exists := a.algorithmCache[strategy]
+	a.mu.RUnlock()
+	if exists {
+		return algo
+	}
 
-	// Only create algorithm based on strategy (this is the only strategy-specific component)
-	a.algorithm = algorithm.NewScalingAlgorithm(strategy, algorithm.AlgorithmConfig{
-		Strategy:       strategy,
-		StableWindow:   120 * time.Second,
-		PanicWindow:    15 * time.Second,
-		PanicThreshold: 2.0,
-		ScaleToZero:    false,
-	})
+	// Need to create, acquire write lock
+	a.mu.Lock()
+	defer a.mu.Unlock()
 
-	// Update current strategy
-	a.strategy = strategy
+	// Double-check after acquiring write lock
+	if algo, exists := a.algorithmCache[strategy]; exists {
+		return algo
+	}
+
+	// Create new stateless algorithm instance
+	algo = algorithm.NewScalingAlgorithm(strategy)
+	a.algorithmCache[strategy] = algo
+	return algo
 }
 
 func (a *DefaultAutoScaler) ComputeDesiredReplicas(ctx context.Context, request ReplicaComputeRequest) (*ReplicaComputeResult, error) {
-	// Ensure configuration is up to date
-	if err := a.UpdateConfiguration(request.PodAutoscaler); err != nil {
-		return &ReplicaComputeResult{Valid: false}, fmt.Errorf("failed to update configuration: %w", err)
+	// Extract per-request configuration
+	metricKey, metricSource, err := metrics.NewNamespaceNameMetric(&request.PodAutoscaler)
+	if err != nil {
+		return &ReplicaComputeResult{Valid: false}, fmt.Errorf("failed to create metric key: %w", err)
 	}
 
-	// Execute the common scaling pipeline
-	recommendation, err := a.executeScalingPipeline(ctx, request)
+	// Extract algorithm config from PodAutoscaler spec
+	algorithmConfig, err := a.configExtractor.ExtractAlgorithmConfig(request.PodAutoscaler)
+	if err != nil {
+		return &ReplicaComputeResult{Valid: false}, fmt.Errorf("failed to extract algorithm config: %w", err)
+	}
+
+	// Get or create stateless algorithm instance (cached for reuse)
+	algo := a.getOrCreateAlgorithm(request.PodAutoscaler.Spec.ScalingStrategy)
+
+	// Execute the scaling pipeline with per-request state
+	recommendation, err := a.executeScalingPipeline(ctx, request, metricKey, metricSource, algo, algorithmConfig)
 	if err != nil {
 		return &ReplicaComputeResult{Valid: false}, err
 	}
@@ -148,110 +155,23 @@ func (a *DefaultAutoScaler) ComputeDesiredReplicas(ctx context.Context, request 
 	}, nil
 }
 
-func (a *DefaultAutoScaler) UpdateConfiguration(pa autoscalingv1alpha1.PodAutoscaler) error {
-	// Extract metric key and source
-	metricKey, metricSource, err := metrics.NewNamespaceNameMetric(&pa)
-	if err != nil {
-		return fmt.Errorf("failed to create metric key: %w", err)
-	}
-
-	// Calculate configuration hash for change detection
-	configHash := a.calculateConfigHash(pa)
-
-	// Check if we need to reconfigure components
-	// TODO: address the locking issue.
-	// TODO: lastConfiguredStrategy could be empty, in this case, we do not need to print logs etc.
-	strategyChanged := a.lastConfiguredStrategy != pa.Spec.ScalingStrategy
-	configChanged := a.lastConfigHash != configHash
-
-	a.metricKey = metricKey
-	a.metricSource = metricSource
-
-	// Only recreate components if strategy changed
-	if strategyChanged {
-		klog.V(4).InfoS("Strategy changed, reconfiguring components",
-			"oldStrategy", a.lastConfiguredStrategy,
-			"newStrategy", pa.Spec.ScalingStrategy)
-		a.configureForStrategy(pa.Spec.ScalingStrategy, metricSource)
-		a.lastConfiguredStrategy = pa.Spec.ScalingStrategy
-	}
-
-	// Update component configurations if config changed or components were recreated
-	if configChanged || strategyChanged {
-		if err := a.updateComponentConfigurations(pa); err != nil {
-			return fmt.Errorf("failed to update component configurations: %w", err)
-		}
-		a.lastConfigHash = configHash
-	}
-
-	return nil
-}
-
-// calculateConfigHash creates a hash of the configuration to detect changes
-func (a *DefaultAutoScaler) calculateConfigHash(pa autoscalingv1alpha1.PodAutoscaler) uint64 {
-	// Use a more robust hashing mechanism to reduce collision probability.
-	h := fnv.New64a()
-
-	// Strategy
-	_, _ = fmt.Fprint(h, string(pa.Spec.ScalingStrategy))
-
-	// Min/Max replicas
-	if pa.Spec.MinReplicas != nil {
-		_, _ = fmt.Fprintf(h, "%d", *pa.Spec.MinReplicas)
-	}
-	_, _ = fmt.Fprintf(h, "%d", pa.Spec.MaxReplicas)
-
-	// Metric sources
-	for _, source := range pa.Spec.MetricsSources {
-		_, _ = fmt.Fprint(h, string(source.MetricSourceType))
-		_, _ = fmt.Fprint(h, source.TargetMetric)
-		_, _ = fmt.Fprint(h, source.TargetValue)
-		_, _ = fmt.Fprint(h, source.Path)
-	}
-
-	return h.Sum64()
-}
-
-// updateComponentConfigurations updates existing component configurations
-func (a *DefaultAutoScaler) updateComponentConfigurations(pa autoscalingv1alpha1.PodAutoscaler) error {
-	// Update aggregator configuration if it exists
-	if a.aggregator != nil {
-		aggregationConfig, err := a.configExtractor.ExtractAggregationConfig(pa)
-		if err != nil {
-			return fmt.Errorf("failed to extract aggregation configuration: %w", err)
-		}
-		if err := a.aggregator.UpdateConfiguration(aggregationConfig); err != nil {
-			return fmt.Errorf("failed to update aggregator configuration: %w", err)
-		}
-	}
-
-	// Update algorithm configuration if it exists
-	if a.algorithm != nil {
-		algorithmConfig, err := a.configExtractor.ExtractAlgorithmConfig(pa)
-		if err != nil {
-			return fmt.Errorf("failed to extract algorithm configuration: %w", err)
-		}
-		if err := a.algorithm.UpdateConfiguration(algorithmConfig); err != nil {
-			return fmt.Errorf("failed to update algorithm configuration: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (a *DefaultAutoScaler) GetStrategy() autoscalingv1alpha1.ScalingStrategyType {
-	return a.strategy
-}
-
 // executeScalingPipeline contains the common scaling logic for replica computation
-func (a *DefaultAutoScaler) executeScalingPipeline(ctx context.Context, request ReplicaComputeRequest) (*algorithm.ScalingRecommendation, error) {
+func (a *DefaultAutoScaler) executeScalingPipeline(
+	ctx context.Context,
+	request ReplicaComputeRequest,
+	metricKey types.MetricKey,
+	metricSource autoscalingv1alpha1.MetricSource,
+	algo algorithm.ScalingAlgorithm,
+	algorithmConfig algorithm.AlgorithmConfig,
+) (*algorithm.ScalingRecommendation, error) {
 	workloadKey := fmt.Sprintf("%s/%s", request.PodAutoscaler.Namespace, request.PodAutoscaler.Name)
+
 	// Step 1: Collect metrics
 	collectionSpec := types.CollectionSpec{
-		Namespace:    a.metricKey.Namespace,
-		TargetName:   a.metricKey.Name,
-		MetricName:   a.metricKey.MetricName,
-		MetricSource: a.metricSource,
+		Namespace:    metricKey.Namespace,
+		TargetName:   metricKey.Name,
+		MetricName:   metricKey.MetricName,
+		MetricSource: metricSource,
 		Pods:         request.Pods,
 		Timestamp:    request.Timestamp,
 	}
@@ -264,13 +184,18 @@ func (a *DefaultAutoScaler) executeScalingPipeline(ctx context.Context, request 
 
 	// Step 2: Process and aggregate metrics
 	klog.InfoS("Processing metrics snapshot", "source", workloadKey, "healthy metrics pods", len(snapshot.Values), "values", snapshot.Values)
-	if err := a.aggregator.ProcessSnapshot(a.metricKey, snapshot); err != nil {
+	// Convert algorithmConfig to metricsConfig to propagate window sizes
+	metricsConfig := metrics.MetricsConfig{
+		StableWindow: algorithmConfig.StableWindow,
+		PanicWindow:  algorithmConfig.PanicWindow,
+	}
+	if err := a.aggregator.ProcessSnapshot(metricKey, snapshot, metricsConfig); err != nil {
 		return nil, fmt.Errorf("failed to process metrics snapshot for %s: %w", workloadKey, err)
 	}
 	// Use the full metricKey with PaNamespace and PaName for proper multi-tenancy
-	aggregatedMetrics, err := a.aggregator.GetAggregatedMetrics(a.metricKey, request.Timestamp)
+	aggregatedMetrics, err := a.aggregator.GetAggregatedMetrics(metricKey, request.Timestamp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get aggregated metrics for %s %s: %w", workloadKey, a.metricKey, err)
+		return nil, fmt.Errorf("failed to get aggregated metrics for %s %s: %w", workloadKey, metricKey, err)
 	}
 
 	// Step 3: Enhance confidence with pod count awareness
@@ -296,24 +221,25 @@ func (a *DefaultAutoScaler) executeScalingPipeline(ctx context.Context, request 
 			Name:       request.PodAutoscaler.Spec.ScaleTargetRef.Name,
 			Kind:       request.PodAutoscaler.Spec.ScaleTargetRef.Kind,
 			APIVersion: request.PodAutoscaler.Spec.ScaleTargetRef.APIVersion,
-			MetricKey:  a.metricKey,
+			MetricKey:  metricKey,
 		},
 		CurrentReplicas:   request.CurrentReplicas,
 		AggregatedMetrics: aggregatedMetrics,
 		ScalingContext:    a.createScalingContext(request.PodAutoscaler),
 		Constraints:       a.createConstraints(request.PodAutoscaler),
+		Config:            algorithmConfig,
 		Timestamp:         request.Timestamp,
 	}
 
 	klog.InfoS("Computing scaling recommendation", "source", workloadKey,
-		"algorithm", a.algorithm.GetAlgorithmType())
-	recommendation, err := a.algorithm.ComputeRecommendation(ctx, scalingRequest)
+		"algorithm", algo.GetAlgorithmType())
+	recommendation, err := algo.ComputeRecommendation(ctx, scalingRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute scaling recommendation for %s: %w", workloadKey, err)
 	}
 	klog.InfoS("Scaling recommendation computed",
 		"source", workloadKey,
-		"algorithm", a.algorithm.GetAlgorithmType(),
+		"algorithm", algo.GetAlgorithmType(),
 		"recommendation", recommendation)
 
 	return recommendation, nil


### PR DESCRIPTION
## Pull Request Description

```
  DefaultAutoScaler (thread-safe)
  ├── factory (immutable)
  ├── client (immutable)
  ├── metricsClient (thread-safe with mutex)
  ├── aggregator (stateless)
  └── algorithmCache (RWMutex)
      ├── KPA instance (stateless empty struct)
      ├── APA instance (stateless empty struct)
      └── HPA instance (stateless empty struct)
```

## Related Issues
Resolves: #1422

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>