### PR TITLE
[fix] Add missing model name in unit test

### DIFF
--- a/pkg/plugins/gateway/algorithms/prefix_cache_new_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_new_test.go
@@ -834,7 +834,7 @@ func TestPrefixCacheRouterModelExtraction(t *testing.T) {
 
 	c := cache.NewWithPodsMetricsForTest(
 		readyPods,
-		"", // Empty model in cache
+		"llama-2-7b", // Use the same model as the pod label
 		map[string]map[string]metrics.MetricValue{
 			"pod1": {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 0}},
 		})


### PR DESCRIPTION
## Pull Request Description

 The test TestPrefixCacheRouterModelExtraction was failing because:

- Recent PR https://github.com/vllm-project/aibrix/pull/1894  added a validation in `getModelNameFromPod()` that rejects empty model names (modelName != "" check), the `TestPrefixCacheRouterModelExtraction` added earlier has  with empty model "".  Result: `ListPods()` returned empty, leading to "no target pod found" error

- the #1894 author doesn't know how to debug it and thought that's no the file he edited. Considering that change was pending for long time and not merged yet, we help him fix the issue.


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>