### PR TITLE
[feat] add distribute-dp api server least_request route

### DIFF
--- a/pkg/plugins/gateway/algorithms/least_load_test.go
+++ b/pkg/plugins/gateway/algorithms/least_load_test.go
@@ -98,6 +98,10 @@ func (m *mockPodList) ListByIndex(index string) []*v1.Pod {
 	return nil
 }
 
+func (m *mockPodList) ListPortsForPod() map[string][]int {
+	return nil
+}
+
 func newMockPodList(pods []*v1.Pod, indexes map[string][]*v1.Pod) *mockPodList {
 	if indexes == nil {
 		indexes = make(map[string][]*v1.Pod)

--- a/pkg/plugins/gateway/algorithms/prefix_cache_preble_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_preble_test.go
@@ -48,6 +48,10 @@ func (m *MockPodList) ListByIndex(index string) []*v1.Pod {
 	return m.pods
 }
 
+func (m *MockPodList) ListPortsForPod() map[string][]int {
+	return nil
+}
+
 func createTestRoutingContext(model, message, requestID string) *types.RoutingContext {
 	ctx := context.Background()
 	return types.NewRoutingContext(ctx, RouterPrefixCachePreble, model, message, requestID, "")

--- a/pkg/plugins/gateway/algorithms/vtc/vtc_basic_test.go
+++ b/pkg/plugins/gateway/algorithms/vtc/vtc_basic_test.go
@@ -106,6 +106,10 @@ func (p *SimplePodList) ListByIndex(index string) []*v1.Pod {
 	return p.pods
 }
 
+func (p *SimplePodList) ListPortsForPod() map[string][]int {
+	return nil
+}
+
 func TestVTCRouterSimple(t *testing.T) {
 	trackerConfig := &VTCConfig{
 		InputTokenWeight:  1.0,

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -180,7 +180,7 @@ func (s *Server) selectTargetPod(ctx *types.RoutingContext, pods types.PodList, 
 	if len(readyPods) == 0 {
 		return "", fmt.Errorf("no ready pods for routing")
 	}
-	if len(readyPods) == 1 {
+	if len(readyPods) == 1 && len(utils.GetPortsForPod(readyPods[0])) <= 1 {
 		ctx.SetTargetPod(readyPods[0])
 		return ctx.TargetAddress(), nil
 	}

--- a/pkg/types/pod_list.go
+++ b/pkg/types/pod_list.go
@@ -30,4 +30,7 @@ type PodList interface {
 
 	// ListByIndex returns a slice of pods that match the given index.
 	ListByIndex(index string) []*v1.Pod
+
+	// ListPortsForPod returns a map of portList that bind with pod, key podname
+	ListPortsForPod() map[string][]int
 }

--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -71,6 +71,7 @@ type RoutingContext struct {
 
 	targetPodSet chan struct{}
 	targetPod    atomic.Pointer[v1.Pod]
+	targetPort   atomic.Int32
 	lastError    atomic.Pointer[error]
 	tokens       []int           // Cache of tokenized prompts
 	predictor    OutputPredictor // OutputPredictor gained from cache
@@ -204,6 +205,14 @@ func (r *RoutingContext) TargetPod() *v1.Pod {
 	return targetPod
 }
 
+func (r *RoutingContext) TargetPort() int {
+	return int(r.targetPort.Load())
+}
+
+func (r *RoutingContext) SetTargetPort(port int) {
+	r.targetPort.Store(int32(port))
+}
+
 // GetError returns the error of the routing context.
 func (r *RoutingContext) GetError() error {
 	if r.TargetPod() == nil {
@@ -217,6 +226,11 @@ func (r *RoutingContext) TargetAddress() string {
 	pod := r.TargetPod()
 	if pod == nil {
 		return ""
+	}
+
+	port := r.TargetPort()
+	if port != 0 {
+		return r.targetAddressWithPort(pod.Status.PodIP, port)
 	}
 	return r.targetAddress(r.TargetPod())
 }
@@ -254,6 +268,10 @@ func (r *RoutingContext) GetRoutingDelay() time.Duration {
 
 func (r *RoutingContext) targetAddress(pod *v1.Pod) string {
 	return fmt.Sprintf("%v:%v", pod.Status.PodIP, utils.GetModelPortForPod(r.RequestID, pod))
+}
+
+func (r *RoutingContext) targetAddressWithPort(podIP string, port int) string {
+	return fmt.Sprintf("%v:%v", podIP, port)
 }
 
 func (r *RoutingContext) getError() (err error) {

--- a/pkg/utils/pod_array.go
+++ b/pkg/utils/pod_array.go
@@ -118,3 +118,22 @@ func (arr *PodArray) initDeployments() {
 	arr.deployments = deployments
 	arr.podsByDeployment = podsByDeployment
 }
+
+func (arr *PodArray) ListPortsForPod() map[string][]int {
+	pods := arr.All()
+	if len(pods) == 0 {
+		return nil
+	}
+
+	podWithPort := make(map[string][]int, len(pods))
+	for _, pod := range pods {
+		ports := GetPortsForPod(pod)
+		if len(ports) > 0 {
+			podWithPort[pod.Name] = append(podWithPort[pod.Name], ports...)
+		} else {
+			podWithPort[pod.Name] = []int{}
+		}
+	}
+
+	return podWithPort
+}

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -24,10 +25,13 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/pkoukk/tiktoken-go"
 	tiktoken_loader "github.com/pkoukk/tiktoken-go-loader"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+
+	"github.com/vllm-project/aibrix/pkg/constants"
 )
 
 // https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken
@@ -157,6 +161,93 @@ func LoadEnvDuration(key string, defaultValue time.Duration) time.Duration {
 	return defaultValue
 }
 
+// GetPortsForPod returns all ports for a pod based on its configuration.
+// For distributed data-parallel (DP) inference, a pod may expose multiple ports:
+// - Base port from pod labels (e.g., "model-port")
+// - Additional ports for each DP rank (base_port + rank_index)
+// Returns nil if the pod doesn't have the required configuration.
+func GetPortsForPod(pod *v1.Pod) []int {
+	if pod == nil || pod.Labels == nil {
+		return nil
+	}
+
+	// Get base port from pod labels
+	basePort, err := getBasePortFromLabels(pod)
+	if err != nil {
+		return nil
+	}
+
+	// Get data-parallel size from environment variables
+	dpSize := getDataParallelSize(pod)
+	if dpSize <= 1 {
+		// If no DP size, return only the base port
+		return []int{basePort}
+	}
+
+	// Generate ports for each DP rank: basePort, basePort+1, ..., basePort+(dpSize-1)
+	ports := make([]int, dpSize)
+	for i := 0; i < dpSize; i++ {
+		ports[i] = basePort + i
+	}
+
+	return ports
+}
+
+// getBasePortFromLabels extracts the base port from pod labels
+func getBasePortFromLabels(pod *v1.Pod) (int, error) {
+	portStr, ok := pod.Labels[constants.ModelLabelPort]
+	if !ok || portStr == "" {
+		return 0, fmt.Errorf("no %s label found", constants.ModelLabelPort)
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		klog.Warningf("Invalid port value in label %s=%s: %v",
+			constants.ModelLabelPort, portStr, err)
+		return 0, fmt.Errorf("invalid port format: %w", err)
+	}
+
+	if port <= 0 || port > 65535 {
+		klog.Warningf("Port %d from label %s is out of valid range",
+			port, constants.ModelLabelPort)
+		return 0, fmt.Errorf("port %d out of range [1-65535]", port)
+	}
+
+	return port, nil
+}
+
+// getDataParallelSize retrieves the data parallelism degree from the pod's environment variables.
+// This feature requires the user to explicitly pass the "data-parallel-size"
+// variable in the pod template's container env section.
+// Example:
+//
+//		  env:
+//		  - name: "data-parallel-size"
+//	     value: "2"
+func getDataParallelSize(pod *v1.Pod) int {
+	for _, container := range pod.Spec.Containers {
+		for _, env := range container.Env {
+			if env.Name == "data-parallel-size" && env.Value != "" {
+				size, err := strconv.Atoi(env.Value)
+				if err != nil {
+					klog.Warningf("Invalid data-parallel-size value '%s': %v",
+						env.Value, err)
+					return 0
+				}
+
+				if size < 0 {
+					klog.Warningf("Invalid data-parallel-size %d (must be >= 0)", size)
+					return 0
+				}
+
+				return size
+			}
+		}
+	}
+
+	return 0
+}
+
 // GVKCheckExists check if gvk is support
 func GVKCheckExists(cfg *rest.Config, gvk schema.GroupVersionKind) (bool, error) {
 	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
@@ -181,4 +272,20 @@ func GVKCheckExists(cfg *rest.Config, gvk schema.GroupVersionKind) (bool, error)
 	}
 
 	return false, nil
+}
+
+// IsDataParallelPod checks if the pod is configured for Distributed Data Parallel.
+// It returns true if "data-parallel-size" environment variable is present and its value is greater than 1.
+func IsDataParallelPod(pod *v1.Pod) bool {
+	for _, container := range pod.Spec.Containers {
+		for _, env := range container.Env {
+			if env.Name == "data-parallel-size" && env.Value != "" {
+				value, err := strconv.Atoi(env.Value)
+				if err == nil && value > 1 {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
[API][Routing] Add distributed DP-level API server routing with least-request algorithm

This PR enhances the least-request routing algorithm to support distributed data-parallel (DP) inference scenarios where pods expose multiple ports for different DP ranks. Previously, routing was performed at the pod level, but for distributed DP workloads, we need to route requests at the API server level, considering individual (pod + port) combinations.

Key Changes:
Extended routing logic in leastRequestRouter to detect when pods have multiple ports (DP > 1) and switch to distributed DP-level routing

Enhanced port discovery in GetPortsForPod with better validation and error handling

one routing strategy:

DP-level routing: When pods have multiple ports (DP>1), route to specific (pod + port) with least active requests

Improved metrics collection that tracks request counts per (pod, port) combination for accurate load balancing

it's only support multiple  ports bind with simple pod

Benefits:

✅ Better resource utilization across all DP ranks within a pod

Usage Example:
For a pod configured with data-parallel-size=3 and model-port=8000, the router will now consider three endpoints: pod:8000, pod:8001, pod:8002, and route to the one with the least active requests.

dp == n+1 > 1:
    d_set{d0, d1, ,,,dn} belongs to simple pod
        exec.proc("cmd", env={export ascend_rt_devices = 0,1,2,3})
        vllm serve $MODEL --data-parallel-size 2 --data-parallel-rank 0 --host pod_ip --port 8000\
                          --data-parallel-address {pod_ip} --data-parallel-rpc-port 13345

        exec.proc("cmd", env={export ascend_rt_devices = 4,5,6,7})
        vllm serve $MODEL --data-parallel-size 2 --data-parallel-rank 1 --port 8001\
                          --data-parallel-address {pod_ip} --data-parallel-rpc-port 13345

Related Issues
Resolves: #1793 (Add Fine-Grained Server-level routing for multi-server pods)

Important: Before submitting, please complete the description above and review the checklist below.