### PR TITLE
fix(controller): handle io.ReadAll errors in lora_client.go

### DIFF
--- a/pkg/controller/modeladapter/lora_client.go
+++ b/pkg/controller/modeladapter/lora_client.go
@@ -148,11 +148,11 @@ func (c *loraClient) UnloadAdapter(instance *modelv1alpha1.ModelAdapter, targetP
 	}()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		body, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if err != nil {
 			klog.Warningf("Failed to unload LoRA adapter from pod %s (status %d), and failed to read response body: %v", targetPod.Name, resp.StatusCode, err)
 		} else {
-			klog.Warningf("Failed to unload LoRA adapter from pod %s: %s", targetPod.Name, body)
+			klog.Warningf("Failed to unload LoRA adapter from pod %s (status %d): %s", targetPod.Name, resp.StatusCode, body)
 		}
 	}
 
@@ -180,11 +180,11 @@ func (c *loraClient) getModels(url string, instance *modelv1alpha1.ModelAdapter)
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get models (status %d), and failed to read response body: %w", resp.StatusCode, err)
 		}
-		return nil, fmt.Errorf("failed to get models: %s", body)
+		return nil, fmt.Errorf("failed to get models (status %d): %s", resp.StatusCode, body)
 	}
 
 	var response struct {
@@ -300,11 +300,11 @@ func (c *loraClient) loadAdapterCall(ctx context.Context, url string, instance *
 	}()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		body, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if err != nil {
 			return fmt.Errorf("failed to load LoRA adapter (status %d), and failed to read response body: %w", resp.StatusCode, err)
 		}
-		return fmt.Errorf("failed to load LoRA adapter: %s", body)
+		return fmt.Errorf("failed to load LoRA adapter (status %d): %s", resp.StatusCode, body)
 	}
 
 	klog.InfoS("Successfully loaded LoRA adapter",


### PR DESCRIPTION
Three call sites in \`lora_client.go\` discarded the error from \`io.ReadAll(resp.Body)\`. When the read fails, \`body\` is nil/empty, producing error messages like "failed to load LoRA adapter: " with no useful diagnostic info. The actual read error is silently lost.

Each site now checks the \`io.ReadAll\` error and includes the HTTP status code and read failure in the error message.

Fixes #2066