### PR TITLE
[Misc] Benchmark: add duration limit and max concurrent sessions settings to client

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -280,6 +280,13 @@ class BenchmarkRunner:
             # Set to None so it can be handled appropriately later
             self.config["api_key"] = None
         
+        # Get client_duration_limit (in seconds)
+        duration_limit = self.config.get("client_duration_limit", None)
+        
+        # Get client_max_concurrent_sessions from client config (runtime enforcement)
+        # This is separate from workload generator's max_concurrent_sessions
+        max_concurrent_sessions = self.config.get("client_max_concurrent_sessions", None)
+        
         args_dict = {
             "workload_path": workload_file,
             "endpoint": self.config["endpoint"],
@@ -292,6 +299,8 @@ class BenchmarkRunner:
             "time_scale": self.config.get("time_scale", 1.0),
             "timeout_second": self.config.get("timeout_second", 60.0),
             "max_retries": self.config.get("max_retries", 0),
+            "duration_limit": duration_limit,
+            "max_concurrent_sessions": max_concurrent_sessions,
         }
         args = Namespace(**args_dict)
         logging.info(f"Running client with args: {args}")

--- a/benchmarks/client/client.py
+++ b/benchmarks/client/client.py
@@ -34,9 +34,10 @@ async def send_request_streaming(client: openai.AsyncOpenAI,
         history = None if session_id is None else session_history,
         history_lock = None if session_id is None else session_history_lock) 
     start_time = time.time()
-    # Initialize dispatch_time early to prevent UnboundLocalError if exception occurs
-    # before actual dispatch (e.g., during prepare_prompt or sleep)
-    dispatch_time = start_time
+    start_time = time.time()
+    first_response_time = None
+    target_pod = ""
+    target_request_id = ""
     first_response_time = None
     target_pod = ""
     target_request_id = ""

--- a/benchmarks/client/client.py
+++ b/benchmarks/client/client.py
@@ -34,6 +34,9 @@ async def send_request_streaming(client: openai.AsyncOpenAI,
         history = None if session_id is None else session_history,
         history_lock = None if session_id is None else session_history_lock) 
     start_time = time.time()
+    # Initialize dispatch_time early to prevent UnboundLocalError if exception occurs
+    # before actual dispatch (e.g., during prepare_prompt or sleep)
+    dispatch_time = start_time
     first_response_time = None
     target_pod = ""
     target_request_id = ""
@@ -173,6 +176,9 @@ async def send_request_batch(client: openai.AsyncOpenAI,
         history = None if session_id is None else session_history,
         history_lock = None if session_id is None else session_history_lock) 
     start_time = time.time()
+    # Initialize dispatch_time early to prevent UnboundLocalError if exception occurs
+    # before actual dispatch (e.g., during prepare_prompt or sleep)
+    dispatch_time = start_time
     target_pod = ""
     try:
         logging.warning(f"send_request_batch: Prepare to launch task after {target_time - start_time} target_time {target_time} start_time {start_time}")
@@ -269,50 +275,175 @@ async def benchmark_launch(api_key: str,
                               model: str,
                               max_output=int,
                               send_request_func=Callable,
+                              duration_limit: float = None,
+                              max_concurrent_sessions: int = None,
                               ):
     request_id = 0
     base_time = time.time()
     num_requests = 0
     tasks: List[asyncio.Task] = []
     client = create_client(api_key, endpoint, max_retries, timeout, routing_strategy)
-    def send(request):
-        nonlocal request_id
-        task = asyncio.create_task(
-            send_request_func(
-                client=client,
-                model=model,
-                max_output=max_output,
-                request=request,  
-                output_file=output_file,
-                request_id=request_id,
-                session_id=request.get("session_id", None) if "session_id" in request else None,
-                target_time=target_time,
+
+    try:
+        # Track active sessions for max_concurrent_sessions limit
+        active_sessions = set()
+        session_capacity_available = asyncio.Event()
+        session_capacity_available.set()  # Initially available
+
+        if max_concurrent_sessions is not None:
+            logging.info(f"Max concurrent sessions limit: {max_concurrent_sessions}")
+
+        # Set workload duration based on duration_limit parameter
+        # If duration_limit is None, don't set a time limit (wait for all tasks)
+        if duration_limit is None:
+            workload_duration = None
+            logging.info("No duration limit set. Benchmark will wait for all tasks to complete.")
+        else:
+            workload_duration = duration_limit
+            logging.info(f"Duration limit set to {workload_duration:.1f}s")
+
+        def send(request):
+            nonlocal request_id, num_requests
+            task = asyncio.create_task(
+                send_request_func(
+                    client=client,
+                    model=model,
+                    max_output=max_output,
+                    request=request,
+                    output_file=output_file,
+                    request_id=request_id,
+                    session_id=request.get("session_id", None) if "session_id" in request else None,
+                    target_time=target_time,
+                )
             )
-        )
-        request_id += 1
-        tasks.append(task)
-    initiated_sessions = set()
-    for requests_dict in load_struct:
-        ts = int(requests_dict["timestamp"] * scale_factor)
-        requests = requests_dict["requests"]
-        target_time = base_time + ts / 1000.0
-        for i in range(len(requests)):
-            session_id = requests[i].get("session_id", None) if "session_id" in requests[0] else None
-            if session_id == None or session_id not in initiated_sessions:
-                send(requests[i])
-                initiated_sessions.add(session_id)
+            request_id += 1
+            num_requests += 1
+            tasks.append(task)
+        initiated_sessions = set()
+        pending_new_sessions = []  # Queue for sessions that couldn't start due to capacity limit
+
+        async def start_session_if_capacity_available(request, session_id):
+            """Start a new session, waiting for capacity if necessary.
+
+            If max_concurrent_sessions is set and reached, this will block until
+            a session completes and frees up capacity.
+            """
+            if max_concurrent_sessions is not None and session_id is not None:
+                # Wait until there's capacity
+                while len(active_sessions) >= max_concurrent_sessions:
+                    await session_capacity_available.wait()
+                    session_capacity_available.clear()
+                active_sessions.add(session_id)
+                logging.info(f"Starting session {session_id}. Active sessions: {len(active_sessions)}/{max_concurrent_sessions}")
+            send(request)
+            initiated_sessions.add(session_id)
+
+        for requests_dict in load_struct:
+            ts = int(requests_dict["timestamp"] * scale_factor)
+            requests = requests_dict["requests"]
+            target_time = base_time + ts / 1000.0
+            for i in range(len(requests)):
+                session_id = requests[i].get("session_id", None) if "session_id" in requests[0] else None
+                if session_id is None or session_id not in initiated_sessions:
+                    # Check if we can start a new session without blocking
+                    if max_concurrent_sessions is None or len(active_sessions) < max_concurrent_sessions:
+                        await start_session_if_capacity_available(requests[i], session_id)
+                    else:
+                        # Can't start now, add to pending new sessions queue with timing info
+                        logging.info(f"Session {session_id} cannot start yet (capacity full). Adding first request to pending.")
+                        pending_new_sessions.append((requests[i], target_time))
+                        initiated_sessions.add(session_id)  # Mark as initiated so future requests go to pending_sessioned_requests
+                else:
+                    logging.info(f"Adding request for session {session_id} to pending queue. Pending count: {len(pending_sessioned_requests.get(session_id, [])) + 1}")
+                    pending_sessioned_requests.setdefault(session_id, []).append((requests[i], target_time))
+
+        # Merge pending_new_sessions into pending_sessioned_requests
+        for req, ttime in pending_new_sessions:
+            sid = req.get("session_id")
+            if sid is not None:
+                pending_sessioned_requests.setdefault(sid, []).insert(0, (req, ttime))  # Insert at beginning since it's the first request
+
+        logging.info(f"Finished processing all workload entries. Pending sessions: {len(pending_sessioned_requests)}, Pending requests: {sum(len(v) for v in pending_sessioned_requests.values())}")
+
+        while len(pending_sessioned_requests) != 0:
+            # Check if duration limit has been exceeded
+            if workload_duration is not None:
+                elapsed = time.time() - base_time
+                if elapsed >= workload_duration:
+                    logging.warning(f"Duration limit ({workload_duration:.1f}s) reached. Stopping session processing. {len(pending_sessioned_requests)} sessions remain pending.")
+                    break
+
+            logging.info(f"Waiting for session to complete. Pending sessions: {len(pending_sessioned_requests)}")
+            done_session_id = await completed_sessions.get()
+            logging.info(f"Session {done_session_id} signaled completion")
+
+            if done_session_id in pending_sessioned_requests:
+                next_request, target_time = pending_sessioned_requests[done_session_id].pop(0)
+                send(next_request)
+                if len(pending_sessioned_requests[done_session_id]) == 0:
+                    pending_sessioned_requests.pop(done_session_id, None)
             else:
-                pending_sessioned_requests.setdefault(session_id,[]).append(requests[i])  
-    while len(pending_sessioned_requests) != 0:
-        done_session_id = await completed_sessions.get()
-        if done_session_id in pending_sessioned_requests:
-            next_request = pending_sessioned_requests[done_session_id].pop(0)
-            send(next_request)
-            if len(pending_sessioned_requests[done_session_id]) == 0:
-                pending_sessioned_requests.pop(done_session_id, None)
-                
-    await asyncio.gather(*tasks)
-    logging.warning(f"All {num_requests} requests completed for deployment.")
+                # Session has no more pending requests, so it's truly complete
+                if max_concurrent_sessions is not None and done_session_id in active_sessions:
+                    active_sessions.remove(done_session_id)
+                    logging.info(f"Session {done_session_id} completed. Active sessions: {len(active_sessions)}/{max_concurrent_sessions}")
+
+                    # Start a new session from pending if capacity is available
+                    if len(pending_sessioned_requests) > 0:
+                        # Find the first pending session and start it
+                        next_session_id = next(iter(pending_sessioned_requests))
+                        first_request, target_time = pending_sessioned_requests[next_session_id].pop(0)
+                        if len(pending_sessioned_requests[next_session_id]) == 0:
+                            pending_sessioned_requests.pop(next_session_id, None)
+
+                        # Start the new session
+                        active_sessions.add(next_session_id)
+                        logging.info(f"Starting session {next_session_id}. Active sessions: {len(active_sessions)}/{max_concurrent_sessions}")
+                        send(first_request)
+
+        # Wait for tasks with duration limit
+        logging.info(f"All {num_requests} tasks created. Waiting for completion...")
+
+        if workload_duration is not None:
+            elapsed = time.time() - base_time
+            remaining = workload_duration - elapsed
+
+            if remaining > 0:
+                logging.info(f"Waiting up to {remaining:.1f}s more for tasks to complete (total duration: {workload_duration:.1f}s)")
+                try:
+                    await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=remaining)
+                    logging.info("All tasks completed within workload duration.")
+                except asyncio.TimeoutError:
+                    pending_count = sum(1 for task in tasks if not task.done())
+                    logging.warning(f"Workload duration ({workload_duration:.1f}s) reached. Cancelling {pending_count} pending requests...")
+                    for task in tasks:
+                        if not task.done():
+                            task.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
+            else:
+                logging.warning(f"Workload duration already exceeded by {-remaining:.1f}s. Cancelling pending tasks...")
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+            completed_count = sum(1 for task in tasks if task.done() and not task.cancelled())
+            cancelled_count = sum(1 for task in tasks if task.cancelled())
+            logging.warning(f"Benchmark complete. Total: {num_requests}, Completed: {completed_count}, Cancelled: {cancelled_count}")
+        else:
+            await asyncio.gather(*tasks)
+            logging.warning(f"All {num_requests} requests completed for deployment.")
+    finally:
+        # Ensure OpenAI client is properly closed to prevent connection leaks
+        # This runs regardless of whether the benchmark completed successfully,
+        # was cancelled due to timeout, or encountered an error
+        logging.info("Closing OpenAI client...")
+        try:
+            await client.close()
+            logging.info("OpenAI client closed successfully.")
+        except Exception as e:
+            # Log but don't raise - cleanup failures shouldn't crash the program
+            logging.warning(f"Error while closing OpenAI client: {e}")
 
 
 def main(args):
@@ -321,6 +452,15 @@ def main(args):
     with open(args.output_file_path, 'w', encoding='utf-8') as output_file:
         load_struct = load_workload(args.workload_path)
         send_request_func = send_request_streaming if args.streaming else send_request_batch
+        
+        # Get duration limit from args if provided
+        duration_limit = args.duration_limit if hasattr(args, 'duration_limit') else None
+        if duration_limit:
+            logging.info(f"Duration limit set to {duration_limit:.1f}s (from command line)")
+        
+        # Get max_concurrent_sessions from args if provided
+        max_concurrent_sessions = args.max_concurrent_sessions if hasattr(args, 'max_concurrent_sessions') else None
+        
         start_time = time.time()
         asyncio.run(benchmark_launch(
             api_key = args.api_key,
@@ -334,6 +474,8 @@ def main(args):
             model=args.model,
             max_output=args.output_token_limit,
             send_request_func=send_request_func,
+            duration_limit=duration_limit,
+            max_concurrent_sessions=max_concurrent_sessions,
         ))
         end_time = time.time()
         logging.info(f"Benchmark completed in {end_time - start_time:.2f} seconds")
@@ -352,6 +494,8 @@ if __name__ == "__main__":
     parser.add_argument('--time-scale', type=float, default=1.0, help="Scaling factor for workload's logical time.")
     parser.add_argument('--timeout-second', type=float, default=60.0, help="Timeout for each request in seconds.")
     parser.add_argument('--max-retries', type=int, default=0, help="Number of maximum retries for each request.")
+    parser.add_argument('--duration-limit', type=float, default=None, help="Duration limit in seconds. Benchmark stops after this time, cancelling pending requests. If not set, uses workload's last timestamp.")
+    parser.add_argument('--max-concurrent-sessions', type=int, default=None, help="Maximum number of sessions that can run concurrently. Only applies to sessioned workloads.")
 
     args = parser.parse_args()
     main(args)

--- a/benchmarks/client/client.py
+++ b/benchmarks/client/client.py
@@ -177,9 +177,9 @@ async def send_request_batch(client: openai.AsyncOpenAI,
         history = None if session_id is None else session_history,
         history_lock = None if session_id is None else session_history_lock) 
     start_time = time.time()
-    # Initialize dispatch_time early to prevent UnboundLocalError if exception occurs
-    # before actual dispatch (e.g., during prepare_prompt or sleep)
-    dispatch_time = start_time
+    start_time = time.time()
+    target_pod = ""
+    try:
     target_pod = ""
     try:
         logging.warning(f"send_request_batch: Prepare to launch task after {target_time - start_time} target_time {target_time} start_time {start_time}")

--- a/benchmarks/config.yaml
+++ b/benchmarks/config.yaml
@@ -96,6 +96,15 @@ streaming_enabled: true # Options: true, false
 output_token_limit: 128
 timeout_second: 60.0
 max_retries: 0
+# Client-side duration limit in seconds
+# Set to a number (e.g., 240) to cancel pending requests after that time
+# Set to null to wait for ALL requests to complete (no time limit)
+client_duration_limit: null  # null = wait for all tasks, or number like 240 for 4 minutes
+# Client-side max concurrent sessions limit (runtime enforcement)
+# This limits how many sessions can be ACTIVE at once during benchmark execution
+# Note: This is separate from workload generator's max_concurrent_sessions which only affects workload generation
+# Set to null/none for unlimited, or a number to limit concurrent active sessions
+client_max_concurrent_sessions: null  # Example: 10 would limit to 10 active sessions at a time
 
 # ---------------
 # OPTIONAL: ANALYSIS


### PR DESCRIPTION
## Pull Request Description

* Added support to set client duration limit in seconds for benchmark execution, allowing cancellation of requests after the specified time.
* Added support to set client max concurrent sessions to control the number of active sessions during benchmarking.

Initial motivation was to fix issue that in the end of the benchmark, if the benchmark was too slow, it would dispatch all pending requests in the end of the benchmark, making it strange plots for those cases, it was behaving as expected until 16:28, then it and dispatched bursts of pending requests and not predictable:

<img width="3270" height="3954" alt="image" src="https://github.com/user-attachments/assets/615ad2d5-0207-49f5-9141-21f77040f5ce" />

This was due to the behavior of send all requests according to the workload schedule and then waiting for all requests to complete, which may not provide a predictable client behaviour.

### Backward compatibility
Using parameters `client_duration_limit` and `client_max_concurrent_sessions` to better control the benchmark client behaviour, setting them as `null` we preserve current behaviour.

## More controled benchmark client behaviour
To better control the benchmark client, setting a value to `client_duration_limit` will make the client to cancel requests if it has passed the client duration limit, instead of dispatching all the requests.

In slow benchmarks the client can struggle to keep up to follow the generated workload as it can't keep at RPS, in such cases we would want to have control on the concurrent sessions that the client is executing setting `client_max_concurrent_sessions`.

After setting the both values and running a benchmark, we don't have more issues when benchmark is slow of start bursting more requests because the client can't keep up and we can limit the benchmark to run for the exact duration:

<img width="3146" height="3954" alt="image" src="https://github.com/user-attachments/assets/e8e7d406-de44-4cec-b95a-df18b077766e" />


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>