### PR TITLE
Samples and readme for audio endpoints

### DIFF
--- a/samples/multimodality/vllm/README.md
+++ b/samples/multimodality/vllm/README.md
@@ -156,3 +156,69 @@ A sample output would look like:
 ```
 
 More examples could be found [here](https://github.com/vllm-project/aibrix/issues/1512).
+
+## Audio Transcription and Translation
+
+AIBrix gateway exposes OpenAI-compatible `/v1/audio/transcriptions` and `/v1/audio/translations` endpoints backed by [Qwen2-Audio-7B-Instruct](https://huggingface.co/Qwen/Qwen2-Audio-7B-Instruct).
+
+### Deploy the model
+
+```bash
+kubectl apply -f vllm/qwen-audio.yaml
+```
+
+### Forward AIBrix port
+
+```bash
+kubectl -n envoy-gateway-system port-forward service/envoy-aibrix-system-aibrix-eg-903790dc 8888:80
+```
+
+### Transcription
+
+Transcription converts audio to text in the source language.
+
+**Note:** Audio endpoints require `multipart/form-data`. Do **not** set `-H "Content-Type: application/json"`.
+
+```bash
+curl http://localhost:8888/v1/audio/transcriptions \
+  -F file=@audio.mp3 \
+  -F model=qwen-audio-7b \
+  -F response_format=json
+```
+
+Using the Python script:
+
+```bash
+python send_audio.py audio.mp3 --mode transcribe --model qwen-audio-7b
+# With optional language hint:
+python send_audio.py audio.mp3 --mode transcribe --model qwen-audio-7b --language zh
+```
+
+Sample output:
+
+```json
+{"text": "欢迎使用 AIBrix 语音转录服务。"}
+```
+
+### Translation
+
+Translation converts audio to English text.
+
+```bash
+curl http://localhost:8888/v1/audio/translations \
+  -F file=@audio.mp3 \
+  -F model=qwen-audio-7b \
+  -F response_format=json
+```
+
+Using the Python script:
+
+```bash
+python send_audio.py audio.mp3 --mode translate --model qwen-audio-7b
+```
+
+Sample output:
+
+```json
+{"text": "Welcome to the AIBrix speech transcription service."}
+```

--- a/samples/multimodality/vllm/send_audio.py
+++ b/samples/multimodality/vllm/send_audio.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import requests
+import argparse
+
+
+def send_audio_request(file_path, model, mode, url, language=None, response_format=None):
+    """Send audio file to transcription or translation endpoint using multipart/form-data."""
+    if mode == "transcribe":
+        endpoint = f"{url}/v1/audio/transcriptions"
+    else:
+        endpoint = f"{url}/v1/audio/translations"
+
+    with open(file_path, "rb") as f:
+        files = {"file": (os.path.basename(file_path), f)}
+        data = {"model": model}
+        if response_format:
+            data["response_format"] = response_format
+        if mode == "transcribe" and language:
+            data["language"] = language
+
+        response = requests.post(endpoint, files=files, data=data)
+
+    return response
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Send an audio file to the AIBrix audio transcription or translation endpoint"
+    )
+    parser.add_argument("file", help="Path to the audio file (e.g. audio.mp3, audio.wav)")
+    parser.add_argument(
+        "--mode",
+        choices=["transcribe", "translate"],
+        default="transcribe",
+        help="Operation mode: 'transcribe' (speech-to-text) or 'translate' (speech-to-English text)",
+    )
+    parser.add_argument("--model", required=True, help="Model name (e.g. qwen-audio-7b)")
+    parser.add_argument(
+        "--language",
+        help="Source language code (e.g. zh, en, ja). Transcription only; ignored for translation.",
+    )
+    parser.add_argument(
+        "--response-format",
+        dest="response_format",
+        default="json",
+        help="Response format: json or text (default: json)",
+    )
+    parser.add_argument(
+        "--url",
+        default="http://localhost:8888",
+        help="Base URL of the AIBrix gateway (default: http://localhost:8888)",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.file):
+        print(f"Error: file not found: {args.file}", file=sys.stderr)
+        sys.exit(1)
+
+    response = send_audio_request(
+        file_path=args.file,
+        model=args.model,
+        mode=args.mode,
+        url=args.url,
+        language=args.language,
+        response_format=args.response_format,
+    )
+
+    print("Status code:", response.status_code)
+    print("Response:", response.text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Follow-up to #1859 (gateway support for `/v1/audio/transcriptions` and  `/v1/audio/translations`). Adds client samples requested during review.

  - **`samples/multimodality/vllm/send_audio.py`** — new Python CLI script  that sends an audio file to the gateway using `multipart/form-data`. Supports `--mode transcribe` and `--mode translate`, optional `--language` (transcription only), `--response-format`, and `--url`.
  - **`samples/multimodality/vllm/README.md`** — new "Audio Transcription    and Translation" section with deploy steps, port-forward command, curl    examples, Python script usage, and sample JSON output for both    transcription and translation.