### PR TITLE
[Misc] refactor roleSet test validation to use validation Package

### DIFF
--- a/test/integration/controller/podset_test.go
+++ b/test/integration/controller/podset_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	orchestrationapi "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/controller/constants"
 	"github.com/vllm-project/aibrix/test/utils/validation"
 	"github.com/vllm-project/aibrix/test/utils/wrapper"
 )
@@ -117,7 +118,7 @@ var _ = ginkgo.Describe("PodSet controller test", func() {
 							// Step 1: Create the PodSet
 							gomega.Expect(k8sClient.Create(ctx, podset)).To(gomega.Succeed())
 							// Step 2: Wait for all Pods to be created
-							validation.WaitForPodSetPodsCreated(ctx, k8sClient, ns.Name, podset.Name, 3)
+							validation.WaitForPodsCreated(ctx, k8sClient, ns.Name, constants.PodSetNameLabelKey, podset.Name, 3)
 						},
 						checkFunc: func(ctx context.Context, k8sClient client.Client, podset *orchestrationapi.PodSet) {
 							// Validate Spec
@@ -131,9 +132,9 @@ var _ = ginkgo.Describe("PodSet controller test", func() {
 						// trigger PodSet all pods to ready
 						updateFunc: func(podset *orchestrationapi.PodSet) {
 							// Step 1: List all Pods
-							validation.WaitForPodSetPodsCreated(ctx, k8sClient, ns.Name, podset.Name, 3)
+							validation.WaitForPodsCreated(ctx, k8sClient, ns.Name, constants.PodSetNameLabelKey, podset.Name, 3)
 							// Step 2: Patch all Pods to Running and Ready (simulate integration test environment)
-							validation.MarkPodSetPodsReady(ctx, k8sClient, ns.Name, podset.Name)
+							validation.MarkPodsReady(ctx, k8sClient, ns.Name, constants.PodSetNameLabelKey, podset.Name)
 						},
 						checkFunc: func(ctx context.Context, k8sClient client.Client, podset *orchestrationapi.PodSet) {
 							// Validate Spec

--- a/test/integration/controller/roleset_test.go
+++ b/test/integration/controller/roleset_test.go
@@ -79,117 +79,6 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 		updates     []*update
 	}
 
-	// Helper function to create pod template
-	makePodTemplate := func(image string) corev1.PodTemplateSpec {
-		return corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					"app": "test",
-				},
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "test-container",
-						Image: image,
-					},
-				},
-			},
-		}
-	}
-
-	// Helper function to make pod ready
-	makePodReady := func(pod *corev1.Pod) {
-		pod.Status.Phase = corev1.PodRunning
-		pod.Status.Conditions = []corev1.PodCondition{
-			{
-				Type:   corev1.PodReady,
-				Status: corev1.ConditionTrue,
-				Reason: "TestReady",
-			},
-		}
-	}
-
-	// Helper function to wait for pods and make them ready
-	waitAndMakePodsReady := func(rs *orchestrationapi.RoleSet, expectedCount int) {
-		gomega.Eventually(func(g gomega.Gomega) int {
-			podList := &corev1.PodList{}
-			g.Expect(k8sClient.List(ctx, podList,
-				client.InNamespace(ns.Name),
-				client.MatchingLabels{constants.RoleSetNameLabelKey: rs.Name})).To(gomega.Succeed())
-			return len(podList.Items)
-		}, time.Second*10, time.Millisecond*250).Should(gomega.Equal(expectedCount))
-
-		gomega.Eventually(func(g gomega.Gomega) {
-			podList := &corev1.PodList{}
-			g.Expect(k8sClient.List(ctx, podList,
-				client.InNamespace(ns.Name),
-				client.MatchingLabels{constants.RoleSetNameLabelKey: rs.Name})).To(gomega.Succeed())
-
-			for i := range podList.Items {
-				pod := &podList.Items[i]
-				if pod.DeletionTimestamp != nil {
-					continue
-				}
-				makePodReady(pod)
-				g.Expect(k8sClient.Status().Update(ctx, pod)).To(gomega.Succeed())
-			}
-		}, time.Second*5, time.Millisecond*250).Should(gomega.Succeed())
-	}
-
-	// Helper function to get pods for a specific role
-	getPodsForRole := func(rs *orchestrationapi.RoleSet, roleName string) []*corev1.Pod {
-		podList := &corev1.PodList{}
-		gomega.Expect(k8sClient.List(ctx, podList,
-			client.InNamespace(ns.Name),
-			client.MatchingLabels{
-				constants.RoleSetNameLabelKey: rs.Name,
-				constants.RoleNameLabelKey:    roleName,
-			})).To(gomega.Succeed())
-
-		pods := make([]*corev1.Pod, len(podList.Items))
-		for i := range podList.Items {
-			pods[i] = &podList.Items[i]
-		}
-		return pods
-	}
-
-	// Helper function to continuously make pods ready during upgrade
-	startPodReadyHelper := func(rs *orchestrationapi.RoleSet) chan struct{} {
-		stopChan := make(chan struct{})
-		go func() {
-			ticker := time.NewTicker(time.Second)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-stopChan:
-					return
-				case <-ticker.C:
-					podList := &corev1.PodList{}
-					if err := k8sClient.List(ctx, podList,
-						client.InNamespace(ns.Name),
-						client.MatchingLabels{constants.RoleSetNameLabelKey: rs.Name}); err != nil {
-						ginkgo.GinkgoLogr.Error(err, "Failed to list pods in startPodReadyHelper")
-						continue
-					}
-					for i := range podList.Items {
-						pod := &podList.Items[i]
-						if pod.DeletionTimestamp != nil {
-							continue
-						}
-						if pod.Status.Phase != corev1.PodRunning {
-							makePodReady(pod)
-							if err := k8sClient.Status().Update(ctx, pod); err != nil {
-								ginkgo.GinkgoLogr.Error(err, "Failed to update pod status in startPodReadyHelper", "pod", pod.Name)
-							}
-						}
-					}
-				}
-			}
-		}()
-		return stopChan
-	}
-
 	ginkgo.DescribeTable("test RoleSet creation and reconciliation",
 		func(tc *testValidatingCase) {
 			roleset := tc.makeRoleSet()
@@ -245,42 +134,15 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 							gomega.Expect(k8sClient.Create(ctx, rs)).To(gomega.Succeed())
 
 							// Step 2: Wait for 3 Pods to be created (1 master + 2 workers)
-							gomega.Eventually(func(g gomega.Gomega) int {
-								podList := &corev1.PodList{}
-								g.Expect(k8sClient.List(ctx, podList,
-									client.InNamespace(ns.Name),
-									client.MatchingLabels{constants.RoleSetNameLabelKey: rs.Name})).To(gomega.Succeed())
-								return len(podList.Items)
-							}, time.Second*10, time.Millisecond*250).Should(gomega.Equal(3)) // 2 worker + 1 master
+							validation.WaitForPodsCreated(ctx, k8sClient, ns.Name, constants.RoleSetNameLabelKey, rs.Name, 3)
 
 							// Step 3: Patch all Pods to Running and Ready (simulate integration test environment)
-							gomega.Eventually(func(g gomega.Gomega) {
-								podList := &corev1.PodList{}
-								g.Expect(k8sClient.List(ctx, podList,
-									client.InNamespace(ns.Name),
-									client.MatchingLabels{constants.RoleSetNameLabelKey: rs.Name})).To(gomega.Succeed())
+							validation.MarkPodsReady(ctx, k8sClient, ns.Name, constants.RoleSetNameLabelKey, rs.Name)
 
-								for i := range podList.Items {
-									pod := &podList.Items[i]
-									if pod.DeletionTimestamp != nil {
-										continue
-									}
-									pod.Status.Phase = corev1.PodRunning
-									pod.Status.Conditions = []corev1.PodCondition{
-										{
-											Type:   corev1.PodReady,
-											Status: corev1.ConditionTrue,
-											Reason: "TestReady",
-										},
-									}
-									g.Expect(k8sClient.Status().Update(ctx, pod)).To(gomega.Succeed())
-								}
-							}, time.Second*5, time.Millisecond*250).Should(gomega.Succeed())
 						},
 						checkFunc: func(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet) {
 							// Validate Spec
-							gomega.Expect(rs.Spec.UpdateStrategy).To(gomega.Equal(orchestrationapi.SequentialRoleSetStrategyType))
-							gomega.Expect(rs.Spec.Roles).To(gomega.HaveLen(2))
+							validation.ValidateRoleSetSpec(rs, 2, orchestrationapi.SequentialRoleSetStrategyType)
 
 							gomega.Eventually(func() error {
 								latest := &orchestrationapi.RoleSet{}
@@ -288,49 +150,13 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 								if err := k8sClient.Get(ctx, key, latest); err != nil {
 									return fmt.Errorf("failed to get latest RoleSet: %w", err)
 								}
-
-								masterRole := validation.FindRoleStatus(latest, "master")
-								workerRole := validation.FindRoleStatus(latest, "worker")
-
-								if masterRole == nil {
-									return errors.New("master role status not found")
-								}
-								if workerRole == nil {
-									return errors.New("worker role status not found")
-								}
-
 								// Validate master status
-								if masterRole.Replicas != 1 {
-									return fmt.Errorf("expected master.Replicas=1, got %d", masterRole.Replicas)
+								if err := validation.ValidateRoleStatus(latest, "master", 1); err != nil {
+									return err
 								}
-								if masterRole.ReadyReplicas != 1 {
-									return fmt.Errorf("expected master.ReadyReplicas=1, got %d", masterRole.ReadyReplicas)
-								}
-								if masterRole.NotReadyReplicas != 0 {
-									return fmt.Errorf("expected master.NotReadyReplicas=0, got %d", masterRole.NotReadyReplicas)
-								}
-								if masterRole.UpdatedReplicas != 1 {
-									return fmt.Errorf("expected master.UpdatedReplicas=1, got %d", masterRole.UpdatedReplicas)
-								}
-								if masterRole.UpdatedReadyReplicas != 1 {
-									return fmt.Errorf("expected master.UpdatedReadyReplicas=1, got %d", masterRole.UpdatedReadyReplicas)
-								}
-
 								// Validate worker status
-								if workerRole.Replicas != 2 {
-									return fmt.Errorf("expected worker.Replicas=2, got %d", workerRole.Replicas)
-								}
-								if workerRole.ReadyReplicas != 2 {
-									return fmt.Errorf("expected worker.ReadyReplicas=2, got %d", workerRole.ReadyReplicas)
-								}
-								if workerRole.NotReadyReplicas != 0 {
-									return fmt.Errorf("expected worker.NotReadyReplicas=0, got %d", workerRole.NotReadyReplicas)
-								}
-								if workerRole.UpdatedReplicas != 2 {
-									return fmt.Errorf("expected worker.UpdatedReplicas=2, got %d", workerRole.UpdatedReplicas)
-								}
-								if workerRole.UpdatedReadyReplicas != 2 {
-									return fmt.Errorf("expected worker.UpdatedReadyReplicas=2, got %d", workerRole.UpdatedReadyReplicas)
+								if err := validation.ValidateRoleStatus(latest, "worker", 2); err != nil {
+									return err
 								}
 
 								// Validate Conditions
@@ -338,6 +164,7 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 								if cond == nil {
 									return errors.New("RoleSetReady condition not found")
 								}
+
 								return nil
 							}, time.Second*30, time.Millisecond*250).Should(gomega.Succeed(), "RoleSet status did not become ready in time")
 						},
@@ -356,7 +183,7 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 						Name:         router,
 						Replicas:     int32Ptr(1),
 						UpgradeOrder: int32Ptr(1),
-						Template:     makePodTemplate(routerImageVersionV1),
+						Template:     validation.MakePodTemplate(routerImageVersionV1),
 						UpdateStrategy: orchestrationapi.RoleUpdateStrategy{
 							MaxUnavailable: &maxUnavailable,
 						},
@@ -366,7 +193,7 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 						Name:         prefill,
 						Replicas:     int32Ptr(2),
 						UpgradeOrder: int32Ptr(2),
-						Template:     makePodTemplate(prefillImageVersionV1),
+						Template:     validation.MakePodTemplate(prefillImageVersionV1),
 						UpdateStrategy: orchestrationapi.RoleUpdateStrategy{
 							MaxUnavailable: &maxUnavailable,
 						},
@@ -376,7 +203,7 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 						Name:         decode,
 						Replicas:     int32Ptr(2),
 						UpgradeOrder: int32Ptr(3),
-						Template:     makePodTemplate(decodeImageVersionV1),
+						Template:     validation.MakePodTemplate(decodeImageVersionV1),
 						UpdateStrategy: orchestrationapi.RoleUpdateStrategy{
 							MaxUnavailable: &maxUnavailable,
 						},
@@ -394,152 +221,54 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 					{
 						updateFunc: func(rs *orchestrationapi.RoleSet) {
 							gomega.Expect(k8sClient.Create(ctx, rs)).To(gomega.Succeed())
-							waitAndMakePodsReady(rs, 5) // 1 router + 2 prefill + 2 decode
+
+							validation.WaitForPodsCreated(ctx, k8sClient, ns.Name,
+								constants.RoleSetNameLabelKey, rs.Name, 5)
+
+							validation.MarkPodsReady(ctx, k8sClient, ns.Name, constants.RoleSetNameLabelKey, rs.Name)
 						},
 						checkFunc: func(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet) {
-							gomega.Eventually(func() error {
-								latest := &orchestrationapi.RoleSet{}
-								if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), latest); err != nil {
-									return err
-								}
 
-								for _, role := range []string{router, prefill, decode} {
-									roleStatus := validation.FindRoleStatus(latest, role)
-									if roleStatus == nil {
-										return fmt.Errorf("role status for %s not found", role)
-									}
-									if roleStatus.ReadyReplicas == 0 {
-										return fmt.Errorf("role %s not ready yet", role)
-									}
-								}
-								return nil
-							}, time.Second*30, time.Millisecond*250).Should(gomega.Succeed())
+							validation.WaitForRolesReady(ctx, k8sClient, rs, []string{router, prefill, decode})
+
 						},
 					},
 					{
 						updateFunc: func(rs *orchestrationapi.RoleSet) {
-							gomega.Eventually(func(g gomega.Gomega) {
-								latest := &orchestrationapi.RoleSet{}
-								g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), latest)).To(gomega.Succeed())
 
-								for i := range latest.Spec.Roles {
-									switch latest.Spec.Roles[i].Name {
-									case router:
-										latest.Spec.Roles[i].Template = makePodTemplate(routerImageVersionV2)
-									case prefill:
-										latest.Spec.Roles[i].Template = makePodTemplate(prefillImageVersionV2)
-									case decode:
-										latest.Spec.Roles[i].Template = makePodTemplate(decodeImageVersionV2)
-									}
-								}
+							validation.UpdateRolesTemplate(ctx, k8sClient, rs, map[string]string{
+								router:  routerImageVersionV2,
+								prefill: prefillImageVersionV2,
+								decode:  decodeImageVersionV2,
+							})
 
-								g.Expect(k8sClient.Update(ctx, latest)).To(gomega.Succeed())
-							}, time.Second*5, time.Millisecond*250).Should(gomega.Succeed())
 						},
 						checkFunc: func(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet) {
-							stopChan := startPodReadyHelper(rs)
+							stopChan := validation.StartRoleSetPodReadyLoop(ctx, k8sClient, rs, ns.Name)
 							defer close(stopChan)
 
 							// Router should upgrade first
-							gomega.Eventually(func() bool {
-								routerPods := getPodsForRole(rs, router)
-								for _, pod := range routerPods {
-									if pod.Spec.Containers[0].Image == "router:v2" {
-										return true
-									}
-								}
-								return false
-							}, time.Second*15, time.Millisecond*500).Should(gomega.BeTrue(), "router role should start upgrading first")
+							validation.WaitForRoleImage(ctx, k8sClient, rs, ns.Name,
+								router, routerImageVersionV2,
+								"router role should start upgrading first")
 
 							// Prefill should upgrade after router
-							gomega.Eventually(func() bool {
-								routerPods := getPodsForRole(rs, router)
-								routerHasNewImage := false
-								for _, pod := range routerPods {
-									if pod.Spec.Containers[0].Image == "router:v2" {
-										routerHasNewImage = true
-										break
-									}
-								}
-
-								if routerHasNewImage {
-									prefillPods := getPodsForRole(rs, prefill)
-									for _, pod := range prefillPods {
-										if pod.Spec.Containers[0].Image == prefillImageVersionV2 {
-											return true
-										}
-									}
-								}
-								return false
-							}, time.Second*45, time.Millisecond*500).Should(gomega.BeTrue(),
-								"prefill should start upgrading after router starts")
+							validation.WaitForRoleUpgradeInOrder(ctx, k8sClient, rs, ns.Name,
+								router, routerImageVersionV2,
+								prefill, prefillImageVersionV2)
 
 							// Decode should upgrade after prefill
-							gomega.Eventually(func() bool {
-								prefillPods := getPodsForRole(rs, prefill)
-								prefillHasNewImage := false
-								for _, pod := range prefillPods {
-									if pod.Spec.Containers[0].Image == prefillImageVersionV2 {
-										prefillHasNewImage = true
-										break
-									}
-								}
-
-								if prefillHasNewImage {
-									decodePods := getPodsForRole(rs, decode)
-									for _, pod := range decodePods {
-										if pod.Spec.Containers[0].Image == decodeImageVersionV2 {
-											return true
-										}
-									}
-								}
-								return false
-							}, time.Second*45, time.Millisecond*500).Should(gomega.BeTrue(),
-								"decode should start upgrading after prefill starts")
+							validation.WaitForRoleUpgradeInOrder(ctx, k8sClient, rs, ns.Name,
+								prefill, prefillImageVersionV2,
+								decode, decodeImageVersionV2)
 
 							// Verify final state - all roles should be upgraded
-							gomega.Eventually(func() error {
-								latest := &orchestrationapi.RoleSet{}
-								if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), latest); err != nil {
-									return err
-								}
+							validation.WaitForRoleSetFinalState(ctx, k8sClient, rs, ns.Name, map[string]string{
+								router:  routerImageVersionV2,
+								prefill: prefillImageVersionV2,
+								decode:  decodeImageVersionV2,
+							})
 
-								for _, roleName := range []string{router, prefill, decode} {
-									roleStatus := validation.FindRoleStatus(latest, roleName)
-									if roleStatus == nil {
-										return fmt.Errorf("role status for %s not found", roleName)
-									}
-									if roleStatus.UpdatedReadyReplicas != roleStatus.Replicas {
-										return fmt.Errorf("role %s not fully upgraded: %d/%d updated ready",
-											roleName, roleStatus.UpdatedReadyReplicas, roleStatus.Replicas)
-									}
-								}
-
-								// Verify all pods have the new images
-								routerPods := getPodsForRole(rs, router)
-								for _, pod := range routerPods {
-									if pod.Spec.Containers[0].Image != routerImageVersionV2 {
-										return fmt.Errorf("router pod still has old image: %s", pod.Spec.Containers[0].Image)
-									}
-								}
-
-								prefillPods := getPodsForRole(rs, prefill)
-								for _, pod := range prefillPods {
-									if pod.Spec.Containers[0].Image != prefillImageVersionV2 {
-										return fmt.Errorf("prefill pod still has old image: %s", pod.Spec.Containers[0].Image)
-									}
-								}
-
-								decodePods := getPodsForRole(rs, decode)
-								for _, pod := range decodePods {
-									if pod.Spec.Containers[0].Image != decodeImageVersionV2 {
-										return fmt.Errorf("decode pod still has old image: %s", pod.Spec.Containers[0].Image)
-									}
-								}
-
-								return nil
-							}, time.Second*45, time.Millisecond*500).Should(gomega.Succeed(),
-								"All roles should be fully upgraded with new images")
 						},
 					},
 				},
@@ -556,7 +285,7 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 						Name:         prefill,
 						Replicas:     int32Ptr(1),
 						UpgradeOrder: int32Ptr(1),
-						Template:     makePodTemplate(prefillImageVersionV1),
+						Template:     validation.MakePodTemplate(prefillImageVersionV1),
 						UpdateStrategy: orchestrationapi.RoleUpdateStrategy{
 							MaxUnavailable: &maxUnavailable,
 						},
@@ -566,7 +295,7 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 						Name:         decode,
 						Replicas:     int32Ptr(1),
 						UpgradeOrder: int32Ptr(1),
-						Template:     makePodTemplate(decodeImageVersionV1),
+						Template:     validation.MakePodTemplate(decodeImageVersionV1),
 						UpdateStrategy: orchestrationapi.RoleUpdateStrategy{
 							MaxUnavailable: &maxUnavailable,
 						},
@@ -583,86 +312,42 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 					{
 						updateFunc: func(rs *orchestrationapi.RoleSet) {
 							gomega.Expect(k8sClient.Create(ctx, rs)).To(gomega.Succeed())
-							waitAndMakePodsReady(rs, 2)
+							validation.WaitForPodsCreated(ctx, k8sClient, ns.Name, constants.RoleSetNameLabelKey, rs.Name, 2)
+							validation.MarkPodsReady(ctx, k8sClient, ns.Name, constants.RoleSetNameLabelKey, rs.Name)
 						},
 						checkFunc: func(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet) {
-							gomega.Eventually(func() error {
-								latest := &orchestrationapi.RoleSet{}
-								if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), latest); err != nil {
-									return err
-								}
 
-								prefillStatus := validation.FindRoleStatus(latest, prefill)
-								decodeStatus := validation.FindRoleStatus(latest, decode)
+							validation.WaitForRolesReady(ctx, k8sClient, rs, []string{prefill, decode})
 
-								if prefillStatus == nil {
-									return fmt.Errorf("prefill role status not found")
-								}
-								if decodeStatus == nil {
-									return fmt.Errorf("decode role status not found")
-								}
-								if prefillStatus.ReadyReplicas == 0 {
-									return fmt.Errorf("prefill not ready yet")
-								}
-								if decodeStatus.ReadyReplicas == 0 {
-									return fmt.Errorf("decode not ready yet")
-								}
-								return nil
-							}, time.Second*30, time.Millisecond*250).Should(gomega.Succeed())
 						},
 					},
 					{
 						updateFunc: func(rs *orchestrationapi.RoleSet) {
-							gomega.Eventually(func(g gomega.Gomega) {
-								latest := &orchestrationapi.RoleSet{}
-								g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), latest)).To(gomega.Succeed())
 
-								for i := range latest.Spec.Roles {
-									switch latest.Spec.Roles[i].Name {
-									case prefill:
-										latest.Spec.Roles[i].Template = makePodTemplate(prefillImageVersionV2)
-									case decode:
-										latest.Spec.Roles[i].Template = makePodTemplate(decodeImageVersionV2)
-									}
-								}
-								g.Expect(k8sClient.Update(ctx, latest)).To(gomega.Succeed())
-							}, time.Second*5, time.Millisecond*250).Should(gomega.Succeed())
+							validation.UpdateRolesTemplate(ctx, k8sClient, rs, map[string]string{
+								prefill: prefillImageVersionV2,
+								decode:  decodeImageVersionV2,
+							})
+
 						},
 						checkFunc: func(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet) {
 							// Wait for prefill to be upgraded first, as it's defined first in the RoleSet
-							gomega.Eventually(func(g gomega.Gomega) bool {
-								prefillPods := getPodsForRole(rs, prefill)
-								for _, pod := range prefillPods {
-									if pod.Spec.Containers[0].Image == prefillImageVersionV2 {
-										makePodReady(pod)
-										g.Expect(k8sClient.Status().Update(ctx, pod)).To(gomega.Succeed())
-										return true
-									}
-								}
-								return false
-							}, time.Second*15, time.Millisecond*500).Should(gomega.BeTrue(),
+							validation.WaitForRoleImageAndReady(ctx, k8sClient, rs, ns.Name,
+								prefill, prefillImageVersionV2,
 								"prefill role should upgrade first")
 
 							// Verify decode role is not upgraded yet
-							decodePods := getPodsForRole(rs, decode)
+							decodePods := validation.GetRoleSetPodForRole(ctx, k8sClient, rs, ns.Name, decode)
 							for _, pod := range decodePods {
 								gomega.Expect(pod.Spec.Containers[0].Image).To(gomega.Equal(decodeImageVersionV1),
 									"decode role should not be upgraded yet")
 							}
 
 							// Now, wait for decode role to be upgraded
-							gomega.Eventually(func(g gomega.Gomega) bool {
-								decodePods := getPodsForRole(rs, decode)
-								for _, pod := range decodePods {
-									if pod.Spec.Containers[0].Image == decodeImageVersionV2 {
-										makePodReady(pod)
-										g.Expect(k8sClient.Status().Update(ctx, pod)).To(gomega.Succeed())
-										return true
-									}
-								}
-								return false
-							}, time.Second*15, time.Millisecond*500).Should(gomega.BeTrue(),
+							validation.WaitForRoleImageAndReady(ctx, k8sClient, rs, ns.Name,
+								decode, decodeImageVersionV2,
 								"decode role should upgrade after prefill")
+
 						},
 					},
 				},
@@ -679,7 +364,7 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 						Name:         "low-order",
 						Replicas:     int32Ptr(1),
 						UpgradeOrder: int32Ptr(1),
-						Template:     makePodTemplate("low:v1"),
+						Template:     validation.MakePodTemplate("low:v1"),
 						UpdateStrategy: orchestrationapi.RoleUpdateStrategy{
 							MaxUnavailable: &maxUnavailable,
 						},
@@ -689,7 +374,7 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 						Name:         "default-order",
 						Replicas:     int32Ptr(1),
 						UpgradeOrder: nil, // Should upgrade last
-						Template:     makePodTemplate("default:v1"),
+						Template:     validation.MakePodTemplate("default:v1"),
 						UpdateStrategy: orchestrationapi.RoleUpdateStrategy{
 							MaxUnavailable: &maxUnavailable,
 						},
@@ -706,77 +391,35 @@ var _ = ginkgo.Describe("RoleSet controller test", func() {
 					{
 						updateFunc: func(rs *orchestrationapi.RoleSet) {
 							gomega.Expect(k8sClient.Create(ctx, rs)).To(gomega.Succeed())
-							waitAndMakePodsReady(rs, 2)
+							validation.WaitForPodsCreated(ctx, k8sClient, ns.Name, constants.RoleSetNameLabelKey, rs.Name, 2)
+							validation.MarkPodsReady(ctx, k8sClient, ns.Name, constants.RoleSetNameLabelKey, rs.Name)
 						},
 						checkFunc: func(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet) {
-							gomega.Eventually(func() error {
-								latest := &orchestrationapi.RoleSet{}
-								if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), latest); err != nil {
-									return err
-								}
 
-								defaultStatus := validation.FindRoleStatus(latest, "default-order")
-								lowStatus := validation.FindRoleStatus(latest, "low-order")
+							validation.WaitForRolesReady(ctx, k8sClient, rs, []string{"default-order", "low-order"})
 
-								if defaultStatus == nil {
-									return fmt.Errorf("default-order role status not found")
-								}
-								if lowStatus == nil {
-									return fmt.Errorf("low-order role status not found")
-								}
-								if defaultStatus.ReadyReplicas == 0 {
-									return fmt.Errorf("default-order not ready yet")
-								}
-								if lowStatus.ReadyReplicas == 0 {
-									return fmt.Errorf("low-order not ready yet")
-								}
-								return nil
-							}, time.Second*30, time.Millisecond*250).Should(gomega.Succeed())
 						},
 					},
 					{
 						updateFunc: func(rs *orchestrationapi.RoleSet) {
-							gomega.Eventually(func(g gomega.Gomega) {
-								latest := &orchestrationapi.RoleSet{}
-								g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), latest)).To(gomega.Succeed())
 
-								for i := range latest.Spec.Roles {
-									switch latest.Spec.Roles[i].Name {
-									case "default-order":
-										latest.Spec.Roles[i].Template = makePodTemplate("default:v2")
-									case "low-order":
-										latest.Spec.Roles[i].Template = makePodTemplate("low:v2")
-									}
-								}
-								g.Expect(k8sClient.Update(ctx, latest)).To(gomega.Succeed())
-							}, time.Second*5, time.Millisecond*250).Should(gomega.Succeed())
+							validation.UpdateRolesTemplate(ctx, k8sClient, rs, map[string]string{
+								"default-order": "default:v2",
+								"low-order":     "low:v2",
+							})
+
 						},
 						checkFunc: func(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet) {
 							// Low order role (order 1) should upgrade first
-							gomega.Eventually(func() bool {
-								lowPods := getPodsForRole(rs, "low-order")
-								for _, pod := range lowPods {
-									if pod.Spec.Containers[0].Image == "low:v2" {
-										makePodReady(pod)
-										_ = k8sClient.Status().Update(ctx, pod)
-										return true
-									}
-								}
-								return false
-							}, time.Second*15, time.Millisecond*500).Should(gomega.BeTrue(), "Low order role should upgrade first")
+							validation.WaitForRoleImageAndReady(ctx, k8sClient, rs, ns.Name,
+								"low-order", "low:v2",
+								"Low order role should upgrade first")
 
 							// Then default order role (nil) should upgrade last
-							gomega.Eventually(func() bool {
-								defaultPods := getPodsForRole(rs, "default-order")
-								for _, pod := range defaultPods {
-									if pod.Spec.Containers[0].Image == "default:v2" {
-										makePodReady(pod)
-										_ = k8sClient.Status().Update(ctx, pod)
-										return true
-									}
-								}
-								return false
-							}, time.Second*20, time.Millisecond*500).Should(gomega.BeTrue(), "Default order role (nil) should upgrade last")
+							validation.WaitForRoleImageAndReady(ctx, k8sClient, rs, ns.Name,
+								"default-order", "default:v2",
+								"Default order role (nil) should upgrade last")
+
 						},
 					},
 				},

--- a/test/utils/validation/pod.go
+++ b/test/utils/validation/pod.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func WaitForPodsCreated(ctx context.Context, k8sClient client.Client,
+	ns, podLabelKey, podLabelValue string, expected int) {
+	gomega.Eventually(func(g gomega.Gomega) int {
+		podList := &corev1.PodList{}
+		g.Expect(k8sClient.List(ctx, podList,
+			client.InNamespace(ns),
+			client.MatchingLabels{podLabelKey: podLabelValue},
+		)).To(gomega.Succeed())
+		return len(podList.Items)
+	}, time.Second*10, time.Millisecond*250).Should(gomega.Equal(expected))
+}
+
+func MarkPodsReady(ctx context.Context, k8sClient client.Client, ns, podLabelKey, podLabelValue string) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		podList := &corev1.PodList{}
+		g.Expect(k8sClient.List(ctx, podList,
+			client.InNamespace(ns),
+			client.MatchingLabels{podLabelKey: podLabelValue},
+		)).To(gomega.Succeed())
+
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			if pod.DeletionTimestamp != nil {
+				continue
+			}
+			MakePodReady(pod)
+			g.Expect(k8sClient.Status().Update(ctx, pod)).To(gomega.Succeed())
+		}
+	}, time.Second*5, time.Millisecond*250).Should(gomega.Succeed())
+}
+
+func MakePodReady(pod *corev1.Pod) {
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.Conditions = []corev1.PodCondition{
+		{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionTrue,
+			Reason: "TestReady",
+		},
+	}
+}
+
+func MakePodTemplate(image string) corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app": "test",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "test-container",
+					Image: image,
+				},
+			},
+		},
+	}
+}

--- a/test/utils/validation/roleset.go
+++ b/test/utils/validation/roleset.go
@@ -16,7 +16,19 @@ limitations under the License.
 
 package validation
 
-import orchestrationapi "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	orchestrationapi "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/controller/constants"
+)
 
 // TODO: Put some common validation logic here: e.g ValidateRoleSet ValidateRoleSetStatusEqualTo ...
 
@@ -37,4 +49,248 @@ func FindCondition(condType string, c []orchestrationapi.Condition) *orchestrati
 		}
 	}
 	return nil
+}
+
+// ValidateRoleSetSpec verify the roleSet spec
+func ValidateRoleSetSpec(roleSet *orchestrationapi.RoleSet,
+	expectedRoleCount int,
+	updateStrategyType orchestrationapi.RoleSetUpdateStrategyType) {
+	gomega.Expect(roleSet.Spec.UpdateStrategy).To(gomega.Equal(updateStrategyType))
+	gomega.Expect(roleSet.Spec.Roles).To(gomega.HaveLen(expectedRoleCount))
+}
+
+// ValidateRoleStatus verify RoleStatus of a role
+func ValidateRoleStatus(rs *orchestrationapi.RoleSet, role string, expectedReplicas int32) error {
+	roleStatus := FindRoleStatus(rs, role)
+
+	if roleStatus == nil {
+		return fmt.Errorf("%s role status not found", role)
+	}
+
+	// Validate master status
+	if roleStatus.Replicas != expectedReplicas {
+		return fmt.Errorf("expected %s.Replicas=%d, got %d", role, expectedReplicas, roleStatus.Replicas)
+	}
+	if roleStatus.ReadyReplicas != expectedReplicas {
+		return fmt.Errorf("expected %s.ReadyReplicas=%d, got %d", role, expectedReplicas, roleStatus.ReadyReplicas)
+	}
+	if roleStatus.NotReadyReplicas != 0 {
+		return fmt.Errorf("expected %s.NotReadyReplicas=0, got %d", role, roleStatus.NotReadyReplicas)
+	}
+	if roleStatus.UpdatedReplicas != expectedReplicas {
+		return fmt.Errorf("expected %s.UpdatedReplicas=%d, got %d",
+			role, expectedReplicas, roleStatus.UpdatedReplicas)
+	}
+	if roleStatus.UpdatedReadyReplicas != expectedReplicas {
+		return fmt.Errorf("expected %s.UpdatedReadyReplicas=%d, got %d",
+			role, expectedReplicas, roleStatus.UpdatedReadyReplicas)
+	}
+
+	return nil
+}
+
+// GetRoleSetPodForRole list the pod for certain role
+func GetRoleSetPodForRole(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet,
+	ns, roleName string) []*corev1.Pod {
+	podList := &corev1.PodList{}
+	gomega.Expect(k8sClient.List(ctx, podList,
+		client.InNamespace(ns),
+		client.MatchingLabels{
+			constants.RoleSetNameLabelKey: rs.Name,
+			constants.RoleNameLabelKey:    roleName,
+		})).To(gomega.Succeed())
+
+	pods := make([]*corev1.Pod, len(podList.Items))
+	for i := range podList.Items {
+		pods[i] = &podList.Items[i]
+	}
+	return pods
+}
+
+// ValidateRoleImage Verify all pods of a certain role have the new images
+func ValidateRoleImage(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet,
+	ns, role, expectedImage string) error {
+
+	pods := GetRoleSetPodForRole(ctx, k8sClient, rs, ns, role)
+
+	for _, pod := range pods {
+		if pod.Spec.Containers[0].Image != expectedImage {
+			return fmt.Errorf("%s pod still has old image: %s", role, pod.Spec.Containers[0].Image)
+		}
+	}
+
+	return nil
+
+}
+
+// roleHasImage verify role have expected image
+func roleHasImage(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet,
+	ns, role, expectedImage string) (*corev1.Pod, bool) {
+
+	pods := GetRoleSetPodForRole(ctx, k8sClient, rs, ns, role)
+	for _, pod := range pods {
+		if pod.Spec.Containers[0].Image == expectedImage {
+			return pod, true
+		}
+	}
+
+	return nil, false
+
+}
+
+// WaitForRoleImage verify role have expected image and make the pod ready
+func WaitForRoleImage(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet,
+	ns, role, expectedImage string, description ...interface{}) {
+	gomega.Eventually(func(g gomega.Gomega) bool {
+
+		_, ok := roleHasImage(ctx, k8sClient, rs, ns, role, expectedImage)
+
+		return ok
+
+	}, time.Second*15, time.Millisecond*500).Should(gomega.BeTrue(),
+		description...)
+}
+
+// WaitForRoleImageAndReady verify role have expected image and make the pod ready
+func WaitForRoleImageAndReady(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet,
+	ns, role, expectedImage string, description ...interface{}) {
+	gomega.Eventually(func(g gomega.Gomega) bool {
+
+		pod, ok := roleHasImage(ctx, k8sClient, rs, ns, role, expectedImage)
+		if ok {
+			MakePodReady(pod)
+			g.Expect(k8sClient.Status().Update(ctx, pod)).To(gomega.Succeed())
+		}
+		return ok
+
+	}, time.Second*15, time.Millisecond*500).Should(gomega.BeTrue(),
+		description...)
+}
+
+// WaitForRolesReady verify role in the role list is ready
+func WaitForRolesReady(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet, roleList []string) {
+	gomega.Eventually(func() error {
+		latest := &orchestrationapi.RoleSet{}
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), latest); err != nil {
+			return err
+		}
+
+		for _, role := range roleList {
+			roleStatus := FindRoleStatus(latest, role)
+			if roleStatus == nil {
+				return fmt.Errorf("%s role status not found", role)
+			}
+			if roleStatus.ReadyReplicas == 0 {
+				return fmt.Errorf("%s not ready yet", role)
+			}
+		}
+
+		return nil
+	}, time.Second*30, time.Millisecond*250).Should(gomega.Succeed())
+}
+
+// UpdateRolesTemplate update the template of roles
+func UpdateRolesTemplate(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet,
+	roleTemplateMap map[string]string) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		latest := &orchestrationapi.RoleSet{}
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), latest)).To(gomega.Succeed())
+
+		for i := range latest.Spec.Roles {
+			if _, ok := roleTemplateMap[latest.Spec.Roles[i].Name]; !ok {
+				continue
+			}
+
+			latest.Spec.Roles[i].Template = MakePodTemplate(roleTemplateMap[latest.Spec.Roles[i].Name])
+
+		}
+
+		g.Expect(k8sClient.Update(ctx, latest)).To(gomega.Succeed())
+
+	}, time.Second*5, time.Millisecond*250).Should(gomega.Succeed())
+}
+
+// WaitForRoleUpgradeInOrder verify the role upgrade order
+func WaitForRoleUpgradeInOrder(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet, ns,
+	firstRole, firstImage,
+	secondRole, secondImage string) {
+	gomega.Eventually(func() bool {
+		_, firstRoleHasNewImage := roleHasImage(ctx, k8sClient, rs, ns, firstRole, firstImage)
+		_, secondRoleHasNewImage := roleHasImage(ctx, k8sClient, rs, ns, secondRole, secondImage)
+		if secondRoleHasNewImage && !firstRoleHasNewImage {
+			return false
+		}
+		if firstRoleHasNewImage && secondRoleHasNewImage {
+			return true
+		}
+		return false
+
+	}, time.Second*45, time.Millisecond*500).Should(gomega.BeTrue(),
+		"%s should start upgrading after %s starts", secondRole, firstRole)
+}
+
+// WaitForRoleSetFinalState verify roleSet final state
+func WaitForRoleSetFinalState(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet,
+	ns string, roleImageMap map[string]string) {
+	gomega.Eventually(func() error {
+		latest := &orchestrationapi.RoleSet{}
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), latest); err != nil {
+			return err
+		}
+
+		for role, image := range roleImageMap {
+			roleStatus := FindRoleStatus(latest, role)
+			if roleStatus == nil {
+				return fmt.Errorf("role status for %s not found", role)
+			}
+			if roleStatus.UpdatedReadyReplicas != roleStatus.Replicas {
+				return fmt.Errorf("role %s not fully upgraded: %d/%d updated ready",
+					role, roleStatus.UpdatedReadyReplicas, roleStatus.Replicas)
+			}
+			// verify role have the new image
+			if err := ValidateRoleImage(ctx, k8sClient, rs, ns, role, image); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}, time.Second*45, time.Millisecond*500).Should(gomega.Succeed(),
+		"All roles should be fully upgraded with new images")
+}
+
+func StartRoleSetPodReadyLoop(ctx context.Context, k8sClient client.Client, rs *orchestrationapi.RoleSet,
+	ns string) chan struct{} {
+	stopChan := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopChan:
+				return
+			case <-ticker.C:
+				podList := &corev1.PodList{}
+				if err := k8sClient.List(ctx, podList,
+					client.InNamespace(ns),
+					client.MatchingLabels{constants.RoleSetNameLabelKey: rs.Name}); err != nil {
+					ginkgo.GinkgoLogr.Error(err, "Failed to list pods in startPodReadyHelper")
+					continue
+				}
+				for i := range podList.Items {
+					pod := &podList.Items[i]
+					if pod.DeletionTimestamp != nil {
+						continue
+					}
+					if pod.Status.Phase != corev1.PodRunning {
+						MakePodReady(pod)
+						if err := k8sClient.Status().Update(ctx, pod); err != nil {
+							ginkgo.GinkgoLogr.Error(err, "Failed to update pod status in startPodReadyHelper",
+								"pod", pod.Name)
+						}
+					}
+				}
+			}
+		}
+	}()
+	return stopChan
 }


### PR DESCRIPTION
## Pull Request Description

 - Added test/utils/validation/pod.go to host shared pod helpers (WaitForPodsCreated, MarkPodsReady, MakePodTemplate,
    etc.) reused across PodSet, RoleSet, and StormService controller tests.

 - Added a full RoleSet validation toolkit (test/utils/validation/roleset.go) covering spec/status checks, image-rollout waits,
    template updates, upgrade-order assertions, and final-state verification. 

This is my first PR to this repo, please let me know if anything needs to be adjusted or improved.

## Related Issues
Resolves: #1535 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[x] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>