### PR TITLE
[Feat] Implement role status aggregation for StormService

### DIFF
--- a/api/orchestration/v1alpha1/stormservice_types.go
+++ b/api/orchestration/v1alpha1/stormservice_types.go
@@ -119,10 +119,15 @@ type StormServiceStatus struct {
 
 	// The label selector information of the pods belonging to the StormService object.
 	ScalingTargetSelector string `json:"scalingTargetSelector,omitempty"`
-	// RoleStatuses mirrors the role-level status from the underlying RoleSet.
-	// This field is only populated in pool mode, where a single RoleSet contains multiple logical roles
-	// (e.g., "prefill" and "decode"). In traditional replica mode, this field will be empty.
-	// It provides detailed of each role, such as replicas, readyReplicas, and revision info.
+
+	// RoleStatuses provides aggregated pod-level status for each role across all RoleSets.
+	// This field is populated in both pool and replica modes:
+	// - Pool mode: Aggregates roles across RoleSets (e.g., total prefill pods, total decode pods)
+	// - Replica mode: Aggregates the same role across multiple RoleSets
+	//
+	// Unlike top-level fields (Replicas, ReadyReplicas) which count RoleSets, this field
+	// provides pod-level counts grouped by role name, including replicas, readyReplicas,
+	// notReadyReplicas, updatedReplicas, and updatedReadyReplicas.
 	//
 	// +optional
 	RoleStatuses []RoleStatus `json:"roleStatuses,omitempty"`

--- a/pkg/controller/stormservice/sync.go
+++ b/pkg/controller/stormservice/sync.go
@@ -413,6 +413,9 @@ func (r *StormServiceReconciler) updateStatus(ctx context.Context, stormService 
 	// TODO: add pod template hash to avoid errors during upgrade.
 	stormService.Status.ScalingTargetSelector = fmt.Sprintf("%s=%s", constants.StormServiceNameLabelKey, stormService.Name)
 
+	// Aggregate role statuses from all RoleSets for both pool and replica modes
+	stormService.Status.RoleStatuses = aggregateRoleStatuses(allRoleSets)
+
 	if !apiequality.Semantic.DeepEqual(checkpoint, &stormService.Status) {
 		err = utils.UpdateStatus(ctx, r.Scheme, r.Client, stormService)
 		if err != nil {


### PR DESCRIPTION
## Pull Request Description
This is a follow up PR of https://github.com/vllm-project/aibrix/pull/1599. The original PR just adds the api but doesn't come with aggregation logic yet.

Implements pod-level role status aggregation for StormService, populating the `RoleStatuses` field in both pool and replica modes. This field provides valuable pod-level observability that complements the existing top-level status fields:
- **Top-level fields** (`Replicas`, `ReadyReplicas`, `NotReadyReplicas`): Count RoleSets
- **RoleStatuses**: Aggregate pod counts by role name across all RoleSets

This distinction is important because:
- In **pool mode**: Shows aggregated pod counts for each role type (e.g., total prefill pods, total decode pods)
- In **replica mode**: Shows aggregated pod counts for the same role across multiple RoleSet replicas


## Related Issues
Resolves: part of https://github.com/vllm-project/aibrix/issues/1581

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>