### PR TITLE
[Feature] support LWS in model-router controller (#1839)

### DIFF
--- a/config/rbac/controller-manager/role.yaml
+++ b/config/rbac/controller-manager/role.yaml
@@ -309,3 +309,14 @@ rules:
   - podgroups
   verbs:
   - '*'
+- apiGroups:
+  - leaderworkerset.x-k8s.io
+  resources:
+  - leaderworkersets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch

--- a/dist/chart/templates/controller-manager/rbac.yaml
+++ b/dist/chart/templates/controller-manager/rbac.yaml
@@ -301,6 +301,17 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+    - leaderworkerset.x-k8s.io
+  resources:
+    - leaderworkersets
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - update
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/atomic v1.11.0
 	google.golang.org/grpc v1.65.0
+	google.golang.org/protobuf v1.35.1
 	k8s.io/api v0.31.8
 	k8s.io/apiextensions-apiserver v0.31.8
 	k8s.io/apimachinery v0.31.8
@@ -106,7 +107,6 @@ require (
 	golang.org/x/tools v0.24.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
-	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect


### PR DESCRIPTION
Pull Request Description
support lws in model router controller, use lws v0.4.2 but not latest avoiding too much upgrade in go.mod

Related Issues
Resolves: https://github.com/vllm-project/aibrix/issues/1839

if lws crd is not found, informer will not start
```shell
I1215 03:01:17.664783       1 modelrouter_controller.go:77] "Starting modelrouter controller"
I1215 03:01:18.057542       1 modelrouter_controller.go:133] leaderworkersets.leaderworkerset.x-k8s.io CRD not found, skipping add informer for lws. This is optional - install leaderworkersets.leaderworkerset.x-k8s.io CRD if you need
```