### PR TITLE
feat: Unify service discovery with Provider interface

### DIFF
--- a/pkg/cache/cache_init.go
+++ b/pkg/cache/cache_init.go
@@ -399,25 +399,13 @@ func initMetricsCache(store *Store, stopCh <-chan struct{}) {
 }
 
 // initDiscoveryProvider initializes the cache using a discovery provider.
+// All initial state and ongoing changes are delivered through Watch().
 func initDiscoveryProvider(store *Store, provider discovery.Provider, stopCh <-chan struct{}) error {
-	// Process initial load (used by StaticProvider; KubernetesProvider returns nil).
-	objs, err := provider.Load()
-	if err != nil {
-		return err
-	}
-	for _, o := range objs {
-		handleDiscoveryObject(store, discovery.EventAdd, o, nil)
-	}
-
-	// Start watching. The handler is called directly by the provider —
-	// for K8s this means informer callbacks invoke it on the informer goroutine,
-	// for Consul/etcd it would be called from the poll/watch loop.
 	if err := provider.Watch(func(ev discovery.WatchEvent) {
 		handleDiscoveryObject(store, ev.Type, ev.Object, ev.OldObject)
 	}, stopCh); err != nil {
-		return fmt.Errorf("failed to start discovery watch: %w", err)
+		return fmt.Errorf("failed to initialize discovery provider: %w", err)
 	}
-
 	return nil
 }
 

--- a/pkg/cache/cache_init_test.go
+++ b/pkg/cache/cache_init_test.go
@@ -17,13 +17,19 @@ limitations under the License.
 package cache
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	modelv1alpha1 "github.com/vllm-project/aibrix/api/model/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/cache/discovery"
 	"github.com/vllm-project/aibrix/pkg/constants"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestInitKVEventSync_FailureCleanup(t *testing.T) {
@@ -157,6 +163,162 @@ func TestStore_Close_CallsCleanup(t *testing.T) {
 	assert.Nil(t, store.syncPrefixIndexer)
 
 	store.Close() // Ensure idempotency
+}
+
+// mockProvider implements discovery.Provider for testing.
+// It delivers events in a caller-specified order via Watch().
+type mockProvider struct {
+	events []discovery.WatchEvent
+}
+
+func (p *mockProvider) Watch(handler discovery.EventHandler, _ <-chan struct{}) error {
+	for _, ev := range p.events {
+		handler(ev)
+	}
+	return nil
+}
+
+func (p *mockProvider) Type() string { return "mock" }
+
+func testPod(name, namespace, model string, id int) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.ModelLabelName: model,
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP: fmt.Sprintf("10.0.0.%d", id),
+			Conditions: []v1.PodCondition{{
+				Type:   v1.PodReady,
+				Status: v1.ConditionTrue,
+			}},
+		},
+	}
+}
+
+func testModelAdapter(name, namespace, podName string) *modelv1alpha1.ModelAdapter {
+	return &modelv1alpha1.ModelAdapter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: modelv1alpha1.ModelAdapterStatus{
+			Instances: []string{podName},
+		},
+	}
+}
+
+func TestInitDiscoveryProvider_PodBeforeAdapter(t *testing.T) {
+	// Normal case: Pod arrives before ModelAdapter.
+	// The adapter should find the pod and create the mapping.
+	store := NewForTest()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	provider := &mockProvider{
+		events: []discovery.WatchEvent{
+			{Type: discovery.EventAdd, Object: testPod("p1", "ns", "base-model", 1)},
+			{Type: discovery.EventAdd, Object: testModelAdapter("lora-adapter", "ns", "p1")},
+		},
+	}
+
+	err := initDiscoveryProvider(store, provider, stopCh)
+	require.NoError(t, err)
+
+	// The pod should serve both the base model and the adapter model.
+	models := store.ListModels()
+	assert.Contains(t, models, "base-model")
+	assert.Contains(t, models, "lora-adapter")
+
+	// The adapter model should map to the pod.
+	pods, err := store.ListPodsByModel("lora-adapter")
+	require.NoError(t, err)
+	assert.Equal(t, 1, pods.Len())
+}
+
+func TestInitDiscoveryProvider_AdapterBeforePod(t *testing.T) {
+	// Ordering issue: ModelAdapter arrives BEFORE its Pod.
+	// The first addModelAdapter fails silently (pod not in cache).
+	// A post-sync reconcile (re-emitting the adapter) should fix the mapping.
+	store := NewForTest()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	provider := &mockProvider{
+		events: []discovery.WatchEvent{
+			// Adapter arrives first — pod not in cache yet, mapping silently fails
+			{Type: discovery.EventAdd, Object: testModelAdapter("lora-adapter", "ns", "p1")},
+			// Pod arrives
+			{Type: discovery.EventAdd, Object: testPod("p1", "ns", "base-model", 1)},
+			// Post-sync reconcile: re-emit the adapter (simulates what KubernetesProvider does)
+			{Type: discovery.EventAdd, Object: testModelAdapter("lora-adapter", "ns", "p1")},
+		},
+	}
+
+	err := initDiscoveryProvider(store, provider, stopCh)
+	require.NoError(t, err)
+
+	// After reconcile, both models should exist.
+	models := store.ListModels()
+	assert.Contains(t, models, "base-model")
+	assert.Contains(t, models, "lora-adapter")
+
+	// The adapter model should map to the pod.
+	pods, err := store.ListPodsByModel("lora-adapter")
+	require.NoError(t, err)
+	assert.Equal(t, 1, pods.Len())
+}
+
+func TestInitDiscoveryProvider_AdapterBeforePodWithoutReconcile(t *testing.T) {
+	// Demonstrates WHY the reconcile is needed:
+	// Without the re-emit, the adapter-to-pod mapping is lost.
+	store := NewForTest()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	provider := &mockProvider{
+		events: []discovery.WatchEvent{
+			// Adapter arrives first — mapping fails silently
+			{Type: discovery.EventAdd, Object: testModelAdapter("lora-adapter", "ns", "p1")},
+			// Pod arrives — but no one re-triggers the adapter mapping
+			{Type: discovery.EventAdd, Object: testPod("p1", "ns", "base-model", 1)},
+			// NO reconcile
+		},
+	}
+
+	err := initDiscoveryProvider(store, provider, stopCh)
+	require.NoError(t, err)
+
+	// Base model exists (from the pod).
+	models := store.ListModels()
+	assert.Contains(t, models, "base-model")
+
+	// Adapter model does NOT exist — the mapping was lost.
+	assert.NotContains(t, models, "lora-adapter")
+}
+
+func TestInitDiscoveryProvider_DeleteEvent(t *testing.T) {
+	store := NewForTest()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	pod := testPod("p1", "ns", "base-model", 1)
+	provider := &mockProvider{
+		events: []discovery.WatchEvent{
+			{Type: discovery.EventAdd, Object: pod},
+			{Type: discovery.EventDelete, Object: pod},
+		},
+	}
+
+	err := initDiscoveryProvider(store, provider, stopCh)
+	require.NoError(t, err)
+
+	// Pod was added then deleted — no models should remain.
+	models := store.ListModels()
+	assert.Empty(t, models)
 }
 
 func TestInitWithOptions_KVSyncBehavior(t *testing.T) {

--- a/pkg/cache/discovery/README.md
+++ b/pkg/cache/discovery/README.md
@@ -8,29 +8,20 @@ AIBrix was originally built on Kubernetes, and service discovery was tightly cou
 type EventHandler func(event WatchEvent)
 
 type Provider interface {
-    Load() ([]any, error)
     Watch(handler EventHandler, stopCh <-chan struct{}) error
     Type() string
 }
 ```
 
-### `Load() ([]any, error)`
-
-Returns all known resources as a snapshot. Currently returns `*v1.Pod` objects (and potentially `*modelv1alpha1.ModelAdapter`).
-
-- **StaticProvider**: reads YAML file, returns synthetic pods.
-- **KubernetesProvider**: returns nil — all data is delivered via `Watch()`.
-- **Consul/etcd providers**: may return initial snapshot, or nil if they deliver everything via `Watch()`.
-
 ### `Watch(handler EventHandler, stopCh <-chan struct{}) error`
 
 Registers a callback for resource changes and starts watching. The provider calls `handler` directly — there is no intermediate channel or buffer. This design allows K8s informers to invoke the handler on the informer goroutine without backpressure concerns.
 
-- **StaticProvider**: no-op (static config never changes).
-- **KubernetesProvider**: starts informers, blocks until initial list+sync completes, delivers all existing objects as `EventAdd` via the handler, then returns. After return, informer callbacks continue invoking the handler for ongoing changes.
+- **StaticProvider**: reads config, delivers all endpoints as `EventAdd` via the handler, returns. No ongoing changes.
+- **KubernetesProvider**: wires the handler directly into informer callbacks. Events (including the initial list phase) flow to the handler immediately. After `WaitForCacheSync`, does a post-sync reconcile to fix ordering, then returns. Informer callbacks continue invoking the handler for ongoing changes.
 - **Consul/etcd providers**: starts a watch/poll loop in a goroutine, calls handler from that goroutine.
 
-`Watch` should block until the initial state is fully delivered, then return. This ensures the cache is warm before the gateway starts accepting traffic.
+`Watch` should return once the provider has reached a consistent ready state (e.g., initial sync complete, config loaded). This ensures the cache is warm before the gateway starts accepting traffic.
 
 ### `Type() string`
 
@@ -73,13 +64,13 @@ The `rolesets` structure expresses the pairing between prefill and decode worker
 
 Watches Pods and ModelAdapters via K8s informers. This is the default when no `DiscoveryProvider` is set in `InitOptions`.
 
-All data flows through `Watch()`:
-1. Starts informers, waits for initial list+sync.
-2. Delivers all existing Pods as `EventAdd` (ordered before ModelAdapters).
-3. Delivers all existing ModelAdapters as `EventAdd`.
-4. Returns — informer callbacks continue invoking the handler for ongoing changes.
+The handler is wired directly into K8s informer callbacks — events flow from the start, including during the initial list phase. No intermediate channel, no buffer, no snapshot replay.
 
-The handler is wired directly into informer callbacks. No intermediate channel, no buffer, no backpressure concerns.
+1. Registers handler on Pod and ModelAdapter informers.
+2. Starts informers — initial objects arrive via `AddFunc` as part of the informer's list+watch.
+3. Waits for cache sync (`WaitForCacheSync`).
+4. Post-sync reconcile: re-emits all ModelAdapters as `EventAdd` to fix ordering (Pod and ModelAdapter informers list concurrently, so an adapter may arrive before its pods).
+5. Returns — informer callbacks continue delivering ongoing changes.
 
 ## Architecture
 

--- a/pkg/cache/discovery/discovery.go
+++ b/pkg/cache/discovery/discovery.go
@@ -47,17 +47,22 @@ type WatchEvent struct {
 type EventHandler func(event WatchEvent)
 
 // Provider defines the interface for service discovery backends.
+//
+// All initial state and ongoing changes are delivered through Watch() via
+// the EventHandler callback.
 type Provider interface {
-	// Load returns all known resources at the time of the call.
-	// Currently returns *v1.Pod and *modelv1alpha1.ModelAdapter objects.
-	// Providers that deliver all data via Watch may return nil.
-	Load() ([]any, error)
-
 	// Watch registers a handler for resource change events and starts watching.
 	// The provider calls handler for each change (add/update/delete).
-	// For providers like Kubernetes, Watch also delivers initial state as EventAdd.
-	// Static providers may no-op (no dynamic updates).
-	// Watch should block until the initial state is fully delivered, then return.
+	//
+	// Watch should return once the provider has reached a consistent ready state
+	// (e.g., initial sync complete, config loaded). After return, dynamic providers
+	// continue delivering ongoing changes via the handler asynchronously.
+	//
+	// Static providers deliver initial state and return (no ongoing changes).
+	// K8s provider lets informers deliver events directly via the handler from
+	// the start, then does a post-sync reconcile before returning.
+	// Consul/etcd providers may deliver initial state, then start a background
+	// watch/poll loop.
 	Watch(handler EventHandler, stopCh <-chan struct{}) error
 
 	// Type returns a string identifier for the provider type (e.g., "static", "consul").

--- a/pkg/cache/discovery/kubernetes.go
+++ b/pkg/cache/discovery/kubernetes.go
@@ -18,7 +18,6 @@ package discovery
 
 import (
 	"errors"
-	"sync/atomic"
 
 	crdinformers "github.com/vllm-project/aibrix/pkg/client/informers/externalversions"
 
@@ -33,12 +32,6 @@ import (
 )
 
 // KubernetesProvider implements Provider using Kubernetes informers.
-// It watches Pods and ModelAdapters via the K8s API server.
-//
-// All data — both initial state and ongoing changes — is delivered
-// via the Watch handler callback. Load() returns nil.
-// The handler is wired directly into K8s informer callbacks with
-// no intermediate channel or buffer.
 type KubernetesProvider struct {
 	config *rest.Config
 }
@@ -53,18 +46,9 @@ func (p *KubernetesProvider) Type() string {
 	return "kubernetes"
 }
 
-// Load returns nil — all data is delivered via Watch().
-func (p *KubernetesProvider) Load() ([]any, error) {
-	return nil, nil
-}
-
-// Watch starts K8s informers, waits for the initial list+sync to complete,
-// delivers all existing objects via the handler, then returns.
-// After Watch returns, the informers continue running and invoke the handler
-// for ongoing changes until stopCh is closed.
-//
-// Delivery order: all Pods first (as EventAdd), then all ModelAdapters (as EventAdd).
-// This ordering ensures pods exist in the cache before ModelAdapter handlers look them up.
+// Watch starts K8s informers with the handler wired directly into informer callbacks.
+// Watch returns once the initial sync and reconcile are complete. After return,
+// informer callbacks continue delivering ongoing changes asynchronously.
 func (p *KubernetesProvider) Watch(handler EventHandler, stopCh <-chan struct{}) error {
 	if err := v1alpha1scheme.AddToScheme(scheme.Scheme); err != nil {
 		return err
@@ -80,33 +64,30 @@ func (p *KubernetesProvider) Watch(handler EventHandler, stopCh <-chan struct{})
 		return err
 	}
 
+	// Currently watches all pods cluster-wide (same as the old initCacheInformers).
 	factory := informers.NewSharedInformerFactoryWithOptions(k8sClientSet, 0)
 	crdFactory := crdinformers.NewSharedInformerFactoryWithOptions(crdClientSet, 0)
-
-	// synced gates live event delivery. During the initial list+sync phase,
-	// informer callbacks are suppressed — initial objects are delivered
-	// explicitly from the informer stores after sync completes.
-	var synced atomic.Bool
 
 	podInformer := factory.Core().V1().Pods().Informer()
 	modelInformer := crdFactory.Model().V1alpha1().ModelAdapters().Informer()
 
+	// Wire handler directly into informer callbacks.
+	// Events flow from the start — including during the initial list phase.
 	registerHandlers := func(inf cache.SharedIndexInformer) error {
 		_, err := inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				if synced.Load() {
-					handler(WatchEvent{Type: EventAdd, Object: obj})
-				}
+				handler(WatchEvent{Type: EventAdd, Object: obj})
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				if synced.Load() {
-					handler(WatchEvent{Type: EventUpdate, Object: newObj, OldObject: oldObj})
-				}
+				handler(WatchEvent{Type: EventUpdate, Object: newObj, OldObject: oldObj})
 			},
 			DeleteFunc: func(obj interface{}) {
-				if synced.Load() {
-					handler(WatchEvent{Type: EventDelete, Object: obj})
+				// Unwrap tombstones — K8s informers may deliver
+				// cache.DeletedFinalStateUnknown when a delete event is missed.
+				if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+					obj = tombstone.Obj
 				}
+				handler(WatchEvent{Type: EventDelete, Object: obj})
 			},
 		})
 		return err
@@ -120,6 +101,7 @@ func (p *KubernetesProvider) Watch(handler EventHandler, stopCh <-chan struct{})
 	}
 
 	// Start informers and wait for initial list+sync.
+	// During this phase, AddFunc fires for each existing object.
 	factory.Start(stopCh)
 	crdFactory.Start(stopCh)
 
@@ -127,21 +109,18 @@ func (p *KubernetesProvider) Watch(handler EventHandler, stopCh <-chan struct{})
 		return errors.New("timed out waiting for caches to sync")
 	}
 
-	// Deliver all existing objects — pods first, then adapters.
-	pods := podInformer.GetStore().List()
+	// Post-sync reconcile: re-emit all ModelAdapters to fix ordering.
+	// During initial sync, Pod and ModelAdapter informers list concurrently.
+	// A ModelAdapter's AddFunc may fire before its pods' AddFunc, causing
+	// the pod-model mapping to be missed. Re-emitting adapters after sync
+	// ensures all mappings are established (addModelAdapter is idempotent).
 	adapters := modelInformer.GetStore().List()
-	for _, obj := range pods {
-		handler(WatchEvent{Type: EventAdd, Object: obj})
-	}
 	for _, obj := range adapters {
 		handler(WatchEvent{Type: EventAdd, Object: obj})
 	}
 
-	// Enable live event delivery from informer handlers.
-	synced.Store(true)
-
 	klog.InfoS("Kubernetes discovery provider initialized",
-		"pods", len(pods), "modelAdapters", len(adapters))
+		"pods", len(podInformer.GetStore().List()), "modelAdapters", len(adapters))
 
 	return nil
 }

--- a/pkg/cache/discovery/static.go
+++ b/pkg/cache/discovery/static.go
@@ -81,13 +81,21 @@ func (p *StaticProvider) Type() string {
 	return "static"
 }
 
-// Watch implements Provider. Static provider has no dynamic updates.
-func (p *StaticProvider) Watch(_ EventHandler, _ <-chan struct{}) error {
+// Watch reads the config file, delivers all endpoints as EventAdd via the handler,
+// and returns. Static provider has no ongoing dynamic updates.
+func (p *StaticProvider) Watch(handler EventHandler, _ <-chan struct{}) error {
+	pods, err := p.load()
+	if err != nil {
+		return err
+	}
+	for _, pod := range pods {
+		handler(WatchEvent{Type: EventAdd, Object: pod})
+	}
 	return nil
 }
 
-// Load reads the config file and returns all endpoints as synthetic pods.
-func (p *StaticProvider) Load() ([]any, error) {
+// load reads the config file and returns all endpoints as synthetic pods.
+func (p *StaticProvider) load() ([]any, error) {
 	data, err := os.ReadFile(p.configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)

--- a/pkg/cache/discovery/static_test.go
+++ b/pkg/cache/discovery/static_test.go
@@ -27,6 +27,21 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+// watchCollect calls Watch and collects all delivered pods.
+func watchCollect(t *testing.T, p *StaticProvider) ([]*v1.Pod, error) {
+	t.Helper()
+	var pods []*v1.Pod
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	err := p.Watch(func(ev WatchEvent) {
+		if pod, ok := ev.Object.(*v1.Pod); ok {
+			assert.Equal(t, EventAdd, ev.Type)
+			pods = append(pods, pod)
+		}
+	}, stopCh)
+	return pods, err
+}
+
 func TestStaticProviderType(t *testing.T) {
 	p := NewStaticProvider("/tmp/test.yaml")
 	assert.Equal(t, "static", p.Type())
@@ -42,20 +57,18 @@ models:
 `
 	path := writeTestConfig(t, config)
 	p := NewStaticProvider(path)
-	objs, err := p.Load()
+	pods, err := watchCollect(t, p)
 	require.NoError(t, err)
-	assert.Len(t, objs, 2)
+	assert.Len(t, pods, 2)
 
-	pod0 := objs[0].(*v1.Pod)
-	assert.Equal(t, "Qwen/Qwen2.5-1.5B-Instruct", pod0.Labels[constants.ModelLabelName])
-	assert.Equal(t, "8000", pod0.Labels[constants.ModelLabelPort])
-	assert.Equal(t, "vllm-0", pod0.Status.PodIP)
+	assert.Equal(t, "Qwen/Qwen2.5-1.5B-Instruct", pods[0].Labels[constants.ModelLabelName])
+	assert.Equal(t, "8000", pods[0].Labels[constants.ModelLabelPort])
+	assert.Equal(t, "vllm-0", pods[0].Status.PodIP)
 	// No role labels for non-disaggregated
-	assert.Empty(t, pod0.Labels["role-name"])
-	assert.Empty(t, pod0.Labels["roleset-name"])
+	assert.Empty(t, pods[0].Labels["role-name"])
+	assert.Empty(t, pods[0].Labels["roleset-name"])
 
-	pod1 := objs[1].(*v1.Pod)
-	assert.Equal(t, "vllm-1", pod1.Status.PodIP)
+	assert.Equal(t, "vllm-1", pods[1].Status.PodIP)
 }
 
 func TestStaticProviderDisaggregated(t *testing.T) {
@@ -73,26 +86,23 @@ models:
 `
 	path := writeTestConfig(t, config)
 	p := NewStaticProvider(path)
-	objs, err := p.Load()
+	pods, err := watchCollect(t, p)
 	require.NoError(t, err)
-	assert.Len(t, objs, 3)
+	assert.Len(t, pods, 3)
 
 	// First two are prefill
-	prefill0 := objs[0].(*v1.Pod)
-	assert.Equal(t, "prefill", prefill0.Labels["role-name"])
-	assert.Equal(t, "default", prefill0.Labels["roleset-name"])
-	assert.Equal(t, "vllm", prefill0.Labels[constants.ModelLabelEngine])
-	assert.Equal(t, "prefill-0", prefill0.Status.PodIP)
+	assert.Equal(t, "prefill", pods[0].Labels["role-name"])
+	assert.Equal(t, "default", pods[0].Labels["roleset-name"])
+	assert.Equal(t, "vllm", pods[0].Labels[constants.ModelLabelEngine])
+	assert.Equal(t, "prefill-0", pods[0].Status.PodIP)
 
-	prefill1 := objs[1].(*v1.Pod)
-	assert.Equal(t, "prefill", prefill1.Labels["role-name"])
-	assert.Equal(t, "prefill-1", prefill1.Status.PodIP)
+	assert.Equal(t, "prefill", pods[1].Labels["role-name"])
+	assert.Equal(t, "prefill-1", pods[1].Status.PodIP)
 
 	// Third is decode
-	decode0 := objs[2].(*v1.Pod)
-	assert.Equal(t, "decode", decode0.Labels["role-name"])
-	assert.Equal(t, "default", decode0.Labels["roleset-name"])
-	assert.Equal(t, "decode-0", decode0.Status.PodIP)
+	assert.Equal(t, "decode", pods[2].Labels["role-name"])
+	assert.Equal(t, "default", pods[2].Labels["roleset-name"])
+	assert.Equal(t, "decode-0", pods[2].Status.PodIP)
 }
 
 func TestStaticProviderMultipleRoleSets(t *testing.T) {
@@ -113,17 +123,15 @@ models:
 `
 	path := writeTestConfig(t, config)
 	p := NewStaticProvider(path)
-	objs, err := p.Load()
+	pods, err := watchCollect(t, p)
 	require.NoError(t, err)
-	assert.Len(t, objs, 4)
+	assert.Len(t, pods, 4)
 
-	pod0 := objs[0].(*v1.Pod)
-	assert.Equal(t, "group-a", pod0.Labels["roleset-name"])
-	assert.Equal(t, "prefill", pod0.Labels["role-name"])
+	assert.Equal(t, "group-a", pods[0].Labels["roleset-name"])
+	assert.Equal(t, "prefill", pods[0].Labels["role-name"])
 
-	pod2 := objs[2].(*v1.Pod)
-	assert.Equal(t, "group-b", pod2.Labels["roleset-name"])
-	assert.Equal(t, "prefill", pod2.Labels["role-name"])
+	assert.Equal(t, "group-b", pods[2].Labels["roleset-name"])
+	assert.Equal(t, "prefill", pods[2].Labels["role-name"])
 }
 
 func TestStaticProviderMutuallyExclusive(t *testing.T) {
@@ -141,7 +149,9 @@ models:
 `
 	path := writeTestConfig(t, config)
 	p := NewStaticProvider(path)
-	_, err := p.Load()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	err := p.Watch(func(_ WatchEvent) {}, stopCh)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }
@@ -159,7 +169,9 @@ models:
 `
 	path := writeTestConfig(t, config)
 	p := NewStaticProvider(path)
-	_, err := p.Load()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	err := p.Watch(func(_ WatchEvent) {}, stopCh)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "roleset name is required")
 }
@@ -173,13 +185,12 @@ models:
 `
 	path := writeTestConfig(t, config)
 	p := NewStaticProvider(path)
-	objs, err := p.Load()
+	pods, err := watchCollect(t, p)
 	require.NoError(t, err)
-	assert.Len(t, objs, 1)
+	assert.Len(t, pods, 1)
 
-	pod := objs[0].(*v1.Pod)
-	assert.Equal(t, "8000", pod.Labels[constants.ModelLabelPort])
-	assert.Equal(t, int32(8000), pod.Spec.Containers[0].Ports[0].ContainerPort)
+	assert.Equal(t, "8000", pods[0].Labels[constants.ModelLabelPort])
+	assert.Equal(t, int32(8000), pods[0].Spec.Containers[0].Ports[0].ContainerPort)
 }
 
 func TestStaticProviderPodReadyStatus(t *testing.T) {
@@ -191,19 +202,20 @@ models:
 `
 	path := writeTestConfig(t, config)
 	p := NewStaticProvider(path)
-	objs, err := p.Load()
+	pods, err := watchCollect(t, p)
 	require.NoError(t, err)
 
-	pod := objs[0].(*v1.Pod)
-	assert.Equal(t, v1.PodRunning, pod.Status.Phase)
-	require.Len(t, pod.Status.Conditions, 1)
-	assert.Equal(t, v1.PodReady, pod.Status.Conditions[0].Type)
-	assert.Equal(t, v1.ConditionTrue, pod.Status.Conditions[0].Status)
+	assert.Equal(t, v1.PodRunning, pods[0].Status.Phase)
+	require.Len(t, pods[0].Status.Conditions, 1)
+	assert.Equal(t, v1.PodReady, pods[0].Status.Conditions[0].Type)
+	assert.Equal(t, v1.ConditionTrue, pods[0].Status.Conditions[0].Status)
 }
 
 func TestStaticProviderFileNotFound(t *testing.T) {
 	p := NewStaticProvider("/nonexistent/path.yaml")
-	_, err := p.Load()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	err := p.Watch(func(_ WatchEvent) {}, stopCh)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read config file")
 }
@@ -211,7 +223,9 @@ func TestStaticProviderFileNotFound(t *testing.T) {
 func TestStaticProviderInvalidYAML(t *testing.T) {
 	path := writeTestConfig(t, "{{invalid yaml")
 	p := NewStaticProvider(path)
-	_, err := p.Load()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	err := p.Watch(func(_ WatchEvent) {}, stopCh)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse config file")
 }


### PR DESCRIPTION
## Pull Request Description
- Introduce a generic `Provider` interface for pluggable service discovery, replacing the  K8s-coupled pattern
- Implement `KubernetesProvider` wrapping K8s informers behind the same interface, eliminating the if/else split in InitWithOptions

## Related Issues
Resolves: https://github.com/vllm-project/aibrix/issues/2033

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>