### PR TITLE
ci: build vllm-mock as multi-arch image (linux/amd64,linux/arm64)

### DIFF
--- a/.github/workflows/docker-push-images.yml
+++ b/.github/workflows/docker-push-images.yml
@@ -25,6 +25,9 @@ jobs:
             file: build/container/Dockerfile.python
           - name: kvcache-watcher
             file: build/container/Dockerfile.kvcache
+          - name: vllm-mock
+            file: development/app/Dockerfile
+            context: development/app
     steps:
       - uses: actions/checkout@v3
         with:
@@ -42,6 +45,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
+          context: ${{ matrix.component.context || '.' }}
           file: ${{ matrix.component.file }}
           push: true
           tags: |
@@ -67,6 +71,9 @@ jobs:
             file: build/container/Dockerfile.python
           - name: kvcache-watcher
             file: build/container/Dockerfile.kvcache
+          - name: vllm-mock
+            file: development/app/Dockerfile
+            context: development/app
     steps:
       - uses: actions/checkout@v3
         with:
@@ -85,6 +92,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
+          context: ${{ matrix.component.context || '.' }}
           file: ${{ matrix.component.file }}
           push: true
           tags: |

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -26,6 +26,9 @@ jobs:
             file: build/container/Dockerfile.python
           - name: kvcache-watcher
             file: build/container/Dockerfile.kvcache
+          - name: vllm-mock
+            file: development/app/Dockerfile
+            context: development/app
     steps:
       - uses: actions/checkout@v3
         with:
@@ -43,6 +46,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
+          context: ${{ matrix.component.context || '.' }}
           file: ${{ matrix.component.file }}
           push: true
           tags: |
@@ -67,6 +71,9 @@ jobs:
             file: build/container/Dockerfile.python
           - name: kvcache-watcher
             file: build/container/Dockerfile.kvcache
+          - name: vllm-mock
+            file: development/app/Dockerfile
+            context: development/app
     steps:
       - uses: actions/checkout@v3
         with:
@@ -85,6 +92,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
+          context: ${{ matrix.component.context || '.' }}
           file: ${{ matrix.component.file }}
           push: true
           tags: |


### PR DESCRIPTION
The aibrix/vllm-mock image was previously built manually as a single-arch image, causing `exec format error` when running on a different host architecture (e.g. arm64 image on amd64 host or vice versa).

Add vllm-mock to the existing multi-arch matrix in both docker-push-images and release-build workflows so it is built and published for amd64 and arm64 alongside the other control-plane images. A new `context` field is introduced on the matrix entries because the vllm-mock Dockerfile lives in development/app/ and its COPY instructions reference files in that directory rather than the repo root.

Fixes #2054

