### PR TITLE
[Bug]: Make optional fields in MetricSource

### DIFF
--- a/api/autoscaling/v1alpha1/podautoscaler_types.go
+++ b/api/autoscaling/v1alpha1/podautoscaler_types.go
@@ -132,14 +132,18 @@ type MetricSource struct {
 	// Specifies how to fetch metrics: from individual pods, Kubernetes APIs, or external services
 	// +kubebuilder:validation:Enum={pod,resource,custom,external,domain}
 	MetricSourceType MetricSourceType `json:"metricSourceType"`
-	// Protocol for metric collection
+	// Protocol for metric collection. Required only for 'pod' and 'external' types.
+	// +optional
 	// +kubebuilder:validation:Enum={http,https}
-	ProtocolType ProtocolType `json:"protocolType"`
-	// External service endpoint (e.g., gpu-optimizer.aibrix-system.svc.cluster.local). Only used for EXTERNAL type.
+	ProtocolType ProtocolType `json:"protocolType,omitempty"`
+	// External service endpoint (e.g., gpu-optimizer.aibrix-system.svc.cluster.local)
+	// +optional
 	Endpoint string `json:"endpoint,omitempty"`
 	// Path to metrics endpoint (e.g., /api/metrics/cpu)
-	Path string `json:"path"`
-	// Port for pod-level metrics. Only used for POD type.
+	// +optional
+	Path string `json:"path,omitempty"`
+	// Port for pod-level metrics. Only used for 'pod' type.
+	// +optional
 	Port string `json:"port,omitempty"`
 	// TargetMetric identifies the specific metric to monitor (e.g., kv_cache_utilization).
 	TargetMetric string `json:"targetMetric"`

--- a/config/crd/autoscaling/autoscaling.aibrix.ai_podautoscalers.yaml
+++ b/config/crd/autoscaling/autoscaling.aibrix.ai_podautoscalers.yaml
@@ -73,8 +73,6 @@ spec:
                       type: string
                   required:
                   - metricSourceType
-                  - path
-                  - protocolType
                   - targetMetric
                   - targetValue
                   type: object

--- a/dist/chart/crds/autoscaling.aibrix.ai_podautoscalers.yaml
+++ b/dist/chart/crds/autoscaling.aibrix.ai_podautoscalers.yaml
@@ -73,8 +73,6 @@ spec:
                       type: string
                   required:
                   - metricSourceType
-                  - path
-                  - protocolType
                   - targetMetric
                   - targetValue
                   type: object

--- a/samples/autoscaling/apa-resource.yaml
+++ b/samples/autoscaling/apa-resource.yaml
@@ -1,0 +1,24 @@
+apiVersion: autoscaling.aibrix.ai/v1alpha1
+kind: PodAutoscaler
+metadata:
+  name: mock-llama2-7b-hpa1
+  namespace: default
+  labels:
+    app.kubernetes.io/name: aibrix
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    autoscaling.aibrix.ai/up-fluctuation-tolerance: '0.1'
+    autoscaling.aibrix.ai/down-fluctuation-tolerance: '0.2'
+    apa.autoscaling.aibrix.ai/window: 30s
+spec:
+  scalingStrategy: APA
+  minReplicas: 1
+  maxReplicas: 8
+  metricsSources:
+    - metricSourceType: resource
+      targetMetric: cpu
+      targetValue: "50"
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mock-llama2-7b


### PR DESCRIPTION
## Pull Request Description

Currently, the `MetricSource` struct requires fields like `protocolType`, `port`, `path`, and `endpoint`, but sometime they are not relevant to the chosen `metricSourceType` (e.g., `resource` type doesn't need any of them).

```go
(vllm) ➜  autoscaling git:(fix/hpa_resource) ✗ kubectl apply -f apa-resource.yaml                           
The PodAutoscaler "mock-llama2-7b-hpa1" is invalid: 
* spec.metricsSources[0].path: Required value
* spec.metricsSources[0].protocolType: Required value

```

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>