### PR TITLE
refactor(metrics): use Subsystem for aibrix metrics instead of embedding in Name

### DIFF
--- a/cmd/kvcache-watcher/main.go
+++ b/cmd/kvcache-watcher/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/utils"
 
 	corev1 "k8s.io/api/core/v1"
@@ -78,29 +79,34 @@ var (
 
 var (
 	metadataVersionGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "kvcache_cluster_version",
-		Help: "Current version of the KVCache cluster metadata.",
+		Subsystem: constants.AibrixSubsystemName,
+		Name:      "kvcache_cluster_version",
+		Help:      "Current version of the KVCache cluster metadata.",
 	}, []string{"name"})
 
 	metadataUpgradeCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "kvcache_metadata_version_upgrade_counter",
-		Help: "Number of times the metadata version has been upgraded.",
+		Subsystem: constants.AibrixSubsystemName,
+		Name:      "kvcache_metadata_version_upgrade_counter",
+		Help:      "Number of times the metadata version has been upgraded.",
 	}, []string{"name"})
 
 	metadataUpdateSkippedCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "kvcache_metadata_update_skipped",
-		Help: "Number of times there's no valid pods and skip the metadata updates.",
+		Subsystem: constants.AibrixSubsystemName,
+		Name:      "kvcache_metadata_update_skipped",
+		Help:      "Number of times there's no valid pods and skip the metadata updates.",
 	}, []string{"name"})
 
 	metadataUpdateFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "kvcache_metadata_update_failures_total",
-		Help: "Total number of failures when updating cluster metadata to Redis.",
+		Subsystem: constants.AibrixSubsystemName,
+		Name:      "kvcache_metadata_update_failures_total",
+		Help:      "Total number of failures when updating cluster metadata to Redis.",
 	}, []string{"name"})
 
 	podStatusPhaseGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "kvcache_pod_status_phase_total",
-			Help: "Number of KVCache pods per status phase.",
+			Subsystem: constants.AibrixSubsystemName,
+			Name:      "kvcache_pod_status_phase_total",
+			Help:      "Number of KVCache pods per status phase.",
 		},
 		[]string{"name", "phase"},
 	)

--- a/pkg/cache/kvcache/metrics.go
+++ b/pkg/cache/kvcache/metrics.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/klog/v2"
+
+	"github.com/vllm-project/aibrix/pkg/constants"
 )
 
 // Metric labels
@@ -97,22 +99,25 @@ func createKVCacheMetrics() *KVCacheMetrics {
 		// Connection metrics
 		zmqConnectionTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "aibrix_kvcache_zmq_connections_total",
-				Help: "Total number of ZMQ connections established",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_connections_total",
+				Help:      "Total number of ZMQ connections established",
 			},
 			[]string{LabelPodKey},
 		),
 		zmqDisconnectionTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "aibrix_kvcache_zmq_disconnections_total",
-				Help: "Total number of ZMQ disconnections",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_disconnections_total",
+				Help:      "Total number of ZMQ disconnections",
 			},
 			[]string{LabelPodKey},
 		),
 		zmqReconnectAttemptsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "aibrix_kvcache_zmq_reconnect_attempts_total",
-				Help: "Total number of ZMQ reconnection attempts",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_reconnect_attempts_total",
+				Help:      "Total number of ZMQ reconnection attempts",
 			},
 			[]string{LabelPodKey},
 		),
@@ -120,30 +125,34 @@ func createKVCacheMetrics() *KVCacheMetrics {
 		// Event metrics
 		zmqEventsReceivedTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "aibrix_kvcache_zmq_events_received_total",
-				Help: "Total number of KV cache events received",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_events_received_total",
+				Help:      "Total number of KV cache events received",
 			},
 			[]string{LabelPodKey, LabelEventType},
 		),
 		zmqEventsProcessedTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "aibrix_kvcache_zmq_events_processed_total",
-				Help: "Total number of KV cache events successfully processed",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_events_processed_total",
+				Help:      "Total number of KV cache events successfully processed",
 			},
 			[]string{LabelPodKey, LabelEventType},
 		),
 		zmqEventProcessingDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "aibrix_kvcache_zmq_event_processing_duration_seconds",
-				Help:    "Time taken to process KV cache events",
-				Buckets: prometheus.ExponentialBuckets(0.00001, 2, 15), // 10us to ~160ms
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_event_processing_duration_seconds",
+				Help:      "Time taken to process KV cache events",
+				Buckets:   prometheus.ExponentialBuckets(0.00001, 2, 15), // 10us to ~160ms
 			},
 			[]string{LabelPodKey},
 		),
 		zmqMissedEventsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "aibrix_kvcache_zmq_missed_events_total",
-				Help: "Total number of missed events detected",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_missed_events_total",
+				Help:      "Total number of missed events detected",
 			},
 			[]string{LabelPodKey},
 		),
@@ -151,22 +160,25 @@ func createKVCacheMetrics() *KVCacheMetrics {
 		// Replay metrics
 		zmqReplayRequestsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "aibrix_kvcache_zmq_replay_requests_total",
-				Help: "Total number of replay requests sent",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_replay_requests_total",
+				Help:      "Total number of replay requests sent",
 			},
 			[]string{LabelPodKey},
 		),
 		zmqReplaySuccessTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "aibrix_kvcache_zmq_replay_success_total",
-				Help: "Total number of successful replay responses",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_replay_success_total",
+				Help:      "Total number of successful replay responses",
 			},
 			[]string{LabelPodKey},
 		),
 		zmqReplayFailuresTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "aibrix_kvcache_zmq_replay_failures_total",
-				Help: "Total number of failed replay requests",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_replay_failures_total",
+				Help:      "Total number of failed replay requests",
 			},
 			[]string{LabelPodKey},
 		),
@@ -174,8 +186,9 @@ func createKVCacheMetrics() *KVCacheMetrics {
 		// Error metrics
 		zmqErrorsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "aibrix_kvcache_zmq_errors_total",
-				Help: "Total number of errors encountered",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_errors_total",
+				Help:      "Total number of errors encountered",
 			},
 			[]string{LabelPodKey, LabelErrorType},
 		),
@@ -183,15 +196,17 @@ func createKVCacheMetrics() *KVCacheMetrics {
 		// State metrics
 		zmqConnectionStatus: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "aibrix_kvcache_zmq_connection_status",
-				Help: "Current connection status (1=connected, 0=disconnected)",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_connection_status",
+				Help:      "Current connection status (1=connected, 0=disconnected)",
 			},
 			[]string{LabelPodKey},
 		),
 		zmqLastSequenceID: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "aibrix_kvcache_zmq_last_sequence_id",
-				Help: "Last processed sequence ID",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "kvcache_zmq_last_sequence_id",
+				Help:      "Last processed sequence ID",
 			},
 			[]string{LabelPodKey},
 		),

--- a/pkg/constants/metrics.go
+++ b/pkg/constants/metrics.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	AibrixSubsystemName = "aibrix"
+)

--- a/pkg/controller/podautoscaler/monitor/metrics.go
+++ b/pkg/controller/podautoscaler/monitor/metrics.go
@@ -19,13 +19,16 @@ package monitor
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/vllm-project/aibrix/pkg/constants"
 )
 
 var (
 	autoscalerScaleAction = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "aibrix_autoscaler_scale_action",
-			Help: "Records autoscaler scaling decisions with desired replica count",
+			Subsystem: constants.AibrixSubsystemName,
+			Name:      "autoscaler_scale_action",
+			Help:      "Records autoscaler scaling decisions with desired replica count",
 		},
 		[]string{"namespace", "name", "algorithm", "reason"},
 	)

--- a/pkg/plugins/gateway/algorithms/prefix_cache.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache.go
@@ -73,23 +73,26 @@ func createPrefixCacheMetrics() *PrefixCacheMetrics {
 	return &PrefixCacheMetrics{
 		prefixCacheRoutingDecisions: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "aibrix_prefix_cache_routing_decisions_total",
-				Help: "Total number of routing decisions by match percentage",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "prefix_cache_routing_decisions_total",
+				Help:      "Total number of routing decisions by match percentage",
 			},
 			[]string{"model", "match_percent_bucket", "using_kv_sync"},
 		),
 		prefixCacheIndexerStatus: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "aibrix_prefix_cache_indexer_status",
-				Help: "Status of prefix cache indexer (1=available, 0=unavailable)",
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "prefix_cache_indexer_status",
+				Help:      "Status of prefix cache indexer (1=available, 0=unavailable)",
 			},
 			[]string{"model", "indexer_type"},
 		),
 		prefixCacheRoutingLatency: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "aibrix_prefix_cache_routing_latency_seconds",
-				Help:    "Latency of prefix cache routing decisions",
-				Buckets: prometheus.ExponentialBuckets(0.00001, 2, 15), // 10us to ~160ms
+				Subsystem: constants.AibrixSubsystemName,
+				Name:      "prefix_cache_routing_latency_seconds",
+				Help:      "Latency of prefix cache routing decisions",
+				Buckets:   prometheus.ExponentialBuckets(0.00001, 2, 15), // 10us to ~160ms
 			},
 			[]string{"model", "using_kv_sync"},
 		),

--- a/pkg/plugins/gateway/algorithms/tokenizer_pool.go
+++ b/pkg/plugins/gateway/algorithms/tokenizer_pool.go
@@ -81,29 +81,35 @@ type TokenizerPoolMetrics struct {
 func createTokenizerPoolMetrics() *TokenizerPoolMetrics {
 	return &TokenizerPoolMetrics{
 		activeTokenizers: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "aibrix_tokenizer_pool_active_tokenizers",
-			Help: "Number of active tokenizers in the pool",
+			Subsystem: constants.AibrixSubsystemName,
+			Name:      "tokenizer_pool_active_tokenizers",
+			Help:      "Number of active tokenizers in the pool",
 		}),
 		tokenizerCreationSuccesses: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "aibrix_tokenizer_pool_creation_successes_total",
-			Help: "Total number of successful tokenizer creations",
+			Subsystem: constants.AibrixSubsystemName,
+			Name:      "tokenizer_pool_creation_successes_total",
+			Help:      "Total number of successful tokenizer creations",
 		}),
 		tokenizerCreationFailures: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "aibrix_tokenizer_pool_creation_failures_total",
-			Help: "Total number of failed tokenizer creations",
+			Subsystem: constants.AibrixSubsystemName,
+			Name:      "tokenizer_pool_creation_failures_total",
+			Help:      "Total number of failed tokenizer creations",
 		}),
 		unhealthyTokenizers: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "aibrix_tokenizer_pool_unhealthy_tokenizers_total",
-			Help: "Total number of times tokenizers were marked unhealthy",
+			Subsystem: constants.AibrixSubsystemName,
+			Name:      "tokenizer_pool_unhealthy_tokenizers_total",
+			Help:      "Total number of times tokenizers were marked unhealthy",
 		}),
 		tokenizerRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "aibrix_tokenizer_pool_requests_total",
-			Help: "Total number of tokenizer requests by model",
+			Subsystem: constants.AibrixSubsystemName,
+			Name:      "tokenizer_pool_requests_total",
+			Help:      "Total number of tokenizer requests by model",
 		}, []string{"model"}),
 		tokenizerLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "aibrix_tokenizer_pool_latency_seconds",
-			Help:    "Tokenizer request latency in seconds",
-			Buckets: prometheus.DefBuckets,
+			Subsystem: constants.AibrixSubsystemName,
+			Name:      "tokenizer_pool_latency_seconds",
+			Help:      "Tokenizer request latency in seconds",
+			Buckets:   prometheus.DefBuckets,
 		}, []string{"model"}),
 	}
 }


### PR DESCRIPTION


Split hard-coded metric names like "aibrix_kvcache_..." into:
```go
  Subsystem: "aibrix"
  Name:      "kvcache_..."
```

FYI: https://prometheus.io/docs/practices/instrumentation/#subsystems

This aligns with prometheus client best practices and improves maintainability,
while preserving existing metric names exactly.

## Pull Request Description
[Please provide a clear and concise description of your changes here]

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>