### PR TITLE
fix: Dockerfile for new vLLM versions + implement get_num_new_matched_tokens

### DIFF
--- a/build/container/Dockerfile.vllm
+++ b/build/container/Dockerfile.vllm
@@ -1,4 +1,4 @@
-ARG VLLM_VERSION=v0.10.2
+ARG VLLM_VERSION=v0.19.0
 
 # Extract torch version from the vLLM base image
 FROM vllm/vllm-openai:${VLLM_VERSION} AS torch-version
@@ -32,7 +32,7 @@ RUN cd /tmp/aibrix && \
 FROM vllm/vllm-openai:${VLLM_VERSION} AS vllm-openai
 
 ARG PYTHON_BIN=python3
-ARG VLLM_VERSION=v0.10.2
+ARG VLLM_VERSION=v0.19.0
 ARG NIXL_VERSION=0.7.1
 
 COPY --from=builder /tmp/aibrix /tmp/aibrix
@@ -40,14 +40,27 @@ COPY --from=builder /tmp/aibrix /tmp/aibrix
 RUN ${PYTHON_BIN} -m pip uninstall -y aibrix_kvcache && \
     ${PYTHON_BIN} -m pip install /tmp/aibrix/python/aibrix_kvcache/dist/*.whl
 
-# apply patch to vLLM
-RUN DIST_DIR=$(${PYTHON_BIN} -m pip show vllm | grep "Location:" | awk '{print $2}') && \
-    cd $DIST_DIR && \
-    patch -p 1 -l -i /tmp/aibrix/python/aibrix_kvcache/integration/vllm/patches/vllm_${VLLM_VERSION}-aibrix-kvcache.patch
+# apply patch to vLLM (only if patch file exists for this version)
+RUN PATCH_FILE="/tmp/aibrix/python/aibrix_kvcache/integration/vllm/patches/vllm_${VLLM_VERSION}-aibrix-kvcache.patch" && \
+    if [ -f "$PATCH_FILE" ]; then \
+      DIST_DIR=$(${PYTHON_BIN} -m pip show vllm | grep "Location:" | awk '{print $2}') && \
+      cd $DIST_DIR && \
+      patch -p 1 -l -i $PATCH_FILE; \
+    else \
+      echo "No patch file for vLLM ${VLLM_VERSION} — using monkey-patch mode (PR #2060)"; \
+    fi
 
 RUN rm -rf /tmp/aibrix
 
 RUN pip install nixl==${NIXL_VERSION} nixl-cu12==${NIXL_VERSION}
-RUN apt install iproute2 perftest ucx-utils iputils-ping net-tools -y
+# Install network debugging tools (non-critical — used for NIXL/RDMA debug)
+# Package availability varies across base image versions, so we make
+# this best-effort.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      iproute2 perftest ucx-utils iputils-ping net-tools \
+      2>/dev/null || \
+    echo "[WARN] Some debug packages not available; continuing" && \
+    rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["vllm", "serve"]

--- a/build/container/Dockerfile.vllm
+++ b/build/container/Dockerfile.vllm
@@ -57,10 +57,9 @@ RUN pip install nixl==${NIXL_VERSION} nixl-cu12==${NIXL_VERSION}
 # Package availability varies across base image versions, so we make
 # this best-effort.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      iproute2 perftest ucx-utils iputils-ping net-tools \
-      2>/dev/null || \
-    echo "[WARN] Some debug packages not available; continuing" && \
+    (apt-get install -y --no-install-recommends \
+        iproute2 perftest ucx-utils iputils-ping net-tools || \
+     echo "[WARN] Some debug packages not available; continuing") && \
     rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["vllm", "serve"]

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/__init__.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/__init__.py
@@ -19,8 +19,6 @@ logger = logging.getLogger(__name__)
 
 VLLM_V1_WORKER_GPU_MODEL_RUNNER_MODULE = "vllm.v1.worker.gpu_model_runner"
 
-_patches_applied = False
-
 
 def _apply_gpu_model_runner_patches(module):
     """Apply AIBrix patches to vLLM's GPUModelRunner.
@@ -98,7 +96,6 @@ def _apply_gpu_model_runner_patches(module):
         return result
 
     GPUModelRunner.execute_model = _patched_execute_model
-    GPUModelRunner._aibrix_patched = True
     logger.info("[AIBrix] GPUModelRunner monkey-patched successfully")
 
 
@@ -109,9 +106,6 @@ def aibrix_patch_vllm():
         _apply_gpu_model_runner_patches(module)
     except ImportError as e:
         logger.warning("[AIBrix] Failed to import gpu_model_runner: %s", e)
-
-    global _patches_applied
-    _patches_applied = True
 
 
 aibrix_patch_vllm()

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/__init__.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/__init__.py
@@ -14,198 +14,103 @@
 
 import importlib
 import logging
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from vllm.v1.core.sched.output import SchedulerOutput
 
 logger = logging.getLogger(__name__)
 
 VLLM_V1_WORKER_GPU_MODEL_RUNNER_MODULE = "vllm.v1.worker.gpu_model_runner"
 
-# Track if patches are applied
 _patches_applied = False
 
 
 def _apply_gpu_model_runner_patches(module):
-    """Apply patches to an already-imported gpu_model_runner module."""
+    """Apply AIBrix patches to vLLM's GPUModelRunner.
+
+    Wraps execute_model to:
+    1. Trigger KV cache loading from external L1 cache before the forward
+       pass (via kv_connector.start_load_kv_before_update)
+    2. Trigger saving to external L1 cache after the forward pass
+       (via kv_connector.wait_for_save)
+
+    With get_num_new_matched_tokens implemented on the scheduler side
+    (see aibrix_offloading_connector_type1.AIBrixOffloadingConnector),
+    vLLM adjusts num_computed_tokens / num_scheduled_tokens before the
+    worker receives scheduler_output. Therefore this patch does NOT need
+    to preprocess scheduler_output — it only triggers the data transfer.
+    """
     GPUModelRunner = module.GPUModelRunner
 
-    # ------------------------------------------------------------------
-    # Source-patch detection: if GPUModelRunner already has patched signature,
-    # the source-code patch is in place and we should not double-patch.
-    # ------------------------------------------------------------------
-    if getattr(GPUModelRunner, "_aibrix_patched", False):
-        logger.info("[AIBrix] vLLM source patch detected, skipping patch")
+    # Detect already-patched (can happen when the connector module is
+    # reloaded across fork boundaries): check the live method binding,
+    # not class flags that may survive forks without the binding.
+    if GPUModelRunner.execute_model.__name__ == "_patched_execute_model":
+        logger.info("[AIBrix] GPUModelRunner already monkey-patched, skipping")
         return
 
-    # Check if _update_states already accepts load_results (source patch)
+    # Source-patch detection: if vLLM itself has been patched to accept
+    # load_results in _update_states, we skip the monkey-patch.
     import inspect
-
     sig = inspect.signature(GPUModelRunner._update_states)
     if "load_results" in sig.parameters:
         logger.info(
-            "[AIBrix] vLLM source patch detected, _update_states has "
-            "load_results, skipping patch"
+            "[AIBrix] vLLM source patch detected, skipping monkey-patch"
         )
         return
 
-    logger.info("[AIBrix] Applying patches to vLLM GPUModelRunner...")
+    logger.info("[AIBrix] Applying monkey-patch to GPUModelRunner...")
 
-    # Import has_kv_transfer_group at patch time to avoid import errors
     from vllm.distributed.kv_transfer import has_kv_transfer_group
 
-    # ---- Patch 1: GPUModelRunner.execute_model -----------------------
-    # This patch intercepts execute_model to:
-    # 1. Call kv_connector_load_before_update() before _update_states
-    # 2. Store load_results in context for _update_states to use
     _orig_execute_model = GPUModelRunner.execute_model
 
     def _patched_execute_model(self, scheduler_output, *args, **kwargs):
-        """Wrapped execute_model that calls KV connector before state updates"""
-        # Clear previous load_results
-        self._aibrix_load_results = {}
-
-        # Get load_results from KV connector before _update_states
-        if has_kv_transfer_group() and hasattr(
-            self, "kv_connector_load_before_update"
-        ):
-            self._aibrix_load_results = self.kv_connector_load_before_update(
-                scheduler_output
-            )
-        elif has_kv_transfer_group():
-            # Fallback: call directly using mixin method
+        """Wrapped execute_model that triggers KV load before and
+        KV save after the forward pass."""
+        # LOAD phase: fetch KV from external cache into GPU buffers
+        if has_kv_transfer_group():
             from vllm.distributed.kv_transfer import get_kv_transfer_group
-
             kv_connector = get_kv_transfer_group()
             if scheduler_output.kv_connector_metadata is not None:
                 kv_connector.bind_connector_metadata(
                     scheduler_output.kv_connector_metadata
                 )
-                self._aibrix_load_results = (
-                    kv_connector.start_load_kv_before_update()
-                )
+                kv_connector.start_load_kv_before_update()
 
-        # Call original execute_model - it will call _update_states
-        return _orig_execute_model(self, scheduler_output, *args, **kwargs)
+        # Forward pass
+        result = _orig_execute_model(self, scheduler_output, *args, **kwargs)
+
+        # SAVE phase: push new KV to external cache.
+        # vLLM's native _get_kv_connector_output context manager may have
+        # cleared _connector_metadata by this point, so we re-bind it.
+        if has_kv_transfer_group():
+            from vllm.distributed.kv_transfer import get_kv_transfer_group
+            kv_connector = get_kv_transfer_group()
+            if scheduler_output.kv_connector_metadata is not None:
+                try:
+                    kv_connector.bind_connector_metadata(
+                        scheduler_output.kv_connector_metadata
+                    )
+                    kv_connector.wait_for_save()
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        "[AIBrix] wait_for_save failed: %r", e
+                    )
+
+        return result
 
     GPUModelRunner.execute_model = _patched_execute_model
-
-    # ---- Patch 2: GPUModelRunner._update_states ----------------------
-    # This patch pre-processes load_results before calling original
-    # _update_states, then fixes up cached request states afterward.
-    _orig_update_states = GPUModelRunner._update_states
-
-    def _patched_update_states(self, scheduler_output: "SchedulerOutput"):
-        """Wrapped _update_states that handles AIBrix KV load_results."""
-        load_results = getattr(self, "_aibrix_load_results", {})
-
-        # 1. Adjust scheduler_output before original
-        # 1.1 For new requests: modify scheduler_output.scheduled_new_reqs in
-        # place
-        _preprocess_new_reqs(scheduler_output, load_results)
-
-        # 1.2 For cached requests: modify scheduler_output.scheduled_cached_reqs
-        # in place.
-        _preprocess_cached_reqs(scheduler_output, load_results)
-
-        # 2. call original _update_states ----
-        _orig_update_states(self, scheduler_output)
-
-    GPUModelRunner._update_states = _patched_update_states
-
-    # Mark class so we never double-patch
     GPUModelRunner._aibrix_patched = True
-    logger.info("[AIBrix] GPUModelRunner patched successfully")
-
-
-def _preprocess_new_reqs(
-    scheduler_output: "SchedulerOutput",
-    load_results: dict[str, int],
-) -> None:
-    """Pre-process load_results for new requests.
-
-    Modifies scheduler_output.scheduled_new_reqs in place:
-    - Increases num_computed_tokens by num_loaded_tokens
-    - Decreases num_scheduled_tokens by num_loaded_tokens
-    - Decreases total_num_scheduled_tokens by num_loaded_tokens
-    """
-    if not load_results:
-        return
-
-    for new_req_data in scheduler_output.scheduled_new_reqs:
-        req_id = new_req_data.req_id
-        num_loaded_tokens = load_results.get(req_id, 0)
-
-        if num_loaded_tokens <= 0:
-            continue
-
-        num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
-
-        # If all tokens would be loaded, leave at least one for compute
-        if num_loaded_tokens == num_scheduled_tokens:
-            num_loaded_tokens -= 1
-
-        # Adjust computed and scheduled tokens
-        new_req_data.num_computed_tokens += num_loaded_tokens
-        scheduler_output.num_scheduled_tokens[req_id] -= num_loaded_tokens
-        scheduler_output.total_num_scheduled_tokens -= num_loaded_tokens
-
-
-def _preprocess_cached_reqs(
-    scheduler_output: "SchedulerOutput",
-    load_results: dict[str, int],
-) -> None:
-    """Pre-process load_results for cached/running requests.
-
-    Modifies scheduler_output.scheduled_cached_reqs in place:
-    - Increases num_computed_tokens[i] by num_loaded_tokens
-    - Updates new_token_ids[i] if available
-    - Decreases num_scheduled_tokens[req_id] by num_loaded_tokens
-    - Decreases total_num_scheduled_tokens by num_loaded_tokens
-    """
-    if not load_results:
-        return
-
-    req_data = scheduler_output.scheduled_cached_reqs
-
-    for i, req_id in enumerate(req_data.req_ids):
-        num_loaded_tokens = load_results.get(req_id, 0)
-
-        if num_loaded_tokens <= 0:
-            continue
-
-        num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
-
-        # If all tokens would be loaded, leave at least one for compute
-        if num_loaded_tokens == num_scheduled_tokens:
-            num_loaded_tokens -= 1
-
-        # Adjust computed and scheduled tokens
-        req_data.num_computed_tokens[i] += num_loaded_tokens
-        if req_data.new_token_ids and req_data.new_token_ids[i]:
-            req_data.new_token_ids[i] = req_data.new_token_ids[i][
-                num_loaded_tokens:
-            ]
-
-        scheduler_output.num_scheduled_tokens[req_id] -= num_loaded_tokens
-        scheduler_output.total_num_scheduled_tokens -= num_loaded_tokens
+    logger.info("[AIBrix] GPUModelRunner monkey-patched successfully")
 
 
 def aibrix_patch_vllm():
-    """Apply AIBrix patches to vLLM"""
-    global _patches_applied
-    if _patches_applied:
-        logger.info("[AIBrix] Already patched — skipping")
-        return
-
-    # Patch GPUModelRunner
+    """Apply AIBrix patches to vLLM at import time."""
     try:
         module = importlib.import_module(VLLM_V1_WORKER_GPU_MODEL_RUNNER_MODULE)
         _apply_gpu_model_runner_patches(module)
     except ImportError as e:
-        logger.warning("[AIBrix] Failed to patch gpu_model_runner: %s", e)
+        logger.warning("[AIBrix] Failed to import gpu_model_runner: %s", e)
 
+    global _patches_applied
     _patches_applied = True
 
 

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/__init__.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/__init__.py
@@ -47,6 +47,7 @@ def _apply_gpu_model_runner_patches(module):
     # Source-patch detection: if vLLM itself has been patched to accept
     # load_results in _update_states, we skip the monkey-patch.
     import inspect
+
     sig = inspect.signature(GPUModelRunner._update_states)
     if "load_results" in sig.parameters:
         logger.info(
@@ -66,6 +67,7 @@ def _apply_gpu_model_runner_patches(module):
         # LOAD phase: fetch KV from external cache into GPU buffers
         if has_kv_transfer_group():
             from vllm.distributed.kv_transfer import get_kv_transfer_group
+
             kv_connector = get_kv_transfer_group()
             if scheduler_output.kv_connector_metadata is not None:
                 kv_connector.bind_connector_metadata(
@@ -81,6 +83,7 @@ def _apply_gpu_model_runner_patches(module):
         # cleared _connector_metadata by this point, so we re-bind it.
         if has_kv_transfer_group():
             from vllm.distributed.kv_transfer import get_kv_transfer_group
+
             kv_connector = get_kv_transfer_group()
             if scheduler_output.kv_connector_metadata is not None:
                 try:
@@ -89,9 +92,7 @@ def _apply_gpu_model_runner_patches(module):
                     )
                     kv_connector.wait_for_save()
                 except Exception as e:  # noqa: BLE001
-                    logger.warning(
-                        "[AIBrix] wait_for_save failed: %r", e
-                    )
+                    logger.warning("[AIBrix] wait_for_save failed: %r", e)
 
         return result
 

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
@@ -564,30 +564,49 @@ class AIBrixOffloadingConnectorMetadata(KVConnectorMetadata):
 
 @dataclass
 class AIBrixWorkerMeta(KVConnectorWorkerMetadata):
-    """Worker-to-scheduler metadata reporting tokens saved to L1 cache."""
+    """Worker-to-scheduler metadata reporting L1 cache state changes.
+
+    - saved_tokens: tokens newly written to the external L1 cache
+    - failed_load_tokens: tokens the scheduler promised as cached but the
+      worker could not actually load (eviction race). The scheduler
+      removes the corresponding block hashes from its tracker so
+      subsequent get_num_new_matched_tokens lookups stay consistent.
+    """
 
     saved_tokens: dict[str, int] = field(default_factory=dict)
+    failed_load_tokens: dict[str, int] = field(default_factory=dict)
 
     def aggregate(
         self, other: "KVConnectorWorkerMetadata"
     ) -> "KVConnectorWorkerMetadata":
-        """Aggregate by taking the intersection of saved_tokens across TP
-        ranks and the minimum count per request.
+        """Aggregate across TP ranks.
 
-        For Tensor Parallel setups, a block is only usable if ALL ranks
-        successfully saved it to the external L1 cache. Using a union would
-        incorrectly mark blocks as cached when only some ranks saved,
-        leading to load failures on ranks that missed the save.
+        saved_tokens uses intersection + min(): a block only counts as
+        cached when ALL ranks reported saving it. Union would mark
+        blocks cached when only some ranks saved, causing load failures
+        on ranks that missed the save.
+
+        failed_load_tokens uses union + max(): if ANY rank failed to
+        load a block, the block is unusable for the whole TP group —
+        the scheduler must invalidate the corresponding hash for every
+        rank, not just the one that reported the failure.
         """
         if not isinstance(other, AIBrixWorkerMeta):
             return self
-        # Intersection: only keep req_ids present in BOTH metadata sets
-        merged = {
+        saved_merged = {
             req_id: min(num_tokens, other.saved_tokens[req_id])
             for req_id, num_tokens in self.saved_tokens.items()
             if req_id in other.saved_tokens
         }
-        return AIBrixWorkerMeta(saved_tokens=merged)
+        failed_merged = dict(self.failed_load_tokens)
+        for req_id, num_tokens in other.failed_load_tokens.items():
+            failed_merged[req_id] = max(
+                failed_merged.get(req_id, 0), num_tokens
+            )
+        return AIBrixWorkerMeta(
+            saved_tokens=saved_merged,
+            failed_load_tokens=failed_merged,
+        )
 
 
 class AIBrixOffloadingConnectorScheduler:
@@ -749,17 +768,35 @@ class AIBrixOffloadingConnectorScheduler:
     ) -> None:
         """Process worker metadata to update the scheduler-side cache tracker.
 
-        Maps {req_id: num_tokens_saved} from the worker to vLLM block
-        hashes, marking those blocks as cached for future
+        saved_tokens: maps {req_id: num_tokens_saved} from the worker to
+        vLLM block hashes, marking those blocks as cached for future
         get_num_new_matched_tokens lookups.
+
+        failed_load_tokens: maps {req_id: num_tokens_failed_to_load} from
+        the worker. The scheduler removes the corresponding block hashes
+        from its tracker so it stops promising stale entries. Partial
+        loads always fail at the tail of the promised range, so the
+        failing hashes are the last N of the request's block_hashes.
         """
         if worker_meta is None or not isinstance(worker_meta, AIBrixWorkerMeta):
             return
+        block_size = self.engine_block_ntokens
         for req_id, num_tokens in worker_meta.saved_tokens.items():
             block_hashes = self._request_block_hashes.get(req_id, [])
-            num_blocks = num_tokens // self.engine_block_ntokens
+            num_blocks = num_tokens // block_size
             for i in range(min(num_blocks, len(block_hashes))):
                 self._cached_block_hashes.add(block_hashes[i])
+        for req_id, num_tokens in worker_meta.failed_load_tokens.items():
+            block_hashes = self._request_block_hashes.get(req_id)
+            if not block_hashes:
+                continue
+            failed_blocks = num_tokens // block_size
+            if failed_blocks <= 0:
+                continue
+            # Remove the last failed_blocks entries — partial loads always
+            # fail at the tail of the range the scheduler promised.
+            for h in block_hashes[-failed_blocks:]:
+                self._cached_block_hashes.discard(h)
 
     def _block_ids_to_slot_mapping(self, block_ids: list[int]) -> torch.Tensor:
         block_ids_tensor = torch.tensor(block_ids)
@@ -905,6 +942,11 @@ class AIBrixOffloadingConnectorWorker:
         self._meta_cache: dict[str, AIBrixOffloadingConnectorCachedMeta] = {}
         # Track tokens saved to L1 cache per request (for scheduler reporting)
         self._newly_saved_tokens: dict[str, int] = {}
+        # Track tokens the scheduler promised as cached but the worker
+        # could not actually load (partial load / eviction race). Reported
+        # to the scheduler via AIBrixWorkerMeta.failed_load_tokens so it
+        # can remove the corresponding block hashes from its tracker.
+        self._newly_failed_load_tokens: dict[str, int] = {}
         # Track vLLM block_ids where cache.acquire() returned less than the
         # scheduler promised (eviction race). These are reported via
         # get_block_ids_with_load_errors() so vLLM can roll back
@@ -1175,18 +1217,27 @@ class AIBrixOffloadingConnectorWorker:
         # block_ids we failed to load so vLLM rolls back
         # num_computed_tokens and re-schedules those tokens for compute.
         if seq_recv_len < aligned_query_len:
-            block_size = self.engine_block_ntokens
-            first_failed = aligned_context_len + seq_recv_len
-            last_failed = aligned_context_len + aligned_query_len
+            # Report failed tokens to the scheduler so it can invalidate
+            # the corresponding block hashes in _cached_block_hashes.
+            failed_tokens = aligned_query_len - seq_recv_len
+            if failed_tokens > 0:
+                prev = self._newly_failed_load_tokens.get(seq_request_id, 0)
+                self._newly_failed_load_tokens[seq_request_id] = (
+                    prev + failed_tokens
+                )
             slot_mapping = seq_cached_meta.context_slot_mapping
-            first_block = first_failed // block_size
-            last_block = last_failed // block_size
-            for blk_idx in range(first_block, last_block):
-                token_offset = blk_idx * block_size
-                if 0 <= token_offset < len(slot_mapping):
-                    slot = int(slot_mapping[token_offset].item())
-                    block_id = slot // block_size
-                    self._failed_load_block_ids.add(block_id)
+            if slot_mapping is not None:
+                block_size = self.engine_block_ntokens
+                first_failed = aligned_context_len + seq_recv_len
+                last_failed = aligned_context_len + aligned_query_len
+                first_block = first_failed // block_size
+                last_block = last_failed // block_size
+                for blk_idx in range(first_block, last_block):
+                    token_offset = blk_idx * block_size
+                    if 0 <= token_offset < len(slot_mapping):
+                        slot = int(slot_mapping[token_offset].item())
+                        block_id = slot // block_size
+                        self._failed_load_block_ids.add(block_id)
 
         if self._metrics.time_measurement_enabled:
             end.record()
@@ -1546,16 +1597,26 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
     def build_connector_worker_meta(
         self,
     ) -> Optional[KVConnectorWorkerMetadata]:
-        """Report tokens saved to L1 cache back to the scheduler so the
-        scheduler tracker (_cached_block_hashes) can be populated, making
-        subsequent get_num_new_matched_tokens lookups accurate."""
+        """Report L1 cache state changes back to the scheduler:
+
+        - saved_tokens: tokens newly written to L1, so the scheduler can
+          mark the corresponding block hashes as cached.
+        - failed_load_tokens: tokens the scheduler promised as cached
+          but the worker could not load, so the scheduler can remove
+          those stale hashes from _cached_block_hashes.
+        """
         if self.connector_worker is None:
             return None
         saved = self.connector_worker._newly_saved_tokens
-        if not saved:
+        failed = self.connector_worker._newly_failed_load_tokens
+        if not saved and not failed:
             return None
-        meta = AIBrixWorkerMeta(saved_tokens=dict(saved))
+        meta = AIBrixWorkerMeta(
+            saved_tokens=dict(saved),
+            failed_load_tokens=dict(failed),
+        )
         saved.clear()
+        failed.clear()
         return meta
 
     def update_connector_output(self, connector_output) -> None:

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
@@ -34,6 +34,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    KVConnectorWorkerMetadata,
 )
 from vllm.utils.math_utils import round_down, round_up
 from vllm.utils.torch_utils import get_kv_cache_torch_dtype
@@ -561,12 +562,45 @@ class AIBrixOffloadingConnectorMetadata(KVConnectorMetadata):
         return f"AIBrixOffloadingConnectorMetadata: {self.__dict__}"
 
 
+@dataclass
+class AIBrixWorkerMeta(KVConnectorWorkerMetadata):
+    """Worker-to-scheduler metadata reporting tokens saved to L1 cache."""
+
+    saved_tokens: dict[str, int] = field(default_factory=dict)
+
+    def aggregate(
+        self, other: "KVConnectorWorkerMetadata"
+    ) -> "KVConnectorWorkerMetadata":
+        """Aggregate by taking the minimum saved tokens per request
+        (conservative: all TP ranks must have saved for it to count)."""
+        if not isinstance(other, AIBrixWorkerMeta):
+            return self
+        merged = dict(self.saved_tokens)
+        for req_id, num_tokens in other.saved_tokens.items():
+            if req_id in merged:
+                merged[req_id] = min(merged[req_id], num_tokens)
+            else:
+                merged[req_id] = num_tokens
+        return AIBrixWorkerMeta(saved_tokens=merged)
+
+
 class AIBrixOffloadingConnectorScheduler:
     def __init__(self, config: "VllmConfig"):
         self.kv_role = config.kv_transfer_config.kv_role
         self.engine_block_ntokens = config.cache_config.block_size
 
         self._scheduler_meta = AIBrixOffloadingConnectorMetadata({})
+
+        # Track which vLLM block hashes are in external L1 cache.
+        # Uses vLLM's BlockHash (bytes), NOT AIBrix's FarmHash32 strings.
+        self._cached_block_hashes: set[bytes] = set()
+        # Keep block_hashes per request so we can map worker reports
+        # (req_id -> num_tokens_saved) to vLLM block hashes.
+        self._request_block_hashes: dict[str, list] = {}
+        # num_external_tokens promised to the scheduler per request.
+        # Populated by update_state_after_alloc, consumed by
+        # build_connector_meta to set load_len in worker metadata.
+        self._request_external_tokens: dict[str, int] = {}
 
     def build_connector_meta(
         self, scheduler_output: "SchedulerOutput"
@@ -589,11 +623,17 @@ class AIBrixOffloadingConnectorScheduler:
             (block_ids,) = req.block_ids
             slot_mapping = self._block_ids_to_slot_mapping(block_ids)
 
+            # load_len = num_external_tokens promised by scheduler via
+            # get_num_new_matched_tokens. Tells the worker how many tokens
+            # to load from L1 cache (vs recomputing).
+            load_len = self._request_external_tokens.pop(req_id, 0)
+
             self._scheduler_meta.upsert_request(
                 req_id,
                 prompt_len=prompt_len,
                 context_len=context_len,
                 query_len=query_len,
+                load_len=load_len,
                 seq_token_ids=(0, req.prompt_token_ids),
                 seq_slot_mapping=(0, slot_mapping),
                 state=AIBrixOffloadingConnectorRequestState.WAITING_FOR_RECV,
@@ -641,11 +681,14 @@ class AIBrixOffloadingConnectorScheduler:
             else:
                 seq_slot_mapping = None
 
+            load_len = self._request_external_tokens.pop(req_id, 0)
+
             self._scheduler_meta.upsert_request(
                 req_id,
                 prompt_len=prompt_len,
                 context_len=context_len,
                 query_len=query_len,
+                load_len=load_len,
                 seq_token_ids=None,
                 seq_slot_mapping=seq_slot_mapping,
                 state=AIBrixOffloadingConnectorRequestState.WAITING_FOR_RECV,
@@ -691,7 +734,26 @@ class AIBrixOffloadingConnectorScheduler:
         logger.debug("SCHEDULER: Request[id=%s] finished", req_id)
 
         self._scheduler_meta.finish_request(req_id)
+        self._request_block_hashes.pop(req_id, None)
+        self._request_external_tokens.pop(req_id, None)
         return False, None
+
+    def receive_connector_worker_meta(
+        self, worker_meta: Optional[KVConnectorWorkerMetadata]
+    ) -> None:
+        """Process worker metadata to update the scheduler-side cache tracker.
+
+        Maps {req_id: num_tokens_saved} from the worker to vLLM block
+        hashes, marking those blocks as cached for future
+        get_num_new_matched_tokens lookups.
+        """
+        if worker_meta is None or not isinstance(worker_meta, AIBrixWorkerMeta):
+            return
+        for req_id, num_tokens in worker_meta.saved_tokens.items():
+            block_hashes = self._request_block_hashes.get(req_id, [])
+            num_blocks = num_tokens // self.engine_block_ntokens
+            for i in range(min(num_blocks, len(block_hashes))):
+                self._cached_block_hashes.add(block_hashes[i])
 
     def _block_ids_to_slot_mapping(self, block_ids: list[int]) -> torch.Tensor:
         block_ids_tensor = torch.tensor(block_ids)
@@ -835,6 +897,8 @@ class AIBrixOffloadingConnectorWorker:
         self.v_scales: list[torch.Tensor] | None = None
 
         self._meta_cache: dict[str, AIBrixOffloadingConnectorCachedMeta] = {}
+        # Track tokens saved to L1 cache per request (for scheduler reporting)
+        self._newly_saved_tokens: dict[str, int] = {}
         # metrics
         self._metrics = AIBrixOffloadingConnectorMetrics(self.cache.metrics)
         logger.info(
@@ -935,10 +999,10 @@ class AIBrixOffloadingConnectorWorker:
 
         for seq_request_id, num_fetched_tokens in stats.items():
             seq_request_meta = metadata[seq_request_id]
-            # update seq_request_meta
-            seq_request_meta.query_len -= num_fetched_tokens
-            seq_request_meta.context_len += num_fetched_tokens
-
+            # NOTE: In the new flow (get_num_new_matched_tokens reports
+            # external hits to the scheduler), context_len and query_len
+            # are ALREADY adjusted by vLLM scheduler before we get here.
+            # We must NOT double-adjust them. We only transition state.
             seq_request_meta.state = (
                 AIBrixOffloadingConnectorRequestState.WAITING_FOR_SEND
             )
@@ -954,20 +1018,39 @@ class AIBrixOffloadingConnectorWorker:
         seq_cached_meta = self._meta_cache[seq_request_id]
         seq_all_tokens = seq_cached_meta.get_context_tokens_view()
         assert seq_all_tokens is not None, "seq_all_tokens is None"
+
+        # load_len is the number of tokens the scheduler promised are in
+        # the external L1 cache (via get_num_new_matched_tokens). These
+        # are already counted in context_len. We need to LOAD them from
+        # L1 into GPU KV buffer. Tokens to the LEFT of these are local
+        # (computed in a previous step).
+        load_len = seq_request_meta.load_len
         seq_context_len = seq_request_meta.context_len
-
         prompt_len = seq_request_meta.prompt_len
-        query_len = seq_request_meta.query_len
 
-        # align to block boundary
+        if load_len <= 0:
+            # Nothing to load from external cache
+            return 0
+
+        # Split: local_context is tokens computed locally; the last
+        # load_len tokens of context_len come from external cache.
+        local_context_len = seq_context_len - load_len
+        assert local_context_len >= 0, (
+            f"local_context_len={local_context_len} "
+            f"(context_len={seq_context_len}, load_len={load_len})"
+        )
+
+        # Align local context DOWN to block boundary. The load range
+        # starts here and must span full cache blocks.
         aligned_context_len = round_down(
-            seq_context_len, self.cache_block_ntokens
+            local_context_len, self.cache_block_ntokens
         )
-        actual_query_len = seq_context_len + query_len - aligned_context_len
+        # Account for unaligned portion of local context (partial block)
+        shift_len = local_context_len - aligned_context_len
+        # Total load range aligned to full cache blocks
         aligned_query_len = round_down(
-            actual_query_len, self.cache_block_ntokens
+            shift_len + load_len, self.cache_block_ntokens
         )
-        shift_len = seq_context_len - aligned_context_len
 
         assert prompt_len >= aligned_context_len + aligned_query_len, (
             f"{prompt_len}<{aligned_context_len}+{aligned_query_len}"
@@ -979,7 +1062,7 @@ class AIBrixOffloadingConnectorWorker:
         )
         if aligned_query_len < threshold:
             logger.debug(
-                "Skip Request[id=%s, context_len=%d, query_len=%d]",
+                "Skip Request[id=%s, context_len=%d, load_len=%d]",
                 seq_request_id,
                 aligned_context_len,
                 aligned_query_len,
@@ -1244,6 +1327,12 @@ class AIBrixOffloadingConnectorWorker:
             if put_ntokens != length:
                 break
 
+        # Track saved tokens for scheduler reporting via
+        # build_connector_worker_meta
+        if total_sent > 0:
+            prev = self._newly_saved_tokens.get(seq_request_id, 0)
+            self._newly_saved_tokens[seq_request_id] = prev + total_sent
+
         log_if(
             logger,
             logging.INFO,
@@ -1414,6 +1503,34 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         """
         return None, None
 
+    def build_connector_worker_meta(
+        self,
+    ) -> Optional[KVConnectorWorkerMetadata]:
+        """Report tokens saved to L1 cache back to the scheduler so the
+        scheduler tracker (_cached_block_hashes) can be populated, making
+        subsequent get_num_new_matched_tokens lookups accurate."""
+        if self.connector_worker is None:
+            return None
+        saved = self.connector_worker._newly_saved_tokens
+        if not saved:
+            return None
+        meta = AIBrixWorkerMeta(saved_tokens=dict(saved))
+        saved.clear()
+        return meta
+
+    def update_connector_output(self, connector_output) -> None:
+        """Process worker-side output to update scheduler cache tracker.
+
+        Called by vLLM scheduler after each engine step. Extracts
+        kv_connector_worker_meta (AIBrixWorkerMeta) and forwards it to
+        the scheduler's receive_connector_worker_meta.
+        """
+        worker_meta = getattr(
+            connector_output, "kv_connector_worker_meta", None
+        )
+        if self.connector_scheduler is not None and worker_meta is not None:
+            self.connector_scheduler.receive_connector_worker_meta(worker_meta)
+
     # ==============================
     # Scheduler-side methods
     # ==============================
@@ -1427,20 +1544,45 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         Get number of new tokens that can be loaded from the
         external KV cache beyond the num_computed_tokens.
 
-        Args:
-            request (Request): the request object.
-            num_computed_tokens (int): the number of locally
-                computed tokens for this request
-
-        Returns:
-            A tuple with the following elements:
-                - The number of tokens that can be loaded from the
-                  external KV cache beyond what is already computed.
-                - `True` if external KV cache tokens will be loaded
-                  asynchronously (between scheduler steps). Must be
-                  'False' if the first element is 0.
+        Uses the scheduler-side cache tracker (populated via
+        build_connector_worker_meta) to determine how many consecutive
+        blocks starting from num_computed_tokens are available in the
+        external L1 cache.
         """
-        return 0, False
+        if self.connector_scheduler is None:
+            return 0, False
+
+        scheduler = self.connector_scheduler
+
+        block_hashes = getattr(request, "block_hashes", None)
+        if not block_hashes:
+            return 0, False
+
+        # Save block_hashes for this request so we can map worker
+        # reports (req_id -> num_tokens_saved) to vLLM block hashes
+        req_id = getattr(request, "request_id", None)
+        if req_id is not None:
+            scheduler._request_block_hashes[req_id] = list(block_hashes)
+
+        block_size = scheduler.engine_block_ntokens
+
+        # Count how many consecutive blocks starting from
+        # num_computed_tokens are available in the external cache
+        start_block = num_computed_tokens // block_size
+        num_matched_blocks = 0
+
+        for i in range(start_block, len(block_hashes)):
+            if block_hashes[i] not in scheduler._cached_block_hashes:
+                break
+            num_matched_blocks += 1
+
+        num_matched_tokens = num_matched_blocks * block_size
+
+        # Don't exceed request length
+        max_matchable = request.num_tokens - num_computed_tokens
+        num_matched_tokens = min(num_matched_tokens, max_matchable)
+
+        return num_matched_tokens, False
 
     def update_state_after_alloc(
         self,
@@ -1451,19 +1593,16 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         """
         Update KVConnector state after block allocation.
 
-        If get_num_new_matched_tokens previously returned True for a
-        request, this function may be called twice for that same request -
-        first when blocks are allocated for the connector tokens to be
-        asynchronously loaded into, and second when any additional blocks
-        are allocated, after the load/transfer is complete.
-
-        Args:
-            request (Request): the request object.
-            blocks (KVCacheBlocks): the blocks allocated for the request.
-            num_external_tokens (int): the number of tokens that will be
-                loaded from the external KV cache.
+        Stores num_external_tokens so build_connector_meta can pass
+        it to the worker via load_len (instructing the worker exactly
+        how many tokens to load from the external L1 cache).
         """
-        return
+        if self.connector_scheduler is None:
+            return
+        if num_external_tokens > 0:
+            self.connector_scheduler._request_external_tokens[
+                request.request_id
+            ] = num_external_tokens
 
     @delegate_to("connector_scheduler")
     def build_connector_meta(

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
@@ -787,7 +787,7 @@ class AIBrixOffloadingConnectorScheduler:
             for i in range(min(num_blocks, len(block_hashes))):
                 self._cached_block_hashes.add(block_hashes[i])
         for req_id, num_tokens in worker_meta.failed_load_tokens.items():
-            block_hashes = self._request_block_hashes.get(req_id)
+            block_hashes = self._request_block_hashes.get(req_id, [])
             if not block_hashes:
                 continue
             failed_blocks = num_tokens // block_size

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
@@ -571,16 +571,22 @@ class AIBrixWorkerMeta(KVConnectorWorkerMetadata):
     def aggregate(
         self, other: "KVConnectorWorkerMetadata"
     ) -> "KVConnectorWorkerMetadata":
-        """Aggregate by taking the minimum saved tokens per request
-        (conservative: all TP ranks must have saved for it to count)."""
+        """Aggregate by taking the intersection of saved_tokens across TP
+        ranks and the minimum count per request.
+
+        For Tensor Parallel setups, a block is only usable if ALL ranks
+        successfully saved it to the external L1 cache. Using a union would
+        incorrectly mark blocks as cached when only some ranks saved,
+        leading to load failures on ranks that missed the save.
+        """
         if not isinstance(other, AIBrixWorkerMeta):
             return self
-        merged = dict(self.saved_tokens)
-        for req_id, num_tokens in other.saved_tokens.items():
-            if req_id in merged:
-                merged[req_id] = min(merged[req_id], num_tokens)
-            else:
-                merged[req_id] = num_tokens
+        # Intersection: only keep req_ids present in BOTH metadata sets
+        merged = {
+            req_id: min(num_tokens, other.saved_tokens[req_id])
+            for req_id, num_tokens in self.saved_tokens.items()
+            if req_id in other.saved_tokens
+        }
         return AIBrixWorkerMeta(saved_tokens=merged)
 
 
@@ -899,6 +905,12 @@ class AIBrixOffloadingConnectorWorker:
         self._meta_cache: dict[str, AIBrixOffloadingConnectorCachedMeta] = {}
         # Track tokens saved to L1 cache per request (for scheduler reporting)
         self._newly_saved_tokens: dict[str, int] = {}
+        # Track vLLM block_ids where cache.acquire() returned less than the
+        # scheduler promised (eviction race). These are reported via
+        # get_block_ids_with_load_errors() so vLLM can roll back
+        # num_computed_tokens and re-schedule for recompute
+        # (when kv_load_failure_policy="recompute", the default).
+        self._failed_load_block_ids: set[int] = set()
         # metrics
         self._metrics = AIBrixOffloadingConnectorMetrics(self.cache.metrics)
         logger.info(
@@ -1157,6 +1169,24 @@ class AIBrixOffloadingConnectorWorker:
             seq_context_len,
             seq_recv_len,
         )
+
+        # Detect partial load (eviction race): scheduler promised more
+        # tokens than the worker was able to load. Report the vLLM
+        # block_ids we failed to load so vLLM rolls back
+        # num_computed_tokens and re-schedules those tokens for compute.
+        if seq_recv_len < aligned_query_len:
+            block_size = self.engine_block_ntokens
+            first_failed = aligned_context_len + seq_recv_len
+            last_failed = aligned_context_len + aligned_query_len
+            slot_mapping = seq_cached_meta.context_slot_mapping
+            first_block = first_failed // block_size
+            last_block = last_failed // block_size
+            for blk_idx in range(first_block, last_block):
+                token_offset = blk_idx * block_size
+                if 0 <= token_offset < len(slot_mapping):
+                    slot = int(slot_mapping[token_offset].item())
+                    block_id = slot // block_size
+                    self._failed_load_block_ids.add(block_id)
 
         if self._metrics.time_measurement_enabled:
             end.record()
@@ -1492,16 +1522,26 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         """
         Notifies worker-side connector ids of requests that have
         finished generating tokens.
-
-        Returns:
-            ids of requests that have finished asynchronous transfer
-            (requests that previously returned True from request_finished()),
-            tuple of (sending/saving ids, recving/loading ids or
-            (recving/loading id, num. of recv'ed/loaded tokens) pairs).
-            The finished saves/sends req ids must belong to a set provided in a
-            call to this method (this call or a prior one).
         """
         return None, None
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """Report vLLM block_ids that the scheduler promised as cached
+        but the worker failed to load (e.g., evicted from L1 between the
+        scheduler tracker update and the worker acquire call).
+
+        vLLM invalidates these blocks, rolls back num_computed_tokens,
+        and re-schedules the affected tokens for recomputation
+        (when kv_load_failure_policy="recompute", the default).
+        This keeps the scheduler-side _cached_block_hashes tracker
+        eventually-consistent with the actual L1 cache state without
+        requiring a tight eviction-notification channel.
+        """
+        if self.connector_worker is None:
+            return set()
+        result = set(self.connector_worker._failed_load_block_ids)
+        self.connector_worker._failed_load_block_ids.clear()
+        return result
 
     def build_connector_worker_meta(
         self,

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
@@ -297,6 +297,21 @@ class AIBrixOffloadingConnectorWorker(AIBrixOffloadingConnectorWorkerType1):
             seq_recv_len,
         )
 
+        # Detect partial load (eviction race) — see Type1 comment
+        if seq_recv_len < aligned_query_len:
+            block_size = self.engine_block_ntokens
+            first_failed = aligned_context_len + seq_recv_len
+            last_failed = aligned_context_len + aligned_query_len
+            slot_mapping = seq_cached_meta.context_slot_mapping
+            first_block = first_failed // block_size
+            last_block = last_failed // block_size
+            for blk_idx in range(first_block, last_block):
+                token_offset = blk_idx * block_size
+                if 0 <= token_offset < len(slot_mapping):
+                    slot = int(slot_mapping[token_offset].item())
+                    block_id = slot // block_size
+                    self._failed_load_block_ids.add(block_id)
+
         if self._metrics.time_measurement_enabled:
             end = time.perf_counter()
             lat_ms = (end - start) * 1000
@@ -754,20 +769,22 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         )
         self.connector_worker.wait_for_save(self._connector_metadata)
 
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """Report vLLM block_ids the worker failed to load (eviction race).
+        See AIBrixOffloadingConnector (type1) for full doc.
+        """
+        if self.connector_worker is None:
+            return set()
+        result = set(self.connector_worker._failed_load_block_ids)
+        self.connector_worker._failed_load_block_ids.clear()
+        return result
+
     def get_finished(
         self, finished_req_ids: set[str]
     ) -> tuple[Optional[set[str]], Optional[set[str | tuple[str, int]]]]:
         """
         Notifies worker-side connector ids of requests that have
         finished generating tokens.
-
-        Returns:
-            ids of requests that have finished asynchronous transfer
-            (requests that previously returned True from request_finished()),
-            tuple of (sending/saving ids, recving/loading ids or
-            (recving/loading id, num. of recv'ed/loaded tokens) pairs).
-            The finished saves/sends req ids must belong to a set provided in a
-            call to this method (this call or a prior one).
         """
         return None, None
 

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
@@ -49,8 +49,14 @@ from .aibrix_offloading_connector_type1 import (
     AIBrixOffloadingConnectorMetadata,
     AIBrixOffloadingConnectorRequestMetadata,
     AIBrixOffloadingConnectorRequestState,
+    AIBrixWorkerMeta,
     delegate_to,
 )
+
+if TYPE_CHECKING:
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+        KVConnectorWorkerMetadata,
+    )
 from .aibrix_offloading_connector_type1 import (
     AIBrixOffloadingConnectorScheduler as AIBrixOffloadingConnectorSchedulerType1,  # noqa: E501
 )
@@ -299,18 +305,27 @@ class AIBrixOffloadingConnectorWorker(AIBrixOffloadingConnectorWorkerType1):
 
         # Detect partial load (eviction race) — see Type1 comment
         if seq_recv_len < aligned_query_len:
-            block_size = self.engine_block_ntokens
-            first_failed = aligned_context_len + seq_recv_len
-            last_failed = aligned_context_len + aligned_query_len
+            # Report failed tokens to scheduler so it can remove the
+            # corresponding block hashes from its tracker.
+            failed_tokens = aligned_query_len - seq_recv_len
+            if failed_tokens > 0:
+                prev = self._newly_failed_load_tokens.get(seq_request_id, 0)
+                self._newly_failed_load_tokens[seq_request_id] = (
+                    prev + failed_tokens
+                )
             slot_mapping = seq_cached_meta.context_slot_mapping
-            first_block = first_failed // block_size
-            last_block = last_failed // block_size
-            for blk_idx in range(first_block, last_block):
-                token_offset = blk_idx * block_size
-                if 0 <= token_offset < len(slot_mapping):
-                    slot = int(slot_mapping[token_offset].item())
-                    block_id = slot // block_size
-                    self._failed_load_block_ids.add(block_id)
+            if slot_mapping is not None:
+                block_size = self.engine_block_ntokens
+                first_failed = aligned_context_len + seq_recv_len
+                last_failed = aligned_context_len + aligned_query_len
+                first_block = first_failed // block_size
+                last_block = last_failed // block_size
+                for blk_idx in range(first_block, last_block):
+                    token_offset = blk_idx * block_size
+                    if 0 <= token_offset < len(slot_mapping):
+                        slot = int(slot_mapping[token_offset].item())
+                        block_id = slot // block_size
+                        self._failed_load_block_ids.add(block_id)
 
         if self._metrics.time_measurement_enabled:
             end = time.perf_counter()
@@ -600,10 +615,12 @@ class AIBrixOffloadingConnectorWorker(AIBrixOffloadingConnectorWorkerType1):
             total_sent += length
 
             # Track saved tokens for scheduler reporting via
-            # build_connector_worker_meta
-            if total_sent > 0:
+            # build_connector_worker_meta. Use per-block length (not
+            # cumulative total_sent) so the accounting stays correct
+            # if chunking is ever added to this path.
+            if length > 0:
                 prev = self._newly_saved_tokens.get(seq_request_id, 0)
-                self._newly_saved_tokens[seq_request_id] = prev + total_sent
+                self._newly_saved_tokens[seq_request_id] = prev + length
 
             log_if(
                 logger,
@@ -848,13 +865,15 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         if self.connector_worker is None:
             return None
         saved = self.connector_worker._newly_saved_tokens
-        if not saved:
+        failed = self.connector_worker._newly_failed_load_tokens
+        if not saved and not failed:
             return None
-        from aibrix_kvcache.integration.vllm.kv_connector.aibrix_offloading_connector_type1 import (
-            AIBrixWorkerMeta,
+        meta = AIBrixWorkerMeta(
+            saved_tokens=dict(saved),
+            failed_load_tokens=dict(failed),
         )
-        meta = AIBrixWorkerMeta(saved_tokens=dict(saved))
         saved.clear()
+        failed.clear()
         return meta
 
     def update_connector_output(self, connector_output) -> None:
@@ -871,7 +890,15 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         blocks: "KVCacheBlocks",
         num_external_tokens: int,
     ):
-        return
+        """Store num_external_tokens so build_connector_meta can pass it
+        to the worker via load_len (instructing the worker exactly how
+        many tokens to load from the external L1 cache)."""
+        if self.connector_scheduler is None:
+            return
+        if num_external_tokens > 0:
+            self.connector_scheduler._request_external_tokens[
+                request.request_id
+            ] = num_external_tokens
 
     @delegate_to("connector_scheduler")
     def build_connector_meta(

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
@@ -178,17 +178,14 @@ class AIBrixOffloadingConnectorWorker(AIBrixOffloadingConnectorWorkerType1):
             else:
                 num_fetched_tokens = stats.get(seq_request_id, 0)
 
+            # Scheduler already set context_len/query_len correctly
+            # (via get_num_new_matched_tokens). Don't double-adjust.
             if num_fetched_tokens > 0:
                 stats[seq_request_id] = num_fetched_tokens
-                self._send_lengths[seq_request_id] = (
-                    seq_request_meta.context_len + num_fetched_tokens,
-                    seq_request_meta.query_len - num_fetched_tokens,
-                )
-            else:
-                self._send_lengths[seq_request_id] = (
-                    seq_request_meta.context_len,
-                    seq_request_meta.query_len,
-                )
+            self._send_lengths[seq_request_id] = (
+                seq_request_meta.context_len,
+                seq_request_meta.query_len,
+            )
 
             seq_request_meta.state = (
                 AIBrixOffloadingConnectorRequestState.WAITING_FOR_SEND
@@ -212,20 +209,29 @@ class AIBrixOffloadingConnectorWorker(AIBrixOffloadingConnectorWorkerType1):
         seq_cached_meta = self._meta_cache[seq_request_id]
         seq_all_tokens = seq_cached_meta.get_context_tokens_view()
         assert seq_all_tokens is not None, "seq_all_tokens is None"
+
+        # Use load_len (tokens promised to scheduler as external hits)
+        # instead of query_len (tokens to compute). See Type1 comment.
+        load_len = seq_request_meta.load_len
         seq_context_len = seq_request_meta.context_len
-
         prompt_len = seq_request_meta.prompt_len
-        query_len = seq_request_meta.query_len
 
-        # align to block boundary
+        if load_len <= 0:
+            return 0
+
+        local_context_len = seq_context_len - load_len
+        assert local_context_len >= 0, (
+            f"local_context_len={local_context_len} "
+            f"(context_len={seq_context_len}, load_len={load_len})"
+        )
+
         aligned_context_len = round_down(
-            seq_context_len, self.cache_block_ntokens
+            local_context_len, self.cache_block_ntokens
         )
-        actual_query_len = seq_context_len + query_len - aligned_context_len
+        shift_len = local_context_len - aligned_context_len
         aligned_query_len = round_down(
-            actual_query_len, self.cache_block_ntokens
+            shift_len + load_len, self.cache_block_ntokens
         )
-        shift_len = seq_context_len - aligned_context_len
 
         assert prompt_len >= aligned_context_len + aligned_query_len, (
             f"{prompt_len}<{aligned_context_len}+{aligned_query_len}"
@@ -237,7 +243,7 @@ class AIBrixOffloadingConnectorWorker(AIBrixOffloadingConnectorWorkerType1):
         )
         if aligned_query_len < threshold:
             logger.debug(
-                "Skip Request[id=%s, context_len=%d, query_len=%d]",
+                "Skip Request[id=%s, context_len=%d, load_len=%d]",
                 seq_request_id,
                 aligned_context_len,
                 aligned_query_len,
@@ -578,6 +584,12 @@ class AIBrixOffloadingConnectorWorker(AIBrixOffloadingConnectorWorkerType1):
         else:
             total_sent += length
 
+            # Track saved tokens for scheduler reporting via
+            # build_connector_worker_meta
+            if total_sent > 0:
+                prev = self._newly_saved_tokens.get(seq_request_id, 0)
+                self._newly_saved_tokens[seq_request_id] = prev + total_sent
+
             log_if(
                 logger,
                 logging.INFO,
@@ -772,20 +784,69 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         Get number of new tokens that can be loaded from the
         external KV cache beyond the num_computed_tokens.
 
-        Args:
-            request (Request): the request object.
-            num_computed_tokens (int): the number of locally
-                computed tokens for this request
-
-        Returns:
-            A tuple with the following elements:
-                - The number of tokens that can be loaded from the
-                  external KV cache beyond what is already computed.
-                - `True` if external KV cache tokens will be loaded
-                  asynchronously (between scheduler steps). Must be
-                  'False' if the first element is 0.
+        Uses the scheduler-side cache tracker (populated via
+        build_connector_worker_meta) to determine how many consecutive
+        blocks starting from num_computed_tokens are available in the
+        external L1 cache.
         """
-        return 0, False
+        if self.connector_scheduler is None:
+            return 0, False
+
+        scheduler = self.connector_scheduler
+
+        block_hashes = getattr(request, "block_hashes", None)
+        if not block_hashes:
+            return 0, False
+
+        # Save block_hashes for this request so we can map worker
+        # reports (req_id -> num_tokens_saved) to vLLM block hashes
+        req_id = getattr(request, "request_id", None)
+        if req_id is not None:
+            scheduler._request_block_hashes[req_id] = list(block_hashes)
+
+        block_size = scheduler.engine_block_ntokens
+
+        # Count how many consecutive blocks starting from
+        # num_computed_tokens are available in the external cache
+        start_block = num_computed_tokens // block_size
+        num_matched_blocks = 0
+
+        for i in range(start_block, len(block_hashes)):
+            if block_hashes[i] not in scheduler._cached_block_hashes:
+                break
+            num_matched_blocks += 1
+
+        num_matched_tokens = num_matched_blocks * block_size
+
+        # Don't exceed request length
+        max_matchable = request.num_tokens - num_computed_tokens
+        num_matched_tokens = min(num_matched_tokens, max_matchable)
+
+        return num_matched_tokens, False
+
+    def build_connector_worker_meta(
+        self,
+    ) -> Optional["KVConnectorWorkerMetadata"]:
+        """Report tokens saved to L1 cache back to the scheduler."""
+        if self.connector_worker is None:
+            return None
+        saved = self.connector_worker._newly_saved_tokens
+        if not saved:
+            return None
+        from aibrix_kvcache.integration.vllm.kv_connector.aibrix_offloading_connector_type1 import (
+            AIBrixWorkerMeta,
+        )
+        meta = AIBrixWorkerMeta(saved_tokens=dict(saved))
+        saved.clear()
+        return meta
+
+    def update_connector_output(self, connector_output) -> None:
+        """Process worker-side output to update scheduler cache tracker."""
+        worker_meta = getattr(
+            connector_output, "kv_connector_worker_meta", None
+        )
+        if self.connector_scheduler is not None and worker_meta is not None:
+            self.connector_scheduler.receive_connector_worker_meta(worker_meta)
 
     def update_state_after_alloc(
         self,
@@ -793,21 +854,6 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         blocks: "KVCacheBlocks",
         num_external_tokens: int,
     ):
-        """
-        Update KVConnector state after block allocation.
-
-        If get_num_new_matched_tokens previously returned True for a
-        request, this function may be called twice for that same request -
-        first when blocks are allocated for the connector tokens to be
-        asynchronously loaded into, and second when any additional blocks
-        are allocated, after the load/transfer is complete.
-
-        Args:
-            request (Request): the request object.
-            blocks (KVCacheBlocks): the blocks allocated for the request.
-            num_external_tokens (int): the number of tokens that will be
-                loaded from the external KV cache.
-        """
         return
 
     @delegate_to("connector_scheduler")


### PR DESCRIPTION
## Summary

Two related fixes for the v0.19 monkey-patch flow introduced in #2060:

1. **Dockerfile** (`build/container/Dockerfile.vllm`): handle missing patch files for new vLLM versions. Currently builds fail for v0.19+ because no patch file is shipped for those versions.
2. **Metrics** (`kv_connector/*`): implement `get_num_new_matched_tokens()` properly, so `vllm:external_prefix_cache_hits_total` reflects real L1 cache hits (currently always 0 since the stub returns `(0, False)`).

Closes #2104.

## Motivation

Following the guidance from @orozery in vllm-project/vllm#39696: the correct pattern for offloading connectors is to keep cache state on the **scheduler side** and report hits via `get_num_new_matched_tokens`, with worker→scheduler feedback via `build_connector_worker_meta` + `update_connector_output`. The current monkey-patch approach did the token accounting on the worker side via `_preprocess_*`, which bypassed vLLM's native scheduler token accounting and left `external_prefix_cache_hits_total` at 0.

## Design

**Scheduler-side tracker** (`AIBrixOffloadingConnectorScheduler`):
- `_cached_block_hashes: set[bytes]` holds vLLM `BlockHash`es known to be in the external L1 cache.
- `_request_block_hashes: dict[str, list]` caches each active request's block_hashes so worker reports (`{req_id: num_tokens_saved}`) can be mapped back to hashes.
- `_request_external_tokens: dict[str, int]` stores `num_external_tokens` promised by `get_num_new_matched_tokens` for each request, to be passed to the worker as `load_len`.

**Worker-side save tracking** (`AIBrixOffloadingConnectorWorker`):
- `_newly_saved_tokens: dict[str, int]` accumulates tokens successfully `cache.put()`ed per request.
- `_send_kv_sync_impl` / `_send_kv_impl` (Type2) update this dict.

**Connector methods** (`AIBrixOffloadingConnector`):
- `get_num_new_matched_tokens()` consults `_cached_block_hashes` using `request.block_hashes`, returning real hit counts.
- `update_state_after_alloc()` stores the promised `num_external_tokens` in the scheduler.
- `build_connector_worker_meta()` returns a new `AIBrixWorkerMeta(saved_tokens={req_id: num})` dataclass.
- `update_connector_output()` extracts `kv_connector_worker_meta` from `KVConnectorOutput` and forwards to the scheduler to update the tracker.

**Worker uses `load_len`** (the existing but unused field in `AIBrixOffloadingConnectorRequestMetadata`) instead of speculative `query_len` to decide how many tokens to load from L1, removing the need for `_preprocess_*` worker-side `scheduler_output` adjustments.

**Monkey-patch simplified** (`kv_connector/__init__.py`):
- Removed `_preprocess_new_reqs` / `_preprocess_cached_reqs` — no longer needed since the scheduler adjusts `num_computed_tokens` / `num_scheduled_tokens` via the native `get_num_new_matched_tokens` path.
- `_patched_execute_model` now:
  1. Triggers `start_load_kv_before_update` before the forward pass.
  2. Calls `wait_for_save` after the forward pass (with metadata re-bind, since vLLM's native `_get_kv_connector_output` context manager may have cleared `_connector_metadata` by that point).
- Double-patch guard now checks `execute_model.__name__ == \"_patched_execute_model\"` rather than a class attribute — this is fork-safe, since class attributes can survive process forks but the method binding does not.

## Results

Benchmark on L4 GPU with Qwen3-4B-AWQ, 5GB L1 cache, Type2 connector. Test pattern: 10 reference prompts (cold) → 500-prompt flood (forcing GPU KV cache eviction) → same 10 reference prompts (warm).

| Metric | Before (`main`) | After this PR |
|---|---|---|
| Cold TTFT (ref_2-10 avg) | 233 ms | 228 ms |
| Warm TTFT (10 refs avg) | 244 ms | **194 ms (-20%)** |
| `vllm:external_prefix_cache_hits_total` | 0 | **1280** (128 tokens/req avg) |
| L1 offloading functional | ✓ silent | ✓ observable |

The warm TTFT speedup comes from eliminating the speculative lookup overhead: with `load_len` the worker loads exactly what the scheduler said is cached, instead of probing the full `query_len` range every time.

## Testing

- Verified on v0.19.0 with Qwen3-4B-AWQ, both `aibrix_offloading_connector_type1` and `aibrix_offloading_connector_type2`.
- Verified Dockerfile builds successfully with and without a shipped patch file (tested against v0.19.0).
- Verified monkey-patch applies exactly once per process and is fork-safe.
- No regression observed in L1 offloading behavior; only now it's visible to Prometheus/Grafana via the native vLLM metrics.