### PR TITLE
[Misc] Set leader election namespace according to release namespace

### DIFF
--- a/dist/chart/templates/controller-manager/deployment.yaml
+++ b/dist/chart/templates/controller-manager/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
       - args:
         - --leader-elect
+        - --leader-election-namespace={{ .Release.Namespace }}
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --enable-runtime-sidecar


### PR DESCRIPTION
## Pull Request Description
When deploying AIBrix via Helm chart into a namespace other than `aibrix-system`, the controller manager will fail to start, since it attempts to elect a leader running in the `aibrix-system` namespace:

https://github.com/vllm-project/aibrix/blob/cd007a5c554b09a8f22ce6f45c2d6c139f39db25/cmd/controllers/main.go#L141

This change sets the namespace according to the release namespace.

## Related Issues
None