### PR TITLE
[Bug]: fix flaky TestLRUStore_TTL by using injectable clock in Put

### DIFF
--- a/pkg/utils/lrustore/lru_store.go
+++ b/pkg/utils/lrustore/lru_store.go
@@ -37,6 +37,7 @@ type LRUStore[K comparable, V any] struct {
 	getCurrentTime
 	interval time.Duration
 	ttl      time.Duration
+	stop     chan struct{}
 }
 
 func NewLRUStore[K comparable, V any](cap int, ttl, interval time.Duration, f getCurrentTime) *LRUStore[K, V] {
@@ -47,6 +48,7 @@ func NewLRUStore[K comparable, V any](cap int, ttl, interval time.Duration, f ge
 		ttl:            ttl,
 		interval:       interval,
 		getCurrentTime: f,
+		stop:           make(chan struct{}),
 	}
 	store.lruList.head.next = store.lruList.tail
 	store.lruList.tail.prev = store.lruList.head
@@ -55,11 +57,21 @@ func NewLRUStore[K comparable, V any](cap int, ttl, interval time.Duration, f ge
 	return store
 }
 
+// Close stops the background eviction goroutine.
+func (e *LRUStore[K, V]) Close() {
+	close(e.stop)
+}
+
 func (e *LRUStore[K, V]) startEviction() {
 	ticker := time.NewTicker(e.interval)
 	defer ticker.Stop()
-	for range ticker.C {
-		e.evict(e.getCurrentTime())
+	for {
+		select {
+		case <-ticker.C:
+			e.evict(e.getCurrentTime())
+		case <-e.stop:
+			return
+		}
 	}
 }
 
@@ -68,13 +80,13 @@ func (e *LRUStore[K, V]) Put(key K, value V) bool {
 	defer e.Unlock()
 
 	if entry, exists := e.freeTable[key]; exists {
-		entry.lastAccessTime = time.Now()
+		entry.lastAccessTime = e.getCurrentTime()
 		entry.Value = value
 		e.lruList.moveToHead(entry)
 		return false
 	}
 
-	entry := &entry[K, V]{Key: key, Value: value, lastAccessTime: time.Now()}
+	entry := &entry[K, V]{Key: key, Value: value, lastAccessTime: e.getCurrentTime()}
 	e.lruList.addToHead(entry)
 	e.freeTable[key] = entry
 	if len(e.freeTable) > e.cap {

--- a/pkg/utils/lrustore/lru_store_test.go
+++ b/pkg/utils/lrustore/lru_store_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -25,6 +26,7 @@ import (
 // TODO: add performance benchmark tests
 func TestLRUStore_PutAndGet(t *testing.T) {
 	store := NewLRUStore[string, string](2, 5*time.Second, 1*time.Second, DefaultGetCurrentTime)
+	t.Cleanup(func() { store.Close() })
 
 	// Test adding and retrieving items
 	store.Put("key1", "value1")
@@ -49,19 +51,29 @@ func TestLRUStore_PutAndGet(t *testing.T) {
 }
 
 func TestLRUStore_TTL(t *testing.T) {
-	store := NewLRUStore[string, string](2, 2*time.Second, 1*time.Second, DefaultGetCurrentTime)
+	// Use a fake clock so the test doesn't depend on wall time.
+	var unixNano atomic.Int64
+	unixNano.Store(time.Now().UnixNano())
+	fakeClock := func() time.Time { return time.Unix(0, unixNano.Load()) }
 
-	// Test TTL expiration
+	ttl := 2 * time.Second
+	store := NewLRUStore[string, string](2, ttl, time.Hour, fakeClock)
+	t.Cleanup(func() { store.Close() })
+
 	store.Put("key1", "value1")
-	time.Sleep(3 * time.Second) // Wait for TTL to expire
+
+	// Advance fake time past the TTL and trigger eviction manually.
+	unixNano.Add(int64(ttl + time.Millisecond))
+	store.evict(fakeClock())
 
 	if _, ok := store.Get("key1"); ok {
-		t.Errorf("expected key1 to be expired")
+		t.Error("expected key1 to be expired after TTL")
 	}
 }
 
 func TestLRUStore_UpdateExistingKey(t *testing.T) {
 	store := NewLRUStore[string, string](2, 5*time.Second, 1*time.Second, DefaultGetCurrentTime)
+	t.Cleanup(func() { store.Close() })
 
 	// Test updating an existing key
 	store.Put("key1", "value1")
@@ -73,7 +85,9 @@ func TestLRUStore_UpdateExistingKey(t *testing.T) {
 }
 
 func TestLRUStore_ConcurrentEvictions(t *testing.T) {
-	store := NewLRUStore[string, string](5, 5*time.Second, 1*time.Second, DefaultGetCurrentTime) // Small capacity to force evictions
+	const cap = 5
+	store := NewLRUStore[string, string](cap, 5*time.Second, 1*time.Second, DefaultGetCurrentTime)
+	t.Cleanup(func() { store.Close() })
 
 	const numGoroutines = 10
 	const numOperations = 20
@@ -88,9 +102,9 @@ func TestLRUStore_ConcurrentEvictions(t *testing.T) {
 
 				store.Put(key, value)
 
-				if store.Len() > store.cap {
-					done <- fmt.Errorf("store exceeded capacity: expected at most %d, got %d", store.cap, len(store.freeTable))
-					break
+				if n := store.Len(); n > cap {
+					done <- fmt.Errorf("store exceeded capacity: expected at most %d, got %d", cap, n)
+					return
 				}
 			}
 			done <- nil


### PR DESCRIPTION
## Pull Request Description
`Put()` was calling `time.Now()` directly instead of `e.getCurrentTime()`, so the injectable clock had no effect on entry timestamps. This made `TestLRUStore_TTL` rely on real wall time (`time.Sleep`), which is inherently flaky under slow CI.

Changes:
- Use `e.getCurrentTime()` in `Put()` for consistent time injection
- Rewrite `TestLRUStore_TTL` with a fake clock and manual `evict()` call, removing the 3-second sleep
- Fix `TestLRUStore_ConcurrentEvictions` to use `store.Len()` instead of directly accessing `freeTable` without a lock (avoids race detector)

All tests pass with `go test -race`.

## Related Issues
Resolves: #2003