### PR TITLE
Fix: Non-blocking metrics worker pool

### DIFF
--- a/pkg/cache/cache_metrics.go
+++ b/pkg/cache/cache_metrics.go
@@ -229,7 +229,17 @@ func (c *Store) updatePodMetrics() {
 			// Skip unready pod
 			return true
 		}
-		c.podMetricsJobs <- metaPod // Send the job to the worker pool
+		// Non-blocking send: if the worker pool is saturated (all workers busy
+		// and channel buffer full), skip this pod. It will be retried on the
+		// next refresh cycle (every 50ms). This prevents the metrics refresh
+		// goroutine from blocking indefinitely when workers are stuck on slow
+		// or unreachable engine pods.
+		select {
+		case c.podMetricsJobs <- metaPod:
+		default:
+			klog.V(4).InfoS("Metrics worker pool saturated, skipping pod metrics update",
+				"pod", metaPod.Name)
+		}
 		return true
 	})
 }

--- a/pkg/cache/cache_metrics_test.go
+++ b/pkg/cache/cache_metrics_test.go
@@ -304,3 +304,48 @@ func TestInitPrometheusAPI_EndpointSet(t *testing.T) {
 	api := initPrometheusAPI(nil)
 	require.NotNil(t, api)
 }
+
+// TestUpdatePodMetricsNonBlocking verifies that updatePodMetrics does not block
+// when the worker pool is saturated (channel buffer full). This prevents the
+// metrics refresh goroutine from stalling when workers are stuck on slow pods.
+func TestUpdatePodMetricsNonBlocking(t *testing.T) {
+	// Create a store with a tiny channel buffer and NO workers draining it
+	store := &Store{
+		podMetricsJobs: make(chan *Pod, 2),
+	}
+
+	// Add 5 ready pods — more than the channel buffer can hold
+	for i := range 5 {
+		name := fmt.Sprintf("pod-%d", i)
+		store.metaPods.Store(name, &Pod{
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					PodIP: fmt.Sprintf("10.0.0.%d", i+1),
+					Conditions: []v1.PodCondition{
+						{Type: v1.PodReady, Status: v1.ConditionTrue},
+					},
+				},
+			},
+		})
+	}
+
+	// updatePodMetrics must return promptly without blocking.
+	// With the old blocking send, this would deadlock since no worker is reading.
+	done := make(chan struct{})
+	go func() {
+		store.updatePodMetrics()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success: updatePodMetrics returned without blocking
+	case <-time.After(2 * time.Second):
+		t.Fatal("updatePodMetrics blocked — channel send is not non-blocking")
+	}
+
+	// Exactly 2 pods should have been enqueued (channel buffer size)
+	require.Equal(t, 2, len(store.podMetricsJobs))
+}


### PR DESCRIPTION
## Pull Request Description
When inference pods are slow/unreachable, all 10 metrics workers get stuck in HTTP retry loops (up to 5s timeout + exponential backoff). The podMetricsJobs channel buffer (100) fills up, and updatePodMetrics() blocks indefinitely on c.podMetricsJobs <- metaPod. This stalls the entire metrics refresh goroutine, causing cascading failures that lead to pod restart.



## Related Issues
Resolves: https://github.com/vllm-project/aibrix/issues/2049 new issue

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>