### PR TITLE
[Feat]: finished by finish reason

### DIFF
--- a/apps/console/api/store/demo.go
+++ b/apps/console/api/store/demo.go
@@ -197,12 +197,12 @@ func (s *MemoryStore) loadDemoModelDeploymentTemplates() {
 				},
 				Parallelism: &pb.ParallelismSpec{Tp: 4, Pp: 1, Dp: 1},
 				EngineArgs: map[string]string{
-					"max_num_batched_tokens":  "32768",
-					"max_num_seqs":            "256",
-					"max_model_len":           "32768",
-					"gpu_memory_utilization":  "0.92",
-					"enable_prefix_caching":   "true",
-					"enable_chunked_prefill":  "true",
+					"max_num_batched_tokens": "32768",
+					"max_num_seqs":           "256",
+					"max_model_len":          "32768",
+					"gpu_memory_utilization": "0.92",
+					"enable_prefix_caching":  "true",
+					"enable_chunked_prefill": "true",
 				},
 				Quantization: &pb.QuantizationSpec{Weight: "fp8", KvCache: "fp8_e4m3"},
 				ProviderConfig: &pb.ProviderConfig{

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -304,6 +304,9 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		}
 		metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestSuccessTotal, &metrics.SimpleMetricValue{Value: 1.0},
 			map[string]string{"status": pdRoutePrefillRequestSuccess, "status_code": "200"})
+		if ctx.ImmediateResponse != nil {
+			return "", nil
+		}
 	}
 
 	ctx.SetTargetPod(decodePod)

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -1489,6 +1489,128 @@ func TestTensorRTIntegrationWithTestServer(t *testing.T) {
 	// Payload fields from the prefill response should be preserved
 }
 
+func TestTensorRTPrefillFinishReasonShortCircuit(t *testing.T) {
+	resp := `{
+		"choices":[
+			{
+				"message":{"role":"assistant","content":"yes"},
+				"finish_reason":"stop",
+				"disaggregated_params":{"request_type":"context_only","first_gen_tokens":[42]}
+			}
+		],
+		"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}
+	}`
+
+	ts := setupTestServer(t, http.StatusOK, resp, TensorRTLLM)
+	defer ts.Close()
+
+	prefillPods := []*v1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-trt",
+			Labels: map[string]string{
+				LLMEngineIdentifier: TensorRTLLM,
+				PDRoleIdentifier:    "prefill",
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP: "127.0.0.1",
+			Conditions: []v1.PodCondition{{
+				Type:   v1.PodReady,
+				Status: v1.ConditionTrue,
+			}},
+		},
+	}}
+
+	originalBody := []byte(`{"messages":[{"role":"user","content":"test"}],"model":"test-model"}`)
+	routingCtx := &types.RoutingContext{
+		RequestID:  "test-request",
+		Model:      "test-model",
+		ReqPath:    "/v1/chat/completions",
+		ReqBody:    append([]byte(nil), originalBody...),
+		ReqHeaders: map[string]string{"Authorization": "Bearer test"},
+		Context:    context.Background(),
+		Stream:     false,
+	}
+
+	router := &pdRouter{
+		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
+		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
+		cache:                 cache.NewWithPodsForTest(prefillPods, "test-model"),
+		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		httpClient:            &http.Client{},
+	}
+
+	err := router.doPrefillRequest(routingCtx, prefillPods[0], TensorRTLLM)
+	assert.NoError(t, err)
+	if assert.NotNil(t, routingCtx.ImmediateResponse) {
+		assert.Equal(t, http.StatusOK, routingCtx.ImmediateResponse.StatusCode)
+		assert.JSONEq(t, resp, string(routingCtx.ImmediateResponse.Body))
+	}
+	assert.JSONEq(t, string(originalBody), string(routingCtx.ReqBody))
+}
+
+func TestVLLMPrefillFinishReasonDoesNotShortCircuit(t *testing.T) {
+	resp := `{
+		"choices":[
+			{
+				"message":{"role":"assistant","content":"done"},
+				"finish_reason":"stop"
+			}
+		],
+		"kv_transfer_params":{
+			"do_remote_decode":true,
+			"do_remote_prefill":false,
+			"remote_engine_id":"test-engine-123",
+			"remote_block_ids":["block1","block2"],
+			"remote_host":"127.0.0.1",
+			"remote_port":"8080"
+		}
+	}`
+
+	ts := setupTestServer(t, http.StatusOK, resp, VLLMEngine)
+	defer ts.Close()
+
+	prefillPods := []*v1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-vllm",
+			Labels: map[string]string{
+				LLMEngineIdentifier: VLLMEngine,
+				PDRoleIdentifier:    "prefill",
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP: "127.0.0.1",
+			Conditions: []v1.PodCondition{{
+				Type:   v1.PodReady,
+				Status: v1.ConditionTrue,
+			}},
+		},
+	}}
+
+	originalBody := []byte(`{"messages":[{"role":"user","content":"test"}],"model":"test-model"}`)
+	routingCtx := &types.RoutingContext{
+		RequestID:  "test-request",
+		Model:      "test-model",
+		ReqPath:    "/v1/chat/completions",
+		ReqBody:    append([]byte(nil), originalBody...),
+		ReqHeaders: map[string]string{"Authorization": "Bearer test"},
+		Context:    context.Background(),
+		Stream:     false,
+	}
+
+	router := &pdRouter{
+		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
+		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
+		cache:                 cache.NewWithPodsForTest(prefillPods, "test-model"),
+		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		httpClient:            &http.Client{},
+	}
+
+	err := router.doPrefillRequest(routingCtx, prefillPods[0], VLLMEngine)
+	assert.NoError(t, err)
+	assert.Nil(t, routingCtx.ImmediateResponse)
+}
+
 func TestUpdateRoutingContextWithTRTDisaggParams(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/plugins/gateway/algorithms/pd_prefill_request.go
+++ b/pkg/plugins/gateway/algorithms/pd_prefill_request.go
@@ -123,7 +123,7 @@ func (r *pdRouter) doPrefillRequest(routingCtx *types.RoutingContext, prefillPod
 		go func() {
 			defer r.prefillRequestTracker.RemovePrefillRequest(routingCtx.RequestID)
 
-			if _, err := r.executeHTTPRequest(apiURL, routingCtx, payload); err != nil {
+			if _, _, err := r.executeHTTPRequest(apiURL, routingCtx, payload); err != nil {
 				klog.ErrorS(err, "prefill_request_failed",
 					"request_id", routingCtx.RequestID,
 					"llm_engine", llmEngine,
@@ -174,7 +174,7 @@ func (r *pdRouter) handleSyncPrefill(
 	errorContext string) error {
 	defer r.prefillRequestTracker.RemovePrefillRequest(routingCtx.RequestID)
 
-	responseData, err := r.executeHTTPRequest(apiURL, routingCtx, payload)
+	responseData, rawBody, err := r.executeHTTPRequest(apiURL, routingCtx, payload)
 	if err != nil {
 		klog.ErrorS(err, "prefill_request_failed",
 			"request_id", routingCtx.RequestID,
@@ -183,6 +183,28 @@ func (r *pdRouter) handleSyncPrefill(
 			"prefill_pod_ip", prefillPod.Status.PodIP,
 			"elapsed", routingCtx.Elapsed(time.Now()))
 		return fmt.Errorf("prefill request failed for request %s, pod %s: %w", routingCtx.RequestID, prefillPod.Name, err)
+	}
+
+	// TensorRT-LLM: prefill can already produce a terminal response (e.g. short tasks
+	// that finish within max_tokens=1). In that case, skip decode entirely and
+	// return the prefill response directly back to the client via gateway's
+	// ImmediateResponse path.
+	if llmEngine == TensorRTLLM && isPrefillResponseComplete(responseData) {
+		routingCtx.ImmediateResponse = &types.ImmediateHTTPResponse{
+			StatusCode: http.StatusOK,
+			Headers: map[string]string{
+				"Content-Type":   "application/json",
+				"x-prefill-only": "true",
+			},
+			Body: rawBody,
+		}
+		routingCtx.PrefillEndTime = time.Now()
+		fields = append(fields,
+			"routing_time_taken", routingCtx.PrefillStartTime.Sub(routingCtx.RequestTime),
+			"prefill_time_taken", routingCtx.PrefillEndTime.Sub(routingCtx.PrefillStartTime),
+			"outstanding_prefill_requests", r.prefillRequestTracker.GetPrefillRequestCountsForPod(prefillPod.Name)-1)
+		klog.InfoS("prefill_complete_skip_decode", fields...)
+		return nil
 	}
 
 	if updateCtxFunc != nil {
@@ -282,13 +304,13 @@ func (r *pdRouter) preparePrefillPayload(routingCtx *types.RoutingContext, pod *
 // GatewayPrefillRequestFailTotal before being returned as errors.
 // TRT-LLM responses are parsed with UseInt64=true to avoid float64 precision
 // loss on large integer fields such as disagg_request_id.
-func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingContext, payload []byte) (map[string]any, error) {
+func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingContext, payload []byte) (map[string]any, []byte, error) {
 	ctx, cancel := context.WithTimeout(routingCtx.Context, time.Duration(prefillRequestTimeout)*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(payload))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create http prefill request: %w", err)
+		return nil, nil, fmt.Errorf("failed to create http prefill request: %w", err)
 	}
 
 	for key, value := range routingCtx.ReqHeaders {
@@ -302,7 +324,7 @@ func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingConte
 		status, code := metrics.HttpFailureStatusCode(ctx, err, nil)
 		metrics.EmitMetricToPrometheus(routingCtx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
 			map[string]string{"status": status, "status_code": code})
-		return nil, fmt.Errorf("failed to execute http prefill request: %w", err)
+		return nil, nil, fmt.Errorf("failed to execute http prefill request: %w", err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
@@ -310,14 +332,14 @@ func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingConte
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read prefill response body: %w", err)
+		return nil, nil, fmt.Errorf("failed to read prefill response body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		status, code := metrics.HttpFailureStatusCode(ctx, nil, resp)
 		metrics.EmitMetricToPrometheus(routingCtx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
 			map[string]string{"status": status, "status_code": code})
-		return nil, fmt.Errorf("http prefill request failed with status %d: %s", resp.StatusCode, string(body))
+		return nil, body, fmt.Errorf("http prefill request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	// TRT-LLM prefill responses contain large integer IDs in disaggregated_params;
@@ -330,10 +352,29 @@ func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingConte
 		errUnmarshal = sonic.Unmarshal(body, &responseData)
 	}
 	if errUnmarshal != nil {
-		return nil, fmt.Errorf("failed to unmarshal prefill response: %w", errUnmarshal)
+		return nil, body, fmt.Errorf("failed to unmarshal prefill response: %w", errUnmarshal)
 	}
 
-	return responseData, nil
+	return responseData, body, nil
+}
+
+// isPrefillResponseComplete returns true when a TensorRT-LLM prefill response already
+// contains a terminal generation, meaning the decode phase is unnecessary.
+//
+// TRT-LLM can return a terminal finish_reason (e.g. "stop") during a prefill capped
+// with max_tokens=1 for short tasks. When finish_reason is "length" (or "not_finished"),
+// decode is still needed to continue generation.
+func isPrefillResponseComplete(responseData map[string]any) bool {
+	choices, ok := responseData["choices"].([]any)
+	if !ok || len(choices) == 0 {
+		return false
+	}
+	choice, ok := choices[0].(map[string]any)
+	if !ok {
+		return false
+	}
+	finishReason, _ := choice["finish_reason"].(string)
+	return finishReason != "" && finishReason != "length" && finishReason != "not_finished"
 }
 
 // updateRoutingContextWithKVTransferParams merges vLLM KV-transfer metadata

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -291,6 +291,14 @@ func (s *Server) handleProcessingRequest(st *processState, req *extProcPb.Proces
 	}
 
 	statusCode := strconv.Itoa(int(resp.GetImmediateResponse().GetStatus().GetCode()))
+	// ImmediateResponse is used for both error and success short-circuit returns
+	// (e.g. PD prefill-only completion). Only treat it as a failure metric when
+	// the status code is not 2xx.
+	if resp.GetImmediateResponse().GetStatus().GetCode() >= 200 && resp.GetImmediateResponse().GetStatus().GetCode() < 300 {
+		s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, st.metricLabel+"_success", statusCode)
+		return resp, nil
+	}
+
 	metricFail := getMetricErr(resp.GetImmediateResponse(), st.metricLabel)
 	s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, metricFail+"_fail", statusCode)
 

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -67,6 +67,7 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 
 	routingCtx.Model = model
 	routingCtx.Message = message
+	routingCtx.Stream = stream
 	routingCtx.ReqBody = body.RequestBody.GetBody()
 
 	// early reject if model doesn't exist or no pods are ready
@@ -116,6 +117,17 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 	} else {
 		externalFilter := routingCtx.ReqHeaders[HeaderExternalFilter]
 		targetPodIP, err := s.selectTargetPod(routingCtx, podsArr, externalFilter)
+		if routingCtx.ImmediateResponse != nil {
+			klog.InfoS("prefill_only_response",
+				"request_id", requestID,
+				"model", model,
+				"prefill_time_taken", routingCtx.PrefillEndTime.Sub(routingCtx.PrefillStartTime))
+			routingCtx.RequestEndTime = time.Now()
+			term = s.cache.AddRequestCount(routingCtx, requestID, model)
+			return buildImmediateResponseFromHTTPResponse(routingCtx.ImmediateResponse, map[string]string{
+				HeaderRequestID: requestID,
+			}), model, routingCtx, stream, term
+		}
 		if targetPodIP == "" || err != nil {
 			klog.ErrorS(err, "failed to select target pod", "requestID", requestID, "routingStrategy", routingAlgorithm, "model", model, "routingDuration", routingCtx.GetRoutingDelay())
 			return buildErrorResponse(envoyTypePb.StatusCode_ServiceUnavailable, "error on selecting target pod", ErrorCodeServiceUnavailable, "", HeaderErrorRouting, "true"), model, routingCtx, stream, term

--- a/pkg/plugins/gateway/gateway_req_body_test.go
+++ b/pkg/plugins/gateway/gateway_req_body_test.go
@@ -676,3 +676,82 @@ func Test_handleRequestBody(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleRequestBody_ImmediateResponseBypassesTargetPodGuard(t *testing.T) {
+	routingalgorithms.Init()
+
+	mockCache := &MockCache{Cache: cache.NewForTest()}
+	mockRouter := new(mockRouter)
+
+	mockRouterProvider := func() (types.Router, error) {
+		return mockRouter, nil
+	}
+	routingalgorithms.Register(TestRouterAlgorithm, mockRouterProvider)
+	routingalgorithms.Init()
+
+	podList := &utils.PodArray{
+		Pods: []*v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "prefill-pod", Namespace: "default"},
+				Status: v1.PodStatus{
+					PodIP:      "1.2.3.4",
+					Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "decode-pod", Namespace: "default"},
+				Status: v1.PodStatus{
+					PodIP:      "1.2.3.5",
+					Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+				},
+			},
+		},
+	}
+
+	mockCache.On("HasModel", "test-model").Return(true)
+	mockCache.On("ListPodsByModel", "test-model").Return(podList, nil)
+	mockCache.On("AddRequestCount", mock.Anything, "test-request-id", "test-model").Return(int64(7)).Once()
+
+	mockRouter.On("Route", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(*types.RoutingContext)
+		ctx.ImmediateResponse = &types.ImmediateHTTPResponse{
+			StatusCode: 200,
+			Headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			Body: []byte(`{"choices":[{"message":{"role":"assistant","content":"yes"},"finish_reason":"stop"}]}`),
+		}
+	}).Return("", nil).Once()
+
+	server := &Server{
+		cache: mockCache,
+	}
+
+	routingCtx := types.NewRoutingContext(context.Background(), TestRouterAlgorithm, "", "", "test-request-id", "")
+	routingCtx.ReqPath = PathChatCompletions
+	routingCtx.ReqHeaders = map[string]string{
+		HeaderRoutingStrategy: string(TestRouterAlgorithm),
+	}
+
+	req := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestBody{
+			RequestBody: &extProcPb.HttpBody{
+				Body: []byte(`{"model":"test-model","messages":[{"role":"user","content":"hello"}]}`),
+			},
+		},
+	}
+
+	resp, model, updatedCtx, stream, term := server.HandleRequestBody(routingCtx, "test-request-id", req, utils.User{})
+
+	assert.Equal(t, "test-model", model)
+	assert.False(t, stream)
+	assert.Equal(t, int64(7), term)
+	assert.Same(t, routingCtx, updatedCtx)
+	if assert.NotNil(t, resp.GetImmediateResponse()) {
+		assert.Equal(t, envoyTypePb.StatusCode_OK, resp.GetImmediateResponse().GetStatus().GetCode())
+		assert.Contains(t, resp.GetImmediateResponse().GetBody(), `"finish_reason":"stop"`)
+	}
+
+	mockCache.AssertExpectations(t)
+	mockRouter.AssertExpectations(t)
+}

--- a/pkg/plugins/gateway/gateway_req_headers.go
+++ b/pkg/plugins/gateway/gateway_req_headers.go
@@ -56,17 +56,20 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, req
 		case pathKey:
 			requestPath = string(n.RawValue)
 		case authorizationKey:
-			reqHeaders[n.Key] = string(n.RawValue)
+			// Normalize header keys to lower-case constants so downstream lookups
+			// (which use fixed lower-case keys) work regardless of upstream casing
+			// such as "Authorization" vs "authorization".
+			reqHeaders[authorizationKey] = string(n.RawValue)
 		case HeaderExternalFilter:
-			reqHeaders[n.Key] = string(n.RawValue)
+			reqHeaders[HeaderExternalFilter] = string(n.RawValue)
 		case contentTypeKey:
-			reqHeaders[n.Key] = string(n.RawValue)
+			reqHeaders[contentTypeKey] = string(n.RawValue)
 		case HeaderRoutingStrategy:
-			reqHeaders[n.Key] = string(n.RawValue)
+			reqHeaders[HeaderRoutingStrategy] = string(n.RawValue)
 		case HeaderConfigProfile:
 			reqConfigProfile = strings.TrimSpace(string(n.RawValue))
 		case HeaderSessionID:
-			reqHeaders[n.Key] = string(n.RawValue)
+			reqHeaders[HeaderSessionID] = string(n.RawValue)
 		}
 	}
 

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -567,6 +567,41 @@ func buildEnvoyProxyHeaders(headers []*configPb.HeaderValueOption, keyValues ...
 	return headers
 }
 
+func buildImmediateResponseFromHTTPResponse(resp *types.ImmediateHTTPResponse, extraHeaders map[string]string) *extProcPb.ProcessingResponse {
+	if resp == nil {
+		return nil
+	}
+	headers := map[string]string{}
+	for k, v := range resp.Headers {
+		headers[k] = v
+	}
+	for k, v := range extraHeaders {
+		headers[k] = v
+	}
+	if _, ok := headers["Content-Type"]; !ok {
+		headers["Content-Type"] = "application/json"
+	}
+	return &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_ImmediateResponse{
+			ImmediateResponse: &extProcPb.ImmediateResponse{
+				Status: &envoyTypePb.HttpStatus{Code: envoyTypePb.StatusCode(resp.StatusCode)},
+				Headers: &extProcPb.HeaderMutation{
+					SetHeaders: buildEnvoyProxyHeaders([]*configPb.HeaderValueOption{}, flattenHeaderMap(headers)...),
+				},
+				Body: string(resp.Body),
+			},
+		},
+	}
+}
+
+func flattenHeaderMap(headers map[string]string) []string {
+	keyValues := make([]string, 0, len(headers)*2)
+	for k, v := range headers {
+		keyValues = append(keyValues, k, v)
+	}
+	return keyValues
+}
+
 // validateEmbeddingInput validates the input according to OpenAI embedding constraints
 func validateEmbeddingInput(embeddingObj openai.EmbeddingNewParams) error {
 	inputParam := embeddingObj.Input

--- a/pkg/types/response.go
+++ b/pkg/types/response.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+type ImmediateHTTPResponse struct {
+	StatusCode int
+	Headers    map[string]string
+	Body       []byte
+}

--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -78,6 +78,8 @@ type RoutingContext struct {
 	PrefillStartTime time.Time // Time when prefill request is started.
 	PrefillEndTime   time.Time // Time consumed during prefill.
 
+	ImmediateResponse *ImmediateHTTPResponse
+
 	// RespHeaders holds response headers that the router intends to set.
 	// These are typically used to propagate control information back to the client,
 	// such as session affinity id.
@@ -331,6 +333,7 @@ func (r *RoutingContext) reset(ctx context.Context, algorithms RoutingAlgorithm,
 	r.ReqBody = []byte{}
 	r.PrefillStartTime = time.Time{}
 	r.PrefillEndTime = time.Time{}
+	r.ImmediateResponse = nil
 	// RoutedTime will not be reset, it must before ReqeustTime at this time.
 
 	r.RespHeaders = map[string]string{}


### PR DESCRIPTION
## Pull Request Description
This PR fixes the missing `finish_reason` handling in PD disaggregation for TensorRT-LLM.

Previously, the gateway always proceeded to the decode phase after a synchronous TRT-LLM prefill request, even when the prefill response had already completed generation. This could break short outputs such as single-token answers (`yes/no`, numbers, etc.), because the workflow incorrectly assumed a decode hop was still required.

This change adds a TRT-LLM-specific short-circuit for synchronous prefill responses:
- If `finish_reason` is a completed state (that is, neither `"length"` nor `"not_finished"`), the gateway returns the prefill result immediately and skips decode.
- If the request is streaming, the gateway does not short-circuit and preserves the existing streaming behavior.
- The short-circuit is scoped only to `TensorRTLLM` so other engines, including vLLM, keep their original behavior.

In addition, this PR includes:
- A fix for an immediate-response handling compile issue in `gateway.go`
- A regression test covering TRT-LLM prefill completion short-circuit behavior
- A regression test ensuring vLLM does not short-circuit on `finish_reason`
- Defensive nil-context handling in request cleanup paths to avoid panics for invalid requests (for example, unknown model names)
- A mock TRT-LLM PD prefill adjustment in the development app so PD e2e tests continue to exercise the decode path when intended

## Related Issues
Resolves: #2013

**Important: Before submitting, please complete the description above and review the checklist below.**


<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>