### PR TITLE
feat:support set pod recoverypolicy in podset when pod fails

### DIFF
--- a/api/orchestration/v1alpha1/roleset_types.go
+++ b/api/orchestration/v1alpha1/roleset_types.go
@@ -178,6 +178,12 @@ type RoleSpec struct {
 	// +optional
 	DisruptionTolerance DisruptionTolerance `json:"disruptionTolerance,omitempty"`
 
+	// PodRecoveryPolicy defines how pods in the pod sets are recreated when pod failures happen.
+	// +kubebuilder:default=ReplaceUnhealthy
+	// +kubebuilder:validation:Enum={ReplaceUnhealthy,Recreate}
+	// +optional
+	PodRecoveryPolicy PodRecoveryPolicy `json:"podRecoveryPolicy,omitempty"`
+
 	// +optional
 	SchedulingStrategy *SchedulingStrategy `json:"schedulingStrategy,omitempty"`
 }

--- a/pkg/controller/roleset/podset_rollsyncer.go
+++ b/pkg/controller/roleset/podset_rollsyncer.go
@@ -382,6 +382,7 @@ func (p *PodSetRoleSyncer) createPodSetForRole(roleSet *orchestrationv1alpha1.Ro
 			Template:           podTemplate,
 			Stateful:           role.Stateful,
 			SchedulingStrategy: role.SchedulingStrategy,
+			RecoveryPolicy:     role.PodRecoveryPolicy,
 		},
 	}
 


### PR DESCRIPTION
## Pull Request Description
In our scenario, suppose we use pp2 (2*8 GPUs) to deploy the model. If a pod in the podset fails, the default RecoveryPolicy is ReplaceUnhealthy, which only restarts the failed pod. However, the underlying mechanism of the podset already supports Recreate. I want to enable this configuration, which can also be set using stormservice, so that when a pod in the podset fails, all pods are restarted.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>