### PR TITLE
[Bug]: Fix session-affinity routing by preserving x-session-id header

### DIFF
--- a/pkg/plugins/gateway/algorithms/simple_session_affinity.go
+++ b/pkg/plugins/gateway/algorithms/simple_session_affinity.go
@@ -31,7 +31,9 @@ import (
 
 const (
 	RouterSessionAffinity types.RoutingAlgorithm = "session-affinity"
-	sessionIDHeader       string                 = "x-session-id"
+	// NOTE: sessionIDHeader must strictly match types.HeaderSessionID
+	// defined in pkg/plugins/gateway/types.go to prevent routing failures.
+	sessionIDHeader string = "x-session-id"
 )
 
 func init() {

--- a/pkg/plugins/gateway/gateway_req_headers.go
+++ b/pkg/plugins/gateway/gateway_req_headers.go
@@ -65,6 +65,8 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, req
 			reqHeaders[n.Key] = string(n.RawValue)
 		case HeaderConfigProfile:
 			reqConfigProfile = strings.TrimSpace(string(n.RawValue))
+		case HeaderSessionID:
+			reqHeaders[n.Key] = string(n.RawValue)
 		}
 	}
 

--- a/pkg/plugins/gateway/gateway_req_headers_test.go
+++ b/pkg/plugins/gateway/gateway_req_headers_test.go
@@ -56,6 +56,17 @@ func Test_handleRequestHeaders(t *testing.T) {
 		validate       func(*testing.T, *testCase, *extProcPb.ProcessingResponse, utils.User, *types.RoutingContext, int64)
 	}
 
+	// defaultSuccessValidator provides common assertions for successful request header processing.
+	defaultSuccessValidator := func(t *testing.T, tt *testCase, resp *extProcPb.ProcessingResponse, user utils.User, routingCtx *types.RoutingContext, rpm int64) {
+		assert.Equal(t, tt.expected.statusCode, envoyTypePb.StatusCode_OK)
+		assert.Equal(t, tt.expected.headers, resp.GetRequestHeaders().GetResponse().GetHeaderMutation().GetSetHeaders())
+		assert.Equal(t, tt.expected.user, user)
+		assert.NotNil(t, routingCtx)
+		assert.Equal(t, tt.expected.routingCtx.ReqPath, routingCtx.ReqPath)
+		assert.Equal(t, tt.expected.routingCtx.ReqHeaders, routingCtx.ReqHeaders)
+		assert.Equal(t, tt.expected.rpm, rpm)
+	}
+
 	// Define test cases for different routing and error scenarios
 	tests := []testCase{
 		{
@@ -77,14 +88,7 @@ func Test_handleRequestHeaders(t *testing.T) {
 				user: utils.User{},
 				rpm:  0,
 			},
-			validate: func(t *testing.T, tt *testCase, resp *extProcPb.ProcessingResponse, user utils.User, routingCtx *types.RoutingContext, rpm int64) {
-				assert.Equal(t, tt.expected.statusCode, envoyTypePb.StatusCode_OK)
-				assert.Equal(t, tt.expected.headers, resp.GetRequestHeaders().GetResponse().GetHeaderMutation().GetSetHeaders())
-				assert.Equal(t, tt.expected.user, user)
-				assert.NotNil(t, routingCtx)
-				assert.Equal(t, tt.expected.routingCtx.ReqHeaders, routingCtx.ReqHeaders)
-				assert.Equal(t, tt.expected.rpm, rpm)
-			},
+			validate: defaultSuccessValidator,
 		},
 		{
 			name: "not found user in redis cache - should return error",
@@ -153,15 +157,35 @@ func Test_handleRequestHeaders(t *testing.T) {
 				user: utils.User{},
 				rpm:  0,
 			},
-			validate: func(t *testing.T, tt *testCase, resp *extProcPb.ProcessingResponse, user utils.User, routingCtx *types.RoutingContext, rpm int64) {
-				assert.Equal(t, tt.expected.statusCode, envoyTypePb.StatusCode_OK)
-				assert.Equal(t, tt.expected.headers, resp.GetRequestHeaders().GetResponse().GetHeaderMutation().GetSetHeaders())
-				assert.Equal(t, tt.expected.user, user)
-				assert.NotNil(t, routingCtx)
-				assert.Equal(t, tt.expected.routingCtx.ReqPath, routingCtx.ReqPath)
-				assert.Equal(t, tt.expected.routingCtx.ReqHeaders, routingCtx.ReqHeaders)
-				assert.Equal(t, tt.expected.rpm, rpm)
+			validate: defaultSuccessValidator,
+		},
+		{
+			name: "extract x-session-id for session affinity routing",
+			requestHeaders: []*configPb.HeaderValue{
+				{
+					Key:      HeaderSessionID,
+					RawValue: []byte("MTI3LjAuMC4xOjg4OTk="),
+				},
+				{
+					Key:      HeaderRoutingStrategy,
+					RawValue: []byte("session-affinity"),
+				},
 			},
+			expected: testResponse{
+				statusCode: envoyTypePb.StatusCode_OK,
+				headers: []*configPb.HeaderValueOption{
+					{Header: &configPb.HeaderValue{Key: HeaderWentIntoReqHeaders, RawValue: []byte("true")}},
+				},
+				routingCtx: &types.RoutingContext{
+					ReqHeaders: map[string]string{
+						HeaderSessionID:       "MTI3LjAuMC4xOjg4OTk=",
+						HeaderRoutingStrategy: "session-affinity",
+					},
+				},
+				user: utils.User{},
+				rpm:  0,
+			},
+			validate: defaultSuccessValidator,
 		},
 	}
 

--- a/pkg/plugins/gateway/types.go
+++ b/pkg/plugins/gateway/types.go
@@ -52,6 +52,10 @@ const (
 	HeaderModel              = "model"
 	HeaderExternalFilter     = "external-filter"
 	HeaderConfigProfile      = "config-profile"
+	// HeaderSessionID is the header used for session affinity routing.
+	// NOTE: If you change this value, you MUST also update sessionIDHeader in
+	// pkg/plugins/gateway/algorithms/simple_session_affinity.go
+	HeaderSessionID = "x-session-id"
 
 	// RPM & TPM Update Errors
 	HeaderUpdateTPM        = "x-update-tpm"


### PR DESCRIPTION

This PR fixes a bug in the gateway where the `session-affinity` routing strategy silently fails and falls back to random routing.

Currently, when the gateway receives an HTTP request, the `HandleRequestHeaders` function uses a strict switch-case whitelist to extract specific headers into `routingCtx.ReqHeaders`. Because `x-session-id` was missing from this whitelist, the client's session ID was always dropped. As a result, the `sessionAffinityRouter` always evaluated `ctx.ReqHeaders["x-session-id"]` as empty, causing it to incorrectly treat every request as a new session.

**Changes in this PR:**
- Added `x-session-id` to the allowed headers extraction list in `gateway_req_headers.go` to ensure it is properly propagated to the routing context.

This ensures that subsequent requests carrying an `x-session-id` are correctly routed to the target pod, restoring the intended session affinity behavior.


## Related Issues
Resolves: -

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>