### PR TITLE
fix: add missing imports in chat app routers

### DIFF
--- a/apps/chat/api/routers/audio.py
+++ b/apps/chat/api/routers/audio.py
@@ -6,6 +6,7 @@ import logging
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import Response
+import httpx
 
 from models.schemas import AudioSpeechRequest, AudioTranscribeResponse
 from services.providers import get_audio_provider

--- a/apps/chat/api/routers/chat.py
+++ b/apps/chat/api/routers/chat.py
@@ -15,6 +15,7 @@ from middleware.auth import get_current_user
 from models.schemas import CompletionRequest, CompletionResponse, Message, User
 from services.conversation import store
 from services import gateway
+import httpx
 
 router = APIRouter(tags=["chat"])
 

--- a/apps/chat/api/routers/images.py
+++ b/apps/chat/api/routers/images.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+import httpx
 
 from models.schemas import ImageGenerateRequest, ImageGenerateResponse
 from services.providers import get_image_provider

--- a/apps/chat/api/routers/video.py
+++ b/apps/chat/api/routers/video.py
@@ -6,6 +6,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
+import httpx
 
 from models.schemas import VideoGenerateRequest, VideoJobResponse
 from services.providers import get_video_provider


### PR DESCRIPTION
## Pull Request Description
Some Python files were missing required imports, which caused the chat app sample to fail at runtime.  
This PR adds the necessary imports so the chat app sample can run successfully.

## Related Issues
Resolves: #1951

## Changes
Added missing imports in the following files:

- apps/chat/api/routers/audio.py
- apps/chat/api/routers/chat.py
- apps/chat/api/routers/images.py
- apps/chat/api/routers/video.py

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>