### PR TITLE
refactor: add AlgorithmConfig to ModelConfigProfile

### DIFF
--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -19,6 +19,7 @@ package routingalgorithms
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -89,6 +90,35 @@ var (
 
 func init() {
 	Register(RouterPD, NewPDRouter)
+}
+
+// pdAlgorithmConfig holds PD-specific algorithm configuration parsed from RoutingConfig.
+type pdAlgorithmConfig struct {
+	PromptLenBucketMinLength int  `json:"promptLenBucketMinLength"`
+	PromptLenBucketMaxLength int  `json:"promptLenBucketMaxLength"`
+	Combined                 bool `json:"combined"`
+}
+
+// parsePDAlgorithmConfig parses PD-specific config from the generic RoutingConfig.
+// Returns defaults (min=0, max=MaxInt32, combined=false) if raw is nil or empty.
+func parsePDAlgorithmConfig(raw json.RawMessage) *pdAlgorithmConfig {
+	cfg := &pdAlgorithmConfig{
+		PromptLenBucketMaxLength: math.MaxInt32,
+	}
+	if len(raw) == 0 {
+		return cfg
+	}
+	if err := sonic.Unmarshal(raw, cfg); err != nil {
+		klog.ErrorS(err, "failed to unmarshal PD algorithm config, using default values", "rawConfig", string(raw))
+		return &pdAlgorithmConfig{PromptLenBucketMaxLength: math.MaxInt32}
+	}
+	if cfg.PromptLenBucketMinLength < 0 {
+		cfg.PromptLenBucketMinLength = 0
+	}
+	if cfg.PromptLenBucketMaxLength == 0 {
+		cfg.PromptLenBucketMaxLength = math.MaxInt32
+	}
+	return cfg
 }
 
 type pdRouter struct {
@@ -1014,7 +1044,8 @@ func (r *pdRouter) isPodSuitableForPromptLength(routingCtx *types.RoutingContext
 	if profile == nil {
 		return false
 	}
-	minLength, maxLength := profile.PromptLenBucketMinLength, profile.PromptLenBucketMaxLength
+	pdCfg := parsePDAlgorithmConfig(profile.RoutingConfig)
+	minLength, maxLength := pdCfg.PromptLenBucketMinLength, pdCfg.PromptLenBucketMaxLength
 
 	if minLength > maxLength {
 		return false
@@ -1032,7 +1063,8 @@ func isCombinedPod(routingCtx *types.RoutingContext, pod *v1.Pod) bool {
 	if profile == nil {
 		return false
 	}
-	return profile.Combined
+	pdCfg := parsePDAlgorithmConfig(profile.RoutingConfig)
+	return pdCfg.Combined
 }
 
 func (r *pdRouter) collectAndBucketPods(routingCtx *types.RoutingContext, readyPods []*v1.Pod, promptLength int) ([]*v1.Pod, []*v1.Pod, []*v1.Pod, []*v1.Pod, []*v1.Pod) {

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -1791,7 +1791,7 @@ func pdConfigAnnotation(minLen, maxLen int, combined bool) string {
 	if combined {
 		combinedStr = "true"
 	}
-	return `{"defaultProfile":"pd","profiles":{"pd":{"routingStrategy":"pd","promptLenBucketMinLength":` + strconv.Itoa(minLen) + `,"promptLenBucketMaxLength":` + strconv.Itoa(maxLen) + `,"combined":` + combinedStr + `}}}`
+	return `{"defaultProfile":"pd","profiles":{"pd":{"routingStrategy":"pd","routingConfig":{"promptLenBucketMinLength":` + strconv.Itoa(minLen) + `,"promptLenBucketMaxLength":` + strconv.Itoa(maxLen) + `,"combined":` + combinedStr + `}}}}`
 }
 
 func TestFilterPrefillDecodePods_SelectCorrectBucketPods(t *testing.T) {

--- a/pkg/plugins/gateway/configprofiles/configprofiles.go
+++ b/pkg/plugins/gateway/configprofiles/configprofiles.go
@@ -22,7 +22,6 @@ package configprofiles
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -38,10 +37,8 @@ const (
 
 // ModelConfigProfile holds gateway options for a single profile.
 type ModelConfigProfile struct {
-	RoutingStrategy          string `json:"routingStrategy"`
-	PromptLenBucketMinLength int    `json:"promptLenBucketMinLength"`
-	PromptLenBucketMaxLength int    `json:"promptLenBucketMaxLength"`
-	Combined                 bool   `json:"combined"`
+	RoutingStrategy string          `json:"routingStrategy"`
+	RoutingConfig   json.RawMessage `json:"routingConfig,omitempty"`
 }
 
 // ModelConfigProfiles is the root JSON structure from model.aibrix.ai/config.
@@ -114,16 +111,6 @@ func ParseModelConfig(jsonStr string) (*ModelConfigProfiles, error) {
 	}
 	if len(cfg.Profiles) == 0 {
 		return nil, fmt.Errorf("model config has no profiles")
-	}
-	// Default prompt bounds when not provided: min=0, max=MaxInt32
-	for name, p := range cfg.Profiles {
-		if p.PromptLenBucketMinLength < 0 {
-			p.PromptLenBucketMinLength = 0
-		}
-		if p.PromptLenBucketMaxLength == 0 {
-			p.PromptLenBucketMaxLength = math.MaxInt32
-		}
-		cfg.Profiles[name] = p
 	}
 	return &cfg, nil
 }

--- a/pkg/plugins/gateway/configprofiles/configprofiles_test.go
+++ b/pkg/plugins/gateway/configprofiles/configprofiles_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package configprofiles
 
 import (
-	"math"
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -38,15 +38,15 @@ func TestParseModelConfig(t *testing.T) {
 		},
 		{
 			name: "single profile",
-			json: `{"profiles":{"default":{"routingStrategy":"pd","promptLenBucketMinLength":0,"promptLenBucketMaxLength":2048}}}`,
+			json: `{"profiles":{"default":{"routingStrategy":"pd","routingConfig":{"promptLenBucketMinLength":0,"promptLenBucketMaxLength":2048}}}}`,
 		},
 		{
 			name: "multiple profiles with defaultProfile",
-			json: `{"defaultProfile":"pd","profiles":{"default":{"routingStrategy":"random","promptLenBucketMinLength":0,"promptLenBucketMaxLength":4096},"pd":{"routingStrategy":"pd","promptLenBucketMinLength":0,"promptLenBucketMaxLength":2048}}}`,
+			json: `{"defaultProfile":"pd","profiles":{"default":{"routingStrategy":"random","routingConfig":{"promptLenBucketMinLength":0,"promptLenBucketMaxLength":4096}},"pd":{"routingStrategy":"pd","routingConfig":{"promptLenBucketMinLength":0,"promptLenBucketMaxLength":2048}}}}`,
 		},
 		{
-			name: "with combined field",
-			json: `{"profiles":{"default":{"routingStrategy":"pd","promptLenBucketMinLength":0,"promptLenBucketMaxLength":2048,"combined":true}}}`,
+			name: "with routingConfig",
+			json: `{"profiles":{"default":{"routingStrategy":"pd","routingConfig":{"key":"value"}}}}`,
 		},
 		{
 			name:    "invalid json",
@@ -79,38 +79,8 @@ func TestParseModelConfig(t *testing.T) {
 	}
 }
 
-func TestParseModelConfig_DefaultValues(t *testing.T) {
-	// promptLenBucketMinLength negative → normalized to 0
-	// promptLenBucketMaxLength 0 or omitted → MaxInt32
-	json := `{"profiles":{"p1":{"routingStrategy":"pd","promptLenBucketMinLength":-5,"promptLenBucketMaxLength":0},"p2":{"routingStrategy":"random"}}}`
-
-	cfg, err := ParseModelConfig(json)
-	if err != nil || cfg == nil {
-		t.Fatalf("ParseModelConfig failed: %v", err)
-	}
-
-	p1 := cfg.GetProfile("p1")
-	if p1 == nil {
-		t.Fatal("GetProfile(p1) = nil")
-	}
-	if p1.PromptLenBucketMinLength != 0 {
-		t.Errorf("promptLenBucketMinLength -5 should be normalized to 0, got %d", p1.PromptLenBucketMinLength)
-	}
-	if p1.PromptLenBucketMaxLength != math.MaxInt32 {
-		t.Errorf("promptLenBucketMaxLength 0 should become MaxInt32, got %d", p1.PromptLenBucketMaxLength)
-	}
-
-	p2 := cfg.GetProfile("p2")
-	if p2 == nil {
-		t.Fatal("GetProfile(p2) = nil")
-	}
-	if p2.PromptLenBucketMaxLength != math.MaxInt32 {
-		t.Errorf("omitted promptLenBucketMaxLength should become MaxInt32, got %d", p2.PromptLenBucketMaxLength)
-	}
-}
-
 func TestGetProfile(t *testing.T) {
-	json := `{"defaultProfile":"pd","profiles":{"default":{"routingStrategy":"random","promptLenBucketMinLength":0,"promptLenBucketMaxLength":4096},"pd":{"routingStrategy":"pd","promptLenBucketMinLength":0,"promptLenBucketMaxLength":2048}}}`
+	json := `{"defaultProfile":"pd","profiles":{"default":{"routingStrategy":"random","routingConfig":{"promptLenBucketMinLength":0,"promptLenBucketMaxLength":4096}},"pd":{"routingStrategy":"pd","routingConfig":{"promptLenBucketMinLength":0,"promptLenBucketMaxLength":2048}}}}`
 
 	cfg, err := ParseModelConfig(json)
 	if err != nil || cfg == nil {
@@ -148,7 +118,7 @@ func TestGetProfile_NoDefault(t *testing.T) {
 }
 
 func TestResolveProfileFromPod(t *testing.T) {
-	configJSON := `{"defaultProfile":"pd","profiles":{"default":{"routingStrategy":"random"},"pd":{"routingStrategy":"pd","promptLenBucketMaxLength":2048}}}`
+	configJSON := `{"defaultProfile":"pd","profiles":{"default":{"routingStrategy":"random"},"pd":{"routingStrategy":"pd","routingConfig":{"promptLenBucketMaxLength":2048}}}}`
 
 	podWithAnno := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -193,8 +163,48 @@ func TestResolveProfileFromPod(t *testing.T) {
 	}
 }
 
+func TestParseModelConfigWithRoutingConfig(t *testing.T) {
+	jsonStr := `{"defaultProfile":"default","profiles":{"default":{"routingStrategy":"pd","routingConfig":{"promptLenBucketMinLength":0,"promptLenBucketMaxLength":4096,"combined":true}}}}`
+	cfg, err := ParseModelConfig(jsonStr)
+	if err != nil {
+		t.Fatalf("ParseModelConfig() err=%v", err)
+	}
+	profile := cfg.GetProfile("default")
+	if profile == nil {
+		t.Fatal("GetProfile(default) = nil")
+	}
+	if profile.RoutingStrategy != "pd" {
+		t.Errorf("RoutingStrategy = %s, want pd", profile.RoutingStrategy)
+	}
+	if profile.RoutingConfig == nil {
+		t.Fatal("RoutingConfig = nil, want non-nil")
+	}
+	if !strings.Contains(string(profile.RoutingConfig), "promptLenBucketMaxLength") {
+		t.Errorf("RoutingConfig should contain promptLenBucketMaxLength, got %s", string(profile.RoutingConfig))
+	}
+}
+
+func TestParseModelConfigWithoutRoutingConfig(t *testing.T) {
+	// Profiles without routingConfig still work
+	jsonStr := `{"defaultProfile":"default","profiles":{"default":{"routingStrategy":"pd"}}}`
+	cfg, err := ParseModelConfig(jsonStr)
+	if err != nil {
+		t.Fatalf("ParseModelConfig() err=%v", err)
+	}
+	profile := cfg.GetProfile("default")
+	if profile == nil {
+		t.Fatal("GetProfile(default) = nil")
+	}
+	if profile.RoutingStrategy != "pd" {
+		t.Errorf("RoutingStrategy = %s, want pd", profile.RoutingStrategy)
+	}
+	if profile.RoutingConfig != nil {
+		t.Errorf("RoutingConfig = %s, want nil", string(profile.RoutingConfig))
+	}
+}
+
 func TestResolveProfile(t *testing.T) {
-	configJSON := `{"defaultProfile":"pd","profiles":{"default":{"routingStrategy":"random","promptLenBucketMinLength":0,"promptLenBucketMaxLength":4096},"pd":{"routingStrategy":"pd","promptLenBucketMinLength":0,"promptLenBucketMaxLength":2048}}}`
+	configJSON := `{"defaultProfile":"pd","profiles":{"default":{"routingStrategy":"random","routingConfig":{"promptLenBucketMinLength":0,"promptLenBucketMaxLength":4096}},"pd":{"routingStrategy":"pd","routingConfig":{"promptLenBucketMinLength":0,"promptLenBucketMaxLength":2048}}}}`
 
 	podWithAnno := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -329,10 +329,8 @@ func applyConfigProfile(routingCtx *types.RoutingContext, pods []*v1.Pod) {
 		return
 	}
 	routingCtx.ConfigProfile = &types.ResolvedConfigProfile{
-		RoutingStrategy:          profile.RoutingStrategy,
-		PromptLenBucketMinLength: profile.PromptLenBucketMinLength,
-		PromptLenBucketMaxLength: profile.PromptLenBucketMaxLength,
-		Combined:                 profile.Combined,
+		RoutingStrategy: profile.RoutingStrategy,
+		RoutingConfig:   profile.RoutingConfig,
 	}
 }
 

--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -45,10 +46,8 @@ type RequestFeatures []float64
 // Populated from model.aibrix.ai/config annotation based on config-profile header or defaultProfile.
 // Nil when no config is present;
 type ResolvedConfigProfile struct {
-	RoutingStrategy          string
-	PromptLenBucketMinLength int
-	PromptLenBucketMaxLength int
-	Combined                 bool
+	RoutingStrategy string
+	RoutingConfig   json.RawMessage
 }
 
 // RoutingAlgorithm defines the routing algorithms


### PR DESCRIPTION
Move PromptLenBucketMinLength, PromptLenBucketMaxLength, Combined from ModelConfigProfile into AlgorithmConfig. Each algorithm now parses its own config from the generic json.RawMessage field.

## Pull Request Description
[Please provide a clear and concise description of your changes here]

## Related Issues
Resolves: https://github.com/vllm-project/aibrix/issues/2026

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>