### PR TITLE
 [Bug] Modify the way container environment variables are rendered

### DIFF
--- a/pkg/controller/roleset/utils.go
+++ b/pkg/controller/roleset/utils.go
@@ -175,6 +175,10 @@ func renderStormServicePod(roleSet *orchestrationv1alpha1.RoleSet, role *orchest
 }
 
 // injectContainerEnvVars injects env variables into container.
+// Note: Built-in env variables are added first to ensure they're available for expansion
+// in user-defined env variables. User-defined env variables maintain their original order
+// from the container spec, which should be stable across reconcile loops if the upstream
+// RoleSpec preserves order (e.g., through YAML unmarshalling).
 func injectContainerEnvVars(
 	container *v1.Container,
 	roleSet *orchestrationv1alpha1.RoleSet,
@@ -182,12 +186,8 @@ func injectContainerEnvVars(
 	roleIndex *int,
 	templateHash string,
 ) {
-	// Use map to quickly check if env variable already exists
-	existingEnvs := make(map[string]bool, len(container.Env)+6)
 	// Use slice to maintain env variable order
 	envs := make([]v1.EnvVar, 0, len(container.Env)+6)
-
-	// First add built-in env variables
 	builtInEnvs := []v1.EnvVar{
 		{
 			Name:  constants.StormServiceNameEnvKey,
@@ -217,18 +217,15 @@ func injectContainerEnvVars(
 			Value: strconv.Itoa(*roleIndex),
 		})
 	}
-
-	// Add built-in env variables and mark them as existing
+	// First add built-in env variables
 	for _, env := range builtInEnvs {
 		envs = append(envs, env)
-		existingEnvs[env.Name] = true
 	}
 
-	// Add original container env variables, skipping existing ones
+	// Add original container env variables, skipping built-in envs
 	for _, env := range container.Env {
-		if !existingEnvs[env.Name] && !ContainerInjectEnv.Has(env.Name) {
+		if !ContainerInjectEnv.Has(env.Name) {
 			envs = append(envs, env)
-			existingEnvs[env.Name] = true
 		}
 	}
 

--- a/pkg/controller/roleset/utils.go
+++ b/pkg/controller/roleset/utils.go
@@ -182,58 +182,57 @@ func injectContainerEnvVars(
 	roleIndex *int,
 	templateHash string,
 ) {
-	envMap := make(map[string]v1.EnvVar, len(container.Env)+6)
+	// Use map to quickly check if env variable already exists
+	existingEnvs := make(map[string]bool, len(container.Env)+6)
+	// Use slice to maintain env variable order
+	envs := make([]v1.EnvVar, 0, len(container.Env)+6)
 
-	// copy existing env
-	for _, e := range container.Env {
-		if !ContainerInjectEnv.Has(e.Name) {
-			envMap[e.Name] = e
-		}
-	}
-
-	envMap[constants.StormServiceNameEnvKey] = v1.EnvVar{
-		Name:  constants.StormServiceNameEnvKey,
-		Value: roleSet.Labels[constants.StormServiceNameLabelKey],
-	}
-
-	envMap[constants.RoleSetNameEnvKey] = v1.EnvVar{
-		Name:  constants.RoleSetNameEnvKey,
-		Value: roleSet.Name,
-	}
-
-	envMap[constants.RoleSetIndexEnvKey] = v1.EnvVar{
-		Name:  constants.RoleSetIndexEnvKey,
-		Value: roleSet.Annotations[constants.RoleSetIndexAnnotationKey],
-	}
-
-	envMap[constants.RoleNameEnvKey] = v1.EnvVar{
-		Name:  constants.RoleNameEnvKey,
-		Value: role.Name,
-	}
-
-	envMap[constants.RoleTemplateHashEnvKey] = v1.EnvVar{
-		Name:  constants.RoleTemplateHashEnvKey,
-		Value: templateHash,
+	// First add built-in env variables
+	builtInEnvs := []v1.EnvVar{
+		{
+			Name:  constants.StormServiceNameEnvKey,
+			Value: roleSet.Labels[constants.StormServiceNameLabelKey],
+		},
+		{
+			Name:  constants.RoleSetNameEnvKey,
+			Value: roleSet.Name,
+		},
+		{
+			Name:  constants.RoleSetIndexEnvKey,
+			Value: roleSet.Annotations[constants.RoleSetIndexAnnotationKey],
+		},
+		{
+			Name:  constants.RoleNameEnvKey,
+			Value: role.Name,
+		},
+		{
+			Name:  constants.RoleTemplateHashEnvKey,
+			Value: templateHash,
+		},
 	}
 
 	if roleIndex != nil {
-		envMap[constants.RoleReplicaIndexEnvKey] = v1.EnvVar{
+		builtInEnvs = append(builtInEnvs, v1.EnvVar{
 			Name:  constants.RoleReplicaIndexEnvKey,
 			Value: strconv.Itoa(*roleIndex),
+		})
+	}
+
+	// Add built-in env variables and mark them as existing
+	for _, env := range builtInEnvs {
+		envs = append(envs, env)
+		existingEnvs[env.Name] = true
+	}
+
+	// Add original container env variables, skipping existing ones
+	for _, env := range container.Env {
+		if !existingEnvs[env.Name] && !ContainerInjectEnv.Has(env.Name) {
+			envs = append(envs, env)
+			existingEnvs[env.Name] = true
 		}
 	}
-	keys := make([]string, 0, len(envMap))
-	for k := range envMap {
-		keys = append(keys, k)
-	}
-	// sort the env by name before adding them to the container spec
-	// to ensure deterministic output and prevent unnecessary pod updates
-	sort.Strings(keys)
 
-	container.Env = make([]v1.EnvVar, 0, len(envMap))
-	for _, k := range keys {
-		container.Env = append(container.Env, envMap[k])
-	}
+	container.Env = envs
 }
 
 func filterRolePods(role *orchestrationv1alpha1.RoleSpec, pods []*v1.Pod) []*v1.Pod {

--- a/pkg/controller/roleset/utils.go
+++ b/pkg/controller/roleset/utils.go
@@ -178,7 +178,8 @@ func renderStormServicePod(roleSet *orchestrationv1alpha1.RoleSet, role *orchest
 // Note: Built-in env variables are added first to ensure they're available for expansion
 // in user-defined env variables. User-defined env variables maintain their original order
 // from the container spec, which should be stable across reconcile loops if the upstream
-// RoleSpec preserves order (e.g., through YAML unmarshalling).
+// RoleSpec preserves order (e.g., through YAML unmarshalling). Otherwise, unnecessary pod
+// updates may occur.
 func injectContainerEnvVars(
 	container *v1.Container,
 	roleSet *orchestrationv1alpha1.RoleSet,
@@ -217,10 +218,7 @@ func injectContainerEnvVars(
 			Value: strconv.Itoa(*roleIndex),
 		})
 	}
-	// First add built-in env variables
-	for _, env := range builtInEnvs {
-		envs = append(envs, env)
-	}
+	envs = append(envs, builtInEnvs...)
 
 	// Add original container env variables, skipping built-in envs
 	for _, env := range container.Env {

--- a/pkg/controller/roleset/utils_test.go
+++ b/pkg/controller/roleset/utils_test.go
@@ -490,3 +490,104 @@ func TestSortRolesByUpgradeOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestInjectContainerEnvVars(t *testing.T) {
+	// Setup test data
+	roleSet := &orchestrationv1alpha1.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-role-set",
+			Labels: map[string]string{
+				constants.StormServiceNameLabelKey: "test-service",
+			},
+			Annotations: map[string]string{
+				constants.RoleSetIndexAnnotationKey: "1",
+			},
+		},
+	}
+
+	role := &orchestrationv1alpha1.RoleSpec{
+		Name: "test-role",
+	}
+
+	roleIndex := 0
+	templateHash := "test-hash"
+
+	// Create container with:
+	// 1. Some user-defined env vars in reverse alphabetical order
+	// 2. A env var with same name as built-in env var
+	container := &corev1.Container{
+		Name: "test-container",
+		Env: []corev1.EnvVar{
+			{Name: "USER_VAR_Z", Value: "value-z"},                       // Last in alphabetical order
+			{Name: "USER_VAR_M", Value: "value-m"},                       // Middle in alphabetical order
+			{Name: constants.RoleSetNameEnvKey, Value: "override-value"}, // Same name as built-in
+			{Name: "USER_VAR_A", Value: "value-a"},                       // First in alphabetical order
+		},
+	}
+
+	// Call the function under test
+	injectContainerEnvVars(container, roleSet, role, &roleIndex, templateHash)
+
+	// Verify the result
+	// Check that built-in env vars are not overridden
+	builtInEnvNames := []string{
+		constants.StormServiceNameEnvKey,
+		constants.RoleSetNameEnvKey,
+		constants.RoleSetIndexEnvKey,
+		constants.RoleNameEnvKey,
+		constants.RoleTemplateHashEnvKey,
+		constants.RoleReplicaIndexEnvKey,
+	}
+
+	assert.GreaterOrEqual(t, len(container.Env), len(builtInEnvNames), "Should have at least all built-in env vars")
+
+	// Track built-in env vars found
+	foundBuiltInEnvs := make(map[string]bool)
+
+	// Check the order and values
+	// Verify built-in env vars are present at the beginning
+	for i, env := range container.Env {
+		if i < len(builtInEnvNames) {
+			// First N env vars should be built-in
+			assert.Contains(t, builtInEnvNames, env.Name, "Built-in env var should be at the beginning")
+			foundBuiltInEnvs[env.Name] = true
+
+			// Check built-in env var values
+			switch env.Name {
+			case constants.StormServiceNameEnvKey:
+				assert.Equal(t, "test-service", env.Value)
+			case constants.RoleSetNameEnvKey:
+				assert.Equal(t, "test-role-set", env.Value) // Should not be overridden
+			case constants.RoleSetIndexEnvKey:
+				assert.Equal(t, "1", env.Value)
+			case constants.RoleNameEnvKey:
+				assert.Equal(t, "test-role", env.Value)
+			case constants.RoleTemplateHashEnvKey:
+				assert.Equal(t, "test-hash", env.Value)
+			case constants.RoleReplicaIndexEnvKey:
+				assert.Equal(t, "0", env.Value)
+			}
+		} else {
+			// User-defined env vars should come after built-in ones
+			assert.NotContains(t, builtInEnvNames, env.Name, "User-defined env var should not be a built-in name")
+		}
+	}
+
+	// 3. Check that all built-in env vars are present
+	for _, envName := range builtInEnvNames {
+		assert.True(t, foundBuiltInEnvs[envName], "Built-in env var %s should be present", envName)
+	}
+
+	// 4. Check that user-defined env vars maintain their original order
+	// Find the start index of user-defined env vars
+	userEnvStartIndex := len(builtInEnvNames)
+	assert.Less(t, userEnvStartIndex, len(container.Env), "Should have user-defined env vars")
+
+	// Check user-defined env vars order
+	expectedUserEnvOrder := []string{"USER_VAR_Z", "USER_VAR_M", "USER_VAR_A"}
+	for i, expectedName := range expectedUserEnvOrder {
+		actualIndex := userEnvStartIndex + i
+		assert.Less(t, actualIndex, len(container.Env), "Should have enough user-defined env vars")
+		assert.Equal(t, expectedName, container.Env[actualIndex].Name, "User-defined env var should maintain original order")
+	}
+}


### PR DESCRIPTION

## Pull Request Description
Modify the way environment variables are rendered:
- Do not sort. 
- Place the built-in environment variables first.
- Followed by the environment variables defined in the container
- With a fixed order.

## Related Issues
Resolves: #2107