### PR TITLE
[Bug]: The podset built-in envs is placed before container envs.(#2113)

### DIFF
--- a/pkg/controller/podset/podset_controller.go
+++ b/pkg/controller/podset/podset_controller.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -387,28 +386,35 @@ func (r *PodSetReconciler) createPodFromTemplate(podSet *orchestrationv1alpha1.P
 	pod.Spec.Subdomain = podSet.Labels[constants.StormServiceNameLabelKey]
 
 	// Add environment variables for pod coordination
+	isBuiltIn := func(name string) bool {
+		return name == constants.PodSetNameEnvKey ||
+			name == constants.PodSetIndexEnvKey ||
+			name == constants.PodSetSizeEnvKey
+	}
+	addBuiltInEnvVars := func(envs []v1.EnvVar) []v1.EnvVar {
+		builtInEnvs := []v1.EnvVar{
+			{Name: constants.PodSetNameEnvKey, Value: podSet.Name},
+			{Name: constants.PodSetIndexEnvKey, Value: strconv.Itoa(podIndex)},
+			{Name: constants.PodSetSizeEnvKey, Value: strconv.Itoa(int(podSet.Spec.PodGroupSize))},
+		}
+		for _, env := range envs {
+			if isBuiltIn(env.Name) {
+				klog.Warningf("PodSet %s: dropping user-defined env var %q as it conflicts with a built-in env var",
+					podSet.Name, env.Name)
+				continue
+			}
+			builtInEnvs = append(builtInEnvs, env)
+		}
+		return builtInEnvs
+	}
+	if pod.Spec.InitContainers != nil {
+		for i := range pod.Spec.InitContainers {
+			pod.Spec.InitContainers[i].Env = addBuiltInEnvVars(pod.Spec.InitContainers[i].Env)
+		}
+	}
 	if pod.Spec.Containers != nil {
 		for i := range pod.Spec.Containers {
-			// Add built-in environment variables to the beginning
-			builtInEnvs := []v1.EnvVar{
-				{Name: constants.PodSetNameEnvKey, Value: podSet.Name},
-				{Name: constants.PodSetIndexEnvKey, Value: strconv.Itoa(podIndex)},
-				{Name: constants.PodSetSizeEnvKey, Value: strconv.Itoa(int(podSet.Spec.PodGroupSize))},
-			}
-
-			builtInEnvSet := sets.NewString(
-				constants.PodSetNameEnvKey,
-				constants.PodSetIndexEnvKey,
-				constants.PodSetSizeEnvKey,
-			)
-			// Append only user-defined env vars that don't conflict with built-in ones
-			for _, env := range pod.Spec.Containers[i].Env {
-				if !builtInEnvSet.Has(env.Name) {
-					builtInEnvs = append(builtInEnvs, env)
-				}
-			}
-
-			pod.Spec.Containers[i].Env = builtInEnvs
+			pod.Spec.Containers[i].Env = addBuiltInEnvVars(pod.Spec.Containers[i].Env)
 		}
 	}
 

--- a/pkg/controller/podset/podset_controller.go
+++ b/pkg/controller/podset/podset_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -395,13 +396,14 @@ func (r *PodSetReconciler) createPodFromTemplate(podSet *orchestrationv1alpha1.P
 				{Name: constants.PodSetSizeEnvKey, Value: strconv.Itoa(int(podSet.Spec.PodGroupSize))},
 			}
 
-			builtInEnvMap := make(map[string]bool)
-			for _, env := range builtInEnvs {
-				builtInEnvMap[env.Name] = true
-			}
+			builtInEnvSet := sets.NewString(
+				constants.PodSetNameEnvKey,
+				constants.PodSetIndexEnvKey,
+				constants.PodSetSizeEnvKey,
+			)
 			// Append only user-defined env vars that don't conflict with built-in ones
 			for _, env := range pod.Spec.Containers[i].Env {
-				if !builtInEnvMap[env.Name] {
+				if !builtInEnvSet.Has(env.Name) {
 					builtInEnvs = append(builtInEnvs, env)
 				}
 			}

--- a/pkg/controller/podset/podset_controller.go
+++ b/pkg/controller/podset/podset_controller.go
@@ -388,11 +388,25 @@ func (r *PodSetReconciler) createPodFromTemplate(podSet *orchestrationv1alpha1.P
 	// Add environment variables for pod coordination
 	if pod.Spec.Containers != nil {
 		for i := range pod.Spec.Containers {
-			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env,
-				v1.EnvVar{Name: constants.PodSetNameEnvKey, Value: podSet.Name},
-				v1.EnvVar{Name: constants.PodSetIndexEnvKey, Value: strconv.Itoa(podIndex)},
-				v1.EnvVar{Name: constants.PodSetSizeEnvKey, Value: strconv.Itoa(int(podSet.Spec.PodGroupSize))},
-			)
+			// Add built-in environment variables to the beginning
+			builtInEnvs := []v1.EnvVar{
+				{Name: constants.PodSetNameEnvKey, Value: podSet.Name},
+				{Name: constants.PodSetIndexEnvKey, Value: strconv.Itoa(podIndex)},
+				{Name: constants.PodSetSizeEnvKey, Value: strconv.Itoa(int(podSet.Spec.PodGroupSize))},
+			}
+
+			builtInEnvMap := make(map[string]bool)
+			for _, env := range builtInEnvs {
+				builtInEnvMap[env.Name] = true
+			}
+			// Append only user-defined env vars that don't conflict with built-in ones
+			for _, env := range pod.Spec.Containers[i].Env {
+				if !builtInEnvMap[env.Name] {
+					builtInEnvs = append(builtInEnvs, env)
+				}
+			}
+
+			pod.Spec.Containers[i].Env = builtInEnvs
 		}
 	}
 

--- a/pkg/controller/podset/podset_controller_test.go
+++ b/pkg/controller/podset/podset_controller_test.go
@@ -45,6 +45,14 @@ func TestCreatePodFromTemplate_EnvOrder(t *testing.T) {
 			PodGroupSize: 2,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "init-container",
+							Env: []corev1.EnvVar{
+								{Name: "INIT_USER_VAR", Value: "init-value"},
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name: "test-container",
@@ -99,6 +107,19 @@ func TestCreatePodFromTemplate_EnvOrder(t *testing.T) {
 		assert.Less(t, actualIndex, len(container.Env), "should have enough user-defined env vars")
 		assert.Equal(t, expectedName, container.Env[actualIndex].Name, "User-defined env var should maintain original order")
 	}
+
+	// Verify InitContainers have built-in env vars at the beginning
+	assert.Len(t, pod.Spec.InitContainers, 1, "pod should have one init container")
+	initContainer := &pod.Spec.InitContainers[0]
+	expectedInitEnvCount := len(builtInEnvNames) + 1 // 3 built-in + 1 user-defined
+	assert.Equal(t, expectedInitEnvCount, len(initContainer.Env), "init container should have correct number of env vars")
+	// Verify built-in env vars are at the beginning of init container
+	for i := 0; i < len(builtInEnvNames); i++ {
+		assert.Equal(t, builtInEnvNames[i], initContainer.Env[i].Name, "Built-in env var should be at the beginning of init container")
+	}
+	// Verify user-defined env var in init container
+	assert.Equal(t, "INIT_USER_VAR", initContainer.Env[len(builtInEnvNames)].Name, "User-defined env var should be present in init container")
+	assert.Equal(t, "init-value", initContainer.Env[len(builtInEnvNames)].Value, "User-defined env var value should be preserved in init container")
 }
 
 func TestCreatePodFromTemplate_EnvConflict(t *testing.T) {

--- a/pkg/controller/podset/podset_controller_test.go
+++ b/pkg/controller/podset/podset_controller_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicFake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/tools/record"
+	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
 	"github.com/vllm-project/aibrix/pkg/controller/constants"
@@ -54,9 +58,13 @@ func TestCreatePodFromTemplate_EnvOrder(t *testing.T) {
 			},
 		},
 	}
-
-	// Create a PodSetReconciler
-	reconciler := &PodSetReconciler{}
+	scheme := runtime.NewScheme()
+	reconciler := &PodSetReconciler{
+		Client:        clientFake.NewClientBuilder().Build(),
+		Scheme:        scheme,
+		EventRecorder: &record.FakeRecorder{},
+		DynamicClient: dynamicFake.NewSimpleDynamicClient(scheme),
+	}
 
 	// Call createPodFromTemplate with podIndex 0
 	pod, err := reconciler.createPodFromTemplate(podSet, 0)
@@ -79,30 +87,12 @@ func TestCreatePodFromTemplate_EnvOrder(t *testing.T) {
 	assert.Equal(t, expectedEnvCount, len(container.Env), "container should have correct number of env vars")
 
 	// Verify built-in env vars are at the beginning
-	for i, env := range container.Env {
-		if i < len(builtInEnvNames) {
-			// First N env vars should be built-in
-			assert.Contains(t, builtInEnvNames, env.Name, "Built-in env var should be at the beginning")
-
-			// Check built-in env var values
-			switch env.Name {
-			case constants.PodSetNameEnvKey:
-				assert.Equal(t, "test-podset", env.Value)
-			case constants.PodSetIndexEnvKey:
-				assert.Equal(t, "0", env.Value)
-			case constants.PodSetSizeEnvKey:
-				assert.Equal(t, "2", env.Value)
-			}
-		} else {
-			// User-defined env vars should come after built-in ones
-			assert.NotContains(t, builtInEnvNames, env.Name, "User-defined env var should not be a built-in name")
-		}
+	for i := 0; i < len(builtInEnvNames); i++ {
+		assert.Equal(t, builtInEnvNames[i], container.Env[i].Name, "Built-in env var should be at the beginning")
 	}
 
 	// Verify user-defined env vars maintain their order
 	userEnvStartIndex := len(builtInEnvNames)
-	assert.Less(t, userEnvStartIndex, len(container.Env), "should have user-defined env vars")
-
 	expectedUserEnvOrder := []string{"USER_VAR_Z", "USER_VAR_A"}
 	for i, expectedName := range expectedUserEnvOrder {
 		actualIndex := userEnvStartIndex + i
@@ -139,9 +129,13 @@ func TestCreatePodFromTemplate_EnvConflict(t *testing.T) {
 			},
 		},
 	}
-
-	// Create a PodSetReconciler
-	reconciler := &PodSetReconciler{}
+	scheme := runtime.NewScheme()
+	reconciler := &PodSetReconciler{
+		Client:        clientFake.NewClientBuilder().Build(),
+		Scheme:        scheme,
+		EventRecorder: &record.FakeRecorder{},
+		DynamicClient: dynamicFake.NewSimpleDynamicClient(scheme),
+	}
 
 	// Call createPodFromTemplate with podIndex 0
 	pod, err := reconciler.createPodFromTemplate(podSet, 0)
@@ -164,24 +158,13 @@ func TestCreatePodFromTemplate_EnvConflict(t *testing.T) {
 	assert.Equal(t, expectedEnvCount, len(container.Env), "container should have correct number of env vars")
 
 	// Verify built-in env vars are at the beginning and not overridden
-	for i, env := range container.Env {
-		if i < len(builtInEnvNames) {
-			// First N env vars should be built-in
-			assert.Contains(t, builtInEnvNames, env.Name, "Built-in env var should be at the beginning")
-
-			// Check built-in env var values are not overridden
-			switch env.Name {
-			case constants.PodSetNameEnvKey:
-				assert.Equal(t, "test-podset", env.Value, "Built-in env var should not be overridden")
-			case constants.PodSetIndexEnvKey:
-				assert.Equal(t, "0", env.Value, "Built-in env var should not be overridden")
-			case constants.PodSetSizeEnvKey:
-				assert.Equal(t, "2", env.Value, "Built-in env var should not be overridden")
-			}
-		} else {
-			// Only non-conflicting user-defined env var should be present
-			assert.Equal(t, "USER_VAR", env.Name, "Only non-conflicting user-defined env var should be present")
-			assert.Equal(t, "value", env.Value, "User-defined env var value should be preserved")
-		}
+	for i := 0; i < len(builtInEnvNames); i++ {
+		assert.Equal(t, builtInEnvNames[i], container.Env[i].Name, "Built-in env var should be at the beginning")
 	}
+
+	// Only non-conflicting user-defined env var should be present
+	env := container.Env[len(builtInEnvNames)]
+	assert.NotNil(t, env, "should have non-conflicting user-defined env var")
+	assert.Equal(t, "USER_VAR", env.Name, "Only non-conflicting user-defined env var should be present")
+	assert.Equal(t, "value", env.Value, "User-defined env var value should be preserved")
 }

--- a/pkg/controller/podset/podset_controller_test.go
+++ b/pkg/controller/podset/podset_controller_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/controller/constants"
+)
+
+func TestCreatePodFromTemplate_EnvOrder(t *testing.T) {
+	// Create a podSet with podGroupSize: 2
+	podSet := &orchestrationv1alpha1.PodSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-podset",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				constants.StormServiceNameLabelKey: "test-service",
+			},
+		},
+		Spec: orchestrationv1alpha1.PodSetSpec{
+			PodGroupSize: 2,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Env: []corev1.EnvVar{
+								{Name: "USER_VAR_Z", Value: "value-z"},
+								{Name: "USER_VAR_A", Value: "value-a"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Create a PodSetReconciler
+	reconciler := &PodSetReconciler{}
+
+	// Call createPodFromTemplate with podIndex 0
+	pod, err := reconciler.createPodFromTemplate(podSet, 0)
+	assert.NoError(t, err, "createPodFromTemplate should not return error")
+	assert.NotNil(t, pod, "pod should not be nil")
+
+	// Verify container count
+	assert.Len(t, pod.Spec.Containers, 1, "pod should have one container")
+	container := &pod.Spec.Containers[0]
+
+	// Define built-in environment variables
+	builtInEnvNames := []string{
+		constants.PodSetNameEnvKey,
+		constants.PodSetIndexEnvKey,
+		constants.PodSetSizeEnvKey,
+	}
+
+	// Verify environment variables count
+	expectedEnvCount := len(builtInEnvNames) + 2 // 3 built-in + 2 user-defined
+	assert.Equal(t, expectedEnvCount, len(container.Env), "container should have correct number of env vars")
+
+	// Verify built-in env vars are at the beginning
+	for i, env := range container.Env {
+		if i < len(builtInEnvNames) {
+			// First N env vars should be built-in
+			assert.Contains(t, builtInEnvNames, env.Name, "Built-in env var should be at the beginning")
+
+			// Check built-in env var values
+			switch env.Name {
+			case constants.PodSetNameEnvKey:
+				assert.Equal(t, "test-podset", env.Value)
+			case constants.PodSetIndexEnvKey:
+				assert.Equal(t, "0", env.Value)
+			case constants.PodSetSizeEnvKey:
+				assert.Equal(t, "2", env.Value)
+			}
+		} else {
+			// User-defined env vars should come after built-in ones
+			assert.NotContains(t, builtInEnvNames, env.Name, "User-defined env var should not be a built-in name")
+		}
+	}
+
+	// Verify user-defined env vars maintain their order
+	userEnvStartIndex := len(builtInEnvNames)
+	assert.Less(t, userEnvStartIndex, len(container.Env), "should have user-defined env vars")
+
+	expectedUserEnvOrder := []string{"USER_VAR_Z", "USER_VAR_A"}
+	for i, expectedName := range expectedUserEnvOrder {
+		actualIndex := userEnvStartIndex + i
+		assert.Less(t, actualIndex, len(container.Env), "should have enough user-defined env vars")
+		assert.Equal(t, expectedName, container.Env[actualIndex].Name, "User-defined env var should maintain original order")
+	}
+}
+
+func TestCreatePodFromTemplate_EnvConflict(t *testing.T) {
+	// Create a podSet with podGroupSize: 2 and conflicting env vars
+	podSet := &orchestrationv1alpha1.PodSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-podset",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				constants.StormServiceNameLabelKey: "test-service",
+			},
+		},
+		Spec: orchestrationv1alpha1.PodSetSpec{
+			PodGroupSize: 2,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Env: []corev1.EnvVar{
+								{Name: constants.PodSetNameEnvKey, Value: "user-override"}, // Conflict with built-in
+								{Name: "USER_VAR", Value: "value"},                         // Non-conflicting
+								{Name: constants.PodSetSizeEnvKey, Value: "999"},           // Conflict with built-in
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Create a PodSetReconciler
+	reconciler := &PodSetReconciler{}
+
+	// Call createPodFromTemplate with podIndex 0
+	pod, err := reconciler.createPodFromTemplate(podSet, 0)
+	assert.NoError(t, err, "createPodFromTemplate should not return error")
+	assert.NotNil(t, pod, "pod should not be nil")
+
+	// Verify container count
+	assert.Len(t, pod.Spec.Containers, 1, "pod should have one container")
+	container := &pod.Spec.Containers[0]
+
+	// Define built-in environment variables
+	builtInEnvNames := []string{
+		constants.PodSetNameEnvKey,
+		constants.PodSetIndexEnvKey,
+		constants.PodSetSizeEnvKey,
+	}
+
+	// Verify environment variables count
+	expectedEnvCount := len(builtInEnvNames) + 1 // 3 built-in + 1 non-conflicting user-defined
+	assert.Equal(t, expectedEnvCount, len(container.Env), "container should have correct number of env vars")
+
+	// Verify built-in env vars are at the beginning and not overridden
+	for i, env := range container.Env {
+		if i < len(builtInEnvNames) {
+			// First N env vars should be built-in
+			assert.Contains(t, builtInEnvNames, env.Name, "Built-in env var should be at the beginning")
+
+			// Check built-in env var values are not overridden
+			switch env.Name {
+			case constants.PodSetNameEnvKey:
+				assert.Equal(t, "test-podset", env.Value, "Built-in env var should not be overridden")
+			case constants.PodSetIndexEnvKey:
+				assert.Equal(t, "0", env.Value, "Built-in env var should not be overridden")
+			case constants.PodSetSizeEnvKey:
+				assert.Equal(t, "2", env.Value, "Built-in env var should not be overridden")
+			}
+		} else {
+			// Only non-conflicting user-defined env var should be present
+			assert.Equal(t, "USER_VAR", env.Name, "Only non-conflicting user-defined env var should be present")
+			assert.Equal(t, "value", env.Value, "User-defined env var value should be preserved")
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Peakpine <hechao9988@gmail.com>

## Pull Request Description

- The podset built-in envs is placed before container envs.
- The built-in environment variables are not overwritten.

## Related Issues
Resolves: #2113 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[x] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>