### PR TITLE
refactor(kv_connector): Type2 Connector inherits from Type1 Connector

### DIFF
--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
@@ -42,8 +42,26 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
-    KVConnectorWorkerMetadata,
 )
+
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+        KVConnectorWorkerMetadata,
+    )
+except ImportError:
+    # vLLM versions that predate the worker-meta feedback API
+    # (e.g. the 0.10.x line pinned in aibrix_kvcache's test.txt) don't
+    # expose KVConnectorWorkerMetadata. Keep the module importable with
+    # a lightweight stand-in; at runtime the save/load path that
+    # depends on worker metadata only runs on a vLLM that does expose
+    # the real class, so the stand-in is never actually used for
+    # dispatch — it exists purely so `AIBrixWorkerMeta` below has a
+    # valid base class and the type annotations resolve.
+    class KVConnectorWorkerMetadata:  # type: ignore[no-redef]
+        """Fallback base class for vLLM versions without native
+        KVConnectorWorkerMetadata. See comment above the try/except."""
+
+
 from vllm.utils.math_utils import round_down, round_up
 from vllm.utils.torch_utils import get_kv_cache_torch_dtype
 from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
@@ -18,7 +18,7 @@ import enum
 import logging
 from dataclasses import dataclass, field
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar
 
 import numpy as np
 import torch
@@ -1274,6 +1274,42 @@ class AIBrixOffloadingConnectorWorker:
                 10,
             )
 
+    def wait_for_layer_load(
+        self,
+        metadata: AIBrixOffloadingConnectorMetadata,
+        layer_name: str,
+    ) -> None:
+        """Layer-wise load is not supported by the Type1 (sync) worker.
+
+        Subclasses that implement async layer-wise loading (e.g. Type2)
+        must override this method. The Connector interface declares it
+        here so that the shared `AIBrixOffloadingConnector` Connector
+        class can call `self.connector_worker.wait_for_layer_load(...)`
+        without mypy complaining — at runtime, Type1 never reaches this
+        path because Type1.Connector's wait_for_layer_load is a no-op
+        stub.
+        """
+        raise NotImplementedError(
+            "Layer-wise load is not supported by the sync Type1 worker"
+        )
+
+    def save_kv_layer(
+        self,
+        metadata: AIBrixOffloadingConnectorMetadata,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: "AttentionMetadata",
+    ) -> None:
+        """Layer-wise save is not supported by the Type1 (sync) worker.
+
+        Subclasses that implement async layer-wise saving (e.g. Type2)
+        must override this method. See wait_for_layer_load above for the
+        rationale for defining the stub at this level.
+        """
+        raise NotImplementedError(
+            "Layer-wise save is not supported by the sync Type1 worker"
+        )
+
     def _send_kv_sync_impl(
         self,
         seq_request_meta: AIBrixOffloadingConnectorRequestMetadata,
@@ -1442,8 +1478,12 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
     # Subclasses override these class attributes to plug in their own
     # Scheduler/Worker implementations while inheriting the full
     # connector contract. Used by __init__ below.
-    SCHEDULER_CLASS: type = AIBrixOffloadingConnectorScheduler
-    WORKER_CLASS: type = AIBrixOffloadingConnectorWorker
+    SCHEDULER_CLASS: Type["AIBrixOffloadingConnectorScheduler"] = (
+        AIBrixOffloadingConnectorScheduler
+    )
+    WORKER_CLASS: Type["AIBrixOffloadingConnectorWorker"] = (
+        AIBrixOffloadingConnectorWorker
+    )
 
     def __init__(
         self,

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
@@ -18,7 +18,15 @@ import enum
 import logging
 from dataclasses import dataclass, field
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Optional,
+    Type,
+    TypeVar,
+)
 
 import numpy as np
 import torch
@@ -1289,6 +1297,12 @@ class AIBrixOffloadingConnectorWorker:
         path because Type1.Connector's wait_for_layer_load is a no-op
         stub.
         """
+        # NOTE: unreachable in Type1 execution paths. self.connector_worker
+        # is typed as Type1.Worker in the shared Connector __init__, so
+        # this stub exists purely as type-checker scaffolding for the
+        # Type2 override's self.connector_worker.wait_for_layer_load(...)
+        # call — at runtime, Type1.Connector's wait_for_layer_load is a
+        # no-op and never dispatches here.
         raise NotImplementedError(
             "Layer-wise load is not supported by the sync Type1 worker"
         )
@@ -1306,6 +1320,9 @@ class AIBrixOffloadingConnectorWorker:
         must override this method. See wait_for_layer_load above for the
         rationale for defining the stub at this level.
         """
+        # NOTE: unreachable in Type1 execution paths — same reason as
+        # wait_for_layer_load above. Exists only so the shared Connector's
+        # Type2 override type-checks against self.connector_worker.
         raise NotImplementedError(
             "Layer-wise save is not supported by the sync Type1 worker"
         )
@@ -1478,10 +1495,10 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
     # Subclasses override these class attributes to plug in their own
     # Scheduler/Worker implementations while inheriting the full
     # connector contract. Used by __init__ below.
-    SCHEDULER_CLASS: Type["AIBrixOffloadingConnectorScheduler"] = (
+    SCHEDULER_CLASS: ClassVar[Type["AIBrixOffloadingConnectorScheduler"]] = (
         AIBrixOffloadingConnectorScheduler
     )
-    WORKER_CLASS: Type["AIBrixOffloadingConnectorWorker"] = (
+    WORKER_CLASS: ClassVar[Type["AIBrixOffloadingConnectorWorker"]] = (
         AIBrixOffloadingConnectorWorker
     )
 

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
@@ -1439,6 +1439,12 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
     to the kv cache offloading service.
     """
 
+    # Subclasses override these class attributes to plug in their own
+    # Scheduler/Worker implementations while inheriting the full
+    # connector contract. Used by __init__ below.
+    SCHEDULER_CLASS: type = AIBrixOffloadingConnectorScheduler
+    WORKER_CLASS: type = AIBrixOffloadingConnectorWorker
+
     def __init__(
         self,
         config: "VllmConfig",
@@ -1455,11 +1461,9 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
 
         self.connector_worker: Optional[AIBrixOffloadingConnectorWorker] = None
         if role == KVConnectorRole.SCHEDULER:
-            self.connector_scheduler = AIBrixOffloadingConnectorScheduler(
-                config
-            )
+            self.connector_scheduler = self.SCHEDULER_CLASS(config)
         elif role == KVConnectorRole.WORKER:
-            self.connector_worker = AIBrixOffloadingConnectorWorker(config)
+            self.connector_worker = self.WORKER_CLASS(config)
 
     # ==============================
     # Worker-side methods

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
@@ -16,7 +16,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.distributed as dist
@@ -24,11 +24,6 @@ import torch.distributed as dist
 # from vllm.v1.attention.backends.flashinfer import FlashInferBackend
 # from vllm.v1.attention.backends.flex_attention import FlexAttentionBackend
 # from vllm.v1.attention.backends.triton_attn import TritonAttentionBackend
-from vllm.distributed.kv_transfer.kv_connector.v1.base import (
-    KVConnectorBase_V1,
-    KVConnectorMetadata,
-    KVConnectorRole,
-)
 from vllm.utils.math_utils import round_down
 from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
 from vllm.v1.attention.backends.flashinfer import FlashInferBackend
@@ -46,17 +41,13 @@ from aibrix_kvcache.common.absl_logging import (
 from aibrix_kvcache.profiling import tag_wrapper
 
 from .aibrix_offloading_connector_type1 import (
+    AIBrixOffloadingConnector as AIBrixOffloadingConnectorType1,
+)
+from .aibrix_offloading_connector_type1 import (
     AIBrixOffloadingConnectorMetadata,
     AIBrixOffloadingConnectorRequestMetadata,
     AIBrixOffloadingConnectorRequestState,
-    AIBrixWorkerMeta,
-    delegate_to,
 )
-
-if TYPE_CHECKING:
-    from vllm.distributed.kv_transfer.kv_connector.v1.base import (
-        KVConnectorWorkerMetadata,
-    )
 from .aibrix_offloading_connector_type1 import (
     AIBrixOffloadingConnectorScheduler as AIBrixOffloadingConnectorSchedulerType1,  # noqa: E501
 )
@@ -66,12 +57,7 @@ from .aibrix_offloading_connector_type1 import (
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
-    from vllm.forward_context import ForwardContext
     from vllm.v1.attention.backend import AttentionMetadata
-    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-    from vllm.v1.core.sched.output import SchedulerOutput
-    from vllm.v1.kv_cache_interface import KVCacheConfig
-    from vllm.v1.request import Request
 
 logger = getLogger(__name__)
 
@@ -641,98 +627,27 @@ class AIBrixOffloadingConnectorWorker(AIBrixOffloadingConnectorWorkerType1):
             )
 
 
-class AIBrixOffloadingConnector(KVConnectorBase_V1):
-    """AIBrixOffloadingConnector is a KVConnector that offloads KV caches
-    to the kv cache offloading service.
+class AIBrixOffloadingConnector(AIBrixOffloadingConnectorType1):
+    """Type2 offloading connector: adds async layer-wise load/save on
+    top of the sync Type1 connector.
+
+    All scheduler-side bookkeeping (get_num_new_matched_tokens,
+    update_state_after_alloc, build_connector_worker_meta, eviction
+    propagation, etc.) is inherited from AIBrixOffloadingConnectorType1.
+
+    Only the two layer-wise hooks that Type1 leaves as "Not supported"
+    stubs are overridden here with real implementations. The
+    SCHEDULER_CLASS and WORKER_CLASS class attributes plug the
+    Type2-specific Scheduler/Worker into the inherited __init__.
     """
 
-    def __init__(
-        self,
-        config: "VllmConfig",
-        role: KVConnectorRole,
-        kv_cache_config: Optional["KVCacheConfig"] = None,
-    ):
-        super().__init__(
-            vllm_config=config, role=role, kv_cache_config=kv_cache_config
-        )
-
-        self.connector_scheduler: Optional[
-            AIBrixOffloadingConnectorScheduler
-        ] = None
-
-        self.connector_worker: Optional[AIBrixOffloadingConnectorWorker] = None
-        if role == KVConnectorRole.SCHEDULER:
-            self.connector_scheduler = AIBrixOffloadingConnectorScheduler(
-                config
-            )
-        elif role == KVConnectorRole.WORKER:
-            self.connector_worker = AIBrixOffloadingConnectorWorker(config)
-
-    # ==============================
-    # Worker-side methods
-    # ==============================
-
-    @delegate_to("connector_worker")
-    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
-        """
-        Initialize with the KV caches. Useful for pre-registering the
-        KV Caches in the KVConnector (e.g. for NIXL).
-
-        Args: kv_caches:
-            dictionary of layer names, kv cache
-        """
-        pass
-
-    def start_load_kv_before_update(self, **kwargs) -> dict[str, int]:
-        """
-        Start loading the KV cache from the connector to vLLM's paged
-        KV buffer before gpu runner updating its states.
-
-        Args:
-            **kwargs: additional arguments for the load operation
-
-        Returns:
-            dict[str, int]: a dictionary of request ids and the number of
-            tokens loaded for each request.
-        """
-        assert self.connector_worker is not None
-        assert isinstance(
-            self._connector_metadata,
-            AIBrixOffloadingConnectorMetadata,
-        )
-        return self.connector_worker.start_load_kv_before_update(
-            self._connector_metadata
-        )
-
-    def start_load_kv(
-        self, forward_context: "ForwardContext", **kwargs
-    ) -> None:
-        """
-        Start loading the KV cache from the connector to vLLM's paged
-        KV buffer. This is called from the forward context before the
-        forward pass to enable async loading during model execution.
-
-        Args:
-            forward_context (ForwardContext): the forward context.
-            **kwargs: additional arguments for the load operation
-
-        Note:
-            The number of elements in kv_caches and layer_names should be
-            the same.
-
-        """
-        pass
+    SCHEDULER_CLASS = AIBrixOffloadingConnectorScheduler
+    WORKER_CLASS = AIBrixOffloadingConnectorWorker
 
     def wait_for_layer_load(self, layer_name: str) -> None:
-        """
-        Block until the KV for a specific layer is loaded into vLLM's
-        paged buffer. This is called from within attention layer to ensure
-        async copying from start_load_kv is complete.
-
-        This interface will be useful for layer-by-layer pipelining.
-
-        Args:
-            layer_name: the name of that layer
+        """Block until the KV for a specific layer is loaded into vLLM's
+        paged buffer. Called from within the attention layer to ensure
+        the async copy started by start_load_kv_before_update is done.
         """
         assert self.connector_worker is not None
         assert isinstance(
@@ -750,17 +665,9 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         attn_metadata: "AttentionMetadata",
         **kwargs,
     ) -> None:
-        """
-        Start saving a layer of KV cache from vLLM's paged buffer
-        to the connector. This is called from within attention layer to
-        enable async copying during execution.
-
-        Args:
-            layer_name (str): the name of the layer.
-            kv_layer (torch.Tensor): the paged KV buffer of the current
-                layer in vLLM.
-            attn_metadata (AttentionMetadata): the attention metadata.
-            **kwargs: additional arguments for the save operation.
+        """Start saving a layer of KV cache from vLLM's paged buffer to
+        the connector. Called from within the attention layer to enable
+        async copying during execution.
         """
         assert self.connector_worker is not None
         assert isinstance(
@@ -770,165 +677,3 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         self.connector_worker.save_kv_layer(
             self._connector_metadata, layer_name, kv_layer, attn_metadata
         )
-
-    def wait_for_save(self) -> None:
-        """
-        Block until all the save operations is done. This is called
-        as the forward context exits to ensure that the async saving
-        from save_kv_layer is complete before finishing the forward.
-
-        This prevents overwrites of paged KV buffer before saving done.
-        """
-        assert self.connector_worker is not None
-        assert isinstance(
-            self._connector_metadata,
-            AIBrixOffloadingConnectorMetadata,
-        )
-        self.connector_worker.wait_for_save(self._connector_metadata)
-
-    def get_block_ids_with_load_errors(self) -> set[int]:
-        """Report vLLM block_ids the worker failed to load (eviction race).
-        See AIBrixOffloadingConnector (type1) for full doc.
-        """
-        if self.connector_worker is None:
-            return set()
-        result = set(self.connector_worker._failed_load_block_ids)
-        self.connector_worker._failed_load_block_ids.clear()
-        return result
-
-    def get_finished(
-        self, finished_req_ids: set[str]
-    ) -> tuple[Optional[set[str]], Optional[set[str | tuple[str, int]]]]:
-        """
-        Notifies worker-side connector ids of requests that have
-        finished generating tokens.
-        """
-        return None, None
-
-    # ==============================
-    # Scheduler-side methods
-    # ==============================
-
-    def get_num_new_matched_tokens(
-        self,
-        request: "Request",
-        num_computed_tokens: int,
-    ) -> tuple[int, bool]:
-        """
-        Get number of new tokens that can be loaded from the
-        external KV cache beyond the num_computed_tokens.
-
-        Uses the scheduler-side cache tracker (populated via
-        build_connector_worker_meta) to determine how many consecutive
-        blocks starting from num_computed_tokens are available in the
-        external L1 cache.
-        """
-        if self.connector_scheduler is None:
-            return 0, False
-
-        scheduler = self.connector_scheduler
-
-        block_hashes = getattr(request, "block_hashes", None)
-        if not block_hashes:
-            return 0, False
-
-        # Save block_hashes for this request so we can map worker
-        # reports (req_id -> num_tokens_saved) to vLLM block hashes
-        req_id = getattr(request, "request_id", None)
-        if req_id is not None:
-            scheduler._request_block_hashes[req_id] = list(block_hashes)
-
-        block_size = scheduler.engine_block_ntokens
-
-        # Count how many consecutive blocks starting from
-        # num_computed_tokens are available in the external cache
-        start_block = num_computed_tokens // block_size
-        num_matched_blocks = 0
-
-        for i in range(start_block, len(block_hashes)):
-            if block_hashes[i] not in scheduler._cached_block_hashes:
-                break
-            num_matched_blocks += 1
-
-        num_matched_tokens = num_matched_blocks * block_size
-
-        # Don't exceed request length
-        max_matchable = request.num_tokens - num_computed_tokens
-        num_matched_tokens = min(num_matched_tokens, max_matchable)
-
-        return num_matched_tokens, False
-
-    def build_connector_worker_meta(
-        self,
-    ) -> Optional["KVConnectorWorkerMetadata"]:
-        """Report tokens saved to L1 cache back to the scheduler."""
-        if self.connector_worker is None:
-            return None
-        saved = self.connector_worker._newly_saved_tokens
-        failed = self.connector_worker._newly_failed_load_tokens
-        if not saved and not failed:
-            return None
-        meta = AIBrixWorkerMeta(
-            saved_tokens=dict(saved),
-            failed_load_tokens=dict(failed),
-        )
-        saved.clear()
-        failed.clear()
-        return meta
-
-    def update_connector_output(self, connector_output) -> None:
-        """Process worker-side output to update scheduler cache tracker."""
-        worker_meta = getattr(
-            connector_output, "kv_connector_worker_meta", None
-        )
-        if self.connector_scheduler is not None and worker_meta is not None:
-            self.connector_scheduler.receive_connector_worker_meta(worker_meta)
-
-    def update_state_after_alloc(
-        self,
-        request: "Request",
-        blocks: "KVCacheBlocks",
-        num_external_tokens: int,
-    ):
-        """Store num_external_tokens so build_connector_meta can pass it
-        to the worker via load_len (instructing the worker exactly how
-        many tokens to load from the external L1 cache)."""
-        if self.connector_scheduler is None:
-            return
-        if num_external_tokens > 0:
-            self.connector_scheduler._request_external_tokens[
-                request.request_id
-            ] = num_external_tokens
-
-    @delegate_to("connector_scheduler")
-    def build_connector_meta(
-        self, scheduler_output: "SchedulerOutput"
-    ) -> KVConnectorMetadata:
-        """
-        Build the connector metadata for this step.
-
-        This function should NOT modify fields in the scheduler_output.
-        Also, calling this function will reset the state of the connector.
-
-        Args:
-            scheduler_output (SchedulerOutput): the scheduler output object.
-        """
-        pass
-
-    @delegate_to("connector_scheduler")
-    def request_finished(  # type: ignore
-        self,
-        request: "Request",
-        block_ids: list[int],
-    ) -> tuple[bool, Optional[dict[str, Any]]]:
-        """
-        Called when a request has finished, before its blocks are freed.
-
-        Returns:
-            True if the request is being saved/sent asynchronously and blocks
-            should not be freed until the request_id is returned from
-            get_finished().
-            Optional KVTransferParams to be included in the request outputs
-            returned by the engine.
-        """
-        pass

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
@@ -49,10 +49,10 @@ from .aibrix_offloading_connector_type1 import (
     AIBrixOffloadingConnectorRequestState,
 )
 from .aibrix_offloading_connector_type1 import (
-    AIBrixOffloadingConnectorScheduler as AIBrixOffloadingConnectorSchedulerType1,  # noqa: E501
+    AIBrixOffloadingConnectorScheduler as Type1Scheduler,
 )
 from .aibrix_offloading_connector_type1 import (
-    AIBrixOffloadingConnectorWorker as AIBrixOffloadingConnectorWorkerType1,
+    AIBrixOffloadingConnectorWorker as Type1Worker,
 )
 
 if TYPE_CHECKING:
@@ -68,14 +68,12 @@ OFFLOADING_CONNECTOR_SUPPORTED_ATTN_BACKENDS = {
 }
 
 
-class AIBrixOffloadingConnectorScheduler(
-    AIBrixOffloadingConnectorSchedulerType1
-):
+class AIBrixOffloadingConnectorScheduler(Type1Scheduler):
     def __init__(self, config: "VllmConfig"):
         super().__init__(config)
 
 
-class AIBrixOffloadingConnectorWorker(AIBrixOffloadingConnectorWorkerType1):
+class AIBrixOffloadingConnectorWorker(Type1Worker):
     """AIBrixOffloadingConnectorWorker carries out the data-plane operations."""
 
     def __init__(self, config: "VllmConfig"):

--- a/python/aibrix_kvcache/tests/test_connector_inheritance.py
+++ b/python/aibrix_kvcache/tests/test_connector_inheritance.py
@@ -1,0 +1,76 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lightweight asserts that the Type2 Connector correctly inherits from
+Type1 and that the shared ``__init__`` wires the right Scheduler/Worker
+subclass through the ``SCHEDULER_CLASS`` / ``WORKER_CLASS`` class
+attributes.
+
+No vLLM runtime / GPU dependency at test time — we only inspect class
+attributes, not runtime instances. Catches regressions where someone
+shadows ``SCHEDULER_CLASS`` / ``WORKER_CLASS`` with the wrong type, or
+breaks the Connector / Scheduler / Worker hierarchy.
+"""
+
+from aibrix_kvcache.integration.vllm.kv_connector import (
+    aibrix_offloading_connector_type1 as t1,
+)
+from aibrix_kvcache.integration.vllm.kv_connector import (
+    aibrix_offloading_connector_type2 as t2,
+)
+
+
+def test_type1_class_attrs_point_to_type1_subclasses():
+    assert (
+        t1.AIBrixOffloadingConnector.SCHEDULER_CLASS
+        is t1.AIBrixOffloadingConnectorScheduler
+    )
+    assert (
+        t1.AIBrixOffloadingConnector.WORKER_CLASS
+        is t1.AIBrixOffloadingConnectorWorker
+    )
+
+
+def test_type2_overrides_class_attrs_to_type2_subclasses():
+    assert (
+        t2.AIBrixOffloadingConnector.SCHEDULER_CLASS
+        is t2.AIBrixOffloadingConnectorScheduler
+    )
+    assert (
+        t2.AIBrixOffloadingConnector.WORKER_CLASS
+        is t2.AIBrixOffloadingConnectorWorker
+    )
+    # Must NOT still point at the Type1 subclasses.
+    assert (
+        t2.AIBrixOffloadingConnector.SCHEDULER_CLASS
+        is not t1.AIBrixOffloadingConnectorScheduler
+    )
+    assert (
+        t2.AIBrixOffloadingConnector.WORKER_CLASS
+        is not t1.AIBrixOffloadingConnectorWorker
+    )
+
+
+def test_type2_inherits_from_type1():
+    assert issubclass(
+        t2.AIBrixOffloadingConnector, t1.AIBrixOffloadingConnector
+    )
+    assert issubclass(
+        t2.AIBrixOffloadingConnectorScheduler,
+        t1.AIBrixOffloadingConnectorScheduler,
+    )
+    assert issubclass(
+        t2.AIBrixOffloadingConnectorWorker,
+        t1.AIBrixOffloadingConnectorWorker,
+    )

--- a/python/aibrix_kvcache/tests/test_connector_inheritance.py
+++ b/python/aibrix_kvcache/tests/test_connector_inheritance.py
@@ -12,65 +12,150 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Lightweight asserts that the Type2 Connector correctly inherits from
-Type1 and that the shared ``__init__`` wires the right Scheduler/Worker
-subclass through the ``SCHEDULER_CLASS`` / ``WORKER_CLASS`` class
-attributes.
+"""Source-level asserts that the Type2 Connector correctly inherits
+from Type1 and that the shared ``__init__`` wires the right
+Scheduler/Worker subclass through the ``SCHEDULER_CLASS`` /
+``WORKER_CLASS`` class attributes.
 
-No vLLM runtime / GPU dependency at test time — we only inspect class
-attributes, not runtime instances. Catches regressions where someone
-shadows ``SCHEDULER_CLASS`` / ``WORKER_CLASS`` with the wrong type, or
-breaks the Connector / Scheduler / Worker hierarchy.
+We parse the two connector source files with ``ast`` instead of
+importing them at runtime. This deliberately avoids pulling in vLLM
+(and its CUDA/torch dependencies) at test time: the module can't be
+imported cleanly under the ``vllm==0.10.2`` pin in
+``requirements/test.txt`` because the connector depends on symbols
+(``KVConnectorWorkerMetadata``, ``vllm.utils.math_utils``) that only
+appear in newer vLLM releases. The tests still catch the regression
+pattern the reviewer asked for — namely, a future change that shadows
+``SCHEDULER_CLASS`` / ``WORKER_CLASS`` with the wrong class, or breaks
+the Connector / Scheduler / Worker hierarchy — because the only runtime
+magic involved is plain Python class inheritance, which is visible at
+the source level.
 """
 
-from aibrix_kvcache.integration.vllm.kv_connector import (
-    aibrix_offloading_connector_type1 as t1,
+import ast
+from pathlib import Path
+from typing import Optional
+
+CONNECTOR_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "aibrix_kvcache"
+    / "integration"
+    / "vllm"
+    / "kv_connector"
 )
-from aibrix_kvcache.integration.vllm.kv_connector import (
-    aibrix_offloading_connector_type2 as t2,
-)
+TYPE1_SRC = CONNECTOR_DIR / "aibrix_offloading_connector_type1.py"
+TYPE2_SRC = CONNECTOR_DIR / "aibrix_offloading_connector_type2.py"
 
 
-def test_type1_class_attrs_point_to_type1_subclasses():
-    assert (
-        t1.AIBrixOffloadingConnector.SCHEDULER_CLASS
-        is t1.AIBrixOffloadingConnectorScheduler
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _find_class(tree: ast.Module, name: str) -> Optional[ast.ClassDef]:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    return None
+
+
+def _base_names(cls: ast.ClassDef) -> list[str]:
+    """Return the textual names of the class's base classes.
+
+    Handles both plain names (``Foo``) and dotted attribute access
+    (``module.Foo`` -> ``Foo``). Subscripted bases (``Generic[T]``) are
+    resolved to the base name (``Generic``).
+    """
+    out = []
+    for base in cls.bases:
+        if isinstance(base, ast.Name):
+            out.append(base.id)
+        elif isinstance(base, ast.Attribute):
+            out.append(base.attr)
+        elif isinstance(base, ast.Subscript) and isinstance(
+            base.value, ast.Name
+        ):
+            out.append(base.value.id)
+    return out
+
+
+def _class_attr_rhs_name(cls: ast.ClassDef, attr_name: str) -> Optional[str]:
+    """Return the identifier on the RHS of ``attr_name = X`` or
+    ``attr_name: T = X`` if the RHS is a plain Name; ``None`` otherwise.
+    """
+    for node in cls.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(
+            node.target, ast.Name
+        ):
+            if node.target.id == attr_name and isinstance(node.value, ast.Name):
+                return node.value.id
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id == attr_name
+                    and isinstance(node.value, ast.Name)
+                ):
+                    return node.value.id
+    return None
+
+
+def test_type1_connector_declares_scheduler_and_worker_class_attrs():
+    """Type1's Connector must declare SCHEDULER_CLASS / WORKER_CLASS
+    pointing at its own Scheduler / Worker subclasses. If these go
+    missing or get pointed at the wrong class, the shared __init__
+    would instantiate the wrong Scheduler/Worker everywhere.
+    """
+    tree = _parse(TYPE1_SRC)
+    cls = _find_class(tree, "AIBrixOffloadingConnector")
+    assert cls is not None, (
+        "AIBrixOffloadingConnector class not found in type1 source"
     )
     assert (
-        t1.AIBrixOffloadingConnector.WORKER_CLASS
-        is t1.AIBrixOffloadingConnectorWorker
+        _class_attr_rhs_name(cls, "SCHEDULER_CLASS")
+        == "AIBrixOffloadingConnectorScheduler"
+    )
+    assert (
+        _class_attr_rhs_name(cls, "WORKER_CLASS")
+        == "AIBrixOffloadingConnectorWorker"
     )
 
 
-def test_type2_overrides_class_attrs_to_type2_subclasses():
-    assert (
-        t2.AIBrixOffloadingConnector.SCHEDULER_CLASS
-        is t2.AIBrixOffloadingConnectorScheduler
+def test_type2_connector_inherits_from_type1_connector():
+    """Type2's Connector must inherit from Type1's Connector so it
+    picks up the full connector contract (get_num_new_matched_tokens,
+    build_connector_worker_meta, update_state_after_alloc, etc.) via
+    inheritance rather than copy-paste.
+    """
+    tree = _parse(TYPE2_SRC)
+    cls = _find_class(tree, "AIBrixOffloadingConnector")
+    assert cls is not None, (
+        "AIBrixOffloadingConnector class not found in type2 source"
     )
-    assert (
-        t2.AIBrixOffloadingConnector.WORKER_CLASS
-        is t2.AIBrixOffloadingConnectorWorker
-    )
-    # Must NOT still point at the Type1 subclasses.
-    assert (
-        t2.AIBrixOffloadingConnector.SCHEDULER_CLASS
-        is not t1.AIBrixOffloadingConnectorScheduler
-    )
-    assert (
-        t2.AIBrixOffloadingConnector.WORKER_CLASS
-        is not t1.AIBrixOffloadingConnectorWorker
+    # Type2 imports Type1's Connector as AIBrixOffloadingConnectorType1
+    # and inherits from it under that alias.
+    assert "AIBrixOffloadingConnectorType1" in _base_names(cls), (
+        f"Type2 Connector bases are {_base_names(cls)}, expected to "
+        "include AIBrixOffloadingConnectorType1"
     )
 
 
-def test_type2_inherits_from_type1():
-    assert issubclass(
-        t2.AIBrixOffloadingConnector, t1.AIBrixOffloadingConnector
+def test_type2_scheduler_and_worker_inherit_from_type1():
+    """Type2's Scheduler / Worker must inherit from their Type1
+    counterparts (aliased as Type1Scheduler / Type1Worker in type2).
+    """
+    tree = _parse(TYPE2_SRC)
+    scheduler = _find_class(tree, "AIBrixOffloadingConnectorScheduler")
+    worker = _find_class(tree, "AIBrixOffloadingConnectorWorker")
+    assert scheduler is not None, (
+        "AIBrixOffloadingConnectorScheduler not found in type2 source"
     )
-    assert issubclass(
-        t2.AIBrixOffloadingConnectorScheduler,
-        t1.AIBrixOffloadingConnectorScheduler,
+    assert worker is not None, (
+        "AIBrixOffloadingConnectorWorker not found in type2 source"
     )
-    assert issubclass(
-        t2.AIBrixOffloadingConnectorWorker,
-        t1.AIBrixOffloadingConnectorWorker,
+    assert "Type1Scheduler" in _base_names(scheduler), (
+        f"Type2 Scheduler bases are {_base_names(scheduler)}, expected "
+        "to include Type1Scheduler"
+    )
+    assert "Type1Worker" in _base_names(worker), (
+        f"Type2 Worker bases are {_base_names(worker)}, expected to "
+        "include Type1Worker"
     )


### PR DESCRIPTION
## Summary

Follow-up to #2119. Removes ~280 lines of copy-pasted code in `aibrix_offloading_connector_type2.py` by making the Type2 `AIBrixOffloadingConnector` class inherit from its Type1 counterpart.

## Motivation

In the #2119 review, @varungup90 noted that Type1 and Type2 share a lot of code in the `AIBrixOffloadingConnector` class (`get_num_new_matched_tokens`, `update_state_after_alloc`, `build_connector_worker_meta`, etc.) and suggested a follow-up PR to hoist it to a common base. In my reply on #2119 I committed to opening this once the parent PR merged.

Type2's `AIBrixOffloadingConnectorScheduler` and `AIBrixOffloadingConnectorWorker` already inherited from their Type1 counterparts — only the top-level Connector class was still a separate sibling under `KVConnectorBase_V1`. Semantically, Type2 = Type1 + async layer-wise load/save: Type1 declares `wait_for_layer_load` and `save_kv_layer` as "Not supported" stubs; Type2 provides the real implementations. The inheritance hierarchy now reflects that.

## Change

- `class AIBrixOffloadingConnector` in `type2.py` now extends `AIBrixOffloadingConnectorType1` instead of `KVConnectorBase_V1` directly.
- 13 methods that were bit-for-bit duplicates of Type1 are removed and inherited (`__init__`, `register_kv_caches`, `start_load_kv_before_update`, `start_load_kv`, `wait_for_save`, `get_block_ids_with_load_errors`, `get_finished`, `get_num_new_matched_tokens`, `build_connector_worker_meta`, `update_connector_output`, `update_state_after_alloc`, `build_connector_meta`, `request_finished`).
- 2 methods remain as overrides: `wait_for_layer_load` and `save_kv_layer` — the real layer-wise implementations.
- `SCHEDULER_CLASS` / `WORKER_CLASS` class attributes are added on Type1's Connector and used by the shared `__init__` so subclasses can plug in their own Scheduler/Worker without duplicating `__init__`. This is a 3-line mechanical change on Type1 with no behavior difference when Type1 is used directly.

Net: **+31 / -282 lines**.

## Testing

Smoke-tested on L4 GPU with Qwen3-4B-AWQ, 5GB L1, 500-prompt flood pattern (same harness as #2119):

| Connector | `external_prefix_cache_hits_total` | Warm TTFT avg |
|---|---|---|
| Type2 pre-refactor | 1280 | 0.189 s |
| Type2 post-refactor | 1280 | 0.197 s |
| Type1 pre-refactor | 1280 | 0.157 s |
| Type1 post-refactor | 1280 | 0.143 s |

Zero functional delta — the removed methods were bit-for-bit identical to their Type1 counterparts before this refactor.

Addresses the code-duplication item from #2119.
