### PR TITLE
feat(metadata): introduce MetadataStore abstraction layer

### DIFF
--- a/python/aibrix/aibrix/metadata/api/v1/users.py
+++ b/python/aibrix/aibrix/metadata/api/v1/users.py
@@ -14,11 +14,11 @@
 
 from typing import Optional
 
-import redis.asyncio as redis
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field, field_validator
 
 from aibrix.logger import init_logger
+from aibrix.metadata.store import MetadataStore
 
 logger = init_logger(__name__)
 router = APIRouter()
@@ -54,27 +54,27 @@ class UserResponse(BaseModel):
 
 
 def _gen_key(name: str) -> str:
-    """Generate Redis key for user.
+    """Generate storage key for user.
 
     Args:
         name: User name
 
     Returns:
-        Redis key in format: aibrix-users/{name}
+        Storage key in format: aibrix-users/{name}
     """
     return f"aibrix-users/{name}"
 
 
-async def _get_redis_client(request: Request) -> redis.Redis:
-    """Get Redis client from app state.
+def _get_metadata_store(request: Request) -> MetadataStore:
+    """Get metadata store from app state.
 
     Args:
         request: FastAPI request object
 
     Returns:
-        Redis client instance
+        MetadataStore instance
     """
-    return request.app.state.redis_client
+    return request.app.state.metadata_store
 
 
 @router.post("/CreateUser")
@@ -90,17 +90,16 @@ async def create_user(request: Request, user: User) -> UserResponse:
     Returns:
         UserResponse with creation status
     """
-    redis_client = await _get_redis_client(request)
+    store = _get_metadata_store(request)
     key = _gen_key(user.name)
 
     # Check if user exists
-    exists = await redis_client.exists(key)
-    if exists:
+    if await store.exists(key):
         logger.info(f"User already exists: {user.name}")
         return UserResponse(message=f"User: {user.name} exists", user=user)
 
     # Store user as JSON
-    await redis_client.set(key, user.model_dump_json())
+    await store.set(key, user.model_dump_json())
 
     logger.info(f"Created user: {user.name}, rpm={user.rpm}, tpm={user.tpm}")
     return UserResponse(message=f"Created User: {user.name}", user=user)
@@ -120,10 +119,10 @@ async def read_user(request: Request, user: User) -> UserResponse:
     Raises:
         HTTPException: 404 if user not found
     """
-    redis_client = await _get_redis_client(request)
+    store = _get_metadata_store(request)
     key = _gen_key(user.name)
 
-    data = await redis_client.get(key)
+    data = await store.get(key)
     if not data:
         logger.warning(f"User not found: {user.name}")
         raise HTTPException(status_code=404, detail="user does not exist")
@@ -149,17 +148,16 @@ async def update_user(request: Request, user: User) -> UserResponse:
     Raises:
         HTTPException: 404 if user not found
     """
-    redis_client = await _get_redis_client(request)
+    store = _get_metadata_store(request)
     key = _gen_key(user.name)
 
     # Check if user exists
-    exists = await redis_client.exists(key)
-    if not exists:
+    if not await store.exists(key):
         logger.warning(f"Cannot update non-existent user: {user.name}")
         raise HTTPException(status_code=404, detail=f"User: {user.name} does not exist")
 
     # Update user
-    await redis_client.set(key, user.model_dump_json())
+    await store.set(key, user.model_dump_json())
 
     logger.info(f"Updated user: {user.name}, rpm={user.rpm}, tpm={user.tpm}")
     return UserResponse(message=f"Updated User: {user.name}", user=user)
@@ -179,17 +177,16 @@ async def delete_user(request: Request, user: User) -> UserResponse:
     Raises:
         HTTPException: 404 if user not found
     """
-    redis_client = await _get_redis_client(request)
+    store = _get_metadata_store(request)
     key = _gen_key(user.name)
 
     # Check if user exists
-    exists = await redis_client.exists(key)
-    if not exists:
+    if not await store.exists(key):
         logger.warning(f"Cannot delete non-existent user: {user.name}")
         raise HTTPException(status_code=404, detail=f"User: {user.name} does not exist")
 
     # Delete user
-    await redis_client.delete(key)
+    await store.delete(key)
 
     logger.info(f"Deleted user: {user.name}")
     return UserResponse(message=f"Deleted User: {user.name}", user=user)

--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -30,6 +30,7 @@ from aibrix.metadata.api.v1 import batch, files, models, users
 from aibrix.metadata.cache import JobCache
 from aibrix.metadata.core import HTTPXClientWrapper, KopfOperatorWrapper
 from aibrix.metadata.setting import settings
+from aibrix.metadata.store import RedisMetadataStore
 from aibrix.storage import create_storage
 
 logger = init_logger(__name__)
@@ -44,13 +45,16 @@ async def liveness_check():
 
 @router.get("/readyz")
 async def readiness_check(request: Request):
-    # Check if Redis is ready
+    # Check if metadata store is ready
     try:
-        if hasattr(request.app.state, "redis_client"):
+        if hasattr(request.app.state, "metadata_store"):
+            await request.app.state.metadata_store.ping()
+        # Backward compatibility: check redis_client if metadata_store not set
+        elif hasattr(request.app.state, "redis_client"):
             await request.app.state.redis_client.ping()
         return JSONResponse(content={"status": "ready"}, status_code=200)
     except Exception as e:
-        logger.error(f"Redis health check failed: {e}")
+        logger.error(f"Metadata store health check failed: {e}")
         return JSONResponse(
             content={"status": "not ready", "error": str(e)}, status_code=503
         )
@@ -87,16 +91,19 @@ async def lifespan(app: FastAPI):
     # Code executed on startup
     logger.info("Initializing FastAPI app...")
 
-    # Initialize Redis client
-    app.state.redis_client = redis.Redis(
+    # Initialize metadata store (abstraction over Redis)
+    metadata_store = RedisMetadataStore(
         host=envs.STORAGE_REDIS_HOST or "localhost",
         port=envs.STORAGE_REDIS_PORT,
         db=envs.STORAGE_REDIS_DB,
         password=envs.STORAGE_REDIS_PASSWORD,
-        decode_responses=False,
     )
+    app.state.metadata_store = metadata_store
+    # Backward compatibility: expose underlying Redis client for components
+    # that haven't migrated to the MetadataStore interface yet
+    app.state.redis_client = metadata_store.client
     logger.info(
-        f"Redis client initialized: {envs.STORAGE_REDIS_HOST}:{envs.STORAGE_REDIS_PORT}"
+        f"Metadata store initialized: {envs.STORAGE_REDIS_HOST}:{envs.STORAGE_REDIS_PORT}"
     )
 
     if hasattr(app.state, "httpx_client_wrapper"):
@@ -115,7 +122,9 @@ async def lifespan(app: FastAPI):
         app.state.kopf_operator_wrapper.stop()
     if hasattr(app.state, "httpx_client_wrapper"):
         await app.state.httpx_client_wrapper.stop()
-    if hasattr(app.state, "redis_client"):
+    if hasattr(app.state, "metadata_store"):
+        await app.state.metadata_store.close()
+    elif hasattr(app.state, "redis_client"):
         await app.state.redis_client.aclose()  # type: ignore[attr-defined]
         logger.info("Redis client closed")
 

--- a/python/aibrix/aibrix/metadata/store.py
+++ b/python/aibrix/aibrix/metadata/store.py
@@ -1,0 +1,159 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Metadata store abstraction layer.
+
+Provides a clean interface for metadata key-value operations
+(e.g., user CRUD) instead of directly referencing a Redis client.
+This allows for easier testing, backend swapping, and separation of concerns.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import redis.asyncio as redis
+
+from aibrix.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class MetadataStore(ABC):
+    """Abstract base class for metadata key-value storage.
+
+    This interface defines the operations needed by the metadata service
+    for storing and retrieving structured data (users, configs, etc.).
+    Unlike the storage.BaseStorage which is designed for file/object storage,
+    this interface is tailored for simple key-value metadata operations.
+    """
+
+    @abstractmethod
+    async def get(self, key: str) -> Optional[bytes]:
+        """Get value by key.
+
+        Args:
+            key: The key to look up.
+
+        Returns:
+            The value as bytes if found, None otherwise.
+        """
+        ...
+
+    @abstractmethod
+    async def set(self, key: str, value: str | bytes) -> bool:
+        """Set a key-value pair.
+
+        Args:
+            key: The key to store.
+            value: The value to store (string or bytes).
+
+        Returns:
+            True if the operation succeeded.
+        """
+        ...
+
+    @abstractmethod
+    async def exists(self, key: str) -> bool:
+        """Check if a key exists.
+
+        Args:
+            key: The key to check.
+
+        Returns:
+            True if the key exists, False otherwise.
+        """
+        ...
+
+    @abstractmethod
+    async def delete(self, key: str) -> bool:
+        """Delete a key.
+
+        Args:
+            key: The key to delete.
+
+        Returns:
+            True if the key was deleted, False if it didn't exist.
+        """
+        ...
+
+    @abstractmethod
+    async def ping(self) -> bool:
+        """Check if the store backend is reachable.
+
+        Returns:
+            True if the backend is healthy.
+        """
+        ...
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Close the connection to the store backend."""
+        ...
+
+
+class RedisMetadataStore(MetadataStore):
+    """Redis-backed implementation of the metadata store."""
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 6379,
+        db: int = 0,
+        password: Optional[str] = None,
+    ):
+        self._client = redis.Redis(
+            host=host,
+            port=port,
+            db=db,
+            password=password,
+            decode_responses=False,
+        )
+        logger.info(f"Redis metadata store initialized: {host}:{port}")
+
+    @property
+    def client(self) -> redis.Redis:
+        """Expose underlying Redis client for backward compatibility.
+
+        This property allows existing code that directly accesses the
+        Redis client to continue working during the migration period.
+        New code should use the MetadataStore interface methods instead.
+        """
+        return self._client
+
+    async def get(self, key: str) -> Optional[bytes]:
+        data = await self._client.get(key)
+        return data
+
+    async def set(self, key: str, value: str | bytes) -> bool:
+        result = await self._client.set(key, value)
+        return bool(result)
+
+    async def exists(self, key: str) -> bool:
+        result = await self._client.exists(key)
+        return bool(result)
+
+    async def delete(self, key: str) -> bool:
+        result = await self._client.delete(key)
+        return bool(result)
+
+    async def ping(self) -> bool:
+        try:
+            return await self._client.ping()
+        except Exception:
+            return False
+
+    async def close(self) -> None:
+        await self._client.aclose()
+        logger.info("Redis metadata store closed")

--- a/python/aibrix/tests/metadata/test_users_api.py
+++ b/python/aibrix/tests/metadata/test_users_api.py
@@ -17,11 +17,11 @@ Tests for the metadata users API.
 
 Test Coverage:
 - User Pydantic model validation
-- User CRUD API: Redis-backed user management with rate limiting
+- User CRUD API: MetadataStore-backed user management with rate limiting
+- MetadataStore abstraction unit tests
 """
 
 import os
-from unittest.mock import AsyncMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -33,6 +33,7 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing")
 try:
     from aibrix.metadata.api.v1.users import User
     from aibrix.metadata.app import build_app
+    from aibrix.metadata.store import MetadataStore
 
     DEPENDENCIES_AVAILABLE = True
 except ModuleNotFoundError as e:
@@ -43,6 +44,35 @@ pytestmark = pytest.mark.skipif(
     not DEPENDENCIES_AVAILABLE,
     reason="Dependencies not available. Run: poetry install --with dev",
 )
+
+
+class MockMetadataStore(MetadataStore):
+    """In-memory MetadataStore for testing."""
+
+    def __init__(self):
+        self._data: dict[str, bytes] = {}
+
+    async def get(self, key: str):
+        return self._data.get(key)
+
+    async def set(self, key: str, value) -> bool:
+        self._data[key] = value if isinstance(value, bytes) else value.encode()
+        return True
+
+    async def exists(self, key: str) -> bool:
+        return key in self._data
+
+    async def delete(self, key: str) -> bool:
+        if key in self._data:
+            del self._data[key]
+            return True
+        return False
+
+    async def ping(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        pass
 
 
 class TestUserModel:
@@ -74,17 +104,16 @@ class TestUserModel:
 
 
 class TestUsersAPI:
-    """Integration tests for Users CRUD API."""
+    """Integration tests for Users CRUD API using MetadataStore abstraction."""
 
     @pytest.fixture
-    def mock_redis(self):
-        """Mock Redis client."""
-        mock = AsyncMock()
-        return mock
+    def mock_store(self):
+        """Create a MockMetadataStore instance for testing."""
+        return MockMetadataStore()
 
     @pytest.fixture
-    def app_with_redis(self, mock_redis):
-        """Build app with mocked Redis."""
+    def app_with_store(self, mock_store):
+        """Build app with mocked MetadataStore."""
         from argparse import Namespace
 
         args = Namespace(
@@ -95,14 +124,14 @@ class TestUsersAPI:
             e2e_test=False,
         )
         app = build_app(args)
-        app.state.redis_client = mock_redis
+        app.state.metadata_store = mock_store
+        # Also set redis_client for backward compatibility (via .client if needed)
+        app.state.redis_client = None
         return app
 
-    def test_create_user(self, app_with_redis, mock_redis):
+    def test_create_user(self, app_with_store, mock_store):
         """Test creating a new user."""
-        client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 0  # User doesn't exist
-        mock_redis.set.return_value = True
+        client = TestClient(app_with_store)
 
         user_data = {"name": "test-user", "rpm": 100, "tpm": 1000}
 
@@ -116,14 +145,16 @@ class TestUsersAPI:
         assert data["user"]["tpm"] == 1000
         assert "Created User" in data["message"]
 
-        # Verify Redis was called correctly
-        mock_redis.exists.assert_called_once_with("aibrix-users/test-user")
-        mock_redis.set.assert_called_once()
+        # Verify store contains the user
+        assert "aibrix-users/test-user" in mock_store._data
 
-    def test_create_user_already_exists(self, app_with_redis, mock_redis):
+    def test_create_user_already_exists(self, app_with_store, mock_store):
         """Test creating user that already exists returns success with existing user."""
-        client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 1  # User exists
+        client = TestClient(app_with_store)
+
+        # Pre-populate store with existing user
+        user = User(name="test-user", rpm=50, tpm=500)
+        mock_store._data["aibrix-users/test-user"] = user.model_dump_json().encode()
 
         user_data = {"name": "test-user", "rpm": 100, "tpm": 1000}
 
@@ -132,12 +163,14 @@ class TestUsersAPI:
         data = response.json()
         assert "exists" in data["message"]
 
-    def test_read_user(self, app_with_redis, mock_redis):
+    def test_read_user(self, app_with_store, mock_store):
         """Test reading a user."""
-        client = TestClient(app_with_redis)
+        client = TestClient(app_with_store)
         user_data = {"name": "test-user", "rpm": 100, "tpm": 1000}
         user = User(**user_data)
-        mock_redis.get.return_value = user.model_dump_json().encode()
+
+        # Pre-populate store
+        mock_store._data["aibrix-users/test-user"] = user.model_dump_json().encode()
 
         response = client.post("/ReadUser", json=user_data)
         assert response.status_code == 200
@@ -148,20 +181,21 @@ class TestUsersAPI:
         assert data["user"]["rpm"] == 100
         assert data["user"]["tpm"] == 1000
 
-    def test_read_user_not_found(self, app_with_redis, mock_redis):
+    def test_read_user_not_found(self, app_with_store, mock_store):
         """Test reading non-existent user returns 404."""
-        client = TestClient(app_with_redis)
-        mock_redis.get.return_value = None
+        client = TestClient(app_with_store)
 
         response = client.post("/ReadUser", json={"name": "nonexistent"})
         assert response.status_code == 404
         assert "does not exist" in response.json()["detail"]
 
-    def test_update_user(self, app_with_redis, mock_redis):
+    def test_update_user(self, app_with_store, mock_store):
         """Test updating a user."""
-        client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 1  # User exists
-        mock_redis.set.return_value = True
+        client = TestClient(app_with_store)
+
+        # Pre-populate store with existing user
+        user = User(name="test-user", rpm=100, tpm=1000)
+        mock_store._data["aibrix-users/test-user"] = user.model_dump_json().encode()
 
         updated_data = {"name": "test-user", "rpm": 200, "tpm": 2000}
 
@@ -175,10 +209,9 @@ class TestUsersAPI:
         assert data["user"]["tpm"] == 2000
         assert "Updated User" in data["message"]
 
-    def test_update_user_not_found(self, app_with_redis, mock_redis):
+    def test_update_user_not_found(self, app_with_store, mock_store):
         """Test updating non-existent user returns 404."""
-        client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 0  # User doesn't exist
+        client = TestClient(app_with_store)
 
         user_data = {"name": "nonexistent", "rpm": 100, "tpm": 1000}
 
@@ -186,22 +219,25 @@ class TestUsersAPI:
         assert response.status_code == 404
         assert "does not exist" in response.json()["detail"]
 
-    def test_delete_user(self, app_with_redis, mock_redis):
+    def test_delete_user(self, app_with_store, mock_store):
         """Test deleting a user."""
-        client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 1  # User exists
-        mock_redis.delete.return_value = 1
+        client = TestClient(app_with_store)
+
+        # Pre-populate store with existing user
+        user = User(name="test-user", rpm=100, tpm=1000)
+        mock_store._data["aibrix-users/test-user"] = user.model_dump_json().encode()
 
         response = client.post("/DeleteUser", json={"name": "test-user"})
         assert response.status_code == 200
 
         data = response.json()
         assert "Deleted User" in data["message"]
+        # Verify user was removed from store
+        assert "aibrix-users/test-user" not in mock_store._data
 
-    def test_delete_user_not_found(self, app_with_redis, mock_redis):
+    def test_delete_user_not_found(self, app_with_store, mock_store):
         """Test deleting non-existent user returns 404."""
-        client = TestClient(app_with_redis)
-        mock_redis.exists.return_value = 0  # User doesn't exist
+        client = TestClient(app_with_store)
 
         response = client.post("/DeleteUser", json={"name": "nonexistent"})
         assert response.status_code == 404


### PR DESCRIPTION
## Summary

Introduces a MetadataStore abstract base class to decouple the metadata service from direct Redis client usage, improving testability and enabling future backend flexibility.

## Changes

### New: store.py - MetadataStore abstraction
- MetadataStore ABC with get/set/exists/delete/ping/close interface
- RedisMetadataStore implementation wrapping edis.asyncio.Redis
- Backward-compatible .client property for migration period

### Modified: pp.py - Lifespan management
- Creates RedisMetadataStore instead of raw edis.Redis
- Exposes both pp.state.metadata_store (new) and pp.state.redis_client (backward compat via .client)
- Health check uses metadata_store.ping() with fallback to edis_client.ping()
- Shutdown closes via metadata_store.close()

### Modified: users.py - CRUD operations
- Imports and uses MetadataStore interface instead of edis.asyncio
- \_get_metadata_store()\ replaces \_get_redis_client()\
- All CRUD operations use store methods directly

### Modified: 	est_users_api.py - Tests
- \MockMetadataStore\ (in-memory dict-backed) replaces \AsyncMock()\ Redis mocking
- Tests use real store behavior instead of mock return value configuration
- Cleaner, more maintainable test setup

## Benefits
- **Testability**: Tests use \MockMetadataStore\ with real behavior instead of fragile mocks
- **Extensibility**: Easy to swap in etcd, DynamoDB, or other backends by implementing \MetadataStore\
- **Separation of concerns**: Business logic decoupled from storage implementation
- **Backward compatibility**: Existing code using \edis_client\ continues to work via \.client\ property

Closes #1642