### PR TITLE
update stable and panic value for KPA

### DIFF
--- a/pkg/controller/podautoscaler/context/context.go
+++ b/pkg/controller/podautoscaler/context/context.go
@@ -88,6 +88,9 @@ type BaseScalingContext struct {
 	// Stable and Panic values
 	StableValue float64
 	PanicValue  float64
+
+	// Panic mode state
+	InPanicMode bool
 }
 
 var _ ScalingContext = (*BaseScalingContext)(nil)
@@ -276,11 +279,11 @@ func (b *BaseScalingContext) GetPanicThreshold() float64 {
 }
 
 func (b *BaseScalingContext) GetInPanicMode() bool {
-	return false
+	return b.InPanicMode
 }
 
 func (b *BaseScalingContext) SetInPanicMode(inPanic bool) {
-	// No-op in base implementation
+	b.InPanicMode = inPanic
 }
 
 func (b *BaseScalingContext) GetMaxPanicPods() int32 {


### PR DESCRIPTION
## Pull Request Description
Hi team,

I am using the KPA scaling method locally, but it did not work as expected. After reviewing the implementation, I found that in the kpa `computeTargetReplicas` method, both `observedStableValue` and `observedPanicValue` were always 0. 

```
func (a *KPAAlgorithm) computeTargetReplicas(currentPodCount float64, context scalingctx.ScalingContext) int32 {
	// Get all the necessary values from context
	observedStableValue := context.GetStableValue()
	observedPanicValue := context.GetPanicValue()
```

However, in the `ComputeRecommendation`method, `request.ScalingContext.SetStableValue(metrics.StableValue)` and `request.ScalingContext.SetPanicValue(metrics.PanicValue)` are called to set these values. 
```
	// Update context with current metrics
	request.ScalingContext.SetStableValue(metrics.StableValue)
	request.ScalingContext.SetPanicValue(metrics.PanicValue)
```


After applying this change, the scaling behavior works correctly in my local environment.

Could you please help verify this? If my understanding or fix is incorrect, please let me know. Thank you so much!