### PR TITLE
[Feat] Make Redis optional in local mode

### DIFF
--- a/cmd/plugins/main.go
+++ b/cmd/plugins/main.go
@@ -77,11 +77,19 @@ func main() {
 	}
 
 	redisClient := utils.GetRedisClient()
-	defer func() {
-		if err := redisClient.Close(); err != nil {
-			klog.Warningf("Error closing Redis client: %v", err)
+	if redisClient == nil {
+		if standalone {
+			klog.Warning("Running without Redis: rate limiting and user auth disabled")
+		} else {
+			klog.Fatal("Redis is required in Kubernetes mode")
 		}
-	}()
+	} else {
+		defer func() {
+			if err := redisClient.Close(); err != nil {
+				klog.Warningf("Error closing Redis client: %v", err)
+			}
+		}()
+	}
 
 	// register additional routing algorithms that need dependences
 	if redisClient != nil {

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -94,7 +94,12 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 	if err != nil {
 		panic(err)
 	}
-	r := ratelimiter.NewRedisAccountRateLimiter("aibrix", redisClient, 1*time.Minute)
+	var r ratelimiter.RateLimiter
+	if redisClient != nil {
+		r = ratelimiter.NewRedisAccountRateLimiter("aibrix", redisClient, 1*time.Minute)
+	} else {
+		r = ratelimiter.NewNoopRateLimiter()
+	}
 
 	// Initialize the routers
 	routing.Init()

--- a/pkg/plugins/gateway/gateway_req_headers.go
+++ b/pkg/plugins/gateway/gateway_req_headers.go
@@ -69,6 +69,9 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, req
 	}
 
 	if username != "" {
+		user.Name = username
+	}
+	if username != "" && s.redisClient != nil {
 		user, err = utils.GetUser(ctx, utils.User{Name: username}, s.redisClient)
 		if err != nil {
 			klog.ErrorS(err, "unable to process user info", "requestID", requestID, "username", username)

--- a/pkg/plugins/gateway/ratelimiter/noop.go
+++ b/pkg/plugins/gateway/ratelimiter/noop.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimiter
+
+import "context"
+
+type noopRateLimiter struct{}
+
+func NewNoopRateLimiter() RateLimiter {
+	return &noopRateLimiter{}
+}
+
+func (n *noopRateLimiter) Get(ctx context.Context, key string) (int64, error) {
+	return 0, nil
+}
+
+func (n *noopRateLimiter) GetLimit(ctx context.Context, key string) (int64, error) {
+	return 9223372036854775807, nil
+}
+
+func (n *noopRateLimiter) Incr(ctx context.Context, key string, val int64) (int64, error) {
+	return 0, nil
+}

--- a/pkg/utils/redis.go
+++ b/pkg/utils/redis.go
@@ -36,7 +36,11 @@ func GetRedisClient() *redis.Client {
 	})
 	pong, err := client.Ping(context.Background()).Result()
 	if err != nil {
-		klog.Fatalf("Error connecting to Redis: %v", err)
+		klog.Warningf("Redis not available: %v", err)
+		if closeErr := client.Close(); closeErr != nil {
+			klog.Warningf("Error closing Redis client: %v", closeErr)
+		}
+		return nil
 	}
 	klog.Infof("Connected to Redis: %s", pong)
 	return client


### PR DESCRIPTION
## Pull Request Description

Make Redis a soft dependency so the gateway can start and serve requests
without a running Redis server. This is needed for local development/testing
where Redis adds unnecessary setup friction.

### Changes

- **`pkg/utils/redis.go`**: Replace `klog.Fatalf` with `klog.Warningf` and
  return `nil` when Redis is unreachable, instead of crashing the process.
- **`cmd/plugins/main.go`**: Handle `nil` Redis client gracefully at startup;
  skip defer close and log a warning that rate limiting and user auth are disabled.
- **`pkg/plugins/gateway/gateway.go`**: Use a `NoopRateLimiter` when Redis
  client is nil, instead of creating a `RedisAccountRateLimiter` that would panic.
- **`pkg/plugins/gateway/gateway_req_headers.go`**: Skip user lookup via Redis
  when `redisClient` is nil.
- **`pkg/plugins/gateway/ratelimiter/noop.go`** (new): Add a no-op
  `RateLimiter` implementation that allows all requests through.

### Behavior

- **With Redis**: No change — everything works as before (rate limiting, user auth, po2 routing).
- **Without Redis**: Gateway starts normally; rate limiting and user auth are
  disabled.

## Related Issues
Resolves: #2050 