### PR TITLE
fix: disable rate limiting when Redis backend is not configured

### DIFF
--- a/cmd/plugins/main.go
+++ b/cmd/plugins/main.go
@@ -64,10 +64,12 @@ func main() {
 		klog.Fatal("--endpoints-config is required when running in standalone mode")
 	}
 
-	redisClient := utils.GetRedisClient()
+	redisClient := utils.TryGetRedisClient()
 	defer func() {
-		if err := redisClient.Close(); err != nil {
-			klog.Warningf("Error closing Redis client: %v", err)
+		if redisClient != nil {
+			if err := redisClient.Close(); err != nil {
+				klog.Warningf("Error closing Redis client: %v", err)
+			}
 		}
 	}()
 

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -90,7 +90,14 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 	if err != nil {
 		panic(err)
 	}
-	r := ratelimiter.NewRedisAccountRateLimiter("aibrix", redisClient, 1*time.Minute)
+
+	// Use NoOpRateLimiter when Redis is not configured, effectively disabling rate limiting
+	var r ratelimiter.RateLimiter
+	if redisClient != nil {
+		r = ratelimiter.NewRedisAccountRateLimiter("aibrix", redisClient, 1*time.Minute)
+	} else {
+		r = ratelimiter.NewNoOpRateLimiter()
+	}
 
 	// Initialize the routers
 	routing.Init()

--- a/pkg/plugins/gateway/ratelimiter/noop.go
+++ b/pkg/plugins/gateway/ratelimiter/noop.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimiter
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+)
+
+// noOpRateLimiter is a rate limiter that does nothing and always allows requests.
+// It is used when the Redis backend is not configured, effectively disabling rate limiting.
+type noOpRateLimiter struct{}
+
+// NewNoOpRateLimiter creates a rate limiter that performs no rate limiting.
+// This is used as a fallback when Redis is not available or not configured.
+func NewNoOpRateLimiter() RateLimiter {
+	klog.Info("Rate limiting is disabled: no Redis backend configured")
+	return &noOpRateLimiter{}
+}
+
+func (n *noOpRateLimiter) Get(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
+
+func (n *noOpRateLimiter) GetLimit(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
+
+func (n *noOpRateLimiter) Incr(_ context.Context, _ string, _ int64) (int64, error) {
+	return 0, nil
+}

--- a/pkg/plugins/gateway/ratelimiter/noop_test.go
+++ b/pkg/plugins/gateway/ratelimiter/noop_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimiter
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNoOpRateLimiter_Get(t *testing.T) {
+	rl := NewNoOpRateLimiter()
+	val, err := rl.Get(context.Background(), "test_key")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if val != 0 {
+		t.Fatalf("expected 0, got %d", val)
+	}
+}
+
+func TestNoOpRateLimiter_GetLimit(t *testing.T) {
+	rl := NewNoOpRateLimiter()
+	val, err := rl.GetLimit(context.Background(), "test_key")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if val != 0 {
+		t.Fatalf("expected 0, got %d", val)
+	}
+}
+
+func TestNoOpRateLimiter_Incr(t *testing.T) {
+	rl := NewNoOpRateLimiter()
+	val, err := rl.Incr(context.Background(), "test_key", 1)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if val != 0 {
+		t.Fatalf("expected 0, got %d", val)
+	}
+}
+
+func TestNoOpRateLimiter_ImplementsInterface(t *testing.T) {
+	var _ RateLimiter = &noOpRateLimiter{}
+	var _ RateLimiter = NewNoOpRateLimiter()
+}

--- a/pkg/utils/redis.go
+++ b/pkg/utils/redis.go
@@ -41,3 +41,30 @@ func GetRedisClient() *redis.Client {
 	klog.Infof("Connected to Redis: %s", pong)
 	return client
 }
+
+// TryGetRedisClient attempts to connect to Redis and returns the client if successful.
+// Returns nil if Redis is not configured or connection fails, instead of fatally crashing.
+func TryGetRedisClient() *redis.Client {
+	redisHost := LoadEnv("REDIS_HOST", "")
+	if redisHost == "" {
+		klog.Info("REDIS_HOST is not set, Redis client will not be initialized")
+		return nil
+	}
+
+	redisPort := LoadEnv("REDIS_PORT", "6379")
+	redisPassword := LoadEnv("REDIS_PASSWORD", "")
+	client := redis.NewClient(&redis.Options{
+		Addr:     redisHost + ":" + redisPort,
+		Password: redisPassword,
+		DB:       0,
+	})
+
+	pong, err := client.Ping(context.Background()).Result()
+	if err != nil {
+		klog.Warningf("Failed to connect to Redis at %s:%s: %v. Rate limiting will be disabled.", redisHost, redisPort, err)
+		client.Close()
+		return nil
+	}
+	klog.Infof("Connected to Redis: %s", pong)
+	return client
+}


### PR DESCRIPTION
## Summary

Fixes #1874

When Redis is not configured (`REDIS_HOST` is empty or Redis connection fails), the gateway plugin now gracefully falls back to a `NoOpRateLimiter` instead of crashing with a fatal error or rejecting all requests.

## Changes

- **`pkg/plugins/gateway/ratelimiter/noop.go`**: Add `NoOpRateLimiter` implementation that always allows requests through, effectively disabling rate limiting
- **`pkg/plugins/gateway/ratelimiter/noop_test.go`**: Add unit tests for `NoOpRateLimiter`
- **`pkg/utils/redis.go`**: Add `TryGetRedisClient()` that returns `nil` instead of calling `klog.Fatalf` when Redis is unavailable
- **`pkg/plugins/gateway/gateway.go`**: Modify `NewServer` to use `NoOpRateLimiter` when `redisClient` is nil
- **`cmd/plugins/main.go`**: Use `TryGetRedisClient()` and handle nil redis client in defer

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Redis configured and running | Rate limiting works | Rate limiting works (no change) |
| Redis not configured (REDIS_HOST empty) | Fatal crash on startup | Starts normally, rate limiting disabled |
| Redis configured but unreachable | Fatal crash on startup | Starts normally, rate limiting disabled with warning |
