### PR TITLE
[Feature] KVCache support block-first layout

### DIFF
--- a/python/aibrix_kvcache/aibrix_kvcache/_custom_ops.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/_custom_ops.py
@@ -33,10 +33,12 @@ def reshape_and_cache_multi_layer(
     k_scales: list[torch.Tensor],
     v_scales: list[torch.Tensor],
     layout: str,
+    kv_layout_blocks_first: bool = False,
 ) -> None:
     torch.ops._aibrix_C_cache_ops.reshape_and_cache_multi_layer(
         offload_kv_cache_blocks,
         kv_caches,
+        kv_layout_blocks_first,
         slot_mapping,
         block_size,
         kv_cache_dtype,
@@ -55,10 +57,12 @@ def reshape_and_offload_multi_layer(
     k_scales: list[torch.Tensor],
     v_scales: list[torch.Tensor],
     layout: str,
+    kv_layout_blocks_first: bool = False,
 ) -> None:
     torch.ops._aibrix_C_cache_ops.reshape_and_offload_multi_layer(
         offload_kv_cache_blocks,
         kv_caches,
+        kv_layout_blocks_first,
         slot_mapping,
         block_size,
         kv_cache_dtype,

--- a/python/aibrix_kvcache/csrc/cache.h
+++ b/python/aibrix_kvcache/csrc/cache.h
@@ -7,14 +7,16 @@
 
 void reshape_and_cache_multi_layer(
     const std::vector<torch::Tensor> &offload_kv_cache_blocks,
-    const std::vector<torch::Tensor> &kv_caches, torch::Tensor &slot_mapping,
-    const int64_t block_size, const std::string &kv_cache_dtype,
+    const std::vector<torch::Tensor> &kv_caches, bool kv_layout_blocks_first,
+    torch::Tensor &slot_mapping, const int64_t block_size,
+    const std::string &kv_cache_dtype,
     const std::vector<torch::Tensor> &k_scales,
     const std::vector<torch::Tensor> &v_scales, const std::string &layout_str);
 
 void reshape_and_offload_multi_layer(
     const std::vector<torch::Tensor> &offload_kv_cache_blocks,
-    const std::vector<torch::Tensor> &kv_caches, torch::Tensor &slot_mapping,
-    const int64_t block_size, const std::string &kv_cache_dtype,
+    const std::vector<torch::Tensor> &kv_caches, bool kv_layout_blocks_first,
+    torch::Tensor &slot_mapping, const int64_t block_size,
+    const std::string &kv_cache_dtype,
     const std::vector<torch::Tensor> &k_scales,
     const std::vector<torch::Tensor> &v_scales, const std::string &layout_str);

--- a/python/aibrix_kvcache/csrc/torch_bindings.cpp
+++ b/python/aibrix_kvcache/csrc/torch_bindings.cpp
@@ -19,7 +19,8 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
   // Cache ops
   cache_ops.def(
       "reshape_and_cache_multi_layer(Tensor[] offload_kv_cache_blocks,"
-      "                              Tensor(b!)[] key_caches,"
+      "                              Tensor(b!)[] kv_caches,"
+      "                              bool kv_layout_blocks_first,"
       "                              Tensor slot_mapping,"
       "                              SymInt block_size,"
       "                              str kv_cache_dtype,"
@@ -30,7 +31,8 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
 
   cache_ops.def(
       "reshape_and_offload_multi_layer(Tensor(a!)[] offload_kv_cache_blocks,"
-      "                                Tensor[] key_caches,"
+      "                                Tensor[] kv_caches,"
+      "                                bool kv_layout_blocks_first,"
       "                                Tensor slot_mapping,"
       "                                SymInt block_size,"
       "                                str kv_cache_dtype,"


### PR DESCRIPTION


## Pull Request Description
- Support block-first kvcache layout used by FlashInfer etc.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>