### PR TITLE
fix: panic inconsistent label cardinality in emit metrics

### DIFF
--- a/pkg/metrics/custom_metrics.go
+++ b/pkg/metrics/custom_metrics.go
@@ -82,11 +82,6 @@ func defaultSetGaugeMetric(name string, help string, value float64, labelNames [
 		customGaugesMu.Unlock()
 	}
 
-	if len(canonicalNames) == 0 {
-		gauge.WithLabelValues(labelValues...).Set(value)
-		return
-	}
-
 	orderedValues := make([]string, len(canonicalNames))
 	for i, ln := range canonicalNames {
 		orderedValues[i] = labelValueMap[ln]
@@ -150,11 +145,6 @@ func defaultIncrementCounterMetric(name string, help string, value float64, labe
 			canonicalNames = namesCopy
 		}
 		customCountersMu.Unlock()
-	}
-
-	if len(canonicalNames) == 0 {
-		counter.WithLabelValues(labelValues...).Add(value)
-		return
 	}
 
 	orderedValues := make([]string, len(canonicalNames))


### PR DESCRIPTION
## Pull Request Description
```
I0303 20:51:21.775828       1 main.go:142] starting gRPC server on :50052
panic: inconsistent label cardinality: expected 10 label values but got 11 in []string{"sglang", "aibrix-gateway-plugins-6c468569bd-f5qsv", "qwen3-32b", "default", "sglang-pd-roleset-8m6q4-decode-f5fdc8-0", "decode", "0", "sglang-pd-roleset-8m6q4", "qwen3-32b", "0", "0"}

goroutine 206 [running]:
github.com/prometheus/client_golang/prometheus.(*GaugeVec).WithLabelValues(...)
	github.com/prometheus/client_golang@v1.20.2/prometheus/gauge.go:238
github.com/vllm-project/aibrix/pkg/metrics.defaultSetGaugeMetric({0xc001f1e56a, 0x14}, {0x2777d06, 0x1a}, 0x0, {0xc001f82240, 0xb, 0xc}, {0xc001f82300, 0xb, ...})
	github.com/vllm-project/aibrix/pkg/metrics/custom_metrics.go:69 +0x276
github.com/vllm-project/aibrix/pkg/metrics.SetGaugeMetric(...)
	github.com/vllm-project/aibrix/pkg/metrics/custom_metrics.go:48
github.com/vllm-project/aibrix/pkg/metrics.emitGaugeMetric(0x23087a0?, 0xc000713b30?, {0xc001f1e56a, 0x14}, 0x0, 0x2e26c18?)
	github.com/vllm-project/aibrix/pkg/metrics/custom_metrics.go:84 +0x1cd
github.com/vllm-project/aibrix/pkg/metrics.EmitMetricToPrometheus(0xc000063b00, 0xc0012fbb08, {0xc001f1e56a, 0x14}, {0x2e265d0, 0xc001f30120}, 0xc001f2a720)
	github.com/vllm-project/aibrix/pkg/metrics/custom_metrics.go:282 +0x1a9
github.com/vllm-project/aibrix/pkg/cache.(*Store).worker(0xc00062c9a0, 0xc00088b680)
	github.com/vllm-project/aibrix/pkg/cache/cache_metrics.go:289 +0x10ee
created by github.com/vllm-project/aibrix/pkg/cache.New in goroutine 1
	github.com/vllm-project/aibrix/pkg/cache/cache_init.go:160 +0x2eb
```

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>