### PR TITLE
[Bug] Add roleset-index to annotations

### DIFF
--- a/pkg/controller/stormservice/rolesetoperations.go
+++ b/pkg/controller/stormservice/rolesetoperations.go
@@ -113,7 +113,7 @@ func (r *StormServiceReconciler) createRoleSet(stormService *orchestrationv1alph
 	}
 	var toCreate []*orchestrationv1alpha1.RoleSet
 	for i := 0; i < count; i++ {
-		roleSet, err := r.renderRoleSet(stormService, nil, revisionName, roleRevisions)
+		roleSet, err := r.renderRoleSet(stormService, &i, revisionName, roleRevisions)
 		if err != nil {
 			return 0, err
 		}
@@ -147,7 +147,9 @@ func (r *StormServiceReconciler) updateRoleSet(stormService *orchestrationv1alph
 		klog.Infof("[rolesetoperation] update roleset %s", toUpdate[i].Name)
 		// overwrite labels and annotations, to keep the revision updated
 		toUpdate[i].Labels = target.Labels
+		rsIdx := toUpdate[i].Annotations[constants.RoleSetIndexAnnotationKey]
 		toUpdate[i].Annotations = target.Annotations
+		toUpdate[i].Annotations[constants.RoleSetIndexAnnotationKey] = rsIdx
 		// update roleset spec
 		toUpdate[i].Spec = target.Spec
 		return r.Client.Update(context.TODO(), toUpdate[i])

--- a/pkg/controller/stormservice/rolesetoperations_test.go
+++ b/pkg/controller/stormservice/rolesetoperations_test.go
@@ -371,6 +371,9 @@ func TestUpdateRoleSet(t *testing.T) {
 			Labels: map[string]string{
 				"app": "test",
 			},
+			Annotations: map[string]string{
+				constants.RoleSetIndexAnnotationKey: "0",
+			},
 		},
 		Spec: orchestrationv1alpha1.RoleSetSpec{
 			Roles: []orchestrationv1alpha1.RoleSpec{
@@ -394,6 +397,7 @@ func TestUpdateRoleSet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "updated-role", updatedRoleSet.Spec.Roles[0].Name)
 	assert.Equal(t, "new-revision", updatedRoleSet.Labels[constants.StormServiceRevisionLabelKey])
+	assert.Equal(t, "0", updatedRoleSet.Annotations[constants.RoleSetIndexAnnotationKey])
 }
 
 func TestCreateRoleSet(t *testing.T) {


### PR DESCRIPTION
## Pull Request Description
Currently, roleset does not have index in its annotations, resulting in pod not having this index either:
<img width="838" height="152" alt="WeChatWorkScreenshot_1559ff1d-ae7c-442e-bcfa-9210191f423f" src="https://github.com/user-attachments/assets/89f4b06c-9a52-44f7-b7e1-515ae5d385e6" />

It will be helpful to read this index in some scenarios and the logic actually exists but not used, so I add it for future use:
<img width="1200" height="1170" alt="WeChatWorkScreenshot_e441c475-b630-4fe3-8d98-4a2e37e44e4a" src="https://github.com/user-attachments/assets/ef9e8672-ca57-40dc-a701-93dc7c1f25de" />
