### PR TITLE
fix: fix the failed after add mdoeladapter

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -35,6 +36,7 @@ import (
 	"github.com/vllm-project/aibrix/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scache "k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
@@ -228,6 +230,66 @@ var _ = Describe("Cache", func() {
 		// No model meta cratead on failure
 		_, exist = cache.metaModels.Load("m0adapter")
 		Expect(exist).To(BeFalse())
+	})
+
+	It("should resyncModelAdapters repair missing adapter mapping", func() {
+		cache.addPod(getReadyPod("p1", "default", "m1", 0))
+
+		adapter := getNewModelAdapter("m1adapter", "default", "p1")
+		store := k8scache.NewStore(k8scache.MetaNamespaceKeyFunc)
+		Expect(store.Add(adapter)).To(Succeed())
+
+		cache.resyncModelAdapters(store, nil)
+
+		metaPod, exist := cache.metaPods.Load("default/p1")
+		Expect(exist).To(BeTrue())
+		modelName, exist := metaPod.Models.Load("m1adapter")
+		Expect(exist).To(BeTrue())
+		Expect(modelName).To(Equal("m1adapter"))
+
+		metaModel, exist := cache.metaModels.Load("m1adapter")
+		Expect(exist).To(BeTrue())
+		modelPod, exist := metaModel.Pods.Load("default/p1")
+		Expect(exist).To(BeTrue())
+		Expect(modelPod).To(Equal(metaPod.Pod))
+	})
+
+	It("should resyncModelAdapters retry until pod arrives", func() {
+		adapter := getNewModelAdapter("m1adapter", "default", "p1")
+		store := k8scache.NewStore(k8scache.MetaNamespaceKeyFunc)
+		Expect(store.Add(adapter)).To(Succeed())
+
+		originalRetries := modelAdapterResyncMaxRetries
+		originalInterval := modelAdapterResyncRetryInterval
+		modelAdapterResyncMaxRetries = 5
+		modelAdapterResyncRetryInterval = 10 * time.Millisecond
+		defer func() {
+			modelAdapterResyncMaxRetries = originalRetries
+			modelAdapterResyncRetryInterval = originalInterval
+		}()
+
+		done := make(chan struct{})
+		go func() {
+			cache.resyncModelAdapters(store, nil)
+			close(done)
+		}()
+
+		time.Sleep(15 * time.Millisecond)
+		cache.addPod(getReadyPod("p1", "default", "m1", 0))
+
+		Eventually(done).Should(BeClosed())
+
+		metaPod, exist := cache.metaPods.Load("default/p1")
+		Expect(exist).To(BeTrue())
+		modelName, exist := metaPod.Models.Load("m1adapter")
+		Expect(exist).To(BeTrue())
+		Expect(modelName).To(Equal("m1adapter"))
+
+		metaModel, exist := cache.metaModels.Load("m1adapter")
+		Expect(exist).To(BeTrue())
+		modelPod, exist := metaModel.Pods.Load("default/p1")
+		Expect(exist).To(BeTrue())
+		Expect(modelPod).To(Equal(metaPod.Pod))
 	})
 
 	It("should updatePod clear old mappings with no model adapter inherited", func() {

--- a/pkg/cache/informers.go
+++ b/pkg/cache/informers.go
@@ -17,6 +17,7 @@ package cache
 
 import (
 	"errors"
+	"time"
 
 	crdinformers "github.com/vllm-project/aibrix/pkg/client/informers/externalversions"
 	"github.com/vllm-project/aibrix/pkg/constants"
@@ -38,6 +39,11 @@ const (
 	modelIdentifier = constants.ModelLabelName
 	nodeType        = "ray.io/node-type"
 	nodeWorker      = "worker"
+)
+
+var (
+	modelAdapterResyncMaxRetries    = 30
+	modelAdapterResyncRetryInterval = 1 * time.Second
 )
 
 func initCacheInformers(instance *Store, config *rest.Config, stopCh <-chan struct{}) error {
@@ -85,7 +91,7 @@ func initCacheInformers(instance *Store, config *rest.Config, stopCh <-chan stru
 
 	// After cache sync, resync all ModelAdapters to ensure pod mappings are correct
 	// This handles the case where ModelAdapters were processed before their pods were cached
-	instance.resyncModelAdapters(modelInformer.GetStore())
+	instance.resyncModelAdapters(modelInformer.GetStore(), stopCh)
 
 	// Log cache state after initialization
 	klog.Infof("Cache initialization completed. Models: %v", instance.ListModels())
@@ -381,29 +387,91 @@ func (c *Store) deletePodAndModelMappingLocked(podName, namespace, modelName str
 }
 
 // resyncModelAdapters processes all ModelAdapters from the informer store to ensure
-// all pod mappings are correctly established after cache initialization
-func (c *Store) resyncModelAdapters(store cache.Store) {
+// all pod mappings are correctly established after cache initialization.
+// It retries missing pod mappings in batches so startup delay is bounded by
+// maxRetries * retryInterval regardless of the number of adapters.
+func (c *Store) resyncModelAdapters(store cache.Store, stopCh <-chan struct{}) {
 	klog.Info("Resyncing ModelAdapters to ensure pod mappings are correct")
 
-	objects := store.List()
-	for _, obj := range objects {
+	adapters := make([]*modelv1alpha1.ModelAdapter, 0)
+	for _, obj := range store.List() {
 		if modelAdapter, ok := obj.(*modelv1alpha1.ModelAdapter); ok {
-			c.mu.Lock()
-			// Process each pod instance in the ModelAdapter
-			for _, podName := range modelAdapter.Status.Instances {
-				// Check if pod exists in cache before creating mapping
-				if _, exists := c.metaPods.Load(utils.GeneratePodKey(modelAdapter.Namespace, podName)); exists {
-					c.addPodAndModelMappingLockedByName(podName, modelAdapter.Namespace, modelAdapter.Name)
-					klog.V(4).Infof("Resynced pod mapping for adapter %s, pod %s/%s",
-						modelAdapter.Name, modelAdapter.Namespace, podName)
-				} else {
-					klog.Warningf("Pod %s/%s not found in cache for ModelAdapter %s during resync",
-						modelAdapter.Namespace, podName, modelAdapter.Name)
-				}
-			}
-			c.mu.Unlock()
+			adapters = append(adapters, modelAdapter)
 		}
 	}
 
+	lastMissing := make(map[string][]string)
+	for i := 0; i < modelAdapterResyncMaxRetries; i++ {
+		klog.V(4).Infof("resyncModelAdapters retry attempt %d/%d", i+1, modelAdapterResyncMaxRetries)
+
+		incompleteModels := 0
+		lastMissing = make(map[string][]string)
+		for _, modelAdapter := range adapters {
+			missingPods := []string{}
+
+			c.mu.Lock()
+			for _, podName := range modelAdapter.Status.Instances {
+				podKey := utils.GeneratePodKey(modelAdapter.Namespace, podName)
+				if metaPod, exists := c.metaPods.Load(podKey); exists {
+					c.addPodAndModelMappingLocked(metaPod, modelAdapter.Name)
+					klog.V(4).Infof("Resynced pod mapping for adapter %s, pod %s/%s",
+						modelAdapter.Name, modelAdapter.Namespace, podName)
+				} else {
+					missingPods = append(missingPods, podName)
+					klog.V(4).Infof("Pod %s/%s not found in cache for ModelAdapter %s during resync (attempt %d/%d)",
+						modelAdapter.Namespace, podName, modelAdapter.Name, i+1, modelAdapterResyncMaxRetries)
+				}
+			}
+			c.mu.Unlock()
+
+			if len(missingPods) > 0 {
+				incompleteModels++
+				lastMissing[modelAdapter.Name] = missingPods
+			}
+		}
+
+		if incompleteModels == 0 {
+			break
+		}
+
+		if i == modelAdapterResyncMaxRetries-1 {
+			break
+		}
+
+		if !waitForModelAdapterResyncRetry(stopCh, modelAdapterResyncRetryInterval) {
+			klog.Warning("ModelAdapter resync interrupted by stop signal")
+			return
+		}
+	}
+
+	totalModels := len(adapters)
+	completeModels := totalModels - len(lastMissing)
+	for _, modelAdapter := range adapters {
+		if missingPods, exists := lastMissing[modelAdapter.Name]; exists {
+			klog.Errorf("Failed to find all pods for ModelAdapter %s after %d retries", modelAdapter.Name, modelAdapterResyncMaxRetries)
+			klog.Errorf("Missing pods for ModelAdapter %s: %v", modelAdapter.Name, missingPods)
+		} else {
+			klog.V(4).Infof("ModelAdapter %s has all pod mappings established", modelAdapter.Name)
+		}
+	}
+	klog.Infof("ModelAdapter mapping resync completed: %d total, %d complete, %d incomplete",
+		totalModels, completeModels, len(lastMissing))
 	klog.Info("ModelAdapter resync completed")
+}
+
+func waitForModelAdapterResyncRetry(stopCh <-chan struct{}, interval time.Duration) bool {
+	if stopCh == nil {
+		time.Sleep(interval)
+		return true
+	}
+
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	select {
+	case <-stopCh:
+		return false
+	case <-timer.C:
+		return true
+	}
 }


### PR DESCRIPTION
## Pull Request Description
This PR fixes a startup race in the gateway cache where `ModelAdapter` events can be processed before the corresponding pod has been added into the internal pod cache.

When that happens, `addModelAdapter()` fails to build the adapter-to-pod mapping, which can leave the adapter model missing from `metaModels` and cause requests to fail with `model_not_found` after gateway restart.

Changes in this PR:
- add retry logic in `resyncModelAdapters()` to wait for late pod cache population during informer initialization
- add `verifyModelAdapterMappings()` after resync to validate mapping completeness and repair missing adapter mappings when pods are already present in cache
- add regression tests covering:
  - repairing missing adapter mappings through verification
  - recovering adapter mappings when pod cache population is delayed during resync

This improves cache recovery after restart and reduces the chance of transient `model_not_found` errors for valid `ModelAdapter` models.

## Related Issues
Resolves: #2090 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>