### PR TITLE
[Bugfix]: need set password for redis server

### DIFF
--- a/dist/chart/templates/metadata-service/redis.yaml
+++ b/dist/chart/templates/metadata-service/redis.yaml
@@ -32,6 +32,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "aibrix.fullname" . }}-redis
                   key: redis-password
+          args:
+            - --requirepass
+            - "{{ .Values.metadata.redis.password }}"
           {{- end }}
 ---
 apiVersion: v1


### PR DESCRIPTION
## Pull Request Description
add args for redisserver in helm so redisserver can set default user password

even if your set  metadata.redis.password such as 
```bash
helm install aibrix  aibrix/dist/chart/ -f  aibrix/dist/chart/stable.yaml -n aibrix-system --create-namespace \
...
  --set metadata.redis.container.image.tag=7.4 \
  --set metadata.redis.enablePassword=true \
  --set metadata.redis.password=B4epgEYrBakNANabQx1f
```

your metaserver still logs bugs because your password no set in redis-server
<img width="3324" height="124" alt="image" src="https://github.com/user-attachments/assets/34da292d-8457-43e9-8fcf-cea6db078eac" />

your need set redis-server by this commit in helm
