### PR TITLE
Feature/prefix cache with redis reqcnt

### DIFF
--- a/cmd/plugins/main.go
+++ b/cmd/plugins/main.go
@@ -95,6 +95,7 @@ func main() {
 	// register additional routing algorithms that need dependences
 	if redisClient != nil {
 		routing.RegisterPowerOfTwoRouter(redisClient)
+		routing.RegisterPrefixCacheRouterWithRedis(redisClient)
 	}
 
 	// stopCh is closed either on normal return (via defer) or proactively in

--- a/cmd/plugins/main.go
+++ b/cmd/plugins/main.go
@@ -95,7 +95,11 @@ func main() {
 	// register additional routing algorithms that need dependences
 	if redisClient != nil {
 		routing.RegisterPowerOfTwoRouter(redisClient)
-		routing.RegisterPrefixCacheRouterWithRedis(redisClient)
+
+		// Only register prefix cache router with Redis if the feature is enabled
+		if utils.LoadEnvBool(constants.EnvPrefixCacheUseRedisReqCnt, false) {
+			routing.RegisterPrefixCacheRouterWithRedis(redisClient)
+		}
 	}
 
 	// stopCh is closed either on normal return (via defer) or proactively in

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
+	github.com/go-redis/redismock/v9 v9.2.0 
 	github.com/kubewharf/godel-scheduler-api v0.0.0-20240910073424-8068ac118f44
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.20.1

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
+github.com/go-redis/redismock/v9 v9.2.0 h1:ZrMYQeKPECZPjOj5u9eyOjg8Nnb0BS9lkVIZ6IpsKLw=
+github.com/go-redis/redismock/v9 v9.2.0/go.mod h1:18KHfGDK4Y6c2R0H38EUGWAdc7ZQS9gfYxc94k7rWT0=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=

--- a/pkg/cache/cache_api.go
+++ b/pkg/cache/cache_api.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
-	syncindexer "github.com/vllm-project/aibrix/pkg/utils/syncprefixcacheindexer"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -31,7 +30,6 @@ type Cache interface {
 	RequestTracker
 	RequestTrackerRegistry
 	ProfileCache
-	SyncIndexerProvider
 	types.OutputPredictorProvider
 	types.RouterProvider
 }
@@ -168,11 +166,4 @@ type ProfileCache interface {
 	//   deploymentName: Name of the deployment
 	//   modelName: Name of the model
 	GetModelProfileByDeploymentName(deploymentName string, modelName string) (*ModelGPUProfile, error)
-}
-
-// SyncIndexerProvider provides access to the sync prefix indexer for KV sync routing
-type SyncIndexerProvider interface {
-	// GetSyncPrefixIndexer returns the shared sync prefix indexer instance
-	// Returns nil if KV sync is not enabled or indexer is not initialized
-	GetSyncPrefixIndexer() *syncindexer.SyncPrefixHashTable
 }

--- a/pkg/cache/cache_api.go
+++ b/pkg/cache/cache_api.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
+	syncindexer "github.com/vllm-project/aibrix/pkg/utils/syncprefixcacheindexer"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -30,6 +31,7 @@ type Cache interface {
 	RequestTracker
 	RequestTrackerRegistry
 	ProfileCache
+	SyncIndexerProvider
 	types.OutputPredictorProvider
 	types.RouterProvider
 }
@@ -166,4 +168,11 @@ type ProfileCache interface {
 	//   deploymentName: Name of the deployment
 	//   modelName: Name of the model
 	GetModelProfileByDeploymentName(deploymentName string, modelName string) (*ModelGPUProfile, error)
+}
+
+// SyncIndexerProvider provides access to the sync prefix indexer for KV sync routing
+type SyncIndexerProvider interface {
+	// GetSyncPrefixIndexer returns the shared sync prefix indexer instance
+	// Returns nil if KV sync is not enabled or indexer is not initialized
+	GetSyncPrefixIndexer() *syncindexer.SyncPrefixHashTable
 }

--- a/pkg/cache/cache_init.go
+++ b/pkg/cache/cache_init.go
@@ -567,7 +567,7 @@ func (s *Store) initKVEventSync() error {
 	// Create sync indexer after validation passes - use shared singleton
 	s.syncPrefixIndexer = syncindexer.GetSharedSyncPrefixHashTable()
 	if s.syncPrefixIndexer == nil {
-		return fmt.Errorf("failed to create sync prefix indexer")
+		return fmt.Errorf("failed to get shared sync prefix indexer")
 	}
 
 	// Start event manager

--- a/pkg/constants/kv_event_sync.go
+++ b/pkg/constants/kv_event_sync.go
@@ -60,6 +60,10 @@ const (
 	// EnvPrefixCacheRemoteTokenizerEndpoint specifies the remote tokenizer service endpoint
 	// Format: "http://service:port" - required when using remote tokenizer
 	EnvPrefixCacheRemoteTokenizerEndpoint = "AIBRIX_PREFIX_CACHE_REMOTE_TOKENIZER_ENDPOINT"
+
+	// EnvPrefixCacheUseRedisReqCnt enables Redis-based request counting
+	// When true, uses Redis to track request counts instead of local metrics
+	EnvPrefixCacheUseRedisReqCnt = "AIBRIX_PREFIX_CACHE_USE_REDIS_REQCNT"
 )
 
 // Helper functions for KV Event Sync labels

--- a/pkg/plugins/gateway/algorithms/power_of_two.go
+++ b/pkg/plugins/gateway/algorithms/power_of_two.go
@@ -107,9 +107,9 @@ type podServerKey struct {
 
 func (k podServerKey) String() string {
 	if k.port == 0 {
-		return k.pod.Name
+		return fmt.Sprintf("%s_%s", k.pod.Namespace, k.pod.Name)
 	}
-	return fmt.Sprintf("%s_%d", k.pod.Name, k.port)
+	return fmt.Sprintf("%s_%s_%d", k.pod.Namespace, k.pod.Name, k.port)
 }
 
 // Route implements [types.Router] using power of two choices algorithm.

--- a/pkg/plugins/gateway/algorithms/power_of_two.go
+++ b/pkg/plugins/gateway/algorithms/power_of_two.go
@@ -99,19 +99,6 @@ func NewPowerOfTwoRouterWithRedis(redisClient *redis.Client, keyRotationSec ...i
 	return router, nil
 }
 
-// podServerKey represents a pod with specific port
-type podServerKey struct {
-	pod  *v1.Pod
-	port int
-}
-
-func (k podServerKey) String() string {
-	if k.port == 0 {
-		return fmt.Sprintf("%s_%s", k.pod.Namespace, k.pod.Name)
-	}
-	return fmt.Sprintf("%s_%s_%d", k.pod.Namespace, k.pod.Name, k.port)
-}
-
 // Route implements [types.Router] using power of two choices algorithm.
 // It randomly selects two candidates and routes to the one with fewer running requests.
 func (p *PowerOfTwoRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) (string, error) {

--- a/pkg/plugins/gateway/algorithms/power_of_two_test.go
+++ b/pkg/plugins/gateway/algorithms/power_of_two_test.go
@@ -134,7 +134,7 @@ func TestPowerOfTwoRouter_podServerKey(t *testing.T) {
 				pod:  pod,
 				port: 8001,
 			},
-			want: "test-pod_8001",
+			want: "default_test-pod_8001",
 		},
 		{
 			name: "without port",
@@ -142,7 +142,7 @@ func TestPowerOfTwoRouter_podServerKey(t *testing.T) {
 				pod:  pod,
 				port: 0,
 			},
-			want: "test-pod",
+			want: "default_test-pod",
 		},
 	}
 
@@ -174,7 +174,7 @@ func TestPowerOfTwoRouter_buildRedisKey(t *testing.T) {
 				pod:  pod,
 				port: 8001,
 			},
-			wantMatch: "po2_req_count:test-model:test-pod_8001:",
+			wantMatch: "po2_req_count:test-model:default_test-pod_8001:",
 		},
 		{
 			name:      "without port",
@@ -183,7 +183,7 @@ func TestPowerOfTwoRouter_buildRedisKey(t *testing.T) {
 				pod:  pod,
 				port: 0,
 			},
-			wantMatch: "po2_req_count:test-model:test-pod:",
+			wantMatch: "po2_req_count:test-model:default_test-pod:",
 		},
 	}
 

--- a/pkg/plugins/gateway/algorithms/power_of_two_test.go
+++ b/pkg/plugins/gateway/algorithms/power_of_two_test.go
@@ -134,7 +134,7 @@ func TestPowerOfTwoRouter_podServerKey(t *testing.T) {
 				pod:  pod,
 				port: 8001,
 			},
-			want: "default_test-pod_8001",
+			want: "default/test-pod/8001",
 		},
 		{
 			name: "without port",
@@ -142,7 +142,7 @@ func TestPowerOfTwoRouter_podServerKey(t *testing.T) {
 				pod:  pod,
 				port: 0,
 			},
-			want: "default_test-pod",
+			want: "default/test-pod",
 		},
 	}
 
@@ -174,7 +174,7 @@ func TestPowerOfTwoRouter_buildRedisKey(t *testing.T) {
 				pod:  pod,
 				port: 8001,
 			},
-			wantMatch: "po2_req_count:test-model:default_test-pod_8001:",
+			wantMatch: "po2_req_count:test-model:default/test-pod/8001:",
 		},
 		{
 			name:      "without port",
@@ -183,7 +183,7 @@ func TestPowerOfTwoRouter_buildRedisKey(t *testing.T) {
 				pod:  pod,
 				port: 0,
 			},
-			wantMatch: "po2_req_count:test-model:default_test-pod:",
+			wantMatch: "po2_req_count:test-model:default/test-pod:",
 		},
 	}
 

--- a/pkg/plugins/gateway/algorithms/prefix_cache.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"os"
 	"sort"
 	"strconv"
 	"sync"
@@ -171,8 +170,8 @@ func RegisterPrefixCacheRouterWithRedis(redisClient *redis.Client) {
 // kvSyncPrefixCacheRouter handles routing when KV sync is enabled
 type kvSyncPrefixCacheRouter struct {
 	cache          cache.Cache
-	tokenizerPool  TokenizerPoolInterface // Add TokenizerPool reference
-	syncIndexer    *syncindexer.SyncPrefixHashTable
+	tokenizerPool  TokenizerPoolInterface           // Add TokenizerPool reference
+	syncIndexer    *syncindexer.SyncPrefixHashTable // Use concrete type
 	metricsEnabled bool
 	requestCounter RequestCounter // Request counter for load balancing
 }
@@ -290,10 +289,10 @@ func NewPrefixCacheRouterWithRedis(redisClient *redis.Client) (types.Router, err
 
 	// Initialize request counter
 	var requestCounter RequestCounter
-	useRedisReqCnt := redisClient != nil && os.Getenv("AIBRIX_PREFIX_CACHE_USE_REDIS_REQCNT") == "true"
+	useRedisReqCnt := redisClient != nil && utils.LoadEnvBool(constants.EnvPrefixCacheUseRedisReqCnt, false)
 	if useRedisReqCnt {
 		// Use Redis-based request counter
-		requestCounter = NewRedisRequestCounter(redisClient, podRunningRequestImbalanceAbsCount)
+		requestCounter = NewRedisRequestCounter(redisClient)
 		klog.Info("Using Redis-based request counter for prefix cache router")
 	} else {
 		// Use local metrics-based request counter
@@ -326,22 +325,36 @@ func NewPrefixCacheRouterWithRedis(redisClient *redis.Client) (types.Router, err
 
 	// Only create KV sync router if enabled
 	if kvSyncEnabled && useRemoteTokenizer && tokenizerPool != nil {
-		kvSyncRouter := &kvSyncPrefixCacheRouter{
-			cache:          c,
-			tokenizerPool:  tokenizerPool, // Pass the pool reference
-			syncIndexer:    syncindexer.GetSharedSyncPrefixHashTable(),
-			metricsEnabled: true,
-			requestCounter: requestCounter, // Use the same request counter
-		}
+		// Get the shared sync indexer instance - this is the same instance
+		// that receives KV events from vLLM pods via the KV event subscriber
+		syncIdx := syncindexer.GetSharedSyncPrefixHashTable()
+		if syncIdx == nil {
+			klog.Warning("KV sync enabled but sync indexer not initialized, falling back to local indexer")
+			// Update metrics to reflect fallback to local indexer
+			if metrics := getPrefixCacheMetrics(); metrics != nil {
+				metrics.prefixCacheIndexerStatus.WithLabelValues("", "local").Set(1)
+				metrics.prefixCacheIndexerStatus.WithLabelValues("", "sync").Set(0)
+			}
+		} else {
+			kvSyncRouter := &kvSyncPrefixCacheRouter{
+				cache:          c,
+				tokenizerPool:  tokenizerPool, // Pass the pool reference
+				syncIndexer:    syncIdx,       // Use the shared sync indexer
+				metricsEnabled: true,
+				requestCounter: requestCounter, // Use the same request counter
+			}
 
-		router.kvSyncRouter = kvSyncRouter
+			router.kvSyncRouter = kvSyncRouter
 
-		// Set initial metrics only if KV sync is enabled
-		if metrics := getPrefixCacheMetrics(); metrics != nil {
-			metrics.prefixCacheIndexerStatus.WithLabelValues("", "sync").Set(1)
-			metrics.prefixCacheIndexerStatus.WithLabelValues("", "local").Set(0)
+			// Set initial metrics only if KV sync is enabled
+			if metrics := getPrefixCacheMetrics(); metrics != nil {
+				metrics.prefixCacheIndexerStatus.WithLabelValues("", "sync").Set(1)
+				metrics.prefixCacheIndexerStatus.WithLabelValues("", "local").Set(0)
+			}
 		}
-	} else {
+	}
+
+	if router.kvSyncRouter == nil {
 		// Set local indexer metrics only if metrics are enabled
 		metricsEnabled := utils.LoadEnvBool(constants.EnvPrefixCacheLocalRouterMetricsEnabled, false)
 		if metricsEnabled {
@@ -403,11 +416,13 @@ func (p prefixCacheRouter) routeOriginal(ctx *types.RoutingContext, readyPodList
 	readyPods := readyPodList.All()
 	readyPodsMap := map[string]struct{}{}
 	for _, pod := range readyPods {
-		readyPodsMap[pod.Name] = struct{}{}
+		podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+		readyPodsMap[podKey] = struct{}{}
 	}
 
 	// Get request counts once for consistency across all subsequent operations
-	podRequestCount := p.requestCounter.GetRequestCounts(ctx.Context, readyPods, false)
+	// Pass ctx directly so RequestTime can be extracted for key rotation
+	podRequestCount := p.requestCounter.GetRequestCounts(ctx, readyPods)
 
 	leastReqPodList, isLoadImbalanced := getTargetPodListOnLoadImbalance(podRequestCount, readyPods)
 	if isLoadImbalanced {
@@ -420,7 +435,8 @@ func (p prefixCacheRouter) routeOriginal(ctx *types.RoutingContext, readyPodList
 		readyPodsMap = map[string]struct{}{}
 		// filter the readyPodsMap by leastReqPodList used by below codes
 		for _, pod := range leastReqPodList {
-			readyPodsMap[pod.Name] = struct{}{}
+			podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+			readyPodsMap[podKey] = struct{}{}
 		}
 		klog.V(4).InfoS("prefix_cache_load_imbalanced",
 			"request_id", ctx.RequestID,
@@ -432,7 +448,7 @@ func (p prefixCacheRouter) routeOriginal(ctx *types.RoutingContext, readyPodList
 	klog.V(4).InfoS("prefix_hashes", "request_id", ctx.RequestID, "prefix_hashes", prefixHashes)
 
 	if len(matchedPods) > 0 {
-		targetPod = getTargetPodFromMatchedPods(podRequestCount, readyPods, matchedPods)
+		targetPod = getTargetPodFromMatchedPodsWithKeys(podRequestCount, readyPods, matchedPods)
 		if targetPod != nil {
 			klog.InfoS("prefix_cache_matched_pods",
 				"request_id", ctx.RequestID,
@@ -470,7 +486,8 @@ func (p prefixCacheRouter) routeOriginal(ctx *types.RoutingContext, readyPodList
 	}
 
 	if len(prefixHashes) > 0 {
-		p.prefixCacheIndexer.AddPrefix(prefixHashes, ctx.Model, targetPod.Name)
+		podKey := &podServerKey{pod: targetPod}
+		p.prefixCacheIndexer.AddPrefix(prefixHashes, ctx.Model, podKey.String())
 	}
 
 	ctx.SetTargetPod(targetPod)
@@ -582,6 +599,7 @@ func (k *kvSyncPrefixCacheRouter) tokenizeChatRequest(ctx *types.RoutingContext,
 		return nil
 	}
 
+	startTime := time.Now()
 	// Perform tokenization with chat template
 	result, err := extTokenizer.TokenizeWithOptions(ctx.Context, *input)
 	if err != nil {
@@ -598,7 +616,8 @@ func (k *kvSyncPrefixCacheRouter) tokenizeChatRequest(ctx *types.RoutingContext,
 		"message_count", len(input.Messages),
 		"token_count", len(result.Tokens),
 		"add_generation_prompt", input.AddGenerationPrompt,
-		"add_special_tokens", input.AddSpecialTokens)
+		"add_special_tokens", input.AddSpecialTokens,
+		"duration", time.Since(startTime))
 	return tokens
 }
 
@@ -654,12 +673,14 @@ func (k *kvSyncPrefixCacheRouter) Route(ctx *types.RoutingContext, readyPodList 
 	// Build pod key map for sync indexer
 	readyPodsMap := map[string]struct{}{}
 	for _, pod := range readyPods {
-		podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-		readyPodsMap[podKey] = struct{}{}
+		// TODO: support multi-card
+		podKey := &podServerKey{pod: pod}
+		readyPodsMap[podKey.String()] = struct{}{}
 	}
 
 	// Get request counts once for consistency across all subsequent operations
-	podRequestCount := k.requestCounter.GetRequestCounts(ctx.Context, readyPods, false)
+	// Pass ctx directly so RequestTime can be extracted for key rotation
+	podRequestCount := k.requestCounter.GetRequestCounts(ctx, readyPods)
 
 	// Check for load imbalance first
 	leastReqPodList, isLoadImbalanced := getTargetPodListOnLoadImbalance(podRequestCount, readyPods)
@@ -673,8 +694,8 @@ func (k *kvSyncPrefixCacheRouter) Route(ctx *types.RoutingContext, readyPodList 
 		readyPodsMap = map[string]struct{}{}
 		// filter the readyPodsMap by leastReqPodList used by below codes
 		for _, pod := range leastReqPodList {
-			podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-			readyPodsMap[podKey] = struct{}{}
+			podKey := &podServerKey{pod: pod}
+			readyPodsMap[podKey.String()] = struct{}{}
 		}
 		klog.InfoS("prefix_cache_load_imbalanced",
 			"request_id", ctx.RequestID,
@@ -697,15 +718,8 @@ func (k *kvSyncPrefixCacheRouter) Route(ctx *types.RoutingContext, readyPodList 
 		"ready_pods", readyPodList.Len())
 
 	if len(matchedPods) > 0 {
-		// For KV sync router, we need to convert podRequestCount to use pod keys (namespace/podName)
-		podRequestCountWithKeys := make(map[string]int)
-		for _, pod := range readyPods {
-			podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-			if count, exists := podRequestCount[pod.Name]; exists {
-				podRequestCountWithKeys[podKey] = count
-			}
-		}
-		targetPod = getTargetPodFromMatchedPodsWithKeys(podRequestCountWithKeys, readyPods, matchedPods)
+		// For KV sync router, we need podRequestCount to use pod keys (namespace/podName)
+		targetPod = getTargetPodFromMatchedPodsWithKeys(podRequestCount, readyPods, matchedPods)
 		if targetPod != nil {
 			klog.InfoS("prefix_cache_matched_pods",
 				"request_id", ctx.RequestID,
@@ -741,11 +755,6 @@ func (k *kvSyncPrefixCacheRouter) Route(ctx *types.RoutingContext, readyPodList 
 
 	selectedPodKey := fmt.Sprintf("%s/%s", targetPod.Namespace, targetPod.Name)
 
-	// Add prefix to sync indexer if we have prefixes
-	if len(prefixHashes) > 0 {
-		_ = k.syncIndexer.AddPrefix(modelName, loraID, selectedPodKey, prefixHashes)
-	}
-
 	// Record routing decision metric if metrics are enabled
 	if k.metricsEnabled {
 		matchPercent := 0
@@ -769,8 +778,8 @@ func getTargetPodFromMatchedPodsWithKeys(podRequestCount map[string]int, readyPo
 	// Build pod key to pod mapping
 	podKeyToPod := make(map[string]*v1.Pod)
 	for _, pod := range readyPods {
-		podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-		podKeyToPod[podKey] = pod
+		podKey := &podServerKey{pod: pod}
+		podKeyToPod[podKey.String()] = pod
 	}
 
 	for _, cnt := range podRequestCount {
@@ -807,44 +816,6 @@ func getTargetPodFromMatchedPodsWithKeys(podRequestCount map[string]int, readyPo
 	return podKeyToPod[targetPodKey]
 }
 
-func getTargetPodFromMatchedPods(podRequestCount map[string]int, readyPods []*v1.Pod, matchedPods map[string]int) *v1.Pod {
-	var targetPodName string
-	requestCount := []float64{}
-
-	for _, cnt := range podRequestCount {
-		requestCount = append(requestCount, float64(cnt))
-	}
-	meanRequestCount := mean(requestCount)
-	stdDevRequestCount := standardDeviation(requestCount)
-
-	podnames := []string{}
-	for podname := range matchedPods {
-		podnames = append(podnames, podname)
-	}
-	rand.Shuffle(len(podnames), func(i, j int) {
-		podnames[i], podnames[j] = podnames[j], podnames[i]
-	})
-
-	// sort pods with decreasing %perfixmatch AND for same %prefixmatch sort by increasing request count
-	sort.SliceStable(podnames, func(i, j int) bool {
-		if matchedPods[podnames[i]] == matchedPods[podnames[j]] {
-			return podRequestCount[podnames[i]] < podRequestCount[podnames[j]]
-		}
-		return matchedPods[podnames[i]] > matchedPods[podnames[j]]
-	})
-
-	// select targetpod with highest %prefixmatch and request_count within stddev
-	for _, podname := range podnames {
-		reqCnt := float64(podRequestCount[podname])
-		if reqCnt <= meanRequestCount+float64(standardDeviationFactor)*stdDevRequestCount {
-			targetPodName = podname
-			break
-		}
-	}
-	targetPod, _ := utils.FilterPodByName(targetPodName, readyPods)
-	return targetPod
-}
-
 // getTargetPodListOnLoadImbalance evaluates if the load is imbalanced based on the abs difference between
 // pods with min and max outstanding request counts
 func getTargetPodListOnLoadImbalance(podRequestCount map[string]int, readyPods []*v1.Pod) ([]*v1.Pod, bool) {
@@ -867,9 +838,17 @@ func getTargetPodListOnLoadImbalance(podRequestCount map[string]int, readyPods [
 			maxValue = value
 		}
 	}
-	for podname, value := range podRequestCount {
+
+	// get pods with min request count
+	minKeys := make(map[string]bool)
+	for podKey, value := range podRequestCount {
 		if minValue == value {
-			pod, _ := utils.FilterPodByName(podname, readyPods)
+			minKeys[podKey] = true
+		}
+	}
+	for _, pod := range readyPods {
+		podKey := &podServerKey{pod: pod}
+		if minKeys[podKey.String()] {
 			targetPodList = append(targetPodList, pod)
 		}
 	}
@@ -898,20 +877,27 @@ func getRequestCountsWithKeys(cache cache.Cache, readyPods []*v1.Pod) map[string
 // selectTargetPodFromRequestCounts selects a pod with the least request count from the given podRequestCount map
 func selectTargetPodFromRequestCounts(podRequestCount map[string]int, readyPods []*v1.Pod) *v1.Pod {
 	var targetPod *v1.Pod
-	targetPods := []string{}
+	targetPodKeys := []string{}
 
 	minCount := math.MaxInt32
 	klog.V(4).InfoS("selectTargetPodFromRequestCounts", "podRequestCount", podRequestCount)
-	for podname, totalReq := range podRequestCount {
+	for podKey, totalReq := range podRequestCount {
 		if totalReq < minCount {
 			minCount = totalReq
-			targetPods = []string{podname}
+			targetPodKeys = []string{podKey}
 		} else if totalReq == minCount {
-			targetPods = append(targetPods, podname)
+			targetPodKeys = append(targetPodKeys, podKey)
 		}
 	}
-	if len(targetPods) > 0 {
-		targetPod, _ = utils.FilterPodByName(targetPods[rand.Intn(len(targetPods))], readyPods)
+	if len(targetPodKeys) > 0 {
+		selectedPodKey := targetPodKeys[rand.Intn(len(targetPodKeys))]
+		for _, pod := range readyPods {
+			key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+			if key == selectedPodKey {
+				targetPod = pod
+				break
+			}
+		}
 	}
 	return targetPod
 }

--- a/pkg/plugins/gateway/algorithms/prefix_cache.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache.go
@@ -22,12 +22,14 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"sort"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
@@ -155,7 +157,15 @@ func getPrefixCacheMetrics() *PrefixCacheMetrics {
 }
 
 func init() {
-	Register(RouterPrefixCache, NewPrefixCacheRouter)
+	Register(RouterPrefixCache, func() (types.Router, error) {
+		return NewPrefixCacheRouterWithRedis(nil)
+	})
+}
+
+func RegisterPrefixCacheRouterWithRedis(redisClient *redis.Client) {
+	Register(RouterPrefixCache, func() (types.Router, error) {
+		return NewPrefixCacheRouterWithRedis(redisClient)
+	})
 }
 
 // kvSyncPrefixCacheRouter handles routing when KV sync is enabled
@@ -164,6 +174,7 @@ type kvSyncPrefixCacheRouter struct {
 	tokenizerPool  TokenizerPoolInterface // Add TokenizerPool reference
 	syncIndexer    *syncindexer.SyncPrefixHashTable
 	metricsEnabled bool
+	requestCounter RequestCounter // Request counter for load balancing
 }
 
 type prefixCacheRouter struct {
@@ -176,6 +187,9 @@ type prefixCacheRouter struct {
 
 	// KV sync router - only created when needed
 	kvSyncRouter *kvSyncPrefixCacheRouter
+
+	// Request counter for load balancing
+	requestCounter RequestCounter
 }
 
 // TokenizerPoolInterface defines the interface for tokenizer pools
@@ -194,7 +208,7 @@ func (p *panicTokenizer) TokenizeInputText(text string) ([]byte, error) {
 		"Use the model-aware getTokenizerForRequest(ctx) helper method instead.")
 }
 
-func NewPrefixCacheRouter() (types.Router, error) {
+func NewPrefixCacheRouterWithRedis(redisClient *redis.Client) (types.Router, error) {
 	// Initialize prefix cache metrics if enabled
 	if err := initializePrefixCacheMetrics(); err != nil {
 		klog.Errorf("Failed to initialize prefix cache metrics: %v", err)
@@ -274,11 +288,25 @@ func NewPrefixCacheRouter() (types.Router, error) {
 		}
 	}
 
+	// Initialize request counter
+	var requestCounter RequestCounter
+	useRedisReqCnt := redisClient != nil && os.Getenv("AIBRIX_PREFIX_CACHE_USE_REDIS_REQCNT") == "true"
+	if useRedisReqCnt {
+		// Use Redis-based request counter
+		requestCounter = NewRedisRequestCounter(redisClient, podRunningRequestImbalanceAbsCount)
+		klog.Info("Using Redis-based request counter for prefix cache router")
+	} else {
+		// Use local metrics-based request counter
+		requestCounter = NewLocalRequestCounter(c)
+		klog.Info("Using local metrics-based request counter for prefix cache router")
+	}
+
 	// Log final configuration
 	klog.InfoS("prefix_cache_configurations",
 		"tokenizer_type", tokenizerType,
 		"remote_tokenizer_enabled", tokenizerPool != nil,
 		"kv_sync_enabled", kvSyncEnabled,
+		"redis_request_counter_enabled", useRedisReqCnt,
 		"pod_running_request_imbalance_abs_count", podRunningRequestImbalanceAbsCount,
 		"matched_pods_running_requests_standard_deviation_factor", standardDeviationFactor)
 
@@ -287,6 +315,7 @@ func NewPrefixCacheRouter() (types.Router, error) {
 		cache:              c,
 		tokenizer:          tokenizerObj,
 		prefixCacheIndexer: prefixcacheindexer.GetSharedPrefixHashTable(),
+		requestCounter:     requestCounter,
 		// Only assign tokenizerPool if it's not nil to avoid interface nil issues
 	}
 
@@ -302,6 +331,7 @@ func NewPrefixCacheRouter() (types.Router, error) {
 			tokenizerPool:  tokenizerPool, // Pass the pool reference
 			syncIndexer:    syncindexer.GetSharedSyncPrefixHashTable(),
 			metricsEnabled: true,
+			requestCounter: requestCounter, // Use the same request counter
 		}
 
 		router.kvSyncRouter = kvSyncRouter
@@ -376,12 +406,15 @@ func (p prefixCacheRouter) routeOriginal(ctx *types.RoutingContext, readyPodList
 		readyPodsMap[pod.Name] = struct{}{}
 	}
 
-	leastReqPodList, isLoadImbalanced := getTargetPodListOnLoadImbalance(p.cache, readyPods)
+	// Get request counts once for consistency across all subsequent operations
+	podRequestCount := p.requestCounter.GetRequestCounts(ctx.Context, readyPods, false)
+
+	leastReqPodList, isLoadImbalanced := getTargetPodListOnLoadImbalance(podRequestCount, readyPods)
 	if isLoadImbalanced {
 		if len(leastReqPodList) == 0 {
 			klog.InfoS("prefix_cache_load_imbalanced_no_target",
 				"request_id", ctx.RequestID,
-				"pod_request_count", getRequestCounts(p.cache, readyPods))
+				"pod_request_count", podRequestCount)
 			return "", errors.New("no target pod found when load imbalanced")
 		}
 		readyPodsMap = map[string]struct{}{}
@@ -391,7 +424,7 @@ func (p prefixCacheRouter) routeOriginal(ctx *types.RoutingContext, readyPodList
 		}
 		klog.V(4).InfoS("prefix_cache_load_imbalanced",
 			"request_id", ctx.RequestID,
-			"pod_request_count", getRequestCounts(p.cache, readyPods),
+			"pod_request_count", podRequestCount,
 			"target_pod_list", readyPodsMap)
 	}
 	// handle request with readyPodsMap from balanced or imbalanced filter
@@ -399,37 +432,37 @@ func (p prefixCacheRouter) routeOriginal(ctx *types.RoutingContext, readyPodList
 	klog.V(4).InfoS("prefix_hashes", "request_id", ctx.RequestID, "prefix_hashes", prefixHashes)
 
 	if len(matchedPods) > 0 {
-		targetPod = getTargetPodFromMatchedPods(p.cache, readyPods, matchedPods)
+		targetPod = getTargetPodFromMatchedPods(podRequestCount, readyPods, matchedPods)
 		if targetPod != nil {
 			klog.InfoS("prefix_cache_matched_pods",
 				"request_id", ctx.RequestID,
 				"target_pod", targetPod.Name,
 				"target_pod_ip", targetPod.Status.PodIP,
 				"matched_pods", matchedPods,
-				"pod_request_count", getRequestCounts(p.cache, readyPods))
+				"pod_request_count", podRequestCount)
 		} else {
 			klog.InfoS("prefix_cache_skip_matched_pods",
 				"request_id", ctx.RequestID,
 				"matched_pods", matchedPods,
-				"pod_request_count", getRequestCounts(p.cache, readyPods))
+				"pod_request_count", podRequestCount)
 		}
 	}
 
 	// no pod with prefix match, as a fallback select pod with least request count
 	if len(matchedPods) == 0 || targetPod == nil {
-		targetPod = selectTargetPodWithLeastRequestCount(p.cache, readyPods)
+		targetPod = selectTargetPodFromRequestCounts(podRequestCount, readyPods)
 		if targetPod != nil {
 			klog.InfoS("prefix_cache_fallback_least_request_count",
 				"request_id", ctx.RequestID,
 				"target_pod", targetPod.Name,
 				"target_pod_ip", targetPod.Status.PodIP,
 				"matched_pods", matchedPods,
-				"pod_request_count", getRequestCounts(p.cache, readyPods))
+				"pod_request_count", podRequestCount)
 		} else {
 			klog.InfoS("prefix_cache_no_pods_available",
 				"request_id", ctx.RequestID,
 				"matched_pods", matchedPods,
-				"pod_request_count", getRequestCounts(p.cache, readyPods))
+				"pod_request_count", podRequestCount)
 		}
 	}
 	if targetPod == nil {
@@ -625,13 +658,16 @@ func (k *kvSyncPrefixCacheRouter) Route(ctx *types.RoutingContext, readyPodList 
 		readyPodsMap[podKey] = struct{}{}
 	}
 
+	// Get request counts once for consistency across all subsequent operations
+	podRequestCount := k.requestCounter.GetRequestCounts(ctx.Context, readyPods, false)
+
 	// Check for load imbalance first
-	leastReqPodList, isLoadImbalanced := getTargetPodListOnLoadImbalance(k.cache, readyPods)
+	leastReqPodList, isLoadImbalanced := getTargetPodListOnLoadImbalance(podRequestCount, readyPods)
 	if isLoadImbalanced {
 		if len(leastReqPodList) == 0 {
 			klog.InfoS("prefix_cache_load_imbalanced_no_target",
 				"request_id", ctx.RequestID,
-				"pod_request_count", getRequestCounts(k.cache, readyPods))
+				"pod_request_count", podRequestCount)
 			return "", errors.New("no target pod found when load imbalanced")
 		}
 		readyPodsMap = map[string]struct{}{}
@@ -642,7 +678,7 @@ func (k *kvSyncPrefixCacheRouter) Route(ctx *types.RoutingContext, readyPodList 
 		}
 		klog.InfoS("prefix_cache_load_imbalanced",
 			"request_id", ctx.RequestID,
-			"pod_request_count", getRequestCounts(k.cache, readyPods),
+			"pod_request_count", podRequestCount,
 			"target_pod_list", readyPodsMap)
 	}
 
@@ -661,32 +697,40 @@ func (k *kvSyncPrefixCacheRouter) Route(ctx *types.RoutingContext, readyPodList 
 		"ready_pods", readyPodList.Len())
 
 	if len(matchedPods) > 0 {
-		targetPod = getTargetPodFromMatchedPodsWithKeys(k.cache, readyPods, matchedPods)
+		// For KV sync router, we need to convert podRequestCount to use pod keys (namespace/podName)
+		podRequestCountWithKeys := make(map[string]int)
+		for _, pod := range readyPods {
+			podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+			if count, exists := podRequestCount[pod.Name]; exists {
+				podRequestCountWithKeys[podKey] = count
+			}
+		}
+		targetPod = getTargetPodFromMatchedPodsWithKeys(podRequestCountWithKeys, readyPods, matchedPods)
 		if targetPod != nil {
 			klog.InfoS("prefix_cache_matched_pods",
 				"request_id", ctx.RequestID,
 				"target_pod", targetPod.Name,
 				"target_pod_ip", targetPod.Status.PodIP,
 				"matched_pods", matchedPods,
-				"pod_request_count", getRequestCounts(k.cache, readyPods))
+				"pod_request_count", podRequestCount)
 		} else {
 			klog.InfoS("prefix_cache_skip_matched_pods",
 				"request_id", ctx.RequestID,
 				"matched_pods", matchedPods,
-				"pod_request_count", getRequestCounts(k.cache, readyPods))
+				"pod_request_count", podRequestCount)
 		}
 	}
 
 	// Fallback to least request count selection
 	if len(matchedPods) == 0 || targetPod == nil {
-		targetPod = selectTargetPodWithLeastRequestCount(k.cache, readyPods)
+		targetPod = selectTargetPodFromRequestCounts(podRequestCount, readyPods)
 		if targetPod != nil {
 			klog.InfoS("prefix_cache_fallback_least_request_count",
 				"request_id", ctx.RequestID,
 				"target_pod", targetPod.Name,
 				"target_pod_ip", targetPod.Status.PodIP,
 				"matched_pods", matchedPods,
-				"pod_request_count", getRequestCounts(k.cache, readyPods))
+				"pod_request_count", podRequestCount)
 		}
 	}
 
@@ -718,7 +762,7 @@ func (k *kvSyncPrefixCacheRouter) Route(ctx *types.RoutingContext, readyPodList 
 }
 
 // getTargetPodFromMatchedPodsWithKeys is similar to getTargetPodFromMatchedPods but uses pod keys
-func getTargetPodFromMatchedPodsWithKeys(cache cache.Cache, readyPods []*v1.Pod, matchedPods map[string]int) *v1.Pod {
+func getTargetPodFromMatchedPodsWithKeys(podRequestCount map[string]int, readyPods []*v1.Pod, matchedPods map[string]int) *v1.Pod {
 	var targetPodKey string
 	requestCount := []float64{}
 
@@ -729,7 +773,6 @@ func getTargetPodFromMatchedPodsWithKeys(cache cache.Cache, readyPods []*v1.Pod,
 		podKeyToPod[podKey] = pod
 	}
 
-	podRequestCount := getRequestCountsWithKeys(cache, readyPods)
 	for _, cnt := range podRequestCount {
 		requestCount = append(requestCount, float64(cnt))
 	}
@@ -764,11 +807,10 @@ func getTargetPodFromMatchedPodsWithKeys(cache cache.Cache, readyPods []*v1.Pod,
 	return podKeyToPod[targetPodKey]
 }
 
-func getTargetPodFromMatchedPods(cache cache.Cache, readyPods []*v1.Pod, matchedPods map[string]int) *v1.Pod {
+func getTargetPodFromMatchedPods(podRequestCount map[string]int, readyPods []*v1.Pod, matchedPods map[string]int) *v1.Pod {
 	var targetPodName string
 	requestCount := []float64{}
 
-	podRequestCount := getRequestCounts(cache, readyPods)
 	for _, cnt := range podRequestCount {
 		requestCount = append(requestCount, float64(cnt))
 	}
@@ -805,13 +847,11 @@ func getTargetPodFromMatchedPods(cache cache.Cache, readyPods []*v1.Pod, matched
 
 // getTargetPodListOnLoadImbalance evaluates if the load is imbalanced based on the abs difference between
 // pods with min and max outstanding request counts
-func getTargetPodListOnLoadImbalance(cache cache.Cache, readyPods []*v1.Pod) ([]*v1.Pod, bool) {
+func getTargetPodListOnLoadImbalance(podRequestCount map[string]int, readyPods []*v1.Pod) ([]*v1.Pod, bool) {
 	var imbalance bool
 	var targetPodList []*v1.Pod
 	minValue := math.MaxInt32
 	maxValue := math.MinInt32
-
-	podRequestCount := getRequestCounts(cache, readyPods)
 
 	// Handle empty podRequestCount case
 	if len(podRequestCount) == 0 {
@@ -855,20 +895,18 @@ func getRequestCountsWithKeys(cache cache.Cache, readyPods []*v1.Pod) map[string
 	return podRequestCount
 }
 
-func selectPodWithLeastRequestCount(cache cache.Cache, readyPods []*v1.Pod) *v1.Pod {
+// selectTargetPodFromRequestCounts selects a pod with the least request count from the given podRequestCount map
+func selectTargetPodFromRequestCounts(podRequestCount map[string]int, readyPods []*v1.Pod) *v1.Pod {
 	var targetPod *v1.Pod
 	targetPods := []string{}
 
 	minCount := math.MaxInt32
-	podRequestCount := getRequestCounts(cache, readyPods)
-	klog.V(4).InfoS("selectPodWithLeastRequestCount", "podRequestCount", podRequestCount)
-	for _, totalReq := range podRequestCount {
-		if totalReq <= minCount {
-			minCount = totalReq
-		}
-	}
+	klog.V(4).InfoS("selectTargetPodFromRequestCounts", "podRequestCount", podRequestCount)
 	for podname, totalReq := range podRequestCount {
-		if totalReq == minCount {
+		if totalReq < minCount {
+			minCount = totalReq
+			targetPods = []string{podname}
+		} else if totalReq == minCount {
 			targetPods = append(targetPods, podname)
 		}
 	}

--- a/pkg/plugins/gateway/algorithms/prefix_cache_new_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_new_test.go
@@ -102,6 +102,7 @@ func TestPrefixCacheRouterConfiguration(t *testing.T) {
 				cache:              c,
 				tokenizer:          tok,
 				prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
+			requestCounter:     NewLocalRequestCounter(c),
 			}
 
 			// Set up KV sync router if needed
@@ -115,6 +116,7 @@ func TestPrefixCacheRouterConfiguration(t *testing.T) {
 					tokenizerPool:  mockPool,
 					syncIndexer:    syncindexer.NewSyncPrefixHashTable(),
 					metricsEnabled: false,
+		requestCounter: NewLocalRequestCounter(c),
 				}
 				router.kvSyncRouter = kvSyncRouter
 			}
@@ -188,6 +190,7 @@ func TestPrefixCacheRouterWithSyncIndexer(t *testing.T) {
 		tokenizerPool:  mockPool,
 		syncIndexer:    syncindexer.NewSyncPrefixHashTable(),
 		metricsEnabled: false, // Disable metrics for testing
+		requestCounter: NewLocalRequestCounter(c),
 	}
 
 	router := prefixCacheRouter{
@@ -195,6 +198,7 @@ func TestPrefixCacheRouterWithSyncIndexer(t *testing.T) {
 		tokenizer:          tok,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 		kvSyncRouter:       kvSyncRouter,
+		requestCounter:     NewLocalRequestCounter(c),
 	}
 
 	// Create pod list
@@ -268,6 +272,7 @@ func TestPrefixCacheRouterWithLocalIndexer(t *testing.T) {
 		cache:              c,
 		tokenizer:          tok,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
+		requestCounter:     NewLocalRequestCounter(c),
 	}
 
 	// Create pod list
@@ -323,6 +328,7 @@ func TestPrefixCacheRouterFallback(t *testing.T) {
 		tokenizerPool:  mockPool,
 		syncIndexer:    nil,   // No indexer
 		metricsEnabled: false, // Disable metrics for testing
+		requestCounter: NewLocalRequestCounter(c),
 	}
 
 	router := prefixCacheRouter{
@@ -330,6 +336,7 @@ func TestPrefixCacheRouterFallback(t *testing.T) {
 		tokenizer:          tok,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 		kvSyncRouter:       kvSyncRouterNoIndexer,
+		requestCounter: NewLocalRequestCounter(c),
 	}
 
 	ctx := types.NewRoutingContext(context.Background(), RouterPrefixCache, "test-model", "test", "req1", "")
@@ -389,6 +396,7 @@ func TestPrefixCacheRouterMetrics(t *testing.T) {
 		tokenizerPool:  mockPool,
 		syncIndexer:    syncindexer.NewSyncPrefixHashTable(),
 		metricsEnabled: true, // Enable metrics for this test
+		requestCounter: NewLocalRequestCounter(c),
 	}
 
 	router := prefixCacheRouter{
@@ -396,6 +404,7 @@ func TestPrefixCacheRouterMetrics(t *testing.T) {
 		tokenizer:          tok,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 		kvSyncRouter:       kvSyncRouter,
+		requestCounter: NewLocalRequestCounter(c),
 	}
 
 	// Set indexer status metric like the constructor does
@@ -524,6 +533,7 @@ func TestPrefixCacheRouterLatencyMetric(t *testing.T) {
 		tokenizerPool:  mockPool,
 		syncIndexer:    syncindexer.NewSyncPrefixHashTable(),
 		metricsEnabled: true, // Enable metrics for latency test
+		requestCounter: NewLocalRequestCounter(c),
 	}
 
 	router := prefixCacheRouter{
@@ -531,6 +541,7 @@ func TestPrefixCacheRouterLatencyMetric(t *testing.T) {
 		tokenizer:          tok,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 		kvSyncRouter:       kvSyncRouter,
+		requestCounter: NewLocalRequestCounter(c),
 	}
 
 	podList := testPodsFromCache(c)
@@ -626,6 +637,7 @@ func TestPrefixCacheRouterWithRemoteTokenizer(t *testing.T) {
 		tokenizerPool:  mockPool,
 		syncIndexer:    syncIdx,
 		metricsEnabled: false,
+		requestCounter: NewLocalRequestCounter(c),
 	}
 
 	// Create router with remote tokenizer
@@ -634,6 +646,7 @@ func TestPrefixCacheRouterWithRemoteTokenizer(t *testing.T) {
 		tokenizer:          nil, // In tests, we don't create a real pool
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 		kvSyncRouter:       kvSyncRouter,
+		requestCounter: NewLocalRequestCounter(c),
 	}
 
 	// Create pod list
@@ -679,6 +692,7 @@ func TestPrefixCacheRouterEdgeCases(t *testing.T) {
 					tokenizerPool:  mockPool,
 					syncIndexer:    syncindexer.NewSyncPrefixHashTable(),
 					metricsEnabled: false, // Disable metrics for edge case test
+					requestCounter: NewLocalRequestCounter(c),
 				}
 
 				return prefixCacheRouter{
@@ -686,6 +700,7 @@ func TestPrefixCacheRouterEdgeCases(t *testing.T) {
 					tokenizer:          tok,
 					prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 					kvSyncRouter:       kvSyncRouter, // Use KV sync path to test error handling
+				requestCounter:     NewLocalRequestCounter(c),
 				}
 			},
 			setupPods: func() ([]*v1.Pod, *cache.Store) {
@@ -721,6 +736,7 @@ func TestPrefixCacheRouterEdgeCases(t *testing.T) {
 					tokenizerPool:  mockPool,
 					syncIndexer:    nil,   // nil indexer to test error
 					metricsEnabled: false, // Disable metrics for edge case test
+					requestCounter: NewLocalRequestCounter(c),
 				}
 
 				return prefixCacheRouter{
@@ -728,6 +744,7 @@ func TestPrefixCacheRouterEdgeCases(t *testing.T) {
 					tokenizer:          tok,
 					prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 					kvSyncRouter:       kvSyncRouter,
+		requestCounter: NewLocalRequestCounter(c),
 				}
 			},
 			setupPods: func() ([]*v1.Pod, *cache.Store) {
@@ -772,6 +789,7 @@ func TestPrefixCacheRouterEdgeCases(t *testing.T) {
 					tokenizer:          mockTok,
 					prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 					// No KV sync router, so uses original path which should fail on tokenizer
+				requestCounter:     NewLocalRequestCounter(c),
 				}
 			},
 			setupPods: func() ([]*v1.Pod, *cache.Store) {
@@ -847,6 +865,7 @@ func TestPrefixCacheRouterModelExtraction(t *testing.T) {
 		tokenizer:          tok,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 		// No KV sync router for model extraction test
+		requestCounter:     NewLocalRequestCounter(c),
 	}
 
 	podList := testPodsFromCache(c)
@@ -904,6 +923,7 @@ func TestPrefixCacheRouterConcurrency(t *testing.T) {
 				cache:              c,
 				tokenizer:          tok,
 				prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
+			requestCounter:     NewLocalRequestCounter(c),
 			}
 
 			if it.useKVSync {
@@ -916,6 +936,7 @@ func TestPrefixCacheRouterConcurrency(t *testing.T) {
 					tokenizerPool:  mockPool,
 					syncIndexer:    syncindexer.NewSyncPrefixHashTable(),
 					metricsEnabled: false,
+		requestCounter: NewLocalRequestCounter(c),
 				}
 				router.kvSyncRouter = kvSyncRouter
 			}

--- a/pkg/plugins/gateway/algorithms/prefix_cache_new_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_new_test.go
@@ -102,7 +102,7 @@ func TestPrefixCacheRouterConfiguration(t *testing.T) {
 				cache:              c,
 				tokenizer:          tok,
 				prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
-			requestCounter:     NewLocalRequestCounter(c),
+				requestCounter:     NewLocalRequestCounter(c),
 			}
 
 			// Set up KV sync router if needed
@@ -923,7 +923,7 @@ func TestPrefixCacheRouterConcurrency(t *testing.T) {
 				cache:              c,
 				tokenizer:          tok,
 				prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
-			requestCounter:     NewLocalRequestCounter(c),
+				requestCounter:     NewLocalRequestCounter(c),
 			}
 
 			if it.useKVSync {

--- a/pkg/plugins/gateway/algorithms/prefix_cache_new_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_new_test.go
@@ -116,7 +116,7 @@ func TestPrefixCacheRouterConfiguration(t *testing.T) {
 					tokenizerPool:  mockPool,
 					syncIndexer:    syncindexer.NewSyncPrefixHashTable(),
 					metricsEnabled: false,
-		requestCounter: NewLocalRequestCounter(c),
+					requestCounter: NewLocalRequestCounter(c),
 				}
 				router.kvSyncRouter = kvSyncRouter
 			}
@@ -336,7 +336,7 @@ func TestPrefixCacheRouterFallback(t *testing.T) {
 		tokenizer:          tok,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 		kvSyncRouter:       kvSyncRouterNoIndexer,
-		requestCounter: NewLocalRequestCounter(c),
+		requestCounter:     NewLocalRequestCounter(c),
 	}
 
 	ctx := types.NewRoutingContext(context.Background(), RouterPrefixCache, "test-model", "test", "req1", "")
@@ -404,7 +404,7 @@ func TestPrefixCacheRouterMetrics(t *testing.T) {
 		tokenizer:          tok,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 		kvSyncRouter:       kvSyncRouter,
-		requestCounter: NewLocalRequestCounter(c),
+		requestCounter:     NewLocalRequestCounter(c),
 	}
 
 	// Set indexer status metric like the constructor does
@@ -541,7 +541,7 @@ func TestPrefixCacheRouterLatencyMetric(t *testing.T) {
 		tokenizer:          tok,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 		kvSyncRouter:       kvSyncRouter,
-		requestCounter: NewLocalRequestCounter(c),
+		requestCounter:     NewLocalRequestCounter(c),
 	}
 
 	podList := testPodsFromCache(c)
@@ -646,7 +646,7 @@ func TestPrefixCacheRouterWithRemoteTokenizer(t *testing.T) {
 		tokenizer:          nil, // In tests, we don't create a real pool
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 		kvSyncRouter:       kvSyncRouter,
-		requestCounter: NewLocalRequestCounter(c),
+		requestCounter:     NewLocalRequestCounter(c),
 	}
 
 	// Create pod list
@@ -700,7 +700,7 @@ func TestPrefixCacheRouterEdgeCases(t *testing.T) {
 					tokenizer:          tok,
 					prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 					kvSyncRouter:       kvSyncRouter, // Use KV sync path to test error handling
-				requestCounter:     NewLocalRequestCounter(c),
+					requestCounter:     NewLocalRequestCounter(c),
 				}
 			},
 			setupPods: func() ([]*v1.Pod, *cache.Store) {
@@ -744,7 +744,7 @@ func TestPrefixCacheRouterEdgeCases(t *testing.T) {
 					tokenizer:          tok,
 					prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 					kvSyncRouter:       kvSyncRouter,
-		requestCounter: NewLocalRequestCounter(c),
+					requestCounter:     NewLocalRequestCounter(c),
 				}
 			},
 			setupPods: func() ([]*v1.Pod, *cache.Store) {
@@ -789,7 +789,7 @@ func TestPrefixCacheRouterEdgeCases(t *testing.T) {
 					tokenizer:          mockTok,
 					prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 					// No KV sync router, so uses original path which should fail on tokenizer
-				requestCounter:     NewLocalRequestCounter(c),
+					requestCounter: NewLocalRequestCounter(c),
 				}
 			},
 			setupPods: func() ([]*v1.Pod, *cache.Store) {
@@ -865,7 +865,7 @@ func TestPrefixCacheRouterModelExtraction(t *testing.T) {
 		tokenizer:          tok,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
 		// No KV sync router for model extraction test
-		requestCounter:     NewLocalRequestCounter(c),
+		requestCounter: NewLocalRequestCounter(c),
 	}
 
 	podList := testPodsFromCache(c)
@@ -936,7 +936,7 @@ func TestPrefixCacheRouterConcurrency(t *testing.T) {
 					tokenizerPool:  mockPool,
 					syncIndexer:    syncindexer.NewSyncPrefixHashTable(),
 					metricsEnabled: false,
-		requestCounter: NewLocalRequestCounter(c),
+					requestCounter: NewLocalRequestCounter(c),
 				}
 				router.kvSyncRouter = kvSyncRouter
 			}

--- a/pkg/plugins/gateway/algorithms/prefix_cache_routing_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_routing_test.go
@@ -889,7 +889,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "single_pod_match_exceeds_threshold",
 			podMetrics:   map[string]int{"pod-1": 5, "pod-2": 200, "pod-3": 10}, // pod-2 heavily loaded
-			matchedPods:  map[string]int{"default/pod-2": 100},                          // Only one pod matches but overloaded
+			matchedPods:  map[string]int{"default/pod-2": 100}, // Only one pod matches but overloaded
 			stdDevFactor: 1,
 			expectedNil:  true, // Should reject overloaded pod
 			description:  "Single matching pod exceeding threshold should be rejected",

--- a/pkg/plugins/gateway/algorithms/prefix_cache_routing_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_routing_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package routingalgorithms
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"testing"
@@ -191,7 +192,8 @@ func TestGetTargetPodOnLoadImbalance(t *testing.T) {
 			testCache := cache.NewWithPodsMetricsForTest(pods, "test-model", metricsMap)
 
 			// Get request counts from cache
-			podRequestCount := getRequestCounts(testCache, pods)
+			requestCounter := NewLocalRequestCounter(testCache)
+			podRequestCount := requestCounter.GetRequestCounts(context.Background(), pods)
 
 			// Execute function
 			targetPodList, imbalance := getTargetPodListOnLoadImbalance(podRequestCount, pods)
@@ -266,7 +268,7 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 		{
 			name:         "highest_match_within_stddev",
 			podMetrics:   map[string]int{"pod-1": 5, "pod-2": 10, "pod-3": 15},
-			matchedPods:  map[string]int{"pod-1": 100, "pod-2": 50, "pod-3": 25},
+			matchedPods:  map[string]int{"default/pod-1": 100, "default/pod-2": 50, "default/pod-3": 25},
 			stdDevFactor: 1,
 			expectedPod:  "pod-1",
 			description:  "Should select pod with highest match % when within std dev",
@@ -274,7 +276,7 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 		{
 			name:         "skip_overloaded_pod_high_match",
 			podMetrics:   map[string]int{"pod-1": 100, "pod-2": 10, "pod-3": 12},
-			matchedPods:  map[string]int{"pod-1": 100, "pod-2": 80, "pod-3": 60},
+			matchedPods:  map[string]int{"default/pod-1": 100, "default/pod-2": 80, "default/pod-3": 60},
 			stdDevFactor: 1,
 			expectedPod:  "pod-2",
 			description:  "Should skip pod with highest match if overloaded",
@@ -282,7 +284,7 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 		{
 			name:         "same_match_select_least_loaded",
 			podMetrics:   map[string]int{"pod-1": 20, "pod-2": 10, "pod-3": 30},
-			matchedPods:  map[string]int{"pod-1": 50, "pod-2": 50, "pod-3": 50},
+			matchedPods:  map[string]int{"default/pod-1": 50, "default/pod-2": 50, "default/pod-3": 50},
 			stdDevFactor: 1,
 			expectedPod:  "pod-2",
 			description:  "With same match %, should select least loaded",
@@ -290,7 +292,7 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 		{
 			name:         "all_pods_exceed_stddev_select_best_match",
 			podMetrics:   map[string]int{"pod-1": 11, "pod-2": 12, "pod-3": 13},
-			matchedPods:  map[string]int{"pod-1": 90, "pod-2": 80, "pod-3": 70},
+			matchedPods:  map[string]int{"default/pod-1": 90, "default/pod-2": 80, "default/pod-3": 70},
 			stdDevFactor: -10, // Impossible threshold: mean=12, threshold becomes negative, all pods > threshold
 			expectedNil:  true,
 			description:  "When all exceed std dev, should return nil",
@@ -306,7 +308,7 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 		{
 			name:         "single_matched_pod_within_threshold",
 			podMetrics:   map[string]int{"pod-1": 10, "pod-2": 20},
-			matchedPods:  map[string]int{"pod-1": 75},
+			matchedPods:  map[string]int{"default/pod-1": 75},
 			stdDevFactor: 2,
 			expectedPod:  "pod-1",
 			description:  "Single matched pod within threshold",
@@ -314,7 +316,7 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 		{
 			name:         "prefer_higher_match_with_acceptable_load",
 			podMetrics:   map[string]int{"pod-1": 11, "pod-2": 10, "pod-3": 12},
-			matchedPods:  map[string]int{"pod-1": 100, "pod-2": 90, "pod-3": 80},
+			matchedPods:  map[string]int{"default/pod-1": 100, "default/pod-2": 90, "default/pod-3": 80},
 			stdDevFactor: 5,
 			expectedPod:  "pod-1",
 			description:  "Should prefer higher match when load difference is minimal",
@@ -322,7 +324,7 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 		{
 			name:         "match_pod_with_highest_prefix_match_percent",
 			podMetrics:   map[string]int{"pod-1": 1, "pod-2": 2, "pod-3": 3, "pod-4": 4},
-			matchedPods:  map[string]int{"pod-1": 50, "pod-2": 60},
+			matchedPods:  map[string]int{"default/pod-1": 50, "default/pod-2": 60},
 			stdDevFactor: 1,
 			expectedPod:  "pod-2", // Should select highest match % (60%)
 			description:  "Should select pod with highest prefix match percent",
@@ -330,7 +332,7 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 		{
 			name:         "lowest_running_request_count_for_same_prefix_match",
 			podMetrics:   map[string]int{"pod-1": 1, "pod-2": 2, "pod-3": 3, "pod-4": 4},
-			matchedPods:  map[string]int{"pod-1": 50, "pod-2": 50, "pod-3": 50},
+			matchedPods:  map[string]int{"default/pod-1": 50, "default/pod-2": 50, "default/pod-3": 50},
 			stdDevFactor: 1,
 			expectedPod:  "pod-1", // All have 50% match, pod-1 has lowest load (1)
 			description:  "Should select pod with lowest running request count for same prefix match percent",
@@ -338,7 +340,7 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 		{
 			name:         "any_pod_with_same_request_count_and_match_percent",
 			podMetrics:   map[string]int{"pod-1": 1, "pod-2": 1, "pod-3": 1, "pod-4": 4},
-			matchedPods:  map[string]int{"pod-1": 50, "pod-2": 50, "pod-3": 50},
+			matchedPods:  map[string]int{"default/pod-1": 50, "default/pod-2": 50, "default/pod-3": 50},
 			stdDevFactor: 1,
 			expectedPod:  "", // Any of pod-1, pod-2, pod-3 (will be handled in test)
 			description:  "Should select any pod with same running request count and same prefix match percent",
@@ -346,7 +348,7 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 		{
 			name:         "lower_prefix_match_with_requests_below_threshold",
 			podMetrics:   map[string]int{"pod-1": 1, "pod-2": 10, "pod-3": 1, "pod-4": 4},
-			matchedPods:  map[string]int{"pod-1": 50, "pod-2": 100},
+			matchedPods:  map[string]int{"default/pod-1": 50, "default/pod-2": 100},
 			stdDevFactor: 1,
 			expectedPod:  "pod-1", // pod-2 is overloaded (10), so select pod-1 with lower match but acceptable load
 			description:  "Should select pod with lower prefix match percent when other has requests below imbalance threshold",
@@ -358,8 +360,9 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 			standardDeviationFactor = tt.stdDevFactor
 
 			testCache, pods := createTestSetup(tt.podMetrics)
-			podRequestCount := getRequestCounts(testCache, pods)
-			result := getTargetPodFromMatchedPods(podRequestCount, pods, tt.matchedPods)
+			requestCounter := NewLocalRequestCounter(testCache)
+			podRequestCount := requestCounter.GetRequestCounts(context.Background(), pods)
+			result := getTargetPodFromMatchedPodsWithKeys(podRequestCount, pods, tt.matchedPods)
 
 			if tt.expectedNil {
 				assert.Nil(t, result, tt.description)
@@ -395,7 +398,7 @@ func TestGetRequestCounts(t *testing.T) {
 				"pod-2": {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 20}},
 				"pod-3": {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 30}},
 			},
-			expectedCounts: map[string]int{"pod-1": 10, "pod-2": 20, "pod-3": 30},
+			expectedCounts: map[string]int{"default/pod-1": 10, "default/pod-2": 20, "default/pod-3": 30},
 			description:    "Should retrieve all metrics correctly",
 		},
 		{
@@ -405,7 +408,7 @@ func TestGetRequestCounts(t *testing.T) {
 				"pod-2": {}, // No metrics
 				"pod-3": {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 25}},
 			},
-			expectedCounts: map[string]int{"pod-1": 15, "pod-2": 0, "pod-3": 25},
+			expectedCounts: map[string]int{"default/pod-1": 15, "default/pod-2": 0, "default/pod-3": 25},
 			description:    "Missing metrics should default to 0",
 		},
 		{
@@ -420,7 +423,7 @@ func TestGetRequestCounts(t *testing.T) {
 				"pod-1": {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 0}},
 				"pod-2": {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 0}},
 			},
-			expectedCounts: map[string]int{"pod-1": 0, "pod-2": 0},
+			expectedCounts: map[string]int{"default/pod-1": 0, "default/pod-2": 0},
 			description:    "Zero metrics should be preserved",
 		},
 		{
@@ -429,7 +432,7 @@ func TestGetRequestCounts(t *testing.T) {
 				"pod-1": {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 10.7}},
 				"pod-2": {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 20.3}},
 			},
-			expectedCounts: map[string]int{"pod-1": 10, "pod-2": 20},
+			expectedCounts: map[string]int{"default/pod-1": 10, "default/pod-2": 20},
 			description:    "Decimal values should be truncated to int",
 		},
 	}
@@ -452,7 +455,8 @@ func TestGetRequestCounts(t *testing.T) {
 			testCache := cache.NewWithPodsMetricsForTest(pods, "test-model", tt.podMetrics)
 
 			// Get request counts
-			result := getRequestCounts(testCache, pods)
+			requestCounter := NewLocalRequestCounter(testCache)
+			result := requestCounter.GetRequestCounts(context.Background(), pods)
 
 			// Verify results
 			assert.Equal(t, tt.expectedCounts, result, tt.description)
@@ -557,7 +561,8 @@ func TestGetRequestCountsWithKeysHelper(t *testing.T) {
 			testCache := cache.NewWithPodsMetricsForTest(pods, "test-model", tt.podMetrics)
 
 			// Get request counts with keys
-			result := getRequestCountsWithKeys(testCache, pods)
+			requestCounter := NewLocalRequestCounter(testCache)
+			result := requestCounter.GetRequestCounts(context.Background(), pods)
 
 			// Verify
 			assert.Equal(t, tt.expectedCounts, result, tt.description)
@@ -750,7 +755,8 @@ func TestLoadImbalanceEdgeCases(t *testing.T) {
 			testCache := cache.NewWithPodsMetricsForTest(pods, "test-model", metricsMap)
 
 			// Get request counts from cache
-			podRequestCount := getRequestCounts(testCache, pods)
+			requestCounter := NewLocalRequestCounter(testCache)
+			podRequestCount := requestCounter.GetRequestCounts(context.Background(), pods)
 
 			// Execute function
 			targetPodList, imbalance := getTargetPodListOnLoadImbalance(podRequestCount, pods)
@@ -826,7 +832,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "zero_standard_deviation_factor",
 			podMetrics:   map[string]int{"pod-1": 10, "pod-2": 15, "pod-3": 20},
-			matchedPods:  map[string]int{"pod-1": 100, "pod-2": 90, "pod-3": 80},
+			matchedPods:  map[string]int{"default/pod-1": 100, "default/pod-2": 90, "default/pod-3": 80},
 			stdDevFactor: 0,       // No tolerance - only mean
 			expectedPod:  "pod-1", // Should still select best match within mean
 			description:  "Zero stddev factor should use strict mean threshold",
@@ -834,7 +840,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "negative_standard_deviation_factor",
 			podMetrics:   map[string]int{"pod-1": 10, "pod-2": 10, "pod-3": 10},
-			matchedPods:  map[string]int{"pod-1": 100, "pod-2": 90, "pod-3": 80},
+			matchedPods:  map[string]int{"default/pod-1": 100, "default/pod-2": 90, "default/pod-3": 80},
 			stdDevFactor: -1,      // Invalid negative
 			expectedPod:  "pod-1", // Should still select best match
 			description:  "Negative stddev factor should be handled gracefully",
@@ -842,7 +848,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "very_large_standard_deviation_factor",
 			podMetrics:   map[string]int{"pod-1": 1000, "pod-2": 10, "pod-3": 15},
-			matchedPods:  map[string]int{"pod-1": 100, "pod-2": 90, "pod-3": 80},
+			matchedPods:  map[string]int{"default/pod-1": 100, "default/pod-2": 90, "default/pod-3": 80},
 			stdDevFactor: 1000,    // Very large tolerance
 			expectedPod:  "pod-1", // Should select highest match even if overloaded
 			description:  "Large stddev factor should allow overloaded pods",
@@ -850,7 +856,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "all_pods_within_threshold_with_factor_1",
 			podMetrics:   map[string]int{"pod-1": 100, "pod-2": 101, "pod-3": 102},
-			matchedPods:  map[string]int{"pod-1": 90, "pod-2": 80, "pod-3": 70},
+			matchedPods:  map[string]int{"default/pod-1": 90, "default/pod-2": 80, "default/pod-3": 70},
 			stdDevFactor: 1,       // Mean=101, StdDev=1, Threshold=102 - all pods ≤ 102
 			expectedPod:  "pod-1", // Should select highest match % (90%)
 			description:  "When all pods are within threshold, should select highest match",
@@ -858,7 +864,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "all_pods_exceed_threshold_tight_bound",
 			podMetrics:   map[string]int{"pod-1": 200, "pod-2": 201, "pod-3": 202},
-			matchedPods:  map[string]int{"pod-1": 90, "pod-2": 80, "pod-3": 70},
+			matchedPods:  map[string]int{"default/pod-1": 90, "default/pod-2": 80, "default/pod-3": 70},
 			stdDevFactor: 0,     // Mean=201, StdDev=1, Threshold=201 - only pod-1 within
 			expectedNil:  false, // pod-1 (200) should be within threshold (≤201)
 			expectedPod:  "pod-1",
@@ -867,7 +873,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "identical_match_percentages_different_loads",
 			podMetrics:   map[string]int{"pod-1": 50, "pod-2": 10, "pod-3": 30},
-			matchedPods:  map[string]int{"pod-1": 75, "pod-2": 75, "pod-3": 75},
+			matchedPods:  map[string]int{"default/pod-1": 75, "default/pod-2": 75, "default/pod-3": 75},
 			stdDevFactor: 2,       // Generous tolerance
 			expectedPod:  "pod-2", // Should select least loaded with same match
 			description:  "Identical match % should select least loaded",
@@ -875,7 +881,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "single_pod_match_within_threshold",
 			podMetrics:   map[string]int{"pod-1": 5, "pod-2": 50, "pod-3": 60},
-			matchedPods:  map[string]int{"pod-2": 80}, // Only one pod matches
+			matchedPods:  map[string]int{"default/pod-2": 80}, // Only one pod matches
 			stdDevFactor: 2,
 			expectedPod:  "pod-2", // Should select the only matching pod if within threshold
 			description:  "Single matching pod within threshold should be selected",
@@ -883,7 +889,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "single_pod_match_exceeds_threshold",
 			podMetrics:   map[string]int{"pod-1": 5, "pod-2": 200, "pod-3": 10}, // pod-2 heavily loaded
-			matchedPods:  map[string]int{"pod-2": 100},                          // Only one pod matches but overloaded
+			matchedPods:  map[string]int{"default/pod-2": 100},                          // Only one pod matches but overloaded
 			stdDevFactor: 1,
 			expectedNil:  true, // Should reject overloaded pod
 			description:  "Single matching pod exceeding threshold should be rejected",
@@ -891,7 +897,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "extreme_load_imbalance_high_match",
 			podMetrics:   map[string]int{"pod-1": math.MaxInt32, "pod-2": 0, "pod-3": 5},
-			matchedPods:  map[string]int{"pod-1": 100, "pod-2": 50, "pod-3": 25},
+			matchedPods:  map[string]int{"default/pod-1": 100, "default/pod-2": 50, "default/pod-3": 25},
 			stdDevFactor: 1,
 			expectedPod:  "pod-2", // pod-2 and pod-3 both within threshold, pod-2 has higher match (50% > 25%)
 			description:  "With extreme imbalance, should select highest match among low-load pods",
@@ -899,7 +905,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "zero_variance_request_counts",
 			podMetrics:   map[string]int{"pod-1": 10, "pod-2": 10, "pod-3": 10}, // Identical loads
-			matchedPods:  map[string]int{"pod-1": 90, "pod-2": 80, "pod-3": 70},
+			matchedPods:  map[string]int{"default/pod-1": 90, "default/pod-2": 80, "default/pod-3": 70},
 			stdDevFactor: 1,
 			expectedPod:  "pod-1", // With zero variance, all pods are within threshold
 			description:  "Zero variance should allow all pods, select highest match",
@@ -911,8 +917,9 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 			standardDeviationFactor = tt.stdDevFactor
 
 			testCache, pods := createTestSetup(tt.podMetrics)
-			podRequestCount := getRequestCounts(testCache, pods)
-			result := getTargetPodFromMatchedPods(podRequestCount, pods, tt.matchedPods)
+			requestCounter := NewLocalRequestCounter(testCache)
+			podRequestCount := requestCounter.GetRequestCounts(context.Background(), pods)
+			result := getTargetPodFromMatchedPodsWithKeys(podRequestCount, pods, tt.matchedPods)
 
 			if tt.expectedNil {
 				assert.Nil(t, result, tt.description)
@@ -1039,7 +1046,8 @@ func TestKVSyncPodKeyHandlingEdgeCases(t *testing.T) {
 			testCache := cache.NewWithPodsMetricsForTest(pods, "test-model", metricsMap)
 
 			// Get request counts with keys (namespace/podname format) for KV sync function
-			podRequestCountWithKeys := getRequestCountsWithKeys(testCache, pods)
+			requestCounter := NewLocalRequestCounter(testCache)
+			podRequestCountWithKeys := requestCounter.GetRequestCounts(context.Background(), pods)
 
 			// Test KV sync function
 			result := getTargetPodFromMatchedPodsWithKeys(podRequestCountWithKeys, pods, tt.matchedPods)

--- a/pkg/plugins/gateway/algorithms/prefix_cache_routing_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_routing_test.go
@@ -889,7 +889,7 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 		{
 			name:         "single_pod_match_exceeds_threshold",
 			podMetrics:   map[string]int{"pod-1": 5, "pod-2": 200, "pod-3": 10}, // pod-2 heavily loaded
-			matchedPods:  map[string]int{"default/pod-2": 100}, // Only one pod matches but overloaded
+			matchedPods:  map[string]int{"default/pod-2": 100},                  // Only one pod matches but overloaded
 			stdDevFactor: 1,
 			expectedNil:  true, // Should reject overloaded pod
 			description:  "Single matching pod exceeding threshold should be rejected",

--- a/pkg/plugins/gateway/algorithms/prefix_cache_routing_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_routing_test.go
@@ -190,8 +190,11 @@ func TestGetTargetPodOnLoadImbalance(t *testing.T) {
 
 			testCache := cache.NewWithPodsMetricsForTest(pods, "test-model", metricsMap)
 
+			// Get request counts from cache
+			podRequestCount := getRequestCounts(testCache, pods)
+
 			// Execute function
-			targetPodList, imbalance := getTargetPodListOnLoadImbalance(testCache, pods)
+			targetPodList, imbalance := getTargetPodListOnLoadImbalance(podRequestCount, pods)
 
 			// Verify imbalance detection
 			assert.Equal(t, tt.expectImbalance, imbalance, "Imbalance detection mismatch")
@@ -355,7 +358,8 @@ func TestGetTargetPodFromMatchedPods(t *testing.T) {
 			standardDeviationFactor = tt.stdDevFactor
 
 			testCache, pods := createTestSetup(tt.podMetrics)
-			result := getTargetPodFromMatchedPods(testCache, pods, tt.matchedPods)
+			podRequestCount := getRequestCounts(testCache, pods)
+			result := getTargetPodFromMatchedPods(podRequestCount, pods, tt.matchedPods)
 
 			if tt.expectedNil {
 				assert.Nil(t, result, tt.description)
@@ -745,8 +749,11 @@ func TestLoadImbalanceEdgeCases(t *testing.T) {
 
 			testCache := cache.NewWithPodsMetricsForTest(pods, "test-model", metricsMap)
 
+			// Get request counts from cache
+			podRequestCount := getRequestCounts(testCache, pods)
+
 			// Execute function
-			targetPodList, imbalance := getTargetPodListOnLoadImbalance(testCache, pods)
+			targetPodList, imbalance := getTargetPodListOnLoadImbalance(podRequestCount, pods)
 
 			// Verify imbalance detection
 			assert.Equal(t, tt.expectImbalance, imbalance, "Imbalance detection mismatch: %s", tt.description)
@@ -904,7 +911,8 @@ func TestPrefixMatchingStandardDeviationEdgeCases(t *testing.T) {
 			standardDeviationFactor = tt.stdDevFactor
 
 			testCache, pods := createTestSetup(tt.podMetrics)
-			result := getTargetPodFromMatchedPods(testCache, pods, tt.matchedPods)
+			podRequestCount := getRequestCounts(testCache, pods)
+			result := getTargetPodFromMatchedPods(podRequestCount, pods, tt.matchedPods)
 
 			if tt.expectedNil {
 				assert.Nil(t, result, tt.description)
@@ -1030,8 +1038,11 @@ func TestKVSyncPodKeyHandlingEdgeCases(t *testing.T) {
 
 			testCache := cache.NewWithPodsMetricsForTest(pods, "test-model", metricsMap)
 
+			// Get request counts with keys (namespace/podname format) for KV sync function
+			podRequestCountWithKeys := getRequestCountsWithKeys(testCache, pods)
+
 			// Test KV sync function
-			result := getTargetPodFromMatchedPodsWithKeys(testCache, pods, tt.matchedPods)
+			result := getTargetPodFromMatchedPodsWithKeys(podRequestCountWithKeys, pods, tt.matchedPods)
 
 			if tt.expectedNil {
 				assert.Nil(t, result, tt.description)

--- a/pkg/plugins/gateway/algorithms/prefix_cache_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_test.go
@@ -59,6 +59,7 @@ func Test_PrefixCacheE2E(t *testing.T) {
 		cache:              c,
 		tokenizer:          tokenizerObj,
 		prefixCacheIndexer: prefixcacheindexer.NewPrefixHashTable(),
+		requestCounter:     NewLocalRequestCounter(c),
 		// No KV sync router, uses original implementation
 	}
 

--- a/pkg/plugins/gateway/algorithms/request_counter.go
+++ b/pkg/plugins/gateway/algorithms/request_counter.go
@@ -40,6 +40,16 @@ type requestCountDoneKeyType struct{}
 
 var requestCountDoneKey = requestCountDoneKeyType{}
 
+// decrementScript is a cached Lua script for atomically decrementing and deleting hash fields
+// Using redis.NewScript allows Redis to cache the script and use EvalSha for better performance
+var decrementScript = redis.NewScript(`
+	local new_count = redis.call('HINCRBY', KEYS[1], ARGV[1], -1)
+	if new_count <= 0 then
+		redis.call('HDEL', KEYS[1], ARGV[1])
+	end
+	return new_count
+`)
+
 // MetricsProvider provides pod-level metrics
 type MetricsProvider interface {
 	GetMetricValueByPod(podName, namespace, metricName string) (metrics.MetricValue, error)
@@ -370,18 +380,11 @@ func (r *redisRequestCounter) DoneRequestCount(ctx *types.RoutingContext, reques
 	key := r.buildRedisKey(modelName)
 	field := serverKey.String()
 
-	// Use Lua script to atomically decrement and delete if zero
+	// Use cached Lua script to atomically decrement and delete if zero
 	// This prevents race condition where another request increments the counter
 	// between our decrement and delete operations
-	luaScript := `
-		local new_count = redis.call('HINCRBY', KEYS[1], ARGV[1], -1)
-		if new_count <= 0 then
-			redis.call('HDEL', KEYS[1], ARGV[1])
-		end
-		return new_count
-	`
-
-	newCount, err := r.redisCli.Eval(ctx.Context, luaScript, []string{key}, field).Int64()
+	// The script is cached at package level, allowing Redis to use EvalSha for better performance
+	newCount, err := decrementScript.Run(ctx.Context, r.redisCli, []string{key}, field).Int64()
 	if err != nil {
 		klog.ErrorS(err, "failed to decrement request count in hashmap",
 			"request_id", requestID,

--- a/pkg/plugins/gateway/algorithms/request_counter.go
+++ b/pkg/plugins/gateway/algorithms/request_counter.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -50,35 +49,16 @@ type MetricsProvider interface {
 type RequestCounter interface {
 	// GetRequestCounts returns a map of pod name to request count
 	// Returns:
-	//  withNamespace=false:  pod name -> request count
-	//  withNamespace=true: pod namespace/pod name -> request count
-	GetRequestCounts(ctx context.Context, readyPods []*v1.Pod, withNamespace bool) map[string]int
+	//  pod namespace/pod name -> request count
+	GetRequestCounts(ctx context.Context, readyPods []*v1.Pod) map[string]int
 	// GetRequestCountsWithPort returns running request count for each pod-port combination, used when a pod has multiple ports
 	// Returns:
-	//  withNamespace=false:  pod name/port -> request count
-	//  withNamespace=true:   pod namespace/pod name/port -> request count
+	//  pod namespace/pod name/port -> request count
 	GetRequestCountsWithPort(ctx context.Context, readyPods []*v1.Pod,
-		portsMap map[string][]int, withNamespace bool) map[string]int
+		portsMap map[string][]int) map[string]int
 }
 
-// parse the key of map returned by GetRequestCountsWithPort
-func parseKey(key string, withNamespace bool) (namespace string, podName string, port string) {
-	parts := strings.Split(key, "/")
-	if withNamespace {
-		// namespace/podName/port or namespace/podName
-		if len(parts) == 2 {
-			return parts[0], parts[1], ""
-		}
-		return parts[0], parts[1], parts[2]
-	}
-	// podName/port or podName
-	if len(parts) == 2 {
-		return "", parts[0], parts[1]
-	}
-	return "", parts[0], ""
-}
-
-// localRequestCounter is a local implementation of imbalancePodsFilter
+// localRequestCounter is a local implementation of RequestCounter
 type localRequestCounter struct {
 	metricsProvider MetricsProvider
 }
@@ -90,14 +70,17 @@ func NewLocalRequestCounter(provider MetricsProvider) *localRequestCounter {
 	}
 }
 
-func (l *localRequestCounter) GetRequestCounts(ctx context.Context, readyPods []*v1.Pod, withNamespace bool) map[string]int {
+func (l *localRequestCounter) GetRequestCounts(ctx context.Context, readyPods []*v1.Pod) map[string]int {
 	podRequestCount := make(map[string]int, len(readyPods))
 	for _, pod := range readyPods {
 		runningReq, err := l.metricsProvider.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
 		if err != nil {
 			runningReq = &metrics.SimpleMetricValue{Value: 0}
 		}
-		podRequestCount[pod.Name] = int(runningReq.GetSimpleValue())
+
+		// Build key based on withNamespace parameter
+		k := &podServerKey{pod: pod}
+		podRequestCount[k.String()] = int(runningReq.GetSimpleValue())
 	}
 
 	return podRequestCount
@@ -105,7 +88,7 @@ func (l *localRequestCounter) GetRequestCounts(ctx context.Context, readyPods []
 
 // getRequestCountsWithPort returns running request count for each pod-port combination
 func (l *localRequestCounter) GetRequestCountsWithPort(
-	ctx context.Context, readyPods []*v1.Pod, portsMap map[string][]int, withNamespace bool) map[string]int {
+	ctx context.Context, readyPods []*v1.Pod, portsMap map[string][]int) map[string]int {
 	podRequestCount := make(map[string]int)
 	for _, pod := range readyPods {
 		podPorts, exists := portsMap[pod.Name]
@@ -116,7 +99,8 @@ func (l *localRequestCounter) GetRequestCountsWithPort(
 			if err != nil {
 				runningReq = &metrics.SimpleMetricValue{Value: 0}
 			}
-			podRequestCount[pod.Name] = int(runningReq.GetSimpleValue())
+			k := &podServerKey{pod: pod}
+			podRequestCount[k.String()] = int(runningReq.GetSimpleValue())
 			continue
 		}
 
@@ -127,10 +111,13 @@ func (l *localRequestCounter) GetRequestCountsWithPort(
 
 			if len(podPorts) == 1 {
 				metricName = metrics.RealtimeNumRequestsRunning
-				keyName = fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+				k := &podServerKey{pod: pod}
+				keyName = k.String()
 			} else {
 				metricName = fmt.Sprintf("%s/%d", metrics.RealtimeNumRequestsRunning, port)
-				keyName = fmt.Sprintf("%s/%s/%d", pod.Namespace, pod.Name, port)
+				// Multi-port pod
+				k := &podServerKey{pod: pod, port: port}
+				keyName = k.String()
 			}
 
 			var count int
@@ -142,22 +129,6 @@ func (l *localRequestCounter) GetRequestCountsWithPort(
 	}
 
 	return podRequestCount
-}
-
-// deduplicatePods extracts and deduplicates pods from podServerKey list
-func deduplicatePods(serverKeys []podServerKey) []*v1.Pod {
-	podMap := make(map[string]*v1.Pod)
-	for _, serverKey := range serverKeys {
-		if serverKey.pod != nil {
-			podMap[serverKey.pod.Name] = serverKey.pod
-		}
-	}
-
-	result := make([]*v1.Pod, 0, len(podMap))
-	for _, pod := range podMap {
-		result = append(result, pod)
-	}
-	return result
 }
 
 // redisRequestCounter is a redis implementation of imbalancePodsFilter
@@ -179,12 +150,12 @@ type redisRequestCounter struct {
 }
 
 // GetRequestCounts implements [RequestCounter].
-func (r *redisRequestCounter) GetRequestCounts(ctx context.Context, readyPods []*v1.Pod, withNamespace bool) map[string]int {
+func (r *redisRequestCounter) GetRequestCounts(ctx context.Context, readyPods []*v1.Pod) map[string]int {
 	// Get counts with port first and merge them by pod
 	portsMap := make(map[string][]int) // empty ports map
 
 	startTime := time.Now()
-	countsWithPort := r.GetRequestCountsWithPort(ctx, readyPods, portsMap, withNamespace)
+	countsWithPort := r.GetRequestCountsWithPort(ctx, readyPods, portsMap)
 	klog.V(4).InfoS("redisRequestCounter_GetRequestCounts_withPort_done", "duration", time.Since(startTime))
 
 	// Merge counts for the same pod (sum across all ports)
@@ -192,22 +163,8 @@ func (r *redisRequestCounter) GetRequestCounts(ctx context.Context, readyPods []
 	for key, count := range countsWithPort {
 		// Extract pod key (remove port suffix if present)
 		var podKey string
-		if withNamespace {
-			// Format: "namespace/pod-name" or "namespace/pod-name/port"
-			// Split by "/" and take first two parts
-			parts := strings.Split(key, "/")
-			if len(parts) >= 2 {
-				podKey = parts[0] + "/" + parts[1]
-			} else {
-				podKey = key
-			}
-		} else {
-			// Format: "pod-name" or "pod-name/port"
-			// Split by "/" and take first part
-			parts := strings.Split(key, "/")
-			podKey = parts[0]
-		}
-
+		namespace, podName, _ := parseServerKey(key)
+		podKey = fmt.Sprintf("%s/%s", namespace, podName)
 		result[podKey] += count
 	}
 
@@ -215,9 +172,28 @@ func (r *redisRequestCounter) GetRequestCounts(ctx context.Context, readyPods []
 }
 
 // GetRequestCountsWithPort implements [RequestCounter].
-func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, readyPods []*v1.Pod, portsMap map[string][]int, withNamespace bool) map[string]int {
+func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, readyPods []*v1.Pod, portsMap map[string][]int) map[string]int {
 	if len(readyPods) == 0 {
 		return make(map[string]int)
+	}
+
+	// Initialize result with all readyPods set to 0
+	// This ensures we always return counts for all pods, even if Redis query fails
+	result := make(map[string]int)
+	for _, pod := range readyPods {
+		podPorts, hasPorts := portsMap[pod.Name]
+
+		if !hasPorts || len(podPorts) == 0 {
+			// No ports specified, add single entry for this pod
+			k := &podServerKey{pod: pod}
+			result[k.String()] = 0
+		} else {
+			// Has ports, add entry for each port
+			for _, port := range podPorts {
+				k := &podServerKey{pod: pod, port: port}
+				result[k.String()] = 0
+			}
+		}
 	}
 
 	// Get model name from the first pod (all pods should serve the same model)
@@ -229,42 +205,14 @@ func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, read
 	}
 
 	if modelName == "" {
-		klog.V(4).InfoS("cannot determine model name from pod, returning empty counts")
-		return make(map[string]int)
+		klog.V(4).InfoS("cannot determine model name from pod, returning counts initialized to 0")
+		return result
 	}
 
 	// Update last filter time for this model
 	r.lastModelFilterTimeMu.Lock()
 	r.lastModelFilterTime[modelName] = time.Now()
 	r.lastModelFilterTimeMu.Unlock()
-
-	// Initialize result with all readyPods set to 0
-	result := make(map[string]int)
-	for _, pod := range readyPods {
-		podPorts, hasPorts := portsMap[pod.Name]
-
-		if !hasPorts || len(podPorts) == 0 {
-			// No ports specified, add single entry for this pod
-			var resultKey string
-			if withNamespace {
-				resultKey = fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-			} else {
-				resultKey = pod.Name
-			}
-			result[resultKey] = 0
-		} else {
-			// Has ports, add entry for each port
-			for _, port := range podPorts {
-				var resultKey string
-				if withNamespace {
-					resultKey = fmt.Sprintf("%s/%s/%d", pod.Namespace, pod.Name, port)
-				} else {
-					resultKey = fmt.Sprintf("%s/%d", pod.Name, port)
-				}
-				result[resultKey] = 0
-			}
-		}
-	}
 
 	// Get all request counts from Redis using HGETALL
 	key := r.buildRedisKey(modelName)
@@ -275,66 +223,17 @@ func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, read
 		return result
 	}
 
-	// Build a map of valid pods for filtering
-	validPods := make(map[string]*v1.Pod)
-	for _, pod := range readyPods {
-		validPods[pod.Name] = pod
-	}
-
 	// Parse Redis data and update result map
-	for field, countStr := range counts {
-		// field format from podServerKey.String():
-		//   without port: "namespace_podname"
-		//   with port: "namespace_podname_port"
-
-		// Split by underscore
-		parts := strings.Split(field, "_")
-		if len(parts) < 2 {
-			continue
-		}
-
-		podName := parts[1]
-		var port int
-		hasPort := false
-		if len(parts) >= 3 {
-			// Parse port from the last part
-			if p, err := strconv.Atoi(parts[2]); err == nil {
-				port = p
-				hasPort = true
-			}
-		}
-
-		// Check if this pod is in readyPods
-		pod, exists := validPods[podName]
-		if !exists {
-			continue
-		}
-
+	for podKey, countStr := range counts {
 		// Parse count
 		count, err := strconv.Atoi(countStr)
 		if err != nil {
 			continue
 		}
 
-		// Build result key based on withNamespace parameter
-		var resultKey string
-		if withNamespace {
-			if hasPort {
-				resultKey = fmt.Sprintf("%s/%s/%d", pod.Namespace, pod.Name, port)
-			} else {
-				resultKey = fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-			}
-		} else {
-			if hasPort {
-				resultKey = fmt.Sprintf("%s/%d", pod.Name, port)
-			} else {
-				resultKey = pod.Name
-			}
-		}
-
 		// Only update if this key was initialized (exists in result)
-		if _, keyExists := result[resultKey]; keyExists {
-			result[resultKey] = count
+		if _, keyExists := result[podKey]; keyExists {
+			result[podKey] = count
 		}
 	}
 
@@ -419,6 +318,16 @@ func (r *redisRequestCounter) AddRequestCount(ctx *types.RoutingContext, request
 		return 0
 	}
 
+	// Set TTL on the hash key to prevent memory leaks for inactive models
+	// Use requestTrackerTimeout as the expiry duration
+	// This is safe to call on every increment - Redis only updates TTL if key exists
+	if err := r.redisCli.Expire(ctx.Context, key, r.requestTrackerTimeout).Err(); err != nil {
+		klog.ErrorS(err, "failed to set TTL on request count key",
+			"key", key,
+			"ttl", r.requestTrackerTimeout)
+		// Don't return error - the increment succeeded, TTL failure is not critical
+	}
+
 	klog.V(4).InfoS("imbalance_filter_add_request",
 		"request_id", requestID,
 		"model", modelName,
@@ -433,6 +342,15 @@ func (r *redisRequestCounter) AddRequestCount(ctx *types.RoutingContext, request
 func (r *redisRequestCounter) DoneRequestCount(ctx *types.RoutingContext, requestID string, modelName string, traceTerm int64) {
 	// Check whether target pod is set
 	if ctx.TargetPod() == nil {
+		return
+	}
+
+	// Check if AddRequestCount was actually called for this request
+	// This prevents decrementing the counter if it was never incremented
+	if ctx.Context.Value(imbalancePodsFilterReqAddedKey) == nil {
+		klog.V(5).InfoS("skip request count decrement, AddRequestCount was not called",
+			"request_id", requestID,
+			"model", modelName)
 		return
 	}
 

--- a/pkg/plugins/gateway/algorithms/request_counter.go
+++ b/pkg/plugins/gateway/algorithms/request_counter.go
@@ -138,14 +138,13 @@ func (l *localRequestCounter) GetRequestCountsWithPort(
 //	 we use hashmap here which is different from power-of-two router, because hgetall is needed to scan all the keys
 //	 modelName is wrapped in {} to support Redis Cluster hashtag, ensuring all keys for the same model are in the same slot
 type redisRequestCounter struct {
-	redisCli           *redis.Client
-	imbalanceThreshold int // Threshold for considering pods imbalanced (default: 2)
-	redisKeyPrefix     string
+	redisCli       *redis.Client
+	redisKeyPrefix string
 
-	// lastModelFilterTime tracks when FilterPods was last called for each model
-	// Used to stop tracking request counts for models that are no longer being filtered
-	lastModelFilterTime   map[string]time.Time
-	lastModelFilterTimeMu sync.RWMutex // Protects lastModelFilterTime map
+	// lastModelRouteTime tracks when routing was last performed for each model
+	// Used to stop tracking request counts for models that are no longer being routed
+	lastModelRouteTime   map[string]time.Time
+	lastModelRouteTimeMu sync.RWMutex // Protects lastModelRouteTime map
 	requestTrackerTimeout time.Duration
 }
 
@@ -209,10 +208,10 @@ func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, read
 		return result
 	}
 
-	// Update last filter time for this model
-	r.lastModelFilterTimeMu.Lock()
-	r.lastModelFilterTime[modelName] = time.Now()
-	r.lastModelFilterTimeMu.Unlock()
+	// Update last route time for this model
+	r.lastModelRouteTimeMu.Lock()
+	r.lastModelRouteTime[modelName] = time.Now()
+	r.lastModelRouteTimeMu.Unlock()
 
 	// Get all request counts from Redis using HGETALL
 	key := r.buildRedisKey(modelName)
@@ -246,12 +245,11 @@ const (
 )
 
 // NewredisRequestCounter creates a new redis-based imbalance pods filter
-func NewRedisRequestCounter(redisClient *redis.Client, imbalanceThreshold int) *redisRequestCounter {
+func NewRedisRequestCounter(redisClient *redis.Client) *redisRequestCounter {
 	return &redisRequestCounter{
 		redisCli:              redisClient,
-		imbalanceThreshold:    imbalanceThreshold,
 		redisKeyPrefix:        defaultRedisKeyPrefix,
-		lastModelFilterTime:   make(map[string]time.Time),
+		lastModelRouteTime:    make(map[string]time.Time),
 		requestTrackerTimeout: defaultImbalanceTrackerTimeout,
 	}
 }
@@ -269,24 +267,24 @@ func (r *redisRequestCounter) AddRequestCount(ctx *types.RoutingContext, request
 		return 0
 	}
 
-	// Skip counting if this model hasn't been filtered recently
+	// Skip counting if this model hasn't been routed recently
 	// This avoids counting requests that are no longer being load-balanced
-	r.lastModelFilterTimeMu.RLock()
-	lastModelFilterTime, ok := r.lastModelFilterTime[modelName]
-	r.lastModelFilterTimeMu.RUnlock()
+	r.lastModelRouteTimeMu.RLock()
+	lastModelRouteTime, ok := r.lastModelRouteTime[modelName]
+	r.lastModelRouteTimeMu.RUnlock()
 
 	if ok {
-		// If it's been too long since last filter call, skip counting
-		if time.Since(lastModelFilterTime) > r.requestTrackerTimeout {
-			klog.V(5).InfoS("skip request count tracking, model filter timeout",
+		// If it's been too long since last route call, skip counting
+		if time.Since(lastModelRouteTime) > r.requestTrackerTimeout {
+			klog.V(5).InfoS("skip request count tracking, model route timeout",
 				"model", modelName,
-				"last_filter_time", lastModelFilterTime,
+				"last_route_time", lastModelRouteTime,
 				"timeout", r.requestTrackerTimeout)
 			return 0
 		}
 	} else {
-		// No filter history for this model, skip counting
-		klog.V(5).InfoS("skip request count tracking, no filter history",
+		// No route history for this model, skip counting
+		klog.V(5).InfoS("skip request count tracking, no route history",
 			"model", modelName)
 		return 0
 	}
@@ -372,22 +370,24 @@ func (r *redisRequestCounter) DoneRequestCount(ctx *types.RoutingContext, reques
 	key := r.buildRedisKey(modelName)
 	field := serverKey.String()
 
-	newCount, err := r.redisCli.HIncrBy(ctx.Context, key, field, -1).Result()
+	// Use Lua script to atomically decrement and delete if zero
+	// This prevents race condition where another request increments the counter
+	// between our decrement and delete operations
+	luaScript := `
+		local new_count = redis.call('HINCRBY', KEYS[1], ARGV[1], -1)
+		if new_count <= 0 then
+			redis.call('HDEL', KEYS[1], ARGV[1])
+		end
+		return new_count
+	`
+
+	newCount, err := r.redisCli.Eval(ctx.Context, luaScript, []string{key}, field).Int64()
 	if err != nil {
 		klog.ErrorS(err, "failed to decrement request count in hashmap",
 			"request_id", requestID,
 			"key", key,
 			"field", field)
 		return
-	}
-
-	// If count is zero or negative, delete the field
-	if newCount <= 0 {
-		if err := r.redisCli.HDel(ctx.Context, key, field).Err(); err != nil {
-			klog.ErrorS(err, "failed to delete field from hashmap",
-				"key", key,
-				"field", field)
-		}
 	}
 
 	klog.V(4).InfoS("imbalance_filter_done_request",

--- a/pkg/plugins/gateway/algorithms/request_counter.go
+++ b/pkg/plugins/gateway/algorithms/request_counter.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
 	v1 "k8s.io/api/core/v1"
@@ -181,7 +182,10 @@ type redisRequestCounter struct {
 func (r *redisRequestCounter) GetRequestCounts(ctx context.Context, readyPods []*v1.Pod, withNamespace bool) map[string]int {
 	// Get counts with port first and merge them by pod
 	portsMap := make(map[string][]int) // empty ports map
+
+	startTime := time.Now()
 	countsWithPort := r.GetRequestCountsWithPort(ctx, readyPods, portsMap, withNamespace)
+	klog.V(4).InfoS("redisRequestCounter_GetRequestCounts_withPort_done", "duration", time.Since(startTime))
 
 	// Merge counts for the same pod (sum across all ports)
 	result := make(map[string]int)
@@ -219,7 +223,7 @@ func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, read
 	// Get model name from the first pod (all pods should serve the same model)
 	modelName := ""
 	if readyPods[0].Labels != nil {
-		if model, ok := readyPods[0].Labels["model"]; ok {
+		if model, ok := readyPods[0].Labels[constants.ModelLabelName]; ok {
 			modelName = model
 		}
 	}
@@ -234,12 +238,41 @@ func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, read
 	r.lastModelFilterTime[modelName] = time.Now()
 	r.lastModelFilterTimeMu.Unlock()
 
+	// Initialize result with all readyPods set to 0
+	result := make(map[string]int)
+	for _, pod := range readyPods {
+		podPorts, hasPorts := portsMap[pod.Name]
+
+		if !hasPorts || len(podPorts) == 0 {
+			// No ports specified, add single entry for this pod
+			var resultKey string
+			if withNamespace {
+				resultKey = fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+			} else {
+				resultKey = pod.Name
+			}
+			result[resultKey] = 0
+		} else {
+			// Has ports, add entry for each port
+			for _, port := range podPorts {
+				var resultKey string
+				if withNamespace {
+					resultKey = fmt.Sprintf("%s/%s/%d", pod.Namespace, pod.Name, port)
+				} else {
+					resultKey = fmt.Sprintf("%s/%d", pod.Name, port)
+				}
+				result[resultKey] = 0
+			}
+		}
+	}
+
 	// Get all request counts from Redis using HGETALL
 	key := r.buildRedisKey(modelName)
 	counts, err := r.redisCli.HGetAll(ctx, key).Result()
 	if err != nil {
 		klog.ErrorS(err, "failed to get request counts from redis", "key", key)
-		return make(map[string]int)
+		// Return result with all zeros
+		return result
 	}
 
 	// Build a map of valid pods for filtering
@@ -248,8 +281,7 @@ func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, read
 		validPods[pod.Name] = pod
 	}
 
-	// Parse Redis data and build result map
-	result := make(map[string]int)
+	// Parse Redis data and update result map
 	for field, countStr := range counts {
 		// field format from podServerKey.String():
 		//   without port: "namespace_podname"
@@ -294,13 +326,16 @@ func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, read
 			}
 		} else {
 			if hasPort {
-				resultKey = fmt.Sprintf("%s_%d", pod.Name, port)
+				resultKey = fmt.Sprintf("%s/%d", pod.Name, port)
 			} else {
 				resultKey = pod.Name
 			}
 		}
 
-		result[resultKey] = count
+		// Only update if this key was initialized (exists in result)
+		if _, keyExists := result[resultKey]; keyExists {
+			result[resultKey] = count
+		}
 	}
 
 	return result

--- a/pkg/plugins/gateway/algorithms/request_counter.go
+++ b/pkg/plugins/gateway/algorithms/request_counter.go
@@ -144,18 +144,31 @@ func (l *localRequestCounter) GetRequestCountsWithPort(
 // redisRequestCounter is a redis-based implementation of RequestCounter
 // redis key design:
 //
-//		aibrix:prefix-cache-reqcnt:{<modelName>}: hashmap, <pod_name_with_port> -> request_count
-//	 we use hashmap here which is different from power-of-two router, because hgetall is needed to scan all the keys
-//	 modelName is wrapped in {} to support Redis Cluster hashtag, ensuring all keys for the same model are in the same slot
+//	aibrix:prefix-cache-reqcnt:{<modelName>}:<timestamp>: hashmap, <pod_name_with_port> -> request_count
+//	timestamp is rotated every hour to prevent stale counts from accumulating
+//	modelName is wrapped in {} to support Redis Cluster hashtag, ensuring all keys for the same model are in the same slot
 type redisRequestCounter struct {
 	redisCli       *redis.Client
 	redisKeyPrefix string
+	keyRotationSec int64 // Key rotation period in seconds (default: 3600s = 1 hour)
 
 	// lastModelRouteTime tracks when routing was last performed for each model
 	// Used to stop tracking request counts for models that are no longer being routed
 	lastModelRouteTime    map[string]time.Time
 	lastModelRouteTimeMu  sync.RWMutex // Protects lastModelRouteTime map
 	requestTrackerTimeout time.Duration
+}
+
+// getRequestTimeFromContext extracts RequestTime from context if it's a RoutingContext,
+// otherwise returns current time
+func (r *redisRequestCounter) getRequestTimeFromContext(ctx context.Context) time.Time {
+	// Try type assertion to see if this is actually a *types.RoutingContext
+	// In prefix_cache.go, we pass ctx (which embeds context.Context) as the first parameter
+	if routingCtx, ok := ctx.(*types.RoutingContext); ok {
+		return routingCtx.RequestTime
+	}
+	// Fallback to current time
+	return time.Now()
 }
 
 // GetRequestCounts implements [RequestCounter].
@@ -223,8 +236,11 @@ func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, read
 	r.lastModelRouteTime[modelName] = time.Now()
 	r.lastModelRouteTimeMu.Unlock()
 
+	// Extract request time from context or use current time
+	requestTime := r.getRequestTimeFromContext(ctx)
+
 	// Get all request counts from Redis using HGETALL
-	key := r.buildRedisKey(modelName)
+	key := r.buildRedisKey(modelName, requestTime)
 	counts, err := r.redisCli.HGetAll(ctx, key).Result()
 	if err != nil {
 		klog.ErrorS(err, "failed to get request counts from redis", "key", key)
@@ -252,6 +268,8 @@ func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, read
 const (
 	defaultRedisKeyPrefix          = "aibrix:prefix-cache-reqcnt"
 	defaultImbalanceTrackerTimeout = time.Minute * 5 // 5 minutes, stop tracking if filter not called
+	defaultReqCntKeyRotationSec    = int64(3600)     // 1 hour, rotate keys to prevent stale counts
+	defaultReqCntKeyExpiry         = 2 * time.Hour   // TTL for Redis keys (2x rotation period)
 )
 
 // NewredisRequestCounter creates a new redis-based imbalance pods filter
@@ -259,15 +277,21 @@ func NewRedisRequestCounter(redisClient *redis.Client) *redisRequestCounter {
 	return &redisRequestCounter{
 		redisCli:              redisClient,
 		redisKeyPrefix:        defaultRedisKeyPrefix,
+		keyRotationSec:        defaultReqCntKeyRotationSec,
 		lastModelRouteTime:    make(map[string]time.Time),
 		requestTrackerTimeout: defaultImbalanceTrackerTimeout,
 	}
 }
 
-// buildRedisKey constructs the redis key for a model
+// buildRedisKey constructs the redis key for a model with timestamp rotation
+// The timestamp is modulo keyRotationSec to rotate keys periodically (default: every hour)
+// This prevents stale counts from accumulating when gateway instances exit abnormally
 // Uses Redis Cluster hashtag to ensure all keys for the same model are in the same slot
-func (r *redisRequestCounter) buildRedisKey(modelName string) string {
-	return fmt.Sprintf("%s:{%s}", r.redisKeyPrefix, modelName)
+func (r *redisRequestCounter) buildRedisKey(modelName string, requestTime time.Time) string {
+	timestamp := requestTime.Unix()
+	// Rotate key every keyRotationSec seconds (default 3600s = 1 hour)
+	rotatedTimestamp := timestamp - (timestamp % r.keyRotationSec)
+	return fmt.Sprintf("%s:{%s}:%d", r.redisKeyPrefix, modelName, rotatedTimestamp)
 }
 
 // AddRequestCount implements [cache.RequestTracker].
@@ -314,7 +338,8 @@ func (r *redisRequestCounter) AddRequestCount(ctx *types.RoutingContext, request
 	}
 
 	// Increment request count in hashmap
-	key := r.buildRedisKey(modelName)
+	// Use RequestTime from context for key rotation
+	key := r.buildRedisKey(modelName, ctx.RequestTime)
 	field := serverKey.String()
 
 	newCount, err := r.redisCli.HIncrBy(ctx.Context, key, field, 1).Result()
@@ -377,7 +402,8 @@ func (r *redisRequestCounter) DoneRequestCount(ctx *types.RoutingContext, reques
 	}
 
 	// Decrement request count in hashmap
-	key := r.buildRedisKey(modelName)
+	// Use RequestTime from context for key rotation (must match the key used in AddRequestCount)
+	key := r.buildRedisKey(modelName, ctx.RequestTime)
 	field := serverKey.String()
 
 	// Use cached Lua script to atomically decrement and delete if zero

--- a/pkg/plugins/gateway/algorithms/request_counter.go
+++ b/pkg/plugins/gateway/algorithms/request_counter.go
@@ -143,8 +143,8 @@ type redisRequestCounter struct {
 
 	// lastModelRouteTime tracks when routing was last performed for each model
 	// Used to stop tracking request counts for models that are no longer being routed
-	lastModelRouteTime   map[string]time.Time
-	lastModelRouteTimeMu sync.RWMutex // Protects lastModelRouteTime map
+	lastModelRouteTime    map[string]time.Time
+	lastModelRouteTimeMu  sync.RWMutex // Protects lastModelRouteTime map
 	requestTrackerTimeout time.Duration
 }
 

--- a/pkg/plugins/gateway/algorithms/request_counter.go
+++ b/pkg/plugins/gateway/algorithms/request_counter.go
@@ -32,13 +32,13 @@ import (
 	"k8s.io/klog/v2"
 )
 
-type imbalancePodsFilterKeyType struct{}
+type requestCountAddedKeyType struct{}
 
-var imbalancePodsFilterReqAddedKey = imbalancePodsFilterKeyType{}
+var requestCountAddedKey = requestCountAddedKeyType{}
 
-type imbalancePodsFilterReqDelKeyType struct{}
+type requestCountDoneKeyType struct{}
 
-var imbalancePodsFilterReqDelKey = imbalancePodsFilterReqDelKeyType{}
+var requestCountDoneKey = requestCountDoneKeyType{}
 
 // MetricsProvider provides pod-level metrics
 type MetricsProvider interface {
@@ -131,7 +131,7 @@ func (l *localRequestCounter) GetRequestCountsWithPort(
 	return podRequestCount
 }
 
-// redisRequestCounter is a redis implementation of imbalancePodsFilter
+// redisRequestCounter is a redis-based implementation of RequestCounter
 // redis key design:
 //
 //		aibrix:prefix-cache-reqcnt:{<modelName>}: hashmap, <pod_name_with_port> -> request_count
@@ -290,11 +290,11 @@ func (r *redisRequestCounter) AddRequestCount(ctx *types.RoutingContext, request
 	}
 
 	// Check whether it is called the first time
-	v := ctx.Context.Value(imbalancePodsFilterReqAddedKey)
+	v := ctx.Context.Value(requestCountAddedKey)
 	if v != nil {
 		return 0
 	}
-	ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
+	ctx.Context = context.WithValue(ctx.Context, requestCountAddedKey, true)
 
 	// Build pod server key
 	port := ctx.TargetPort()
@@ -345,7 +345,7 @@ func (r *redisRequestCounter) DoneRequestCount(ctx *types.RoutingContext, reques
 
 	// Check if AddRequestCount was actually called for this request
 	// This prevents decrementing the counter if it was never incremented
-	if ctx.Context.Value(imbalancePodsFilterReqAddedKey) == nil {
+	if ctx.Context.Value(requestCountAddedKey) == nil {
 		klog.V(5).InfoS("skip request count decrement, AddRequestCount was not called",
 			"request_id", requestID,
 			"model", modelName)
@@ -353,11 +353,11 @@ func (r *redisRequestCounter) DoneRequestCount(ctx *types.RoutingContext, reques
 	}
 
 	// Check whether it is called the first time
-	v := ctx.Context.Value(imbalancePodsFilterReqDelKey)
+	v := ctx.Context.Value(requestCountDoneKey)
 	if v != nil {
 		return
 	}
-	ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqDelKey, true)
+	ctx.Context = context.WithValue(ctx.Context, requestCountDoneKey, true)
 
 	// Build pod server key
 	port := ctx.TargetPort()

--- a/pkg/plugins/gateway/algorithms/request_counter.go
+++ b/pkg/plugins/gateway/algorithms/request_counter.go
@@ -50,6 +50,17 @@ var decrementScript = redis.NewScript(`
 	return new_count
 `)
 
+// incrementScript is a cached Lua script for atomically incrementing and setting TTL on new keys
+// This ensures TTL is only set when the key is first created, not on every increment
+var incrementScript = redis.NewScript(`
+	local key_existed = redis.call('EXISTS', KEYS[1])
+	local new_count = redis.call('HINCRBY', KEYS[1], ARGV[1], 1)
+	if key_existed == 0 then
+		redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+	end
+	return new_count
+`)
+
 // MetricsProvider provides pod-level metrics
 type MetricsProvider interface {
 	GetMetricValueByPod(podName, namespace, metricName string) (metrics.MetricValue, error)
@@ -266,10 +277,9 @@ func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, read
 }
 
 const (
-	defaultRedisKeyPrefix          = "aibrix:prefix-cache-reqcnt"
-	defaultImbalanceTrackerTimeout = time.Minute * 5 // 5 minutes, stop tracking if filter not called
-	defaultReqCntKeyRotationSec    = int64(3600)     // 1 hour, rotate keys to prevent stale counts
-	defaultReqCntKeyExpiry         = 2 * time.Hour   // TTL for Redis keys (2x rotation period)
+	defaultRedisKeyPrefix       = "aibrix:prefix-cache-reqcnt"
+	defaultReqCntTrackerTimeout = time.Minute * 5 // 5 minutes, stop tracking if GetRequestCounts not called
+	defaultReqCntKeyRotationSec = int64(3600)     // 1 hour, rotate keys to prevent stale counts
 )
 
 // NewredisRequestCounter creates a new redis-based imbalance pods filter
@@ -279,7 +289,7 @@ func NewRedisRequestCounter(redisClient *redis.Client) *redisRequestCounter {
 		redisKeyPrefix:        defaultRedisKeyPrefix,
 		keyRotationSec:        defaultReqCntKeyRotationSec,
 		lastModelRouteTime:    make(map[string]time.Time),
-		requestTrackerTimeout: defaultImbalanceTrackerTimeout,
+		requestTrackerTimeout: defaultReqCntTrackerTimeout,
 	}
 }
 
@@ -337,28 +347,20 @@ func (r *redisRequestCounter) AddRequestCount(ctx *types.RoutingContext, request
 		port: port,
 	}
 
-	// Increment request count in hashmap
+	// Increment request count in hashmap using Lua script
 	// Use RequestTime from context for key rotation
+	// The script will set TTL only when the key is first created
 	key := r.buildRedisKey(modelName, ctx.RequestTime)
 	field := serverKey.String()
+	ttlSeconds := r.keyRotationSec + 300 // rotation period + 5 minute buffer
 
-	newCount, err := r.redisCli.HIncrBy(ctx.Context, key, field, 1).Result()
+	newCount, err := incrementScript.Run(ctx.Context, r.redisCli, []string{key}, field, ttlSeconds).Int64()
 	if err != nil {
 		klog.ErrorS(err, "failed to increment request count in hashmap",
 			"request_id", requestID,
 			"key", key,
 			"field", field)
 		return 0
-	}
-
-	// Set TTL on the hash key to prevent memory leaks for inactive models
-	// Use requestTrackerTimeout as the expiry duration
-	// This is safe to call on every increment - Redis only updates TTL if key exists
-	if err := r.redisCli.Expire(ctx.Context, key, r.requestTrackerTimeout).Err(); err != nil {
-		klog.ErrorS(err, "failed to set TTL on request count key",
-			"key", key,
-			"ttl", r.requestTrackerTimeout)
-		// Don't return error - the increment succeeded, TTL failure is not critical
 	}
 
 	klog.V(4).InfoS("imbalance_filter_add_request",

--- a/pkg/plugins/gateway/algorithms/request_counter.go
+++ b/pkg/plugins/gateway/algorithms/request_counter.go
@@ -1,0 +1,458 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/metrics"
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+type imbalancePodsFilterKeyType struct{}
+
+var imbalancePodsFilterReqAddedKey = imbalancePodsFilterKeyType{}
+
+type imbalancePodsFilterReqDelKeyType struct{}
+
+var imbalancePodsFilterReqDelKey = imbalancePodsFilterReqDelKeyType{}
+
+// MetricsProvider provides pod-level metrics
+type MetricsProvider interface {
+	GetMetricValueByPod(podName, namespace, metricName string) (metrics.MetricValue, error)
+}
+
+// RequestCounter provides pod-level request count
+type RequestCounter interface {
+	// GetRequestCounts returns a map of pod name to request count
+	// Returns:
+	//  withNamespace=false:  pod name -> request count
+	//  withNamespace=true: pod namespace/pod name -> request count
+	GetRequestCounts(ctx context.Context, readyPods []*v1.Pod, withNamespace bool) map[string]int
+	// GetRequestCountsWithPort returns running request count for each pod-port combination, used when a pod has multiple ports
+	// Returns:
+	//  withNamespace=false:  pod name/port -> request count
+	//  withNamespace=true:   pod namespace/pod name/port -> request count
+	GetRequestCountsWithPort(ctx context.Context, readyPods []*v1.Pod,
+		portsMap map[string][]int, withNamespace bool) map[string]int
+}
+
+// parse the key of map returned by GetRequestCountsWithPort
+func parseKey(key string, withNamespace bool) (namespace string, podName string, port string) {
+	parts := strings.Split(key, "/")
+	if withNamespace {
+		// namespace/podName/port or namespace/podName
+		if len(parts) == 2 {
+			return parts[0], parts[1], ""
+		}
+		return parts[0], parts[1], parts[2]
+	}
+	// podName/port or podName
+	if len(parts) == 2 {
+		return "", parts[0], parts[1]
+	}
+	return "", parts[0], ""
+}
+
+// localRequestCounter is a local implementation of imbalancePodsFilter
+type localRequestCounter struct {
+	metricsProvider MetricsProvider
+}
+
+// NewLocalImbalancePodsFilter creates a new local imbalance pods filter
+func NewLocalRequestCounter(provider MetricsProvider) *localRequestCounter {
+	return &localRequestCounter{
+		metricsProvider: provider,
+	}
+}
+
+func (l *localRequestCounter) GetRequestCounts(ctx context.Context, readyPods []*v1.Pod, withNamespace bool) map[string]int {
+	podRequestCount := make(map[string]int, len(readyPods))
+	for _, pod := range readyPods {
+		runningReq, err := l.metricsProvider.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
+		if err != nil {
+			runningReq = &metrics.SimpleMetricValue{Value: 0}
+		}
+		podRequestCount[pod.Name] = int(runningReq.GetSimpleValue())
+	}
+
+	return podRequestCount
+}
+
+// getRequestCountsWithPort returns running request count for each pod-port combination
+func (l *localRequestCounter) GetRequestCountsWithPort(
+	ctx context.Context, readyPods []*v1.Pod, portsMap map[string][]int, withNamespace bool) map[string]int {
+	podRequestCount := make(map[string]int)
+	for _, pod := range readyPods {
+		podPorts, exists := portsMap[pod.Name]
+
+		// Single port or no explicit ports
+		if !exists || len(podPorts) == 0 {
+			runningReq, err := l.metricsProvider.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
+			if err != nil {
+				runningReq = &metrics.SimpleMetricValue{Value: 0}
+			}
+			podRequestCount[pod.Name] = int(runningReq.GetSimpleValue())
+			continue
+		}
+
+		// Multi-port pod
+		for _, port := range podPorts {
+			var metricName string
+			var keyName string
+
+			if len(podPorts) == 1 {
+				metricName = metrics.RealtimeNumRequestsRunning
+				keyName = fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+			} else {
+				metricName = fmt.Sprintf("%s/%d", metrics.RealtimeNumRequestsRunning, port)
+				keyName = fmt.Sprintf("%s/%s/%d", pod.Namespace, pod.Name, port)
+			}
+
+			var count int
+			if val, err := l.metricsProvider.GetMetricValueByPod(pod.Name, pod.Namespace, metricName); err == nil && val != nil {
+				count = int(val.GetSimpleValue())
+			}
+			podRequestCount[keyName] = count
+		}
+	}
+
+	return podRequestCount
+}
+
+// deduplicatePods extracts and deduplicates pods from podServerKey list
+func deduplicatePods(serverKeys []podServerKey) []*v1.Pod {
+	podMap := make(map[string]*v1.Pod)
+	for _, serverKey := range serverKeys {
+		if serverKey.pod != nil {
+			podMap[serverKey.pod.Name] = serverKey.pod
+		}
+	}
+
+	result := make([]*v1.Pod, 0, len(podMap))
+	for _, pod := range podMap {
+		result = append(result, pod)
+	}
+	return result
+}
+
+// redisRequestCounter is a redis implementation of imbalancePodsFilter
+// redis key design:
+//
+//		aibrix:prefix-cache-reqcnt:{<modelName>}: hashmap, <pod_name_with_port> -> request_count
+//	 we use hashmap here which is different from power-of-two router, because hgetall is needed to scan all the keys
+//	 modelName is wrapped in {} to support Redis Cluster hashtag, ensuring all keys for the same model are in the same slot
+type redisRequestCounter struct {
+	redisCli           *redis.Client
+	imbalanceThreshold int // Threshold for considering pods imbalanced (default: 2)
+	redisKeyPrefix     string
+
+	// lastModelFilterTime tracks when FilterPods was last called for each model
+	// Used to stop tracking request counts for models that are no longer being filtered
+	lastModelFilterTime   map[string]time.Time
+	lastModelFilterTimeMu sync.RWMutex // Protects lastModelFilterTime map
+	requestTrackerTimeout time.Duration
+}
+
+// GetRequestCounts implements [RequestCounter].
+func (r *redisRequestCounter) GetRequestCounts(ctx context.Context, readyPods []*v1.Pod, withNamespace bool) map[string]int {
+	// Get counts with port first and merge them by pod
+	portsMap := make(map[string][]int) // empty ports map
+	countsWithPort := r.GetRequestCountsWithPort(ctx, readyPods, portsMap, withNamespace)
+
+	// Merge counts for the same pod (sum across all ports)
+	result := make(map[string]int)
+	for key, count := range countsWithPort {
+		// Extract pod key (remove port suffix if present)
+		var podKey string
+		if withNamespace {
+			// Format: "namespace/pod-name" or "namespace/pod-name/port"
+			// Split by "/" and take first two parts
+			parts := strings.Split(key, "/")
+			if len(parts) >= 2 {
+				podKey = parts[0] + "/" + parts[1]
+			} else {
+				podKey = key
+			}
+		} else {
+			// Format: "pod-name" or "pod-name/port"
+			// Split by "/" and take first part
+			parts := strings.Split(key, "/")
+			podKey = parts[0]
+		}
+
+		result[podKey] += count
+	}
+
+	return result
+}
+
+// GetRequestCountsWithPort implements [RequestCounter].
+func (r *redisRequestCounter) GetRequestCountsWithPort(ctx context.Context, readyPods []*v1.Pod, portsMap map[string][]int, withNamespace bool) map[string]int {
+	if len(readyPods) == 0 {
+		return make(map[string]int)
+	}
+
+	// Get model name from the first pod (all pods should serve the same model)
+	modelName := ""
+	if readyPods[0].Labels != nil {
+		if model, ok := readyPods[0].Labels["model"]; ok {
+			modelName = model
+		}
+	}
+
+	if modelName == "" {
+		klog.V(4).InfoS("cannot determine model name from pod, returning empty counts")
+		return make(map[string]int)
+	}
+
+	// Update last filter time for this model
+	r.lastModelFilterTimeMu.Lock()
+	r.lastModelFilterTime[modelName] = time.Now()
+	r.lastModelFilterTimeMu.Unlock()
+
+	// Get all request counts from Redis using HGETALL
+	key := r.buildRedisKey(modelName)
+	counts, err := r.redisCli.HGetAll(ctx, key).Result()
+	if err != nil {
+		klog.ErrorS(err, "failed to get request counts from redis", "key", key)
+		return make(map[string]int)
+	}
+
+	// Build a map of valid pods for filtering
+	validPods := make(map[string]*v1.Pod)
+	for _, pod := range readyPods {
+		validPods[pod.Name] = pod
+	}
+
+	// Parse Redis data and build result map
+	result := make(map[string]int)
+	for field, countStr := range counts {
+		// field format from podServerKey.String():
+		//   without port: "namespace_podname"
+		//   with port: "namespace_podname_port"
+
+		// Split by underscore
+		parts := strings.Split(field, "_")
+		if len(parts) < 2 {
+			continue
+		}
+
+		podName := parts[1]
+		var port int
+		hasPort := false
+		if len(parts) >= 3 {
+			// Parse port from the last part
+			if p, err := strconv.Atoi(parts[2]); err == nil {
+				port = p
+				hasPort = true
+			}
+		}
+
+		// Check if this pod is in readyPods
+		pod, exists := validPods[podName]
+		if !exists {
+			continue
+		}
+
+		// Parse count
+		count, err := strconv.Atoi(countStr)
+		if err != nil {
+			continue
+		}
+
+		// Build result key based on withNamespace parameter
+		var resultKey string
+		if withNamespace {
+			if hasPort {
+				resultKey = fmt.Sprintf("%s/%s/%d", pod.Namespace, pod.Name, port)
+			} else {
+				resultKey = fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+			}
+		} else {
+			if hasPort {
+				resultKey = fmt.Sprintf("%s_%d", pod.Name, port)
+			} else {
+				resultKey = pod.Name
+			}
+		}
+
+		result[resultKey] = count
+	}
+
+	return result
+}
+
+const (
+	defaultRedisKeyPrefix          = "aibrix:prefix-cache-reqcnt"
+	defaultImbalanceTrackerTimeout = time.Minute * 5 // 5 minutes, stop tracking if filter not called
+)
+
+// NewredisRequestCounter creates a new redis-based imbalance pods filter
+func NewRedisRequestCounter(redisClient *redis.Client, imbalanceThreshold int) *redisRequestCounter {
+	return &redisRequestCounter{
+		redisCli:              redisClient,
+		imbalanceThreshold:    imbalanceThreshold,
+		redisKeyPrefix:        defaultRedisKeyPrefix,
+		lastModelFilterTime:   make(map[string]time.Time),
+		requestTrackerTimeout: defaultImbalanceTrackerTimeout,
+	}
+}
+
+// buildRedisKey constructs the redis key for a model
+// Uses Redis Cluster hashtag to ensure all keys for the same model are in the same slot
+func (r *redisRequestCounter) buildRedisKey(modelName string) string {
+	return fmt.Sprintf("%s:{%s}", r.redisKeyPrefix, modelName)
+}
+
+// AddRequestCount implements [cache.RequestTracker].
+func (r *redisRequestCounter) AddRequestCount(ctx *types.RoutingContext, requestID string, modelName string) (traceTerm int64) {
+	// Check whether target pod is set
+	if !ctx.HasRouted() {
+		return 0
+	}
+
+	// Skip counting if this model hasn't been filtered recently
+	// This avoids counting requests that are no longer being load-balanced
+	r.lastModelFilterTimeMu.RLock()
+	lastModelFilterTime, ok := r.lastModelFilterTime[modelName]
+	r.lastModelFilterTimeMu.RUnlock()
+
+	if ok {
+		// If it's been too long since last filter call, skip counting
+		if time.Since(lastModelFilterTime) > r.requestTrackerTimeout {
+			klog.V(5).InfoS("skip request count tracking, model filter timeout",
+				"model", modelName,
+				"last_filter_time", lastModelFilterTime,
+				"timeout", r.requestTrackerTimeout)
+			return 0
+		}
+	} else {
+		// No filter history for this model, skip counting
+		klog.V(5).InfoS("skip request count tracking, no filter history",
+			"model", modelName)
+		return 0
+	}
+
+	// Check whether it is called the first time
+	v := ctx.Context.Value(imbalancePodsFilterReqAddedKey)
+	if v != nil {
+		return 0
+	}
+	ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
+
+	// Build pod server key
+	port := ctx.TargetPort()
+	serverKey := podServerKey{
+		pod:  ctx.TargetPod(),
+		port: port,
+	}
+
+	// Increment request count in hashmap
+	key := r.buildRedisKey(modelName)
+	field := serverKey.String()
+
+	newCount, err := r.redisCli.HIncrBy(ctx.Context, key, field, 1).Result()
+	if err != nil {
+		klog.ErrorS(err, "failed to increment request count in hashmap",
+			"request_id", requestID,
+			"key", key,
+			"field", field)
+		return 0
+	}
+
+	klog.V(4).InfoS("imbalance_filter_add_request",
+		"request_id", requestID,
+		"model", modelName,
+		"pod", serverKey.String(),
+		"new_count", newCount)
+
+	return newCount
+}
+
+// DoneRequestCount implements [cache.RequestTracker].
+// Only one DoneRequestXXX should be called for a request. Idemptency is not required.
+func (r *redisRequestCounter) DoneRequestCount(ctx *types.RoutingContext, requestID string, modelName string, traceTerm int64) {
+	// Check whether target pod is set
+	if ctx.TargetPod() == nil {
+		return
+	}
+
+	// Check whether it is called the first time
+	v := ctx.Context.Value(imbalancePodsFilterReqDelKey)
+	if v != nil {
+		return
+	}
+	ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqDelKey, true)
+
+	// Build pod server key
+	port := ctx.TargetPort()
+	serverKey := podServerKey{
+		pod:  ctx.TargetPod(),
+		port: port,
+	}
+
+	// Decrement request count in hashmap
+	key := r.buildRedisKey(modelName)
+	field := serverKey.String()
+
+	newCount, err := r.redisCli.HIncrBy(ctx.Context, key, field, -1).Result()
+	if err != nil {
+		klog.ErrorS(err, "failed to decrement request count in hashmap",
+			"request_id", requestID,
+			"key", key,
+			"field", field)
+		return
+	}
+
+	// If count is zero or negative, delete the field
+	if newCount <= 0 {
+		if err := r.redisCli.HDel(ctx.Context, key, field).Err(); err != nil {
+			klog.ErrorS(err, "failed to delete field from hashmap",
+				"key", key,
+				"field", field)
+		}
+	}
+
+	klog.V(4).InfoS("imbalance_filter_done_request",
+		"request_id", requestID,
+		"model", modelName,
+		"pod", serverKey.String(),
+		"new_count", newCount)
+}
+
+// DoneRequestTrace implements [cache.RequestTracker].
+// Only one DoneRequestXXX should be called for a request. Idemptency is not required.
+func (r *redisRequestCounter) DoneRequestTrace(ctx *types.RoutingContext, requestID string, modelName string, inputTokens int64, outputTokens int64, traceTerm int64) {
+	r.DoneRequestCount(ctx, requestID, modelName, traceTerm)
+}
+
+var (
+	_ RequestCounter = &localRequestCounter{}
+	_ RequestCounter = &redisRequestCounter{}
+	// redisRequestCounter also implements RequestTracker
+	_ cache.RequestTracker = &redisRequestCounter{}
+)

--- a/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
+++ b/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package routingalgorithms
 
 import (

--- a/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
+++ b/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
@@ -133,10 +133,10 @@ func TestRedisRequestCounter_AddRequestCount(t *testing.T) {
 		counter.lastModelRouteTime[modelName] = time.Now()
 		counter.lastModelRouteTimeMu.Unlock()
 
-		// Expect HIncrBy to return 1 (first request)
-		mock.ExpectHIncrBy(key, field, 1).SetVal(1)
-		// Expect Expire to be called for TTL
-		mock.ExpectExpire(key, counter.requestTrackerTimeout).SetVal(true)
+		// Expect EvalSha call (script is cached) to return 1
+		// The Lua script will check key existence, increment, and set TTL if needed
+		ttlSeconds := counter.keyRotationSec + 300 // rotation period + 5 minute buffer
+		mock.Regexp().ExpectEvalSha(`.*`, []string{key}, field, ttlSeconds).SetVal(int64(1))
 
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req1", "")
 		ctx.RequestTime = testTime // Set RequestTime to match the key
@@ -154,10 +154,9 @@ func TestRedisRequestCounter_AddRequestCount(t *testing.T) {
 		counter.lastModelRouteTime[modelName] = time.Now()
 		counter.lastModelRouteTimeMu.Unlock()
 
-		// Expect HIncrBy to return 2 (second request)
-		mock.ExpectHIncrBy(key, field, 1).SetVal(2)
-		// Expect Expire to be called for TTL
-		mock.ExpectExpire(key, counter.requestTrackerTimeout).SetVal(true)
+		// Expect EvalSha call to return 2
+		ttlSeconds := counter.keyRotationSec + 300 // rotation period + 5 minute buffer
+		mock.Regexp().ExpectEvalSha(`.*`, []string{key}, field, ttlSeconds).SetVal(int64(2))
 
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req2", "")
 		ctx.RequestTime = testTime // Set RequestTime to match the key

--- a/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
+++ b/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
@@ -42,7 +42,9 @@ func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 
 	counter := NewRedisRequestCounter(client)
 	modelName := testModelName
-	key := counter.buildRedisKey(modelName)
+	// Use a fixed time for consistent key generation in tests
+	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	key := counter.buildRedisKey(modelName, testTime)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
@@ -60,8 +62,9 @@ func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 		// Use Regexp to match any SHA hash
 		mock.Regexp().ExpectEvalSha(`.*`, []string{key}, field).SetVal(int64(0))
 
-		// Create context using constructor
+		// Create context using constructor with the same test time
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req1", "")
+		ctx.RequestTime = testTime // Set RequestTime to match the key
 		ctx.SetTargetPod(pod)
 		// Mark that AddRequestCount was called
 		ctx.Context = context.WithValue(ctx.Context, requestCountAddedKey, true)
@@ -78,6 +81,7 @@ func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 		mock.Regexp().ExpectEvalSha(`.*`, []string{key}, field).SetVal(int64(-1))
 
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req2", "")
+		ctx.RequestTime = testTime // Set RequestTime to match the key
 		ctx.SetTargetPod(pod)
 		ctx.Context = context.WithValue(ctx.Context, requestCountAddedKey, true)
 
@@ -92,6 +96,7 @@ func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 		mock.Regexp().ExpectEvalSha(`.*`, []string{key}, field).SetVal(int64(4))
 
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req3", "")
+		ctx.RequestTime = testTime // Set RequestTime to match the key
 		ctx.SetTargetPod(pod)
 		ctx.Context = context.WithValue(ctx.Context, requestCountAddedKey, true)
 
@@ -108,7 +113,9 @@ func TestRedisRequestCounter_AddRequestCount(t *testing.T) {
 
 	counter := NewRedisRequestCounter(client)
 	modelName := testModelName
-	key := counter.buildRedisKey(modelName)
+	// Use a fixed time for consistent key generation in tests
+	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	key := counter.buildRedisKey(modelName, testTime)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
@@ -132,6 +139,7 @@ func TestRedisRequestCounter_AddRequestCount(t *testing.T) {
 		mock.ExpectExpire(key, counter.requestTrackerTimeout).SetVal(true)
 
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req1", "")
+		ctx.RequestTime = testTime // Set RequestTime to match the key
 		ctx.SetTargetPod(pod)
 
 		traceTerm := counter.AddRequestCount(ctx, "req1", modelName)
@@ -152,6 +160,7 @@ func TestRedisRequestCounter_AddRequestCount(t *testing.T) {
 		mock.ExpectExpire(key, counter.requestTrackerTimeout).SetVal(true)
 
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req2", "")
+		ctx.RequestTime = testTime // Set RequestTime to match the key
 		ctx.SetTargetPod(pod)
 
 		traceTerm := counter.AddRequestCount(ctx, "req2", modelName)
@@ -163,6 +172,7 @@ func TestRedisRequestCounter_AddRequestCount(t *testing.T) {
 	t.Run("skip_if_already_called", func(t *testing.T) {
 		// If AddRequestCount was already called, should skip
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req3", "")
+		ctx.RequestTime = testTime // Set RequestTime to match the key
 		ctx.SetTargetPod(pod)
 		// Mark as already added
 		ctx.Context = context.WithValue(ctx.Context, requestCountAddedKey, true)

--- a/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
+++ b/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
@@ -56,8 +56,9 @@ func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 
 	// Test case 1: Decrement from 1 to 0 should delete the field
 	t.Run("decrement_to_zero", func(t *testing.T) {
-		// Expect any Eval call with key and field, return 0
-		mock.Regexp().ExpectEval(`.*HINCRBY.*`, []string{key}, field).SetVal(int64(0))
+		// Expect EvalSha call (script is cached), return 0
+		// Use Regexp to match any SHA hash
+		mock.Regexp().ExpectEvalSha(`.*`, []string{key}, field).SetVal(int64(0))
 
 		// Create context using constructor
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req1", "")
@@ -74,7 +75,7 @@ func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 
 	// Test case 2: Decrement from 0 to -1 should delete the field
 	t.Run("decrement_to_negative", func(t *testing.T) {
-		mock.Regexp().ExpectEval(`.*HINCRBY.*`, []string{key}, field).SetVal(int64(-1))
+		mock.Regexp().ExpectEvalSha(`.*`, []string{key}, field).SetVal(int64(-1))
 
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req2", "")
 		ctx.SetTargetPod(pod)
@@ -88,7 +89,7 @@ func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 	// Test case 3: Decrement from 5 to 4 should NOT delete the field
 	t.Run("decrement_above_zero", func(t *testing.T) {
 		// Expect Lua script returns 4 (count > 0, so no deletion happens in Lua)
-		mock.Regexp().ExpectEval(`.*HINCRBY.*`, []string{key}, field).SetVal(int64(4))
+		mock.Regexp().ExpectEvalSha(`.*`, []string{key}, field).SetVal(int64(4))
 
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req3", "")
 		ctx.SetTargetPod(pod)

--- a/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
+++ b/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
@@ -31,15 +31,17 @@ import (
 	"github.com/vllm-project/aibrix/pkg/types"
 )
 
+const testModelName = "test-model"
+
 // TestRedisRequestCounter_AtomicDecrementDelete verifies that the Lua script
 // atomically decrements and deletes, preventing race conditions
 func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 	// Create mock Redis client
 	client, mock := redismock.NewClientMock()
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	counter := NewRedisRequestCounter(client)
-	modelName := "test-model"
+	modelName := testModelName
 	key := counter.buildRedisKey(modelName)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -61,7 +63,7 @@ func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req1", "")
 		ctx.SetTargetPod(pod)
 		// Mark that AddRequestCount was called
-		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
+		ctx.Context = context.WithValue(ctx.Context, requestCountAddedKey, true)
 
 		// Call DoneRequestCount which should decrement to 0 and delete
 		counter.DoneRequestCount(ctx, "req1", modelName, 1)
@@ -76,7 +78,7 @@ func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req2", "")
 		ctx.SetTargetPod(pod)
-		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
+		ctx.Context = context.WithValue(ctx.Context, requestCountAddedKey, true)
 
 		counter.DoneRequestCount(ctx, "req2", modelName, 0)
 
@@ -90,7 +92,7 @@ func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req3", "")
 		ctx.SetTargetPod(pod)
-		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
+		ctx.Context = context.WithValue(ctx.Context, requestCountAddedKey, true)
 
 		counter.DoneRequestCount(ctx, "req3", modelName, 5)
 
@@ -101,10 +103,10 @@ func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
 // TestRedisRequestCounter_AddRequestCount verifies increment operation
 func TestRedisRequestCounter_AddRequestCount(t *testing.T) {
 	client, mock := redismock.NewClientMock()
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	counter := NewRedisRequestCounter(client)
-	modelName := "test-model"
+	modelName := testModelName
 	key := counter.buildRedisKey(modelName)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -162,7 +164,7 @@ func TestRedisRequestCounter_AddRequestCount(t *testing.T) {
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req3", "")
 		ctx.SetTargetPod(pod)
 		// Mark as already added
-		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
+		ctx.Context = context.WithValue(ctx.Context, requestCountAddedKey, true)
 
 		traceTerm := counter.AddRequestCount(ctx, "req3", modelName)
 		assert.Equal(t, int64(0), traceTerm)
@@ -176,10 +178,10 @@ func TestRedisRequestCounter_AddRequestCount(t *testing.T) {
 // properly skips when AddRequestCount was not called
 func TestRedisRequestCounter_DoneRequestCount_Skips(t *testing.T) {
 	client, mock := redismock.NewClientMock()
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	counter := NewRedisRequestCounter(client)
-	modelName := "test-model"
+	modelName := testModelName
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
@@ -206,8 +208,8 @@ func TestRedisRequestCounter_DoneRequestCount_Skips(t *testing.T) {
 		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req2", "")
 		ctx.SetTargetPod(pod)
 		// Mark both Add and Done as called
-		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
-		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqDelKey, true)
+		ctx.Context = context.WithValue(ctx.Context, requestCountAddedKey, true)
+		ctx.Context = context.WithValue(ctx.Context, requestCountDoneKey, true)
 
 		// Call DoneRequestCount - should skip because already called
 		counter.DoneRequestCount(ctx, "req2", modelName, 1)

--- a/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
+++ b/pkg/plugins/gateway/algorithms/request_counter_atomic_test.go
@@ -1,0 +1,202 @@
+package routingalgorithms
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redismock/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/types"
+)
+
+// TestRedisRequestCounter_AtomicDecrementDelete verifies that the Lua script
+// atomically decrements and deletes, preventing race conditions
+func TestRedisRequestCounter_AtomicDecrementDelete(t *testing.T) {
+	// Create mock Redis client
+	client, mock := redismock.NewClientMock()
+	defer client.Close()
+
+	counter := NewRedisRequestCounter(client)
+	modelName := "test-model"
+	key := counter.buildRedisKey(modelName)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				constants.ModelLabelName: modelName,
+			},
+		},
+	}
+	field := podServerKey{pod: pod}.String()
+
+	// Test case 1: Decrement from 1 to 0 should delete the field
+	t.Run("decrement_to_zero", func(t *testing.T) {
+		// Expect any Eval call with key and field, return 0
+		mock.Regexp().ExpectEval(`.*HINCRBY.*`, []string{key}, field).SetVal(int64(0))
+
+		// Create context using constructor
+		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req1", "")
+		ctx.SetTargetPod(pod)
+		// Mark that AddRequestCount was called
+		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
+
+		// Call DoneRequestCount which should decrement to 0 and delete
+		counter.DoneRequestCount(ctx, "req1", modelName, 1)
+
+		// Verify all expectations were met
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	// Test case 2: Decrement from 0 to -1 should delete the field
+	t.Run("decrement_to_negative", func(t *testing.T) {
+		mock.Regexp().ExpectEval(`.*HINCRBY.*`, []string{key}, field).SetVal(int64(-1))
+
+		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req2", "")
+		ctx.SetTargetPod(pod)
+		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
+
+		counter.DoneRequestCount(ctx, "req2", modelName, 0)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	// Test case 3: Decrement from 5 to 4 should NOT delete the field
+	t.Run("decrement_above_zero", func(t *testing.T) {
+		// Expect Lua script returns 4 (count > 0, so no deletion happens in Lua)
+		mock.Regexp().ExpectEval(`.*HINCRBY.*`, []string{key}, field).SetVal(int64(4))
+
+		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req3", "")
+		ctx.SetTargetPod(pod)
+		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
+
+		counter.DoneRequestCount(ctx, "req3", modelName, 5)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+// TestRedisRequestCounter_AddRequestCount verifies increment operation
+func TestRedisRequestCounter_AddRequestCount(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	defer client.Close()
+
+	counter := NewRedisRequestCounter(client)
+	modelName := "test-model"
+	key := counter.buildRedisKey(modelName)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				constants.ModelLabelName: modelName,
+			},
+		},
+	}
+	field := podServerKey{pod: pod}.String()
+
+	t.Run("first_request_adds_count", func(t *testing.T) {
+		// Update last route time to enable tracking
+		counter.lastModelRouteTimeMu.Lock()
+		counter.lastModelRouteTime[modelName] = time.Now()
+		counter.lastModelRouteTimeMu.Unlock()
+
+		// Expect HIncrBy to return 1 (first request)
+		mock.ExpectHIncrBy(key, field, 1).SetVal(1)
+		// Expect Expire to be called for TTL
+		mock.ExpectExpire(key, counter.requestTrackerTimeout).SetVal(true)
+
+		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req1", "")
+		ctx.SetTargetPod(pod)
+
+		traceTerm := counter.AddRequestCount(ctx, "req1", modelName)
+		assert.Equal(t, int64(1), traceTerm)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("second_request_increments_count", func(t *testing.T) {
+		// Update last route time
+		counter.lastModelRouteTimeMu.Lock()
+		counter.lastModelRouteTime[modelName] = time.Now()
+		counter.lastModelRouteTimeMu.Unlock()
+
+		// Expect HIncrBy to return 2 (second request)
+		mock.ExpectHIncrBy(key, field, 1).SetVal(2)
+		// Expect Expire to be called for TTL
+		mock.ExpectExpire(key, counter.requestTrackerTimeout).SetVal(true)
+
+		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req2", "")
+		ctx.SetTargetPod(pod)
+
+		traceTerm := counter.AddRequestCount(ctx, "req2", modelName)
+		assert.Equal(t, int64(2), traceTerm)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("skip_if_already_called", func(t *testing.T) {
+		// If AddRequestCount was already called, should skip
+		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req3", "")
+		ctx.SetTargetPod(pod)
+		// Mark as already added
+		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
+
+		traceTerm := counter.AddRequestCount(ctx, "req3", modelName)
+		assert.Equal(t, int64(0), traceTerm)
+
+		// No Redis expectations should be set - verify no calls were made
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+// TestRedisRequestCounter_DoneRequestCount_Skips verifies that DoneRequestCount
+// properly skips when AddRequestCount was not called
+func TestRedisRequestCounter_DoneRequestCount_Skips(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	defer client.Close()
+
+	counter := NewRedisRequestCounter(client)
+	modelName := "test-model"
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				constants.ModelLabelName: modelName,
+			},
+		},
+	}
+
+	t.Run("skip_if_add_not_called", func(t *testing.T) {
+		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req1", "")
+		ctx.SetTargetPod(pod)
+		// Do NOT mark AddRequestCount as called
+
+		// Call DoneRequestCount - should skip and not call Redis
+		counter.DoneRequestCount(ctx, "req1", modelName, 1)
+
+		// No Redis operations should have been performed
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("skip_if_done_already_called", func(t *testing.T) {
+		ctx := types.NewRoutingContext(context.Background(), "", modelName, "", "req2", "")
+		ctx.SetTargetPod(pod)
+		// Mark both Add and Done as called
+		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqAddedKey, true)
+		ctx.Context = context.WithValue(ctx.Context, imbalancePodsFilterReqDelKey, true)
+
+		// Call DoneRequestCount - should skip because already called
+		counter.DoneRequestCount(ctx, "req2", modelName, 1)
+
+		// No Redis operations should have been performed
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/pkg/plugins/gateway/algorithms/utils.go
+++ b/pkg/plugins/gateway/algorithms/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package routingalgorithms
 
 import (

--- a/pkg/plugins/gateway/algorithms/utils.go
+++ b/pkg/plugins/gateway/algorithms/utils.go
@@ -1,0 +1,41 @@
+package routingalgorithms
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+)
+
+// podServerKey represents a pod with specific port
+type podServerKey struct {
+	pod  *v1.Pod
+	port int
+}
+
+func (k podServerKey) String() string {
+	if k.port == 0 {
+		return fmt.Sprintf("%s/%s", k.pod.Namespace, k.pod.Name)
+	}
+	return fmt.Sprintf("%s/%s/%d", k.pod.Namespace, k.pod.Name, k.port)
+}
+
+// revert podServerKey.String to (namespace, name, port)
+func parseServerKey(key string) (namespace string, name string, port int) {
+	parts := strings.Split(key, "/")
+	if len(parts) == 2 {
+		namespace = parts[0]
+		name = parts[1]
+		port = 0
+	} else if len(parts) == 3 {
+		namespace = parts[0]
+		name = parts[1]
+		var err error
+		if port, err = strconv.Atoi(parts[2]); err != nil {
+			klog.ErrorS(err, "failed to parse port from server key", "key", key)
+		}
+	}
+	return
+}


### PR DESCRIPTION
## Summary

  This PR includes critical bugfixes for KV sync prefix cache routing and adds
  Redis-based request counting support for multi-instance gateway deployments.

  ## Changes

  ### ✨ Feature: Redis-Based Request Counter for Multi-Instance Gateway Deployments

  **Motivation:**
  When multiple AIBrix gateway instances are deployed, each instance only tracks local
  request counts. This causes incorrect load imbalance detection since no single
  instance has the complete view of pod request distribution.

  **Implementation:**
  - Added `RequestCounter` interface with two implementations:
    - `localRequestCounter`: Uses local metrics (existing behavior)
    - `redisRequestCounter`: Uses Redis hash to track distributed request counts
  - Modified prefix cache router to accept request counter via dependency injection
  - Refactored load balancing functions to accept `map[string]int` instead of
  `cache.Cache`
  - Environment variable `AIBRIX_PREFIX_CACHE_USE_REDIS_REQCNT=true` enables
  Redis-based counting

  **Key Features:**
  - Redis key design: `aibrix:prefix-cache-reqcnt:{model_name}` (hashmap: pod_key →
  count)
  - Supports Redis Cluster via hashtag `{model_name}` for same-slot operations
  - Automatic cleanup when request count reaches zero
  - Timeout mechanism to stop tracking inactive models (5 minutes)
  - Returns all ready pods with count=0 for pods not in Redis

  **Files Changed:**
  - `pkg/plugins/gateway/algorithms/request_counter.go` (new file): RequestCounter
  interface and implementations
  - `pkg/plugins/gateway/algorithms/prefix_cache.go`: Integration with request counter
  - `pkg/plugins/gateway/algorithms/power_of_two.go`: Updated `podServerKey.String()`
  to include namespace

  ## Testing

  - ✅ All existing tests pass
  - ✅ Updated test fixtures to use `requestCounter`
  - ✅ Fixed test expectations for namespace-aware pod keys

  ## Breaking Changes

  None. Changes are backward compatible:
  - Default behavior remains unchanged (uses local request counter)
  - Redis-based counting is opt-in via environment variable

  ## Related Issues

  Closes: [Issue number if applicable]

  ## Deployment Notes

  To enable Redis-based request counting:
  1. Ensure Redis client is configured
  2. Set environment variable: `AIBRIX_PREFIX_CACHE_USE_REDIS_REQCNT=true`
  3. Multiple gateway instances will now share request count information