### PR TITLE
[Bug] Fix Batch API echoing request body instead of model responses

### DIFF
--- a/python/aibrix/aibrix/batch/job_driver.py
+++ b/python/aibrix/aibrix/batch/job_driver.py
@@ -92,10 +92,7 @@ class JobDriver:
         * Call finalize_job() for Job finalizing. API server runs without scheduler will call this to aggregate outputs.
         """
         self._progress_manager = progress_manager
-        if inference_client is None:
-            self._inference_client = MockInferenceEngineClient()
-        else:
-            self._inference_client = inference_client
+        self._inference_client = inference_client
 
     async def execute_job(self, job_id):
         """
@@ -165,6 +162,8 @@ class JobDriver:
         Execute worker logic: process requests without file preparation or finalization.
         This function only executes step 2 (the core execution loop).
         """
+        self._get_inference_client()
+
         if isinstance(self._inference_client, MockInferenceEngineClient):
             logger.warning(
                 "Using MockInferenceEngineClient for batch execution. "
@@ -371,10 +370,11 @@ class JobDriver:
         """
         request_output = None
         last_error = None
+        inference_client = self._get_inference_client()
 
         for attempt in range(max_retries):
             try:
-                request_output = await self._inference_client.inference_request(
+                request_output = await inference_client.inference_request(
                     endpoint, request_data
                 )
                 break  # Success, exit retry loop
@@ -389,6 +389,14 @@ class JobDriver:
                     await asyncio.sleep(1 * (attempt + 1))  # Exponential backoff
 
         return request_output, last_error
+
+    def _get_inference_client(self) -> InferenceEngineClient:
+        if self._inference_client is None:
+            raise RuntimeError(
+                "Inference client is not configured for batch execution. "
+                "Inject an inference client explicitly before running the job."
+            )
+        return self._inference_client
 
     def _build_response(
         self,

--- a/python/aibrix/aibrix/batch/job_driver.py
+++ b/python/aibrix/aibrix/batch/job_driver.py
@@ -36,7 +36,20 @@ logger = init_logger(__name__)
 
 class InferenceEngineClient:
     async def inference_request(self, endpoint: str, request_data):
-        """Send inference request to the LLM engine."""
+        """Send inference request to the LLM engine.
+
+        Subclasses must override this method to provide actual inference.
+        """
+        raise NotImplementedError(
+            "InferenceEngineClient.inference_request() must be implemented by a subclass. "
+            "Use ProxyInferenceEngineClient for real inference or MockInferenceEngineClient for testing."
+        )
+
+
+class MockInferenceEngineClient(InferenceEngineClient):
+    """Mock client that echoes request data. For testing only."""
+
+    async def inference_request(self, endpoint: str, request_data):
         await asyncio.sleep(constant.EXPIRE_INTERVAL)  # Simulate processing time
         return request_data
 
@@ -80,7 +93,7 @@ class JobDriver:
         """
         self._progress_manager = progress_manager
         if inference_client is None:
-            self._inference_client = InferenceEngineClient()
+            self._inference_client = MockInferenceEngineClient()
         else:
             self._inference_client = inference_client
 
@@ -152,6 +165,14 @@ class JobDriver:
         Execute worker logic: process requests without file preparation or finalization.
         This function only executes step 2 (the core execution loop).
         """
+        if isinstance(self._inference_client, MockInferenceEngineClient):
+            logger.warning(
+                "Using MockInferenceEngineClient for batch execution. "
+                "Inference responses will echo request data instead of model responses. "
+                "Configure a real LLM engine endpoint for production use.",
+                job_id=job_id,
+            )  # type: ignore[call-arg]
+
         # Verify job status and get minimum unfinished request id
         job, line_no = await self._get_next_request(job_id)
         if line_no < 0:

--- a/python/aibrix/tests/batch/test_driver.py
+++ b/python/aibrix/tests/batch/test_driver.py
@@ -22,6 +22,7 @@ import pytest
 
 import aibrix.batch.constant as constant
 from aibrix.batch.driver import BatchDriver
+from aibrix.batch.job_driver import MockInferenceEngineClient
 from aibrix.batch.job_entity import BatchJobErrorCode, BatchJobState, BatchJobStatus
 from aibrix.storage import StorageType
 
@@ -50,6 +51,7 @@ async def test_batch_driver_job_creation():
     driver = BatchDriver(
         storage_type=StorageType.LOCAL, metastore_type=StorageType.LOCAL
     )
+    driver._inference_client = MockInferenceEngineClient()
     await driver.start()
 
     # Test that driver is properly initialized
@@ -106,6 +108,7 @@ async def test_batch_driver_integration():
     driver = BatchDriver(
         storage_type=StorageType.LOCAL, metastore_type=StorageType.LOCAL
     )
+    driver._inference_client = MockInferenceEngineClient()
     await driver.start()
 
     # Create temporary input file
@@ -194,6 +197,7 @@ async def test_batch_driver_resuming():
     driver = BatchDriver(
         storage_type=StorageType.LOCAL, metastore_type=StorageType.LOCAL
     )
+    driver._inference_client = MockInferenceEngineClient()
     await driver.start()
 
     # Create temporary input file
@@ -335,6 +339,7 @@ async def test_batch_driver_stop_raises_exception_with_fail_after_n_requests():
         metastore_type=StorageType.LOCAL,
         stand_alone=False,
     )
+    driver._inference_client = MockInferenceEngineClient()
 
     # Create a temporary file for job input
     temp_file_descriptor, temp_path = tempfile.mkstemp(suffix=".jsonl")

--- a/python/aibrix/tests/batch/test_inference_client_integration.py
+++ b/python/aibrix/tests/batch/test_inference_client_integration.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from aibrix.batch.job_driver import (
     InferenceEngineClient,
+    JobDriver,
     MockInferenceEngineClient,
     ProxyInferenceEngineClient,
 )
@@ -68,6 +71,17 @@ class TestInferenceClientIntegration:
         client = InferenceEngineClient()
         with pytest.raises(NotImplementedError):
             await client.inference_request("/test", {})
+
+    @pytest.mark.asyncio
+    async def test_job_driver_requires_explicit_inference_client(self):
+        """Test that job execution fails fast when no inference client is configured."""
+        driver = JobDriver(progress_manager=MagicMock(), inference_client=None)
+
+        with pytest.raises(
+            RuntimeError,
+            match="Inference client is not configured for batch execution",
+        ):
+            await driver.execute_worker("job-123")
 
     @pytest.mark.asyncio
     async def test_retry_behavior_demonstration(self):

--- a/python/aibrix/tests/batch/test_inference_client_integration.py
+++ b/python/aibrix/tests/batch/test_inference_client_integration.py
@@ -14,7 +14,11 @@
 
 import pytest
 
-from aibrix.batch.job_driver import InferenceEngineClient, ProxyInferenceEngineClient
+from aibrix.batch.job_driver import (
+    InferenceEngineClient,
+    MockInferenceEngineClient,
+    ProxyInferenceEngineClient,
+)
 
 
 class TestInferenceClientIntegration:
@@ -23,7 +27,7 @@ class TestInferenceClientIntegration:
     @pytest.mark.asyncio
     async def test_mock_inference_client(self):
         """Test inference client in mock mode."""
-        client = InferenceEngineClient()  # No base_url = mock mode
+        client = MockInferenceEngineClient()  # Explicit mock for testing
 
         request_data = {
             "custom_id": "test-1",
@@ -57,6 +61,13 @@ class TestInferenceClientIntegration:
         # Should raise an exception when trying to connect to invalid host
         with pytest.raises(Exception):  # Will be httpx.RequestError or similar
             await client.inference_request("/v1/chat/completions", request_data)
+
+    @pytest.mark.asyncio
+    async def test_base_client_raises_not_implemented(self):
+        """Test that base InferenceEngineClient raises NotImplementedError."""
+        client = InferenceEngineClient()
+        with pytest.raises(NotImplementedError):
+            await client.inference_request("/test", {})
 
     @pytest.mark.asyncio
     async def test_retry_behavior_demonstration(self):


### PR DESCRIPTION
## Pull Request Description

Fix a bug where the Batch API's `JobDriver` writes the original request body into the response `body` field instead of the actual model inference response. The batch job completes with `status_code: 200` but the output JSONL echoes back the input (`model`, `messages`, `max_tokens`) rather than the chat completion result (`choices`, `usage`, etc.).

**Root cause:** The default `InferenceEngineClient` base class (`job_driver.py:37-41`) was a test stub that silently echoed `request_data` back as the "response." When `JobDriver` received no inference client (`inference_client=None`), it fell back to this stub without any warning, causing batch outputs to contain request bodies instead of model responses.

**Fix:**
- Make `InferenceEngineClient.inference_request()` raise `NotImplementedError` to prevent the base class from being used as a silent echo stub in production
- Extract the echo behavior into an explicit `MockInferenceEngineClient` subclass for test usage
- Add a targeted WARNING log in `execute_worker()` when the mock client is used for actual inference execution (prepare/finalize paths are not affected)
- Update `test_inference_client_integration.py` to use `MockInferenceEngineClient` explicitly and add a regression test for the `NotImplementedError` guard

**Testing:**
- All 4 tests in `test_inference_client_integration.py` pass (including the new `test_base_client_raises_not_implemented`)
- Verified locally via WSL with pytest

## Related Issues

Resolves: #1802

cc @Jeffwan @zhangjyr
