### PR TITLE
fix(roleset): cleanup orphan resources when podGroupSize changes

### DIFF
--- a/pkg/controller/roleset/orphan_cleanup_test.go
+++ b/pkg/controller/roleset/orphan_cleanup_test.go
@@ -1,0 +1,370 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roleset
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/controller/constants"
+)
+
+func newOrphanTestRoleSet(name, namespace string) *orchestrationv1alpha1.RoleSet {
+	return &orchestrationv1alpha1.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.StormServiceNameLabelKey: "test-storm-service",
+			},
+			Annotations: map[string]string{
+				constants.RoleSetIndexAnnotationKey: "0",
+			},
+		},
+		Spec: orchestrationv1alpha1.RoleSetSpec{
+			UpdateStrategy: orchestrationv1alpha1.ParallelRoleSetUpdateStrategyType,
+		},
+	}
+}
+
+func newOrphanPod(name, namespace, roleName, roleSetName string, ownerKind string) *v1.Pod {
+	controllerRef := true
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.RoleNameLabelKey:         roleName,
+				constants.RoleSetNameLabelKey:      roleSetName,
+				constants.RoleTemplateHashLabelKey: "test-hash",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: orchestrationv1alpha1.SchemeGroupVersion.String(),
+					Kind:       ownerKind,
+					Name:       roleSetName,
+					Controller: &controllerRef,
+				},
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "main", Image: "nginx"},
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			Conditions: []v1.PodCondition{
+				{Type: v1.PodReady, Status: v1.ConditionTrue},
+			},
+		},
+	}
+	return pod
+}
+
+func newOrphanPodSet(name, namespace, roleName, roleSetName string) *orchestrationv1alpha1.PodSet {
+	controllerRef := true
+	return &orchestrationv1alpha1.PodSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.RoleNameLabelKey:         roleName,
+				constants.RoleSetNameLabelKey:      roleSetName,
+				constants.RoleTemplateHashLabelKey: "test-hash",
+				constants.StormServiceNameLabelKey: "test-storm-service",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: orchestrationv1alpha1.SchemeGroupVersion.String(),
+					Kind:       orchestrationv1alpha1.RoleSetKind,
+					Name:       roleSetName,
+					Controller: &controllerRef,
+				},
+			},
+		},
+		Spec: orchestrationv1alpha1.PodSetSpec{
+			PodGroupSize: 3,
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "main", Image: "nginx"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1.AddToScheme(scheme))
+	require.NoError(t, orchestrationv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func TestPodSetRoleSyncer_Scale_CleansUpOrphanPods(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+
+	tests := []struct {
+		name              string
+		description       string
+		existingPods      []client.Object
+		existingPodSets   []client.Object
+		expectedPodCount  int
+		expectedScaled    bool
+		expectedPodSetCnt int
+	}{
+		{
+			name:        "cleans up orphan pods owned by RoleSet when switching to PodSet mode",
+			description: "When podGroupSize changes from 1 to 3, old direct Pods owned by RoleSet should be deleted",
+			existingPods: []client.Object{
+				newOrphanPod("pod-0", "test-ns", "worker", "test-roleset", orchestrationv1alpha1.RoleSetKind),
+			},
+			existingPodSets:   []client.Object{},
+			expectedPodCount:  0,
+			expectedScaled:    true,
+			expectedPodSetCnt: 0,
+		},
+		{
+			name:        "does not clean up pods owned by PodSet",
+			description: "Pods owned by PodSet should not be deleted during orphan cleanup",
+			existingPods: []client.Object{
+				newOrphanPod("pod-0", "test-ns", "worker", "test-roleset", orchestrationv1alpha1.PodSetKind),
+			},
+			existingPodSets:   []client.Object{},
+			expectedPodCount:  1,
+			expectedScaled:    false,
+			expectedPodSetCnt: 0,
+		},
+		{
+			name:              "no orphan pods - normal PodSet scale proceeds",
+			description:       "When no orphan Pods exist, Scale should proceed normally and create PodSets",
+			existingPods:      []client.Object{},
+			existingPodSets:   []client.Object{},
+			expectedPodCount:  0,
+			expectedScaled:    true,
+			expectedPodSetCnt: 1,
+		},
+		{
+			name:        "cleans multiple orphan pods",
+			description: "Multiple orphan Pods owned by RoleSet should all be cleaned up",
+			existingPods: []client.Object{
+				newOrphanPod("pod-0", "test-ns", "worker", "test-roleset", orchestrationv1alpha1.RoleSetKind),
+				newOrphanPod("pod-1", "test-ns", "worker", "test-roleset", orchestrationv1alpha1.RoleSetKind),
+			},
+			existingPodSets:   []client.Object{},
+			expectedPodCount:  0,
+			expectedScaled:    true,
+			expectedPodSetCnt: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var allObjects []client.Object
+			allObjects = append(allObjects, tt.existingPods...)
+			allObjects = append(allObjects, tt.existingPodSets...)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(allObjects...).
+				Build()
+
+			roleSet := newOrphanTestRoleSet("test-roleset", "test-ns")
+			role := &orchestrationv1alpha1.RoleSpec{
+				Name:         "worker",
+				Replicas:     ptr.To(int32(1)),
+				PodGroupSize: ptr.To(int32(3)),
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Name: "main", Image: "nginx"},
+						},
+					},
+				},
+				UpdateStrategy: orchestrationv1alpha1.RoleUpdateStrategy{
+					MaxSurge:       intStrPtr(intstr.FromInt(1)),
+					MaxUnavailable: intStrPtr(intstr.FromInt(1)),
+				},
+			}
+
+			syncer := &PodSetRoleSyncer{
+				cli:             fakeClient,
+				computeHashFunc: fakeComputeHashFunc,
+			}
+
+			scaled, err := syncer.Scale(ctx, roleSet, role)
+			require.NoError(t, err, tt.description)
+			assert.Equal(t, tt.expectedScaled, scaled, tt.description)
+
+			finalPods := &v1.PodList{}
+			err = fakeClient.List(ctx, finalPods, client.InNamespace("test-ns"))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedPodCount, len(finalPods.Items), "pod count mismatch: %s", tt.description)
+
+			finalPodSets := &orchestrationv1alpha1.PodSetList{}
+			err = fakeClient.List(ctx, finalPodSets, client.InNamespace("test-ns"))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedPodSetCnt, len(finalPodSets.Items), "podset count mismatch: %s", tt.description)
+		})
+	}
+}
+
+func TestStatefulRoleSyncer_Scale_CleansUpOrphanPodSets(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+
+	tests := []struct {
+		name              string
+		description       string
+		existingPods      []client.Object
+		existingPodSets   []client.Object
+		expectedScaled    bool
+		expectedPodSetCnt int
+	}{
+		{
+			name:        "cleans up orphan PodSets when switching to Pod mode",
+			description: "When podGroupSize changes from 3 to 1, old PodSets should be deleted",
+			existingPods: []client.Object{},
+			existingPodSets: []client.Object{
+				newOrphanPodSet("podset-0", "test-ns", "worker", "test-roleset"),
+			},
+			expectedScaled:    true,
+			expectedPodSetCnt: 0,
+		},
+		{
+			name:              "no orphan PodSets - normal Pod scale proceeds",
+			description:       "When no orphan PodSets exist, Scale should proceed normally",
+			existingPods:      []client.Object{},
+			existingPodSets:   []client.Object{},
+			expectedScaled:    true,
+			expectedPodSetCnt: 0,
+		},
+		{
+			name:        "cleans multiple orphan PodSets",
+			description: "Multiple orphan PodSets should all be cleaned up",
+			existingPods: []client.Object{},
+			existingPodSets: []client.Object{
+				newOrphanPodSet("podset-0", "test-ns", "worker", "test-roleset"),
+				newOrphanPodSet("podset-1", "test-ns", "worker", "test-roleset"),
+			},
+			expectedScaled:    true,
+			expectedPodSetCnt: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var allObjects []client.Object
+			allObjects = append(allObjects, tt.existingPods...)
+			allObjects = append(allObjects, tt.existingPodSets...)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(allObjects...).
+				Build()
+
+			roleSet := newOrphanTestRoleSet("test-roleset", "test-ns")
+			role := &orchestrationv1alpha1.RoleSpec{
+				Name:     "worker",
+				Replicas: ptr.To(int32(1)),
+				Stateful: true,
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Name: "main", Image: "nginx"},
+						},
+					},
+				},
+				UpdateStrategy: orchestrationv1alpha1.RoleUpdateStrategy{
+					MaxSurge:       intStrPtr(intstr.FromInt(1)),
+					MaxUnavailable: intStrPtr(intstr.FromInt(1)),
+				},
+			}
+
+			syncer := &StatefulRoleSyncer{
+				cli:             fakeClient,
+				computeHashFunc: fakeComputeHashFunc,
+			}
+
+			scaled, err := syncer.Scale(ctx, roleSet, role)
+			require.NoError(t, err, tt.description)
+			assert.Equal(t, tt.expectedScaled, scaled, tt.description)
+
+			finalPodSets := &orchestrationv1alpha1.PodSetList{}
+			err = fakeClient.List(ctx, finalPodSets, client.InNamespace("test-ns"))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedPodSetCnt, len(finalPodSets.Items), "podset count mismatch: %s", tt.description)
+		})
+	}
+}
+
+func TestCleanupOrphanPodSets_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	roleSet := newOrphanTestRoleSet("test-roleset", "test-ns")
+	role := &orchestrationv1alpha1.RoleSpec{
+		Name:     "worker",
+		Replicas: ptr.To(int32(1)),
+	}
+
+	cleaned, err := cleanupOrphanPodSets(ctx, fakeClient, roleSet, role)
+	require.NoError(t, err, "cleanup should not return error when no PodSets exist")
+	assert.False(t, cleaned, "cleanup should report no change when no PodSets exist")
+}
+
+func TestCleanupOrphanPods_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	roleSet := newOrphanTestRoleSet("test-roleset", "test-ns")
+	role := &orchestrationv1alpha1.RoleSpec{
+		Name:     "worker",
+		Replicas: ptr.To(int32(1)),
+	}
+
+	syncer := &PodSetRoleSyncer{
+		cli:             fakeClient,
+		computeHashFunc: fakeComputeHashFunc,
+	}
+
+	cleaned, err := syncer.cleanupOrphanPods(ctx, roleSet, role)
+	require.NoError(t, err, "cleanup should not return error when no orphan Pods exist")
+	assert.False(t, cleaned, "cleanup should report no change when no orphan Pods exist")
+}

--- a/pkg/controller/roleset/podset_rollsyncer.go
+++ b/pkg/controller/roleset/podset_rollsyncer.go
@@ -43,6 +43,17 @@ type PodSetRoleSyncer struct {
 }
 
 func (p *PodSetRoleSyncer) Scale(ctx context.Context, roleSet *orchestrationv1alpha1.RoleSet, role *orchestrationv1alpha1.RoleSpec) (bool, error) {
+	// Clean up orphan Pods left by the old StatefulRoleSyncer/StatelessRoleSyncer
+	// when podGroupSize was switched from <=1 to >1.
+	cleaned, err := p.cleanupOrphanPods(ctx, roleSet, role)
+	if err != nil {
+		return false, err
+	}
+	if cleaned {
+		klog.Infof("[PodSetRoleSyncer.Scale] cleaned orphan pods for roleset %s/%s role %s, waiting for next reconcile", roleSet.Namespace, roleSet.Name, role.Name)
+		return true, nil
+	}
+
 	var podSetsToCreate, podSetsToDelete []*orchestrationv1alpha1.PodSet
 	allPodSets, err := getRolePodSets(ctx, p.cli, roleSet.Namespace, roleSet.Name, role.Name)
 	if err != nil {
@@ -543,4 +554,46 @@ func deletePodSetsInBatch(ctx context.Context, cli client.Client, podSets []*orc
 		}
 	}
 	return len(podSets), nil
+}
+
+// cleanupOrphanPods detects and deletes Pods that were directly created by the old
+// StatefulRoleSyncer/StatelessRoleSyncer (OwnerRef → RoleSet) when podGroupSize switches
+// from <=1 to >1. Returns true if any orphan Pods were deleted.
+func (p *PodSetRoleSyncer) cleanupOrphanPods(ctx context.Context, roleSet *orchestrationv1alpha1.RoleSet, role *orchestrationv1alpha1.RoleSpec) (bool, error) {
+	allPods, err := getRolePods(ctx, p.cli, roleSet.Namespace, roleSet.Name, role.Name)
+	if err != nil {
+		return false, err
+	}
+
+	var orphanPods []*v1.Pod
+	for _, pod := range allPods {
+		if isOwnedByRoleSet(pod, roleSet) {
+			orphanPods = append(orphanPods, pod)
+		}
+	}
+
+	if len(orphanPods) == 0 {
+		return false, nil
+	}
+
+	klog.Infof("[PodSetRoleSyncer.cleanupOrphanPods] found %d orphan pods for roleset %s/%s role %s, cleaning up",
+		len(orphanPods), roleSet.Namespace, roleSet.Name, role.Name)
+	for _, pod := range orphanPods {
+		if err := p.cli.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// isOwnedByRoleSet checks whether a Pod's controller OwnerReference points to the given RoleSet.
+func isOwnedByRoleSet(pod *v1.Pod, roleSet *orchestrationv1alpha1.RoleSet) bool {
+	for _, ref := range pod.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller &&
+			ref.Kind == orchestrationv1alpha1.RoleSetKind &&
+			ref.Name == roleSet.Name {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/controller/roleset/podset_rollsyncer.go
+++ b/pkg/controller/roleset/podset_rollsyncer.go
@@ -587,11 +587,12 @@ func (p *PodSetRoleSyncer) cleanupOrphanPods(ctx context.Context, roleSet *orche
 }
 
 // isOwnedByRoleSet checks whether a Pod's controller OwnerReference points to the given RoleSet.
-func isOwnedByRoleSet(pod *v1.Pod, roleSet *orchestrationv1alpha1.RoleSet) bool {
-	for _, ref := range pod.OwnerReferences {
+func isOwnedByRoleSet(obj client.Object, roleSet *orchestrationv1alpha1.RoleSet) bool {
+	for _, ref := range obj.GetOwnerReferences() {
 		if ref.Controller != nil && *ref.Controller &&
+			ref.APIVersion == orchestrationv1alpha1.SchemeGroupVersion.String() &&
 			ref.Kind == orchestrationv1alpha1.RoleSetKind &&
-			ref.Name == roleSet.Name {
+			ref.UID == roleSet.UID {
 			return true
 		}
 	}

--- a/pkg/controller/roleset/rolesyncer.go
+++ b/pkg/controller/roleset/rolesyncer.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,6 +48,17 @@ type StatefulRoleSyncer struct {
 }
 
 func (s *StatefulRoleSyncer) Scale(ctx context.Context, roleSet *orchestrationv1alpha1.RoleSet, role *orchestrationv1alpha1.RoleSpec) (bool, error) {
+	// Clean up orphan PodSets left by the old PodSetRoleSyncer
+	// when podGroupSize was switched from >1 to <=1.
+	cleaned, err := cleanupOrphanPodSets(ctx, s.cli, roleSet, role)
+	if err != nil {
+		return false, err
+	}
+	if cleaned {
+		klog.Infof("[StatefulRoleSyncer.Scale] cleaned orphan podsets for roleset %s/%s role %s, waiting for next reconcile", roleSet.Namespace, roleSet.Name, role.Name)
+		return true, nil
+	}
+
 	var podsToCreate, podsToDelete []*v1.Pod
 	allPods, err := getRolePods(ctx, s.cli, roleSet.Namespace, roleSet.Name, role.Name)
 	if err != nil {
@@ -379,6 +391,17 @@ type StatelessRoleSyncer struct {
 }
 
 func (s *StatelessRoleSyncer) Scale(ctx context.Context, roleSet *orchestrationv1alpha1.RoleSet, role *orchestrationv1alpha1.RoleSpec) (bool, error) {
+	// Clean up orphan PodSets left by the old PodSetRoleSyncer
+	// when podGroupSize was switched from >1 to <=1.
+	cleaned, err := cleanupOrphanPodSets(ctx, s.cli, roleSet, role)
+	if err != nil {
+		return false, err
+	}
+	if cleaned {
+		klog.Infof("[StatelessRoleSyncer.Scale] cleaned orphan podsets for roleset %s/%s role %s, waiting for next reconcile", roleSet.Namespace, roleSet.Name, role.Name)
+		return true, nil
+	}
+
 	var toCreate, toDelete []*v1.Pod
 	allPods, err := getRolePods(ctx, s.cli, roleSet.Namespace, roleSet.Name, role.Name)
 	if err != nil {
@@ -642,4 +665,28 @@ func GetRoleSyncer(cli client.Client, role *orchestrationv1alpha1.RoleSpec) Role
 		cli:             cli,
 		computeHashFunc: ctrlutil.ComputeHash,
 	}
+}
+
+// cleanupOrphanPodSets detects and deletes PodSets that were created by the old
+// PodSetRoleSyncer when podGroupSize switches from >1 to <=1.
+// Returns true if any orphan PodSets were deleted.
+func cleanupOrphanPodSets(ctx context.Context, cli client.Client, roleSet *orchestrationv1alpha1.RoleSet, role *orchestrationv1alpha1.RoleSpec) (bool, error) {
+	allPodSets, err := getRolePodSets(ctx, cli, roleSet.Namespace, roleSet.Name, role.Name)
+	if err != nil {
+		return false, err
+	}
+
+	if len(allPodSets) == 0 {
+		return false, nil
+	}
+
+	klog.Infof("[cleanupOrphanPodSets] found %d orphan podsets for roleset %s/%s role %s, cleaning up",
+		len(allPodSets), roleSet.Namespace, roleSet.Name, role.Name)
+	for _, podSet := range allPodSets {
+		if err := cli.Delete(ctx, podSet); err != nil && !apierrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+	return true, nil
+
 }


### PR DESCRIPTION
## Summary
- Add orphan Pod cleanup in `PodSetRoleSyncer.Scale()` when `podGroupSize` switches from `<=1` to `>1`
- Add orphan PodSet cleanup in `StatefulRoleSyncer.Scale()` and `StatelessRoleSyncer.Scale()` when `podGroupSize` switches from `>1` to `<=1`
- Cleanup is idempotent (ignores NotFound errors) and executes before creating new resources

## Problem
When `podGroupSize` crosses the boundary between `<=1` and `>1`, the RoleSet controller switches between different syncers. The new syncer doesn't recognize resources created by the old syncer, leaving orphan Pods or PodSets behind that consume cluster resources indefinitely.

## Solution
Each syncer now checks for and cleans up resources that belong to the other syncer type at the start of its `Scale()` method:
- `PodSetRoleSyncer.cleanupOrphanPods()`: detects Pods with OwnerReference pointing to RoleSet (not PodSet) and deletes them
- `cleanupOrphanPodSets()`: detects PodSets belonging to the same Role and deletes them

## Test plan
- [x] Unit tests for `PodSetRoleSyncer.Scale()` with orphan Pods scenario
- [x] Unit tests for `StatefulRoleSyncer.Scale()` with orphan PodSets scenario  
- [x] Unit tests for idempotent cleanup behavior