### PR TITLE
[Fix] Add sidecar injection webhook to helm chart

### DIFF
--- a/dist/chart/templates/webhook/webhooks.yaml
+++ b/dist/chart/templates/webhook/webhooks.yaml
@@ -196,4 +196,24 @@ webhooks:
       resources:
         - stormservices
   sideEffects: None
+- admissionReviewVersions:
+    - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-apps-v1-deployment
+  failurePolicy: Ignore
+  name: vedeployment.aibrix.ai
+  rules:
+    - apiGroups:
+        - apps
+      apiVersions:
+        - v1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - deployments
+  sideEffects: None
 {{- end }}


### PR DESCRIPTION
## Pull Request Description
This addresses the issue of the `medeployment.aibrix.ai` webhook required for sidecar injection not being present in the AIBrix Helm chart by adding it to the respective Helm chart template (see issue #1915 for details).

The obvious downside of this approach is that the webhook has to be kept in sync between the Kustomize-based installation resources in `/config/webhook` and the Helm chart template in `/dist/chart/templates/webhook`. It seems that this is true for basically all (shared) manifests.

If I understand correctly, the plan is to migrate away from the Kustomize-based installation process to Helm, based on this comment ("_Previous_ Kustomize-Based Installs"):

https://github.com/vllm-project/aibrix/blob/fc89173180998a5d97893fd0957b76f70cf28678/dist/chart/README.md?plain=1#L19-L20

I think issue #1915 is not the right place to solve the synchronization issue described above, so I propose just adding the missing webhook.

## Related Issues
Resolves: #1915 