### PR TITLE
refactor: per-service URL/key config for vLLM-Omni multi-model setup

### DIFF
--- a/apps/chat/api/config.py
+++ b/apps/chat/api/config.py
@@ -12,11 +12,17 @@ class Settings(BaseSettings):
     video_provider: str = "openai"
     chat_provider: str = "openai"
 
-    # Per-modality URL/key overrides (fallback to aibrix_gateway_url / api_key)
+    # Per-service URL/key overrides (all fallback to aibrix_gateway_url / api_key)
+    chat_api_url: str = ""
+    chat_api_key: str = ""
+    asr_api_url: str = ""
+    asr_api_key: str = ""
+    tts_api_url: str = ""
+    tts_api_key: str = ""
     image_api_url: str = ""
     image_api_key: str = ""
-    audio_api_url: str = ""
-    audio_api_key: str = ""
+    image_edit_api_url: str = ""
+    image_edit_api_key: str = ""
     video_api_url: str = ""
     video_api_key: str = ""
 
@@ -39,29 +45,41 @@ class Settings(BaseSettings):
 
     model_config = {"env_prefix": "", "case_sensitive": False}
 
+    def get_chat_url(self) -> str:
+        return self.chat_api_url or self.aibrix_gateway_url
+
+    def get_chat_key(self) -> str:
+        return self.chat_api_key or self.api_key
+
+    def get_asr_url(self) -> str:
+        return self.asr_api_url or self.aibrix_gateway_url
+
+    def get_asr_key(self) -> str:
+        return self.asr_api_key or self.api_key
+
+    def get_tts_url(self) -> str:
+        return self.tts_api_url or self.aibrix_gateway_url
+
+    def get_tts_key(self) -> str:
+        return self.tts_api_key or self.api_key
+
     def get_image_url(self) -> str:
         return self.image_api_url or self.aibrix_gateway_url
 
     def get_image_key(self) -> str:
         return self.image_api_key or self.api_key
 
-    def get_audio_url(self) -> str:
-        return self.audio_api_url or self.aibrix_gateway_url
+    def get_image_edit_url(self) -> str:
+        return self.image_edit_api_url or self.aibrix_gateway_url
 
-    def get_audio_key(self) -> str:
-        return self.audio_api_key or self.api_key
+    def get_image_edit_key(self) -> str:
+        return self.image_edit_api_key or self.api_key
 
     def get_video_url(self) -> str:
         return self.video_api_url or self.aibrix_gateway_url
 
     def get_video_key(self) -> str:
         return self.video_api_key or self.api_key
-
-    def get_chat_url(self) -> str:
-        return self.aibrix_gateway_url
-
-    def get_chat_key(self) -> str:
-        return self.api_key
 
 
 settings = Settings()

--- a/apps/chat/api/services/providers/__init__.py
+++ b/apps/chat/api/services/providers/__init__.py
@@ -53,7 +53,8 @@ def get_chat_provider() -> ChatProvider:
         name = settings.chat_provider
         cls = _REGISTRY["chat"][name]
         _provider_cache[key] = cls(
-            base_url=settings.get_chat_url(), api_key=settings.get_chat_key(),
+            base_url=settings.get_chat_url(),
+            api_key=settings.get_chat_key(),
         )
     return _provider_cache[key]
 
@@ -64,7 +65,10 @@ def get_image_provider() -> ImageProvider:
         name = settings.image_provider
         cls = _REGISTRY["image"][name]
         _provider_cache[key] = cls(
-            base_url=settings.get_image_url(), api_key=settings.get_image_key(),
+            base_url=settings.get_image_url(),
+            api_key=settings.get_image_key(),
+            image_edit_url=settings.get_image_edit_url(),
+            image_edit_key=settings.get_image_edit_key(),
         )
     return _provider_cache[key]
 
@@ -75,7 +79,12 @@ def get_audio_provider() -> AudioProvider:
         name = settings.audio_provider
         cls = _REGISTRY["audio"][name]
         _provider_cache[key] = cls(
-            base_url=settings.get_audio_url(), api_key=settings.get_audio_key(),
+            base_url=settings.get_asr_url(),
+            api_key=settings.get_asr_key(),
+            asr_url=settings.get_asr_url(),
+            asr_key=settings.get_asr_key(),
+            tts_url=settings.get_tts_url(),
+            tts_key=settings.get_tts_key(),
         )
     return _provider_cache[key]
 
@@ -86,6 +95,7 @@ def get_video_provider() -> VideoProvider:
         name = settings.video_provider
         cls = _REGISTRY["video"][name]
         _provider_cache[key] = cls(
-            base_url=settings.get_video_url(), api_key=settings.get_video_key(),
+            base_url=settings.get_video_url(),
+            api_key=settings.get_video_key(),
         )
     return _provider_cache[key]

--- a/apps/chat/api/services/providers/openai.py
+++ b/apps/chat/api/services/providers/openai.py
@@ -148,9 +148,16 @@ class OpenAIChatProvider(ChatProvider):
 
 
 class OpenAIImageProvider(ImageProvider):
-    def __init__(self, base_url: str, api_key: str = "") -> None:
+    def __init__(
+        self, base_url: str, api_key: str = "",
+        *, image_edit_url: str = "", image_edit_key: str = "",
+    ) -> None:
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
+        self.image_edit_url = (
+            image_edit_url.rstrip("/") if image_edit_url else self.base_url
+        )
+        self.image_edit_key = image_edit_key or self.api_key
         self._client: httpx.AsyncClient | None = None
 
     def _make_client(self) -> httpx.AsyncClient:
@@ -213,8 +220,8 @@ class OpenAIImageProvider(ImageProvider):
         **kwargs: Any,
     ) -> dict:
         headers: dict[str, str] = {}
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
+        if self.image_edit_key:
+            headers["Authorization"] = f"Bearer {self.image_edit_key}"
 
         # dall-e-2 uses inpainting (transparent pixels only) so we need
         # RGBA conversion and a fully-transparent mask for opaque images.
@@ -257,7 +264,7 @@ class OpenAIImageProvider(ImageProvider):
         }
 
         resp = await self.client.post(
-            f"{self.base_url}/v1/images/edits",
+            f"{self.image_edit_url}/v1/images/edits",
             files=files,
             data=data,
             headers=headers,
@@ -275,9 +282,17 @@ class OpenAIImageProvider(ImageProvider):
 
 
 class OpenAIAudioProvider(AudioProvider):
-    def __init__(self, base_url: str, api_key: str = "") -> None:
+    def __init__(
+        self, base_url: str, api_key: str = "",
+        *, asr_url: str = "", asr_key: str = "",
+        tts_url: str = "", tts_key: str = "",
+    ) -> None:
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
+        self.asr_url = asr_url.rstrip("/") if asr_url else self.base_url
+        self.asr_key = asr_key or self.api_key
+        self.tts_url = tts_url.rstrip("/") if tts_url else self.base_url
+        self.tts_key = tts_key or self.api_key
         self._client: httpx.AsyncClient | None = None
 
     def _make_client(self) -> httpx.AsyncClient:
@@ -309,8 +324,8 @@ class OpenAIAudioProvider(AudioProvider):
         language: str | None = None,
     ) -> dict:
         headers: dict[str, str] = {}
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
+        if self.asr_key:
+            headers["Authorization"] = f"Bearer {self.asr_key}"
 
         files = {"file": (filename, file_bytes)}
         data: dict[str, str] = {"model": model}
@@ -318,7 +333,7 @@ class OpenAIAudioProvider(AudioProvider):
             data["language"] = language
 
         resp = await self.client.post(
-            f"{self.base_url}/v1/audio/transcriptions",
+            f"{self.asr_url}/v1/audio/transcriptions",
             files=files,
             data=data,
             headers=headers,
@@ -342,9 +357,9 @@ class OpenAIAudioProvider(AudioProvider):
             "speed": speed,
         }
         resp = await self.client.post(
-            f"{self.base_url}/v1/audio/speech",
+            f"{self.tts_url}/v1/audio/speech",
             json=payload,
-            headers=_headers(self.api_key),
+            headers=_headers(self.tts_key),
         )
         resp.raise_for_status()
         return resp.content

--- a/apps/chat/api/services/providers/vllm_omni.py
+++ b/apps/chat/api/services/providers/vllm_omni.py
@@ -197,9 +197,16 @@ class VLLMOmniImageProvider(ImageProvider):
     request body (height, width, num_inference_steps, true_cfg_scale, seed).
     """
 
-    def __init__(self, base_url: str, api_key: str = "") -> None:
+    def __init__(
+        self, base_url: str, api_key: str = "",
+        *, image_edit_url: str = "", image_edit_key: str = "",
+    ) -> None:
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
+        self.image_edit_url = (
+            image_edit_url.rstrip("/") if image_edit_url else self.base_url
+        )
+        self.image_edit_key = image_edit_key or self.api_key
         self._client: httpx.AsyncClient | None = None
 
     def _make_client(self) -> httpx.AsyncClient:
@@ -305,9 +312,9 @@ class VLLMOmniImageProvider(ImageProvider):
             payload["seed"] = kwargs["seed"]
 
         resp = await self.client.post(
-            f"{self.base_url}/v1/chat/completions",
+            f"{self.image_edit_url}/v1/chat/completions",
             json=payload,
-            headers=_headers(self.api_key),
+            headers=_headers(self.image_edit_key),
         )
         if resp.status_code != 200:
             logger.error(
@@ -331,9 +338,17 @@ class VLLMOmniAudioProvider(AudioProvider):
     * **TTS** (``speech``) adds the ``language`` field required by Qwen3-TTS.
     """
 
-    def __init__(self, base_url: str, api_key: str = "") -> None:
+    def __init__(
+        self, base_url: str, api_key: str = "",
+        *, asr_url: str = "", asr_key: str = "",
+        tts_url: str = "", tts_key: str = "",
+    ) -> None:
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
+        self.asr_url = asr_url.rstrip("/") if asr_url else self.base_url
+        self.asr_key = asr_key or self.api_key
+        self.tts_url = tts_url.rstrip("/") if tts_url else self.base_url
+        self.tts_key = tts_key or self.api_key
         self._client: httpx.AsyncClient | None = None
 
     def _make_client(self) -> httpx.AsyncClient:
@@ -370,10 +385,10 @@ class VLLMOmniAudioProvider(AudioProvider):
             data["language"] = language
 
         resp = await self.client.post(
-            f"{self.base_url}/v1/audio/transcriptions",
+            f"{self.asr_url}/v1/audio/transcriptions",
             files=files,
             data=data,
-            headers=_auth_headers(self.api_key),
+            headers=_auth_headers(self.asr_key),
         )
         resp.raise_for_status()
         return resp.json()
@@ -399,9 +414,9 @@ class VLLMOmniAudioProvider(AudioProvider):
             "language": "Auto",
         }
         resp = await self.client.post(
-            f"{self.base_url}/v1/audio/speech",
+            f"{self.tts_url}/v1/audio/speech",
             json=payload,
-            headers=_headers(self.api_key),
+            headers=_headers(self.tts_key),
         )
         if resp.status_code != 200:
             logger.error(


### PR DESCRIPTION
## Pull Request Description

Replaces audio_api_url with asr_api_url + tts_api_url, adds chat_api_url and image_edit_api_url. All fall back to aibrix_gateway_url so single-endpoint setups need no changes.

## Related Issues
Resolves: part of #1951 

the earlier override is not complete. let's make sure we can override every url in the development

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>