### PR TITLE
feat: add /v1/models endpoint to gateway plugin for local mode

### DIFF
--- a/cmd/plugins/main.go
+++ b/cmd/plugins/main.go
@@ -44,20 +44,32 @@ import (
 
 var (
 	grpcAddr        string
-	metricsAddr     string
+	httpAddr        string
+	metricsAddr     string // deprecated: use httpAddr
 	standalone      bool
 	endpointsConfig string
 )
 
 func main() {
 	flag.StringVar(&grpcAddr, "grpc-bind-address", ":50052", "The address the gRPC server binds to.")
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&httpAddr, "http-bind-address", "", "The address the HTTP server binds to (metrics, /v1/models).")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "", "[Deprecated] Use --http-bind-address instead.")
 	flag.BoolVar(&standalone, "standalone", false, "Run in standalone mode without Kubernetes.")
 	flag.StringVar(&endpointsConfig, "endpoints-config", "",
 		"Path to endpoints config file (required in standalone mode).")
 	klog.InitFlags(flag.CommandLine)
 	defer klog.Flush()
 	flag.Parse()
+
+	// Resolve HTTP bind address: prefer --http-bind-address, fall back to deprecated --metrics-bind-address
+	if httpAddr == "" {
+		if metricsAddr != "" {
+			klog.Warning("--metrics-bind-address is deprecated, use --http-bind-address instead")
+			httpAddr = metricsAddr
+		} else {
+			httpAddr = ":8080"
+		}
+	}
 
 	// Validate standalone mode flags
 	if standalone && endpointsConfig == "" {
@@ -132,10 +144,10 @@ func main() {
 
 	gatewayServer := gateway.NewServer(redisClient, k8sClient, gatewayK8sClient)
 
-	if err := gatewayServer.StartMetricsServer(metricsAddr); err != nil {
-		klog.Fatalf("Failed to start metrics server: %v", err)
+	if err := gatewayServer.StartHTTPServer(httpAddr); err != nil {
+		klog.Fatalf("Failed to start HTTP server: %v", err)
 	}
-	klog.Infof("Started metrics server on %s", metricsAddr)
+	klog.Infof("Started HTTP server on %s", httpAddr)
 
 	s := grpc.NewServer()
 	extProcPb.RegisterExternalProcessorServer(s, gatewayServer)

--- a/deployment/local/configs/envoy.yaml
+++ b/deployment/local/configs/envoy.yaml
@@ -47,6 +47,13 @@ static_resources:
                     - name: aibrix_api
                       domains: ["*"]
                       routes:
+                        # Model listing - served by gateway plugin (no metadata service in local mode)
+                        - match:
+                            prefix: "/v1/models"
+                          route:
+                            cluster: gateway_http
+                            timeout: 10s
+
                         # Inference endpoints - routed via ORIGINAL_DST using target-pod header
                         - match:
                             prefix: "/v1/"
@@ -63,11 +70,11 @@ static_resources:
                             body:
                               inline_string: '{"status":"ok"}'
 
-                        # Gateway metrics
+                        # Gateway HTTP server (metrics, /v1/models)
                         - match:
                             prefix: "/metrics"
                           route:
-                            cluster: gateway_metrics
+                            cluster: gateway_http
                             timeout: 10s
 
                         # Catch-all
@@ -121,11 +128,11 @@ static_resources:
                       port_value: 50052
       connect_timeout: 5s
 
-    # Gateway Metrics
-    - name: gateway_metrics
+    # Gateway HTTP server (metrics, /v1/models)
+    - name: gateway_http
       type: STATIC
       load_assignment:
-        cluster_name: gateway_metrics
+        cluster_name: gateway_http
         endpoints:
           - lb_endpoints:
               - endpoint:

--- a/deployment/local/run-local.sh
+++ b/deployment/local/run-local.sh
@@ -71,12 +71,12 @@ echo "  Routing algorithm: ${ROUTING_ALGORITHM}"
 echo ""
 
 # Start gateway-plugin
-echo "Starting gateway-plugin (gRPC :50052, metrics :8080)..."
+echo "Starting gateway-plugin (gRPC :50052, HTTP :8080)..."
 ROUTING_ALGORITHM="${ROUTING_ALGORITHM}" setsid --fork "${GATEWAY_BINARY}" \
     --standalone \
     --endpoints-config="${ENDPOINTS_CONFIG}" \
     --grpc-bind-address=":50052" \
-    --metrics-bind-address=":8080" \
+    --http-bind-address=":8080" \
     > "${LOG_DIR}/gateway-plugin.log" 2>&1 &
 GATEWAY_PID=$!
 # setsid --fork creates a grandchild; wait briefly then find the actual PID
@@ -147,6 +147,7 @@ echo "AIBrix gateway is running!"
 echo ""
 echo "Endpoints:"
 echo "  HTTP API:          http://localhost:10080/v1/chat/completions"
+echo "  Model List:        http://localhost:10080/v1/models"
 echo "  Envoy Admin:       http://localhost:9901"
 echo "  Gateway Metrics:   http://localhost:8080/metrics"
 echo "  Health Check:      http://localhost:10080/healthz"

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -18,15 +18,19 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"os"
 	"strings"
 	"time"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/redis/go-redis/v9"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -61,7 +65,7 @@ type Server struct {
 	gatewayClient       gatewayapi.Interface
 	requestCountTracker map[string]int
 	cache               cache.Cache
-	metricsServer       *metrics.Server
+	httpServer          *http.Server
 	// Broadcast channel for server-initiated shutdown
 	shutdownCh <-chan struct{}
 }
@@ -102,7 +106,6 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 		gatewayClient:       gatewayClient,
 		requestCountTracker: map[string]int{},
 		cache:               c,
-		metricsServer:       nil,
 	}
 }
 
@@ -382,23 +385,77 @@ func (s *Server) validateHTTPRouteStatus(ctx context.Context, model string) erro
 	return errors.New(strings.Join(errMsg, ", "))
 }
 
-func (s *Server) StartMetricsServer(addr string) error {
-	if s.metricsServer != nil {
+// StartHTTPServer starts the gateway's HTTP server with metrics and API handlers.
+// In local/standalone mode, Envoy routes /v1/models here since there is no metadata service.
+// In standard K8s deployment, Envoy routes /v1/models to the metadata service instead,
+// so the /v1/models handler here is never reached — no conflict.
+func (s *Server) StartHTTPServer(addr string) error {
+	if s.httpServer != nil {
 		return nil
 	}
 
-	s.metricsServer = metrics.NewServer(addr)
-	if err := s.metricsServer.Start(); err != nil {
-		return fmt.Errorf("failed to start metrics server: %v", err)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/v1/models", s.handleListModels)
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %v", addr, err)
 	}
+
+	s.httpServer = &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	klog.InfoS("Starting HTTP server", "address", addr)
+	go func() {
+		if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+			klog.ErrorS(err, "Failed to start HTTP server")
+		}
+	}()
 
 	return nil
 }
 
+func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		fmt.Fprintf(w, `{"error":"method not allowed"}`)
+		return
+	}
+
+	type modelObject struct {
+		ID      string `json:"id"`
+		Object  string `json:"object"`
+		Created int64  `json:"created"`
+		OwnedBy string `json:"owned_by"`
+	}
+	type modelListResponse struct {
+		Object string        `json:"object"`
+		Data   []modelObject `json:"data"`
+	}
+
+	models := s.cache.ListModels()
+	data := make([]modelObject, len(models))
+	for i, m := range models {
+		data[i] = modelObject{ID: m, Object: "model", Created: 0, OwnedBy: "aibrix"}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(modelListResponse{Object: "list", Data: data}); err != nil {
+		klog.ErrorS(err, "failed to encode model list response")
+	}
+}
+
 func (s *Server) Shutdown() {
-	if s.metricsServer != nil {
-		if err := s.metricsServer.Stop(); err != nil {
-			klog.ErrorS(err, "Error stopping metrics server")
+	if s.httpServer != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.httpServer.Shutdown(ctx); err != nil {
+			klog.ErrorS(err, "Error stopping HTTP server")
 		}
 	}
 }


### PR DESCRIPTION
## Pull Request Description
Serve model list from cache on the gateway's HTTP server so  local/standalone mode works without the metadata service. In standard K8s deployment the Envoy HTTPRoute still sends /v1/models to the metadata service — no conflict

- Refactor gateway to own its HTTP server (metrics + API handlers)
- Deprecate --metrics-bind-address in favor of --http-bind-address
- Add /v1/models route in local envoy config

## Related Issues
Resolves: https://github.com/vllm-project/aibrix/issues/1951#issuecomment-4150682457

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>