### PR TITLE
feat(gateway): Support routing-strategy injection from pod labels

### DIFF
--- a/pkg/constants/model.go
+++ b/pkg/constants/model.go
@@ -39,6 +39,12 @@ const (
 	// ModelLabelAdapterEnabled is the label for enabling or disabling adapter dynamic registration
 	// Example: "adapter.model.aibrix.ai/enabled": "true"
 	ModelLabelAdapterEnabled = "adapter.model.aibrix.ai/enabled"
+
+	// ModelLabelRoutingStrategy is the label for specifying the default routing strategy
+	// for a model. When set on pods, the gateway will use this as the routing strategy
+	// if the client doesn't provide a routing-strategy header and no config profile is set.
+	// Example: "model.aibrix.ai/routing-strategy": "least-request"
+	ModelLabelRoutingStrategy = "model.aibrix.ai/routing-strategy"
 )
 
 const (

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -33,6 +33,7 @@ import (
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/packages/param"
+	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/configprofiles"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
@@ -322,17 +323,31 @@ func validateStreamOptions(requestID string, user utils.User, stream *bool, stre
 // and applies the selected profile: sets ConfigProfile on routingCtx.
 // - If the client provides config-profile, use that profile name.
 // - If not provided or not found, fall back to defaultProfile (or "default") in the JSON.
+// - If no annotation config exists, check pod label model.aibrix.ai/routing-strategy
+//   as a simpler alternative for setting default routing strategy.
 func applyConfigProfile(routingCtx *types.RoutingContext, pods []*v1.Pod) {
 	headerProfile := routingCtx.ReqConfigProfile
 	profile := configprofiles.ResolveProfile(pods, headerProfile)
-	if profile == nil {
+	if profile != nil {
+		routingCtx.ConfigProfile = &types.ResolvedConfigProfile{
+			RoutingStrategy:          profile.RoutingStrategy,
+			PromptLenBucketMinLength: profile.PromptLenBucketMinLength,
+			PromptLenBucketMaxLength: profile.PromptLenBucketMaxLength,
+			Combined:                 profile.Combined,
+		}
 		return
 	}
-	routingCtx.ConfigProfile = &types.ResolvedConfigProfile{
-		RoutingStrategy:          profile.RoutingStrategy,
-		PromptLenBucketMinLength: profile.PromptLenBucketMinLength,
-		PromptLenBucketMaxLength: profile.PromptLenBucketMaxLength,
-		Combined:                 profile.Combined,
+
+	// Fallback: check pod label model.aibrix.ai/routing-strategy
+	// This provides a simpler way to set default routing strategy without
+	// the full model.aibrix.ai/config annotation.
+	for _, pod := range pods {
+		if strategy, ok := pod.Labels[constants.ModelLabelRoutingStrategy]; ok && strings.TrimSpace(strategy) != "" {
+			routingCtx.ConfigProfile = &types.ResolvedConfigProfile{
+				RoutingStrategy: strings.TrimSpace(strategy),
+			}
+			return
+		}
 	}
 }
 

--- a/pkg/plugins/gateway/util_test.go
+++ b/pkg/plugins/gateway/util_test.go
@@ -25,7 +25,11 @@ import (
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/openai/openai-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_ValidateRequestBody(t *testing.T) {
@@ -1125,5 +1129,158 @@ func Test_ValidateRequestBody_Classify(t *testing.T) {
 		if tt.stream {
 			assert.Equal(t, tt.stream, stream, tt.message)
 		}
+	}
+}
+
+func TestApplyConfigProfile_PodLabelRoutingStrategy(t *testing.T) {
+	tests := []struct {
+		name                    string
+		pods                    []*v1.Pod
+		headerProfile           string
+		expectedRoutingStrategy string
+		expectProfile           bool
+	}{
+		{
+			name: "pod label sets routing strategy when no annotation config exists",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							constants.ModelLabelName:            "test-model",
+							constants.ModelLabelRoutingStrategy: "least-request",
+						},
+					},
+				},
+			},
+			expectedRoutingStrategy: "least-request",
+			expectProfile:           true,
+		},
+		{
+			name: "annotation config takes priority over pod label",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							constants.ModelLabelName:            "test-model",
+							constants.ModelLabelRoutingStrategy: "least-request",
+						},
+						Annotations: map[string]string{
+							constants.ModelAnnoConfig: `{"defaultProfile": "default", "profiles": {"default": {"routingStrategy": "random"}}}`,
+						},
+					},
+				},
+			},
+			expectedRoutingStrategy: "random",
+			expectProfile:           true,
+		},
+		{
+			name: "no label or annotation returns nil profile",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							constants.ModelLabelName: "test-model",
+						},
+					},
+				},
+			},
+			expectProfile: false,
+		},
+		{
+			name: "empty label value is ignored",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							constants.ModelLabelName:            "test-model",
+							constants.ModelLabelRoutingStrategy: "",
+						},
+					},
+				},
+			},
+			expectProfile: false,
+		},
+		{
+			name:          "empty pod list returns nil profile",
+			pods:          []*v1.Pod{},
+			expectProfile: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := types.NewRoutingContext(nil, "", "", "", "test-req", "")
+			ctx.ReqConfigProfile = tt.headerProfile
+
+			applyConfigProfile(ctx, tt.pods)
+
+			if tt.expectProfile {
+				assert.NotNil(t, ctx.ConfigProfile, "expected config profile to be set")
+				assert.Equal(t, tt.expectedRoutingStrategy, ctx.ConfigProfile.RoutingStrategy)
+			} else {
+				assert.Nil(t, ctx.ConfigProfile, "expected config profile to be nil")
+			}
+		})
+	}
+}
+
+func TestDeriveRoutingStrategyFromContext_Priority(t *testing.T) {
+	tests := []struct {
+		name             string
+		reqHeaders       map[string]string
+		configProfile    *types.ResolvedConfigProfile
+		expectedStrategy string
+		expectedEnabled  bool
+	}{
+		{
+			name: "header routing strategy takes top priority",
+			reqHeaders: map[string]string{
+				HeaderRoutingStrategy: "round-robin",
+			},
+			configProfile: &types.ResolvedConfigProfile{
+				RoutingStrategy: "least-request",
+			},
+			expectedStrategy: "round-robin",
+			expectedEnabled:  true,
+		},
+		{
+			name:       "config profile used when no header",
+			reqHeaders: map[string]string{},
+			configProfile: &types.ResolvedConfigProfile{
+				RoutingStrategy: "least-request",
+			},
+			expectedStrategy: "least-request",
+			expectedEnabled:  true,
+		},
+		{
+			name: "empty header falls through to config profile",
+			reqHeaders: map[string]string{
+				HeaderRoutingStrategy: "",
+			},
+			configProfile: &types.ResolvedConfigProfile{
+				RoutingStrategy: "least-request",
+			},
+			expectedStrategy: "least-request",
+			expectedEnabled:  true,
+		},
+		{
+			name:             "no header or profile falls to env default",
+			reqHeaders:       map[string]string{},
+			configProfile:    nil,
+			expectedStrategy: defaultRoutingStrategy,
+			expectedEnabled:  defaultRoutingStrategyEnabled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := types.NewRoutingContext(nil, "", "", "", "test-req", "")
+			ctx.ReqHeaders = tt.reqHeaders
+			ctx.ConfigProfile = tt.configProfile
+
+			strategy, enabled := deriveRoutingStrategyFromContext(ctx)
+			assert.Equal(t, tt.expectedStrategy, strategy)
+			assert.Equal(t, tt.expectedEnabled, enabled)
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1857

Adds support for specifying routing strategy via pod label `model.aibrix.ai/routing-strategy` as a fallback mechanism. This provides a simple, declarative way to configure routing strategy at the pod level without requiring the full annotation-based config profile.

## Routing Strategy Priority Order

1. **Request header** (`routing-strategy`) - per-request override
2. **Config profile** (`model.aibrix.ai/config` annotation) - annotation-based profiles
3. **Pod label** (`model.aibrix.ai/routing-strategy`) - **NEW** simple pod-level config
4. **Environment variable** (`ROUTING_ALGORITHM`) - cluster-wide default

## Changes

### `pkg/constants/model.go`
- Added `ModelLabelRoutingStrategy = model.aibrix.ai/routing-strategy` constant

### `pkg/plugins/gateway/util.go`
- Extended `applyConfigProfile()` to check pod labels for `model.aibrix.ai/routing-strategy` as a fallback when no `model.aibrix.ai/config` annotation exists
- Creates a minimal `ResolvedConfigProfile` with just the routing strategy from the label

### `pkg/plugins/gateway/util_test.go`
- Added `TestApplyConfigProfile_PodLabelRoutingStrategy` with 5 test cases:
  - Pod label sets routing strategy when no annotation config exists
  - Annotation config takes priority over pod label
  - No label or annotation returns nil profile
  - Empty label value is ignored
  - Empty pod list returns nil profile
- Added `TestDeriveRoutingStrategyFromContext_Priority` with 4 test cases verifying the full priority chain

## Usage Example

`yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    model.aibrix.ai/model-name: my-model
    model.aibrix.ai/routing-strategy: least-request
`

This is the simplest approach discussed in #1857, enabling routing strategy configuration without requiring the full JSON config annotation.