### PR TITLE
feat: refactor user management API to RESTful conventions

### DIFF
--- a/python/aibrix/aibrix/metadata/api/v1/users.py
+++ b/python/aibrix/aibrix/metadata/api/v1/users.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from typing import Optional
 
 import redis.asyncio as redis
@@ -22,6 +23,9 @@ from aibrix.logger import init_logger
 
 logger = init_logger(__name__)
 router = APIRouter()
+
+# Legacy router for backward compatibility with old POST-based endpoints
+legacy_router = APIRouter()
 
 
 class User(BaseModel):
@@ -77,7 +81,10 @@ async def _get_redis_client(request: Request) -> redis.Redis:
     return request.app.state.redis_client
 
 
-@router.post("/CreateUser")
+# ==================== RESTful API Endpoints ====================
+
+
+@router.post("/users")
 async def create_user(request: Request, user: User) -> UserResponse:
     """Create a new user with rate limits.
 
@@ -106,13 +113,13 @@ async def create_user(request: Request, user: User) -> UserResponse:
     return UserResponse(message=f"Created User: {user.name}", user=user)
 
 
-@router.post("/ReadUser")
-async def read_user(request: Request, user: User) -> UserResponse:
-    """Read user information.
+@router.get("/users/{name}")
+async def get_user(request: Request, name: str) -> UserResponse:
+    """Read user information by name.
 
     Args:
         request: FastAPI request
-        user: User with name to look up
+        name: User name to look up
 
     Returns:
         UserResponse with user data
@@ -121,11 +128,11 @@ async def read_user(request: Request, user: User) -> UserResponse:
         HTTPException: 404 if user not found
     """
     redis_client = await _get_redis_client(request)
-    key = _gen_key(user.name)
+    key = _gen_key(name)
 
     data = await redis_client.get(key)
     if not data:
-        logger.warning(f"User not found: {user.name}")
+        logger.warning(f"User not found: {name}")
         raise HTTPException(status_code=404, detail="user does not exist")
 
     # Parse JSON data
@@ -135,12 +142,13 @@ async def read_user(request: Request, user: User) -> UserResponse:
     return UserResponse(message=f"User: {stored_user.name}", user=stored_user)
 
 
-@router.post("/UpdateUser")
-async def update_user(request: Request, user: User) -> UserResponse:
+@router.put("/users/{name}")
+async def update_user(request: Request, name: str, user: User) -> UserResponse:
     """Update user information.
 
     Args:
         request: FastAPI request
+        name: User name in the URL path
         user: Updated user data
 
     Returns:
@@ -150,28 +158,31 @@ async def update_user(request: Request, user: User) -> UserResponse:
         HTTPException: 404 if user not found
     """
     redis_client = await _get_redis_client(request)
-    key = _gen_key(user.name)
+    key = _gen_key(name)
 
     # Check if user exists
     exists = await redis_client.exists(key)
     if not exists:
-        logger.warning(f"Cannot update non-existent user: {user.name}")
-        raise HTTPException(status_code=404, detail=f"User: {user.name} does not exist")
+        logger.warning(f"Cannot update non-existent user: {name}")
+        raise HTTPException(
+            status_code=404, detail=f"User: {name} does not exist"
+        )
 
-    # Update user
+    # Use the name from URL path, override body if different
+    user.name = name
     await redis_client.set(key, user.model_dump_json())
 
     logger.info(f"Updated user: {user.name}, rpm={user.rpm}, tpm={user.tpm}")
     return UserResponse(message=f"Updated User: {user.name}", user=user)
 
 
-@router.post("/DeleteUser")
-async def delete_user(request: Request, user: User) -> UserResponse:
+@router.delete("/users/{name}")
+async def delete_user(request: Request, name: str) -> UserResponse:
     """Delete a user.
 
     Args:
         request: FastAPI request
-        user: User with name to delete
+        name: User name to delete
 
     Returns:
         UserResponse with deletion status
@@ -180,16 +191,67 @@ async def delete_user(request: Request, user: User) -> UserResponse:
         HTTPException: 404 if user not found
     """
     redis_client = await _get_redis_client(request)
-    key = _gen_key(user.name)
+    key = _gen_key(name)
 
     # Check if user exists
     exists = await redis_client.exists(key)
     if not exists:
-        logger.warning(f"Cannot delete non-existent user: {user.name}")
-        raise HTTPException(status_code=404, detail=f"User: {user.name} does not exist")
+        logger.warning(f"Cannot delete non-existent user: {name}")
+        raise HTTPException(
+            status_code=404, detail=f"User: {name} does not exist"
+        )
 
     # Delete user
     await redis_client.delete(key)
 
-    logger.info(f"Deleted user: {user.name}")
-    return UserResponse(message=f"Deleted User: {user.name}", user=user)
+    logger.info(f"Deleted user: {name}")
+    return UserResponse(message=f"Deleted User: {name}", user=None)
+
+
+# ==================== Legacy API Endpoints (Deprecated) ====================
+# These endpoints are kept for backward compatibility.
+# Use the RESTful endpoints above (/users, /users/{name}) instead.
+
+
+@legacy_router.post("/CreateUser")
+async def legacy_create_user(request: Request, user: User) -> UserResponse:
+    """Create a new user. Deprecated: use POST /users instead."""
+    warnings.warn(
+        "POST /CreateUser is deprecated, use POST /users instead",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+    return await create_user(request, user)
+
+
+@legacy_router.post("/ReadUser")
+async def legacy_read_user(request: Request, user: User) -> UserResponse:
+    """Read user information. Deprecated: use GET /users/{name} instead."""
+    warnings.warn(
+        "POST /ReadUser is deprecated, use GET /users/{name} instead",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+    return await get_user(request, user.name)
+
+
+@legacy_router.post("/UpdateUser")
+async def legacy_update_user(request: Request, user: User) -> UserResponse:
+    """Update user information. Deprecated: use PUT /users/{name} instead."""
+    warnings.warn(
+        "POST /UpdateUser is deprecated, use PUT /users/{name} instead",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+    return await update_user(request, user.name, user)
+
+
+@legacy_router.post("/DeleteUser")
+async def legacy_delete_user(request: Request, user: User) -> UserResponse:
+    """Delete a user. Deprecated: use DELETE /users/{name} instead."""
+    warnings.warn(
+        "POST /DeleteUser is deprecated, use DELETE /users/{name} instead",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+    return await delete_user(request, user.name)

--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -151,9 +151,11 @@ def build_app(args: argparse.Namespace, params={}):
     )
     logger.info("Models API mounted at /v1/models")
 
-    # Initialize user CRUD API
+    # Initialize user CRUD API (RESTful endpoints)
     app.include_router(users.router, tags=["users"])
-    logger.info("User CRUD API mounted")
+    # Mount legacy endpoints for backward compatibility (deprecated)
+    app.include_router(users.legacy_router, tags=["users-legacy"])
+    logger.info("User CRUD API mounted (RESTful + legacy endpoints)")
 
     # Initialize batches API
     if not args.disable_batch_api:

--- a/python/aibrix/tests/metadata/test_users_api.py
+++ b/python/aibrix/tests/metadata/test_users_api.py
@@ -17,7 +17,8 @@ Tests for the metadata users API.
 
 Test Coverage:
 - User Pydantic model validation
-- User CRUD API: Redis-backed user management with rate limiting
+- User RESTful API: GET/POST/PUT/DELETE /users endpoints
+- Legacy API: backward-compatible POST-based endpoints
 """
 
 import os
@@ -73,8 +74,8 @@ class TestUserModel:
             User(name="test-user", tpm=-1)
 
 
-class TestUsersAPI:
-    """Integration tests for Users CRUD API."""
+class TestUsersRESTfulAPI:
+    """Integration tests for RESTful Users API."""
 
     @pytest.fixture
     def mock_redis(self):
@@ -99,14 +100,14 @@ class TestUsersAPI:
         return app
 
     def test_create_user(self, app_with_redis, mock_redis):
-        """Test creating a new user."""
+        """Test creating a new user via POST /users."""
         client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 0  # User doesn't exist
+        mock_redis.exists.return_value = 0
         mock_redis.set.return_value = True
 
         user_data = {"name": "test-user", "rpm": 100, "tpm": 1000}
 
-        response = client.post("/CreateUser", json=user_data)
+        response = client.post("/users", json=user_data)
         assert response.status_code == 200
 
         data = response.json()
@@ -116,30 +117,29 @@ class TestUsersAPI:
         assert data["user"]["tpm"] == 1000
         assert "Created User" in data["message"]
 
-        # Verify Redis was called correctly
         mock_redis.exists.assert_called_once_with("aibrix-users/test-user")
         mock_redis.set.assert_called_once()
 
     def test_create_user_already_exists(self, app_with_redis, mock_redis):
-        """Test creating user that already exists returns success with existing user."""
+        """Test creating user that already exists."""
         client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 1  # User exists
+        mock_redis.exists.return_value = 1
 
         user_data = {"name": "test-user", "rpm": 100, "tpm": 1000}
 
-        response = client.post("/CreateUser", json=user_data)
+        response = client.post("/users", json=user_data)
         assert response.status_code == 200
         data = response.json()
         assert "exists" in data["message"]
 
-    def test_read_user(self, app_with_redis, mock_redis):
-        """Test reading a user."""
+    def test_get_user(self, app_with_redis, mock_redis):
+        """Test reading a user via GET /users/{name}."""
         client = TestClient(app_with_redis)
         user_data = {"name": "test-user", "rpm": 100, "tpm": 1000}
         user = User(**user_data)
         mock_redis.get.return_value = user.model_dump_json().encode()
 
-        response = client.post("/ReadUser", json=user_data)
+        response = client.get("/users/test-user")
         assert response.status_code == 200
 
         data = response.json()
@@ -148,24 +148,24 @@ class TestUsersAPI:
         assert data["user"]["rpm"] == 100
         assert data["user"]["tpm"] == 1000
 
-    def test_read_user_not_found(self, app_with_redis, mock_redis):
+    def test_get_user_not_found(self, app_with_redis, mock_redis):
         """Test reading non-existent user returns 404."""
         client = TestClient(app_with_redis)
         mock_redis.get.return_value = None
 
-        response = client.post("/ReadUser", json={"name": "nonexistent"})
+        response = client.get("/users/nonexistent")
         assert response.status_code == 404
         assert "does not exist" in response.json()["detail"]
 
     def test_update_user(self, app_with_redis, mock_redis):
-        """Test updating a user."""
+        """Test updating a user via PUT /users/{name}."""
         client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 1  # User exists
+        mock_redis.exists.return_value = 1
         mock_redis.set.return_value = True
 
         updated_data = {"name": "test-user", "rpm": 200, "tpm": 2000}
 
-        response = client.post("/UpdateUser", json=updated_data)
+        response = client.put("/users/test-user", json=updated_data)
         assert response.status_code == 200
 
         data = response.json()
@@ -178,21 +178,21 @@ class TestUsersAPI:
     def test_update_user_not_found(self, app_with_redis, mock_redis):
         """Test updating non-existent user returns 404."""
         client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 0  # User doesn't exist
+        mock_redis.exists.return_value = 0
 
         user_data = {"name": "nonexistent", "rpm": 100, "tpm": 1000}
 
-        response = client.post("/UpdateUser", json=user_data)
+        response = client.put("/users/nonexistent", json=user_data)
         assert response.status_code == 404
         assert "does not exist" in response.json()["detail"]
 
     def test_delete_user(self, app_with_redis, mock_redis):
-        """Test deleting a user."""
+        """Test deleting a user via DELETE /users/{name}."""
         client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 1  # User exists
+        mock_redis.exists.return_value = 1
         mock_redis.delete.return_value = 1
 
-        response = client.post("/DeleteUser", json={"name": "test-user"})
+        response = client.delete("/users/test-user")
         assert response.status_code == 200
 
         data = response.json()
@@ -201,8 +201,88 @@ class TestUsersAPI:
     def test_delete_user_not_found(self, app_with_redis, mock_redis):
         """Test deleting non-existent user returns 404."""
         client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 0  # User doesn't exist
+        mock_redis.exists.return_value = 0
 
-        response = client.post("/DeleteUser", json={"name": "nonexistent"})
+        response = client.delete("/users/nonexistent")
         assert response.status_code == 404
         assert "does not exist" in response.json()["detail"]
+
+
+class TestUsersLegacyAPI:
+    """Tests for legacy backward-compatible endpoints (deprecated)."""
+
+    @pytest.fixture
+    def mock_redis(self):
+        """Mock Redis client."""
+        mock = AsyncMock()
+        return mock
+
+    @pytest.fixture
+    def app_with_redis(self, mock_redis):
+        """Build app with mocked Redis."""
+        from argparse import Namespace
+
+        args = Namespace(
+            enable_fastapi_docs=False,
+            disable_batch_api=True,
+            disable_file_api=True,
+            enable_k8s_job=False,
+            e2e_test=False,
+        )
+        app = build_app(args)
+        app.state.redis_client = mock_redis
+        return app
+
+    def test_legacy_create_user(self, app_with_redis, mock_redis):
+        """Test legacy POST /CreateUser still works."""
+        client = TestClient(app_with_redis)
+        mock_redis.exists.return_value = 0
+        mock_redis.set.return_value = True
+
+        user_data = {"name": "test-user", "rpm": 100, "tpm": 1000}
+
+        response = client.post("/CreateUser", json=user_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "user" in data
+        assert data["user"]["name"] == "test-user"
+        assert "Created User" in data["message"]
+
+    def test_legacy_read_user(self, app_with_redis, mock_redis):
+        """Test legacy POST /ReadUser still works."""
+        client = TestClient(app_with_redis)
+        user_data = {"name": "test-user", "rpm": 100, "tpm": 1000}
+        user = User(**user_data)
+        mock_redis.get.return_value = user.model_dump_json().encode()
+
+        response = client.post("/ReadUser", json=user_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["user"]["name"] == "test-user"
+
+    def test_legacy_update_user(self, app_with_redis, mock_redis):
+        """Test legacy POST /UpdateUser still works."""
+        client = TestClient(app_with_redis)
+        mock_redis.exists.return_value = 1
+        mock_redis.set.return_value = True
+
+        updated_data = {"name": "test-user", "rpm": 200, "tpm": 2000}
+
+        response = client.post("/UpdateUser", json=updated_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["user"]["rpm"] == 200
+        assert "Updated User" in data["message"]
+
+    def test_legacy_delete_user(self, app_with_redis, mock_redis):
+        """Test legacy POST /DeleteUser still works."""
+        client = TestClient(app_with_redis)
+        mock_redis.exists.return_value = 1
+        mock_redis.delete.return_value = 1
+
+        response = client.post("/DeleteUser", json={"name": "test-user"})
+        assert response.status_code == 200
+        assert "Deleted User" in response.json()["message"]


### PR DESCRIPTION
## Summary

Fixes #1640

Refactor the metadata user management API from non-standard POST-based endpoints to proper RESTful conventions while maintaining full backward compatibility.

## Changes

### New RESTful endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/users` | Create a new user |
| GET | `/users/{name}` | Read user by name |
| PUT | `/users/{name}` | Update user by name |
| DELETE | `/users/{name}` | Delete user by name |

### Legacy endpoints (deprecated, kept for backward compatibility)
The old POST-based endpoints (`/CreateUser`, `/ReadUser`, `/UpdateUser`, `/DeleteUser`) are preserved via a separate `legacy_router` and delegate to the new RESTful implementations. They emit deprecation warnings.

### Files Changed
- **`python/aibrix/aibrix/metadata/api/v1/users.py`**: New RESTful router + legacy router with deprecation warnings
- **`python/aibrix/aibrix/metadata/app.py`**: Mount both routers
- **`python/aibrix/tests/metadata/test_users_api.py`**: Tests for both RESTful and legacy endpoints
