### PR TITLE
[MISC] add unit test for podautoscaler monitor

### DIFF
--- a/pkg/controller/podautoscaler/monitor/monitor_test.go
+++ b/pkg/controller/podautoscaler/monitor/monitor_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitor
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMonitor_RecordScaleAction(t *testing.T) {
+	// Reset the metric before the test to ensure a clean state and avoid interference between test runs.
+	autoscalerScaleAction.Reset()
+
+	m := New()
+
+	// Define test cases
+	testCases := []struct {
+		namespace       string
+		name            string
+		algorithm       string
+		reason          string
+		desiredReplicas int32
+	}{
+		{"test-namespace", "test-name", "test-algorithm", "test-reason", 5},
+		{"prod-namespace", "prod-name", "prod-algorithm", "prod-reason", 10},
+	}
+
+	// Record all scale actions
+	for _, tc := range testCases {
+		m.RecordScaleAction(tc.namespace, tc.name, tc.algorithm, tc.reason, tc.desiredReplicas)
+	}
+	// Check that all metrics were recorded correctly
+	for _, tc := range testCases {
+		expectedValue := float64(tc.desiredReplicas)
+		actualValue := testutil.ToFloat64(autoscalerScaleAction.WithLabelValues(tc.namespace, tc.name, tc.algorithm, tc.reason))
+		assert.Equal(t, expectedValue, actualValue, "Expected metric for %s/%s to be %v", tc.namespace, tc.name, tc.desiredReplicas)
+	}
+}


### PR DESCRIPTION
## Pull Request Description
Add unit test for podautoscaler monitor.
```bash
ubuntu:~/aibrix(monitor-ut)$ go test ./pkg/controller/podautoscaler/monitor/ -cover 
ok  	github.com/vllm-project/aibrix/pkg/controller/podautoscaler/monitor	0.015s	coverage: 100.0% of statements
```

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[x] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>