### PR TITLE
Make Gateway API compatible with OpenAI API

### DIFF
--- a/development/app/app.py
+++ b/development/app/app.py
@@ -75,7 +75,7 @@ def auth_error(status):
             {
                 "error": {
                     "message": "Incorrect API key provided. You can find your API key at https://platform.openai.com/account/api-keys.",
-                    "type": "invalid_request_error",
+                    "type": "authentication_error",
                     "param": None,
                     "code": "invalid_api_key",
                 }
@@ -368,7 +368,7 @@ def completion():
         err = {
             "error": {
                 "message": f"The server had an error while processing your request. Sorry about that!",
-                "type": "server_error",
+                "type": "api_error",
                 "param": None,
                 "code": None,
             }
@@ -550,7 +550,7 @@ def chat_completions():
         err = {
             "error": {
                 "message": f"The server had an error while processing your request. Sorry about that!",
-                "type": "server_error",
+                "type": "api_error",
                 "param": None,
                 "code": None,
             }
@@ -697,7 +697,7 @@ def embeddings():
         err = {
             "error": {
                 "message": "The server had an error while processing your request. Sorry about that!",
-                "type": "server_error",
+                "type": "api_error",
                 "param": None,
                 "code": None,
             }

--- a/pkg/plugins/gateway/gateway_req_headers.go
+++ b/pkg/plugins/gateway/gateway_req_headers.go
@@ -60,7 +60,7 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, req
 			envoyTypePb.StatusCode_BadRequest,
 			[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
 				Key: HeaderErrorInvalidRouting, RawValue: []byte(routingStrategy),
-			}}}, "incorrect routing strategy"), utils.User{}, rpm, routingCtx
+			}}}, "incorrect routing strategy", "", "routing-strategy"), utils.User{}, rpm, routingCtx
 	}
 
 	if username != "" {
@@ -72,7 +72,7 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, req
 				[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
 					Key: HeaderErrorUser, RawValue: []byte("true"),
 				}}},
-				err.Error()), utils.User{}, rpm, routingCtx
+				err.Error(), "", ""), utils.User{}, rpm, routingCtx
 		}
 
 		rpm, errRes, err = s.checkLimits(ctx, user)

--- a/pkg/plugins/gateway/gateway_rsp_body.go
+++ b/pkg/plugins/gateway/gateway_rsp_body.go
@@ -90,7 +90,7 @@ func (s *Server) HandleResponseBody(ctx context.Context, requestID string, req *
 				[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
 					Key: HeaderErrorStreaming, RawValue: []byte("true"),
 				}}},
-				err.Error()), complete
+				err.Error(), "", ""), complete
 		}
 	} else {
 		if isLanguageRequest(routerCtx.ReqPath) {
@@ -114,7 +114,7 @@ func (s *Server) HandleResponseBody(ctx context.Context, requestID string, req *
 					[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
 						Key: HeaderErrorIncrTPM, RawValue: []byte("true"),
 					}}},
-					err.Error()), complete
+					err.Error(), "", ""), complete
 			}
 
 			headers = append(headers,
@@ -215,7 +215,7 @@ func processLanguageResponse(requestID string, b *extProcPb.ProcessingRequest_Re
 	if err := json.Unmarshal(finalBody, &res); err != nil {
 		klog.ErrorS(err, "error to unmarshal response", "requestID", requestID, "responseBody", string(b.ResponseBody.GetBody()))
 		complete = true
-		processingRes = buildErrorResponse(envoyTypePb.StatusCode_InternalServerError, err.Error(), HeaderErrorResponseUnmarshal, "true")
+		processingRes = buildErrorResponse(envoyTypePb.StatusCode_InternalServerError, err.Error(), "", "", HeaderErrorResponseUnmarshal, "true")
 		return
 	}
 
@@ -233,7 +233,7 @@ func processLanguageResponse(requestID string, b *extProcPb.ProcessingRequest_Re
 		}
 
 		complete = true
-		processingRes = buildErrorResponse(code, msg, HeaderErrorResponseUnknown, "true")
+		processingRes = buildErrorResponse(code, msg, "", "", HeaderErrorResponseUnknown, "true")
 		return
 	}
 


### PR DESCRIPTION
## Pull Request Description
I notice the error response format is completely incompatible. after checking https://github.com/openai/openai-openapi/tree/master?tab=readme-ov-file

- Gateway is missing required fields: type, param
- Gateway uses HTTP status code (int) for code instead of error code string
- 401 errors return invalid JSON: {"error":"unauthorized"}
- Error responses don't match OpenAI format. This affects: authentication errors, validation errors, rate limits, server errors, routing

## Related Issues
Resolves: #1677, part of https://github.com/vllm-project/aibrix/issues/846

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>