### PR TITLE
[Misc] Add missing dependency for benchmark script

### DIFF
--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -3,3 +3,4 @@ openai==2.3.0
 matplotlib==3.10.7
 transformers==4.57.0
 scipy==1.16.2
+pandas==3.0.0


### PR DESCRIPTION
## Pull Request Description
The `dataset_generator` module depends on `pandas`, which was missing from the requirements file.

## Related Issues
None