### PR TITLE
Fix data race on TreeNode.lastAccess in prefix cache MatchPrefix path

### DIFF
--- a/pkg/utils/prefixcacheindexer/tree.go
+++ b/pkg/utils/prefixcacheindexer/tree.go
@@ -89,6 +89,8 @@ func (n *TreeNode) GetLoad() int {
 }
 
 func (n *TreeNode) GetLastAccess() time.Time {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
 	return n.lastAccess
 }
 
@@ -453,7 +455,9 @@ func (c *LPRadixCache) matchPrefixHelper(node *TreeNode, tokens []int) (*TreeNod
 	current := node
 
 	for totalMatched < len(tokens) {
+		current.mu.Lock()
 		current.lastAccess = time.Now()
+		current.mu.Unlock()
 		remaining := tokens[totalMatched:]
 		child, ok := current.children[remaining[0]]
 		if !ok {

--- a/pkg/utils/prefixcacheindexer/tree.go
+++ b/pkg/utils/prefixcacheindexer/tree.go
@@ -450,14 +450,21 @@ func (c *LPRadixCache) matchPrefixHelper(node *TreeNode, tokens []int) (*TreeNod
 		return node, nil
 	}
 
+	// One timestamp for the whole match path so all touched nodes share a
+	// consistent LRU time and we avoid calling time.Now() per hop.
+	now := time.Now()
+	touchLastAccess := func(n *TreeNode) {
+		n.mu.Lock()
+		n.lastAccess = now
+		n.mu.Unlock()
+	}
+
 	bestNode := node
 	totalMatched := 0
 	current := node
 
 	for totalMatched < len(tokens) {
-		current.mu.Lock()
-		current.lastAccess = time.Now()
-		current.mu.Unlock()
+		touchLastAccess(current)
 		remaining := tokens[totalMatched:]
 		child, ok := current.children[remaining[0]]
 		if !ok {
@@ -473,13 +480,16 @@ func (c *LPRadixCache) matchPrefixHelper(node *TreeNode, tokens []int) (*TreeNod
 			totalMatched += prefixLen
 			bestNode = child
 			if totalMatched == len(tokens) {
+				// Final matched node is child; next iteration would not run.
+				touchLastAccess(child)
 				return child, tokens[:totalMatched]
 			}
 			current = child
 			continue
 		}
-		// Partial match with child's key
+		// Partial match with child's key — return child as best node; update it.
 		totalMatched += prefixLen
+		touchLastAccess(child)
 		return child, tokens[:totalMatched]
 	}
 


### PR DESCRIPTION
## Pull Request Description
Concurrent MatchPrefix calls could update lastAccess on the same node without synchronization while only holding the cache read lock, which triggered the race detector in pkg/utils/prefixcacheindexer.

This change serializes reads and writes of lastAccess with the existing per-node mutex: GetLastAccess reads under RLock, and matchPrefixHelper updates lastAccess under Lock before continuing traversal.

Testing: go test -race ./pkg/utils/prefixcacheindexer and make test-race-condition.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>