### PR TITLE
[Bug] use redis auth in helm chart if redis pwd is enabled

### DIFF
--- a/dist/chart/templates/gateway-plugin/deployment.yaml
+++ b/dist/chart/templates/gateway-plugin/deployment.yaml
@@ -57,7 +57,17 @@ spec:
       initContainers:
         - name: init-c
           image: {{ .Values.gatewayPlugin.initContainer.image.repository }}:{{ .Values.gatewayPlugin.initContainer.image.tag }}
+          {{- if .Values.metadata.redis.enablePassword }}
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: aibrix-redis
+                  key: redis-password
+          command: ['sh', '-c', 'until printf ''AUTH %s\nping\n'' "$REDIS_PASSWORD" | nc {{ .Values.gatewayPlugin.dependencies.redis.host }} {{ .Values.gatewayPlugin.dependencies.redis.port }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
+          {{- else }}
           command: ['sh', '-c', 'until echo "ping" | nc {{ .Values.gatewayPlugin.dependencies.redis.host }} {{ .Values.gatewayPlugin.dependencies.redis.port }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
+          {{- end }}
       containers:
         - name: gateway-plugin
           image: {{ .Values.gatewayPlugin.container.image.repository }}:{{ .Values.gatewayPlugin.container.image.tag }}

--- a/dist/chart/templates/metadata-service/deployment.yaml
+++ b/dist/chart/templates/metadata-service/deployment.yaml
@@ -23,10 +23,17 @@ spec:
       initContainers:
         - name: init-redis
           image: {{ .Values.metadata.service.initContainer.image.repository }}:{{ .Values.metadata.service.initContainer.image.tag }}
-          command:
-            - 'sh'
-            - '-c'
-            - 'until echo "ping" | nc {{ .Values.metadata.service.redis.host }} {{ .Values.metadata.service.redis.port }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done'
+          {{- if .Values.metadata.redis.enablePassword }}
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: aibrix-redis
+                  key: redis-password
+          command: ['sh', '-c', 'until printf ''AUTH %s\nping\n'' "$REDIS_PASSWORD" | nc {{ .Values.metadata.service.redis.host }} {{ .Values.metadata.service.redis.port }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
+          {{- else }}
+          command: ['sh', '-c', 'until echo "ping" | nc {{ .Values.metadata.service.redis.host }} {{ .Values.metadata.service.redis.port }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
+          {{- end }}
       containers:
         - name: metadata-service
           image: {{ .Values.metadata.service.container.image.repository }}:{{ .Values.metadata.service.container.image.tag }}


### PR DESCRIPTION
## Pull Request Description
Current helm chart yaml is not correct if redis pwd is enabled. Metadata service and gateway plugin rely on redis using init container to ping the redis host. But if redis has password, it will fail to connect, resulting in these two pods pending forever:
<img width="3350" height="1158" alt="image" src="https://github.com/user-attachments/assets/78daa1e9-1547-49ae-bd5c-a9350ee52afa" />

So I add pwd check and use `printf "AUTH $REDIS_PASSWORD\nping\n"` to ping redis if it has pwd (using printf for better format control). Now it works well:
<img width="3272" height="694" alt="WeChatWorkScreenshot_cee123f2-b462-426b-8d31-552109b6936f" src="https://github.com/user-attachments/assets/8f8f4747-7d8c-462f-9365-573cdfcd7161" />
<img width="1152" height="442" alt="WeChatWorkScreenshot_70ef80d1-3b0e-4beb-83a0-497a090dfb92" src="https://github.com/user-attachments/assets/ae2dab02-1343-41a6-917c-9ac090c91fc7" />
<img width="3114" height="676" alt="WeChatWorkScreenshot_4b40d733-699a-4204-99e1-fd039c9655b4" src="https://github.com/user-attachments/assets/bd9e156a-92ee-4327-90b8-169132409e45" />
<img width="2236" height="506" alt="image" src="https://github.com/user-attachments/assets/8d415f63-c69f-4bb0-96b4-383aa07f0f53" />


## How to reproduce
* use a redis container which requires pwd, e.g. bitnami/redis 
* set pwd when do helm install '--set metadata.redis.enablePassword=true --set metadata.redis.password={YOUR_PWD}'