### PR TITLE
[CLI] Fix replicate args assignment in main.go

### DIFF
--- a/config/dependency/kuberay-operator/templates/deployment.yaml
+++ b/config/dependency/kuberay-operator/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - /manager
           args:
             - --feature-gates=RayClusterStatusConditions=true
-            - --leader-elect
+            - --enable-leader-election=true
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## Pull Request Description
There are two replicate assignment of the flag to `enableLeaderElection` in `aibrix/cmd/controllers/main.go`. I remove the former for the code clarity.

This change will make the user interface different, since the `--leader-elect` flag is not used any more and we could only use `--enable-leader-election` flag in the future.

## Related Issues
Resolves: No Issues, This is a little fix for code clarity.
---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>