### PR TITLE
feat(gateway): add per-model requests-per-second rate limiting

### DIFF
--- a/development/app/config/mock/config-profile.yaml
+++ b/development/app/config/mock/config-profile.yaml
@@ -29,6 +29,10 @@ spec:
               },
               "throughput": {
                 "routingStrategy": "throughput"
+              },
+              "rps-limited": {
+                "routingStrategy": "least-request",
+                "requestsPerSecond": 1
               }
             }
           }

--- a/pkg/plugins/gateway/configprofiles/configprofiles.go
+++ b/pkg/plugins/gateway/configprofiles/configprofiles.go
@@ -37,8 +37,9 @@ const (
 
 // ModelConfigProfile holds gateway options for a single profile.
 type ModelConfigProfile struct {
-	RoutingStrategy string          `json:"routingStrategy"`
-	RoutingConfig   json.RawMessage `json:"routingConfig,omitempty"`
+	RoutingStrategy   string          `json:"routingStrategy"`
+	RoutingConfig     json.RawMessage `json:"routingConfig,omitempty"`
+	RequestsPerSecond int64           `json:"requestsPerSecond,omitempty"`
 }
 
 // ModelConfigProfiles is the root JSON structure from model.aibrix.ai/config.

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -62,6 +62,7 @@ const (
 type Server struct {
 	redisClient         *redis.Client
 	ratelimiter         ratelimiter.RateLimiter
+	modelRateLimiter    ratelimiter.RateLimiter
 	client              kubernetes.Interface
 	gatewayClient       gatewayapi.Interface
 	requestCountTracker map[string]int
@@ -96,10 +97,13 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 		panic(err)
 	}
 	var r ratelimiter.RateLimiter
+	var mr ratelimiter.RateLimiter
 	if redisClient != nil {
 		r = ratelimiter.NewRedisAccountRateLimiter("aibrix", redisClient, 1*time.Minute)
+		mr = ratelimiter.NewRedisAccountRateLimiter("aibrix_model", redisClient, 1*time.Second)
 	} else {
 		r = ratelimiter.NewNoopRateLimiter()
+		mr = ratelimiter.NewNoopRateLimiter()
 	}
 
 	// Initialize the routers
@@ -108,6 +112,7 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 	return &Server{
 		redisClient:         redisClient,
 		ratelimiter:         r,
+		modelRateLimiter:    mr,
 		client:              client,
 		gatewayClient:       gatewayClient,
 		requestCountTracker: map[string]int{},

--- a/pkg/plugins/gateway/gateway_ratelimit.go
+++ b/pkg/plugins/gateway/gateway_ratelimit.go
@@ -111,44 +111,25 @@ func (s *Server) checkTPM(ctx context.Context, username string, tpmLimit int64) 
 	return envoyTypePb.StatusCode_OK, nil
 }
 
-// enforceModelRPS checks and increments the per-model RPS counter when a limit is configured.
-// Returns a non-nil error response if the limit is exceeded or the counter cannot be updated.
+// enforceModelRPS atomically increments the per-model RPS counter and rejects the request
+// if the new value exceeds the configured limit. Increment-first ensures a single Redis
+// round-trip and eliminates the check-then-act race present in a read-then-increment approach.
 func (s *Server) enforceModelRPS(ctx context.Context, model string, routingCtx *types.RoutingContext) *extProcPb.ProcessingResponse {
 	if routingCtx.ConfigProfile == nil || routingCtx.ConfigProfile.RequestsPerSecond <= 0 {
 		return nil
 	}
-	code, err := s.checkModelRPS(ctx, model, routingCtx.ConfigProfile.RequestsPerSecond)
+	limit := routingCtx.ConfigProfile.RequestsPerSecond
+	key := fmt.Sprintf("%v_MODEL_RPS_CURRENT", model)
+	current, err := s.modelRateLimiter.Incr(ctx, key, 1)
 	if err != nil {
-		errorCode := ""
-		if code == envoyTypePb.StatusCode_TooManyRequests {
-			errorCode = ErrorCodeRateLimitExceeded
-		}
-		return buildErrorResponse(code, err.Error(), errorCode, "", HeaderErrorModelRPSExceeded, "true")
+		return buildErrorResponse(envoyTypePb.StatusCode_InternalServerError,
+			fmt.Sprintf("fail to increment RPS for model: %v", model),
+			"", "", HeaderErrorIncrModelRPS, "true")
 	}
-	if code, err = s.incrModelRPS(ctx, model); err != nil {
-		return buildErrorResponse(code, err.Error(), "", "", HeaderErrorIncrModelRPS, "true")
+	if current > limit {
+		return buildErrorResponse(envoyTypePb.StatusCode_TooManyRequests,
+			fmt.Sprintf("model: %v has exceeded RPS: %v", model, limit),
+			ErrorCodeRateLimitExceeded, "", HeaderErrorModelRPSExceeded, "true")
 	}
 	return nil
-}
-
-func (s *Server) checkModelRPS(ctx context.Context, model string, rpsLimit int64) (envoyTypePb.StatusCode, error) {
-	rpsCurrent, err := s.modelRateLimiter.Get(ctx, fmt.Sprintf("%v_MODEL_RPS_CURRENT", model))
-	if err != nil {
-		return envoyTypePb.StatusCode_InternalServerError, fmt.Errorf("fail to get RPS for model: %v", model)
-	}
-
-	if rpsCurrent >= rpsLimit {
-		return envoyTypePb.StatusCode_TooManyRequests, fmt.Errorf("model: %v has exceeded RPS: %v", model, rpsLimit)
-	}
-
-	return envoyTypePb.StatusCode_OK, nil
-}
-
-func (s *Server) incrModelRPS(ctx context.Context, model string) (envoyTypePb.StatusCode, error) {
-	_, err := s.modelRateLimiter.Incr(ctx, fmt.Sprintf("%v_MODEL_RPS_CURRENT", model), 1)
-	if err != nil {
-		return envoyTypePb.StatusCode_InternalServerError, fmt.Errorf("fail to increment RPS for model: %v", model)
-	}
-
-	return envoyTypePb.StatusCode_OK, nil
 }

--- a/pkg/plugins/gateway/gateway_ratelimit.go
+++ b/pkg/plugins/gateway/gateway_ratelimit.go
@@ -111,25 +111,39 @@ func (s *Server) checkTPM(ctx context.Context, username string, tpmLimit int64) 
 	return envoyTypePb.StatusCode_OK, nil
 }
 
-// enforceModelRPS atomically increments the per-model RPS counter and rejects the request
-// if the new value exceeds the configured limit. Increment-first ensures a single Redis
-// round-trip and eliminates the check-then-act race present in a read-then-increment approach.
-func (s *Server) enforceModelRPS(ctx context.Context, model string, routingCtx *types.RoutingContext) *extProcPb.ProcessingResponse {
+// checkModelRPS returns a rejection response if the current per-model RPS counter has
+// reached the configured limit. It does not increment; call incrModelRPS after routing
+// succeeds so that requests failing during routing do not consume quota.
+func (s *Server) checkModelRPS(ctx context.Context, model string, routingCtx *types.RoutingContext) *extProcPb.ProcessingResponse {
 	if routingCtx.ConfigProfile == nil || routingCtx.ConfigProfile.RequestsPerSecond <= 0 {
 		return nil
 	}
 	limit := routingCtx.ConfigProfile.RequestsPerSecond
-	key := fmt.Sprintf("%v_MODEL_RPS_CURRENT", model)
-	current, err := s.modelRateLimiter.Incr(ctx, key, 1)
+	current, err := s.modelRateLimiter.Get(ctx, fmt.Sprintf("%v_MODEL_RPS_CURRENT", model))
+	if err != nil {
+		return buildErrorResponse(envoyTypePb.StatusCode_InternalServerError,
+			fmt.Sprintf("fail to get RPS for model: %v", model),
+			"", "", HeaderErrorModelRPSExceeded, "true")
+	}
+	if current >= limit {
+		return buildErrorResponse(envoyTypePb.StatusCode_TooManyRequests,
+			fmt.Sprintf("model: %v has exceeded RPS: %v", model, limit),
+			ErrorCodeRateLimitExceeded, "", HeaderErrorModelRPSExceeded, "true")
+	}
+	return nil
+}
+
+// incrModelRPS increments the per-model RPS counter. Call this only after routing
+// succeeds to avoid charging quota for requests that never reached the backend.
+func (s *Server) incrModelRPS(ctx context.Context, model string, routingCtx *types.RoutingContext) *extProcPb.ProcessingResponse {
+	if routingCtx.ConfigProfile == nil || routingCtx.ConfigProfile.RequestsPerSecond <= 0 {
+		return nil
+	}
+	_, err := s.modelRateLimiter.Incr(ctx, fmt.Sprintf("%v_MODEL_RPS_CURRENT", model), 1)
 	if err != nil {
 		return buildErrorResponse(envoyTypePb.StatusCode_InternalServerError,
 			fmt.Sprintf("fail to increment RPS for model: %v", model),
 			"", "", HeaderErrorIncrModelRPS, "true")
-	}
-	if current > limit {
-		return buildErrorResponse(envoyTypePb.StatusCode_TooManyRequests,
-			fmt.Sprintf("model: %v has exceeded RPS: %v", model, limit),
-			ErrorCodeRateLimitExceeded, "", HeaderErrorModelRPSExceeded, "true")
 	}
 	return nil
 }

--- a/pkg/plugins/gateway/gateway_ratelimit.go
+++ b/pkg/plugins/gateway/gateway_ratelimit.go
@@ -112,31 +112,26 @@ func (s *Server) checkTPM(ctx context.Context, username string, tpmLimit int64) 
 	return envoyTypePb.StatusCode_OK, nil
 }
 
-// enforceModelRPS checks the current per-model RPS counter and increments it atomically.
-// Returns a rejection response if the limit is already reached, or an error response if
-// the Redis operation fails. On routing failure after this call, use decrModelRPS to
-// return the quota.
+// enforceModelRPS atomically increments the per-model RPS counter and rejects the request
+// if the new value exceeds the limit.
 func (s *Server) enforceModelRPS(ctx context.Context, model string, routingCtx *types.RoutingContext) *extProcPb.ProcessingResponse {
 	if routingCtx.ConfigProfile == nil || routingCtx.ConfigProfile.RequestsPerSecond <= 0 {
 		return nil
 	}
 	limit := routingCtx.ConfigProfile.RequestsPerSecond
-	key := fmt.Sprintf("%v_MODEL_RPS_CURRENT", model)
-	current, err := s.modelRateLimiter.Get(ctx, key)
+	newVal, err := s.modelRateLimiter.Incr(ctx, modelRPSKey(model), 1)
 	if err != nil {
-		return buildErrorResponse(envoyTypePb.StatusCode_InternalServerError,
-			fmt.Sprintf("fail to get RPS for model: %v", model),
-			"", "", HeaderErrorModelRPSExceeded, "true")
-	}
-	if current >= limit {
-		return buildErrorResponse(envoyTypePb.StatusCode_TooManyRequests,
-			fmt.Sprintf("model: %v has exceeded RPS: %v", model, limit),
-			ErrorCodeRateLimitExceeded, "", HeaderErrorModelRPSExceeded, "true")
-	}
-	if _, err = s.modelRateLimiter.Incr(ctx, key, 1); err != nil {
 		return buildErrorResponse(envoyTypePb.StatusCode_InternalServerError,
 			fmt.Sprintf("fail to increment RPS for model: %v", model),
 			"", "", HeaderErrorIncrModelRPS, "true")
+	}
+	if newVal > limit {
+		// if _, err = s.modelRateLimiter.Incr(ctx, modelRPSKey(model), -1); err != nil {
+		// 	klog.ErrorS(err, "fail to roll back RPS increment for model", "model", model)
+		// }
+		return buildErrorResponse(envoyTypePb.StatusCode_TooManyRequests,
+			fmt.Sprintf("model: %v has exceeded RPS: %v", model, limit),
+			ErrorCodeRateLimitExceeded, "", HeaderErrorModelRPSExceeded, "true")
 	}
 	return nil
 }
@@ -144,11 +139,19 @@ func (s *Server) enforceModelRPS(ctx context.Context, model string, routingCtx *
 // decrModelRPS decrements the per-model RPS counter by 1. Call this when a routing
 // failure occurs after enforceModelRPS has already incremented the counter, so that
 // requests which never reached the backend do not consume quota.
+// Note: if the 1-second window expires between the increment and this decrement, the
+// decrement lands on a fresh (zero) key and drives the counter negative. Preventing this
+// would require an atomic floor-at-zero Lua script, which is not worth the added complexity
+// given the window resets within one second and the counter self-corrects.
 func (s *Server) decrModelRPS(ctx context.Context, model string, routingCtx *types.RoutingContext) {
 	if routingCtx.ConfigProfile == nil || routingCtx.ConfigProfile.RequestsPerSecond <= 0 {
 		return
 	}
-	if _, err := s.modelRateLimiter.Incr(ctx, fmt.Sprintf("%v_MODEL_RPS_CURRENT", model), -1); err != nil {
+	if _, err := s.modelRateLimiter.Incr(ctx, modelRPSKey(model), -1); err != nil {
 		klog.ErrorS(err, "fail to decrement RPS for model", "model", model)
 	}
+}
+
+func modelRPSKey(model string) string {
+	return fmt.Sprintf("%v_MODEL_RPS_CURRENT", model)
 }

--- a/pkg/plugins/gateway/gateway_ratelimit.go
+++ b/pkg/plugins/gateway/gateway_ratelimit.go
@@ -23,6 +23,7 @@ import (
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 )
 
@@ -105,6 +106,48 @@ func (s *Server) checkTPM(ctx context.Context, username string, tpmLimit int64) 
 
 	if tpmCurrent >= tpmLimit {
 		return envoyTypePb.StatusCode_TooManyRequests, fmt.Errorf("user: %v has exceeded TPM: %v", username, tpmLimit)
+	}
+
+	return envoyTypePb.StatusCode_OK, nil
+}
+
+// enforceModelRPS checks and increments the per-model RPS counter when a limit is configured.
+// Returns a non-nil error response if the limit is exceeded or the counter cannot be updated.
+func (s *Server) enforceModelRPS(ctx context.Context, model string, routingCtx *types.RoutingContext) *extProcPb.ProcessingResponse {
+	if routingCtx.ConfigProfile == nil || routingCtx.ConfigProfile.RequestsPerSecond <= 0 {
+		return nil
+	}
+	code, err := s.checkModelRPS(ctx, model, routingCtx.ConfigProfile.RequestsPerSecond)
+	if err != nil {
+		errorCode := ""
+		if code == envoyTypePb.StatusCode_TooManyRequests {
+			errorCode = ErrorCodeRateLimitExceeded
+		}
+		return buildErrorResponse(code, err.Error(), errorCode, "", HeaderErrorModelRPSExceeded, "true")
+	}
+	if code, err = s.incrModelRPS(ctx, model); err != nil {
+		return buildErrorResponse(code, err.Error(), "", "", HeaderErrorIncrModelRPS, "true")
+	}
+	return nil
+}
+
+func (s *Server) checkModelRPS(ctx context.Context, model string, rpsLimit int64) (envoyTypePb.StatusCode, error) {
+	rpsCurrent, err := s.modelRateLimiter.Get(ctx, fmt.Sprintf("%v_MODEL_RPS_CURRENT", model))
+	if err != nil {
+		return envoyTypePb.StatusCode_InternalServerError, fmt.Errorf("fail to get RPS for model: %v", model)
+	}
+
+	if rpsCurrent >= rpsLimit {
+		return envoyTypePb.StatusCode_TooManyRequests, fmt.Errorf("model: %v has exceeded RPS: %v", model, rpsLimit)
+	}
+
+	return envoyTypePb.StatusCode_OK, nil
+}
+
+func (s *Server) incrModelRPS(ctx context.Context, model string) (envoyTypePb.StatusCode, error) {
+	_, err := s.modelRateLimiter.Incr(ctx, fmt.Sprintf("%v_MODEL_RPS_CURRENT", model), 1)
+	if err != nil {
+		return envoyTypePb.StatusCode_InternalServerError, fmt.Errorf("fail to increment RPS for model: %v", model)
 	}
 
 	return envoyTypePb.StatusCode_OK, nil

--- a/pkg/plugins/gateway/gateway_ratelimit.go
+++ b/pkg/plugins/gateway/gateway_ratelimit.go
@@ -25,6 +25,7 @@ import (
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
+	"k8s.io/klog/v2"
 )
 
 func (s *Server) checkLimits(ctx context.Context, user utils.User) (int64, *extProcPb.ProcessingResponse, error) {
@@ -111,15 +112,17 @@ func (s *Server) checkTPM(ctx context.Context, username string, tpmLimit int64) 
 	return envoyTypePb.StatusCode_OK, nil
 }
 
-// checkModelRPS returns a rejection response if the current per-model RPS counter has
-// reached the configured limit. It does not increment; call incrModelRPS after routing
-// succeeds so that requests failing during routing do not consume quota.
-func (s *Server) checkModelRPS(ctx context.Context, model string, routingCtx *types.RoutingContext) *extProcPb.ProcessingResponse {
+// enforceModelRPS checks the current per-model RPS counter and increments it atomically.
+// Returns a rejection response if the limit is already reached, or an error response if
+// the Redis operation fails. On routing failure after this call, use decrModelRPS to
+// return the quota.
+func (s *Server) enforceModelRPS(ctx context.Context, model string, routingCtx *types.RoutingContext) *extProcPb.ProcessingResponse {
 	if routingCtx.ConfigProfile == nil || routingCtx.ConfigProfile.RequestsPerSecond <= 0 {
 		return nil
 	}
 	limit := routingCtx.ConfigProfile.RequestsPerSecond
-	current, err := s.modelRateLimiter.Get(ctx, fmt.Sprintf("%v_MODEL_RPS_CURRENT", model))
+	key := fmt.Sprintf("%v_MODEL_RPS_CURRENT", model)
+	current, err := s.modelRateLimiter.Get(ctx, key)
 	if err != nil {
 		return buildErrorResponse(envoyTypePb.StatusCode_InternalServerError,
 			fmt.Sprintf("fail to get RPS for model: %v", model),
@@ -130,20 +133,22 @@ func (s *Server) checkModelRPS(ctx context.Context, model string, routingCtx *ty
 			fmt.Sprintf("model: %v has exceeded RPS: %v", model, limit),
 			ErrorCodeRateLimitExceeded, "", HeaderErrorModelRPSExceeded, "true")
 	}
-	return nil
-}
-
-// incrModelRPS increments the per-model RPS counter. Call this only after routing
-// succeeds to avoid charging quota for requests that never reached the backend.
-func (s *Server) incrModelRPS(ctx context.Context, model string, routingCtx *types.RoutingContext) *extProcPb.ProcessingResponse {
-	if routingCtx.ConfigProfile == nil || routingCtx.ConfigProfile.RequestsPerSecond <= 0 {
-		return nil
-	}
-	_, err := s.modelRateLimiter.Incr(ctx, fmt.Sprintf("%v_MODEL_RPS_CURRENT", model), 1)
-	if err != nil {
+	if _, err = s.modelRateLimiter.Incr(ctx, key, 1); err != nil {
 		return buildErrorResponse(envoyTypePb.StatusCode_InternalServerError,
 			fmt.Sprintf("fail to increment RPS for model: %v", model),
 			"", "", HeaderErrorIncrModelRPS, "true")
 	}
 	return nil
+}
+
+// decrModelRPS decrements the per-model RPS counter by 1. Call this when a routing
+// failure occurs after enforceModelRPS has already incremented the counter, so that
+// requests which never reached the backend do not consume quota.
+func (s *Server) decrModelRPS(ctx context.Context, model string, routingCtx *types.RoutingContext) {
+	if routingCtx.ConfigProfile == nil || routingCtx.ConfigProfile.RequestsPerSecond <= 0 {
+		return
+	}
+	if _, err := s.modelRateLimiter.Incr(ctx, fmt.Sprintf("%v_MODEL_RPS_CURRENT", model), -1); err != nil {
+		klog.ErrorS(err, "fail to decrement RPS for model", "model", model)
+	}
 }

--- a/pkg/plugins/gateway/gateway_ratelimit.go
+++ b/pkg/plugins/gateway/gateway_ratelimit.go
@@ -126,9 +126,6 @@ func (s *Server) enforceModelRPS(ctx context.Context, model string, routingCtx *
 			"", "", HeaderErrorIncrModelRPS, "true")
 	}
 	if newVal > limit {
-		// if _, err = s.modelRateLimiter.Incr(ctx, modelRPSKey(model), -1); err != nil {
-		// 	klog.ErrorS(err, "fail to roll back RPS increment for model", "model", model)
-		// }
 		return buildErrorResponse(envoyTypePb.StatusCode_TooManyRequests,
 			fmt.Sprintf("model: %v has exceeded RPS: %v", model, limit),
 			ErrorCodeRateLimitExceeded, "", HeaderErrorModelRPSExceeded, "true")

--- a/pkg/plugins/gateway/gateway_ratelimit_test.go
+++ b/pkg/plugins/gateway/gateway_ratelimit_test.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/vllm-project/aibrix/pkg/types"
+)
+
+func TestCheckRPM(t *testing.T) {
+	t.Run("get failure returns internal server error", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "alice_RPM_CURRENT").Return(int64(0), errors.New("redis down")).Once()
+
+		s := &Server{ratelimiter: rl}
+		code, err := s.checkRPM(context.Background(), "alice", 10)
+
+		assert.Equal(t, envoyTypePb.StatusCode_InternalServerError, code)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "fail to get RPM for user: alice")
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("exceeding limit returns too many requests", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "alice_RPM_CURRENT").Return(int64(10), nil).Once()
+
+		s := &Server{ratelimiter: rl}
+		code, err := s.checkRPM(context.Background(), "alice", 10)
+
+		assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, code)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "has exceeded RPM")
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("below limit returns ok", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "alice_RPM_CURRENT").Return(int64(9), nil).Once()
+
+		s := &Server{ratelimiter: rl}
+		code, err := s.checkRPM(context.Background(), "alice", 10)
+
+		assert.Equal(t, envoyTypePb.StatusCode_OK, code)
+		assert.NoError(t, err)
+		rl.AssertExpectations(t)
+	})
+}
+
+func TestIncrRPM(t *testing.T) {
+	t.Run("increment failure returns internal server error", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Incr", mock.Anything, "alice_RPM_CURRENT", int64(1)).Return(int64(0), errors.New("redis down")).Once()
+
+		s := &Server{ratelimiter: rl}
+		rpm, code, err := s.incrRPM(context.Background(), "alice")
+
+		assert.Equal(t, int64(0), rpm)
+		assert.Equal(t, envoyTypePb.StatusCode_InternalServerError, code)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "fail to increment RPM for user: alice")
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("increment success returns updated rpm", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Incr", mock.Anything, "alice_RPM_CURRENT", int64(1)).Return(int64(7), nil).Once()
+
+		s := &Server{ratelimiter: rl}
+		rpm, code, err := s.incrRPM(context.Background(), "alice")
+
+		assert.Equal(t, int64(7), rpm)
+		assert.Equal(t, envoyTypePb.StatusCode_OK, code)
+		assert.NoError(t, err)
+		rl.AssertExpectations(t)
+	})
+}
+
+func TestCheckTPM(t *testing.T) {
+	t.Run("get failure returns internal server error", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "alice_TPM_CURRENT").Return(int64(0), errors.New("redis down")).Once()
+
+		s := &Server{ratelimiter: rl}
+		code, err := s.checkTPM(context.Background(), "alice", 100)
+
+		assert.Equal(t, envoyTypePb.StatusCode_InternalServerError, code)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "fail to get TPM for user: alice")
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("exceeding limit returns too many requests", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "alice_TPM_CURRENT").Return(int64(100), nil).Once()
+
+		s := &Server{ratelimiter: rl}
+		code, err := s.checkTPM(context.Background(), "alice", 100)
+
+		assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, code)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "has exceeded TPM")
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("below limit returns ok", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "alice_TPM_CURRENT").Return(int64(99), nil).Once()
+
+		s := &Server{ratelimiter: rl}
+		code, err := s.checkTPM(context.Background(), "alice", 100)
+
+		assert.Equal(t, envoyTypePb.StatusCode_OK, code)
+		assert.NoError(t, err)
+		rl.AssertExpectations(t)
+	})
+}
+
+func TestCheckModelRPS(t *testing.T) {
+	t.Run("get failure returns internal server error", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(0), errors.New("redis down")).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		code, err := s.checkModelRPS(context.Background(), "llama", 5)
+
+		assert.Equal(t, envoyTypePb.StatusCode_InternalServerError, code)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "fail to get RPS for model: llama")
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("exceeding limit returns too many requests", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(5), nil).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		code, err := s.checkModelRPS(context.Background(), "llama", 5)
+
+		assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, code)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "has exceeded RPS")
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("below limit returns ok", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(4), nil).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		code, err := s.checkModelRPS(context.Background(), "llama", 5)
+
+		assert.Equal(t, envoyTypePb.StatusCode_OK, code)
+		assert.NoError(t, err)
+		rl.AssertExpectations(t)
+	})
+}
+
+func TestIncrModelRPS(t *testing.T) {
+	t.Run("increment failure returns internal server error", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(0), errors.New("redis down")).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		code, err := s.incrModelRPS(context.Background(), "llama")
+
+		assert.Equal(t, envoyTypePb.StatusCode_InternalServerError, code)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "fail to increment RPS for model: llama")
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("increment success returns ok", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(3), nil).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		code, err := s.incrModelRPS(context.Background(), "llama")
+
+		assert.Equal(t, envoyTypePb.StatusCode_OK, code)
+		assert.NoError(t, err)
+		rl.AssertExpectations(t)
+	})
+}
+
+func TestEnforceModelRPS(t *testing.T) {
+	t.Run("nil config profile skips enforcement", func(t *testing.T) {
+		s := &Server{modelRateLimiter: &mockRateLimiter{}}
+		rc := &types.RoutingContext{}
+
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("non-positive rps skips enforcement", func(t *testing.T) {
+		s := &Server{modelRateLimiter: &mockRateLimiter{}}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 0}}
+
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("check failure returns 429 with model-rps header", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(2), nil).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
+
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		if assert.NotNil(t, resp) {
+			imm := resp.GetImmediateResponse()
+			assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, imm.GetStatus().GetCode())
+			assert.Contains(t, imm.GetBody(), ErrorCodeRateLimitExceeded)
+			assert.Contains(t, imm.GetBody(), "exceeded RPS")
+			if assert.NotEmpty(t, imm.GetHeaders().GetSetHeaders()) {
+				assert.Equal(t, HeaderErrorModelRPSExceeded, imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetKey())
+				assert.Equal(t, "true", string(imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetRawValue()))
+			}
+		}
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("increment failure returns 500 with incr header", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(1), nil).Once()
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(0), errors.New("redis down")).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
+
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		if assert.NotNil(t, resp) {
+			imm := resp.GetImmediateResponse()
+			assert.Equal(t, envoyTypePb.StatusCode_InternalServerError, imm.GetStatus().GetCode())
+			assert.Contains(t, imm.GetBody(), "fail to increment RPS for model: llama")
+			if assert.NotEmpty(t, imm.GetHeaders().GetSetHeaders()) {
+				assert.Equal(t, HeaderErrorIncrModelRPS, imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetKey())
+				assert.Equal(t, "true", string(imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetRawValue()))
+			}
+		}
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("success returns nil", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(1), nil).Once()
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(2), nil).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
+
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		assert.Nil(t, resp)
+		rl.AssertExpectations(t)
+	})
+}

--- a/pkg/plugins/gateway/gateway_ratelimit_test.go
+++ b/pkg/plugins/gateway/gateway_ratelimit_test.go
@@ -189,10 +189,9 @@ func TestEnforceModelRPS(t *testing.T) {
 		rl.AssertExpectations(t)
 	})
 
-	t.Run("exceeding limit returns 429 and decrements counter", func(t *testing.T) {
+	t.Run("exceeding limit returns 429", func(t *testing.T) {
 		rl := &mockRateLimiter{}
 		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(3), nil).Once()
-		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(-1)).Return(int64(2), nil).Once()
 
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
@@ -208,23 +207,6 @@ func TestEnforceModelRPS(t *testing.T) {
 				assert.Equal(t, HeaderErrorModelRPSExceeded, imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetKey())
 				assert.Equal(t, "true", string(imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetRawValue()))
 			}
-		}
-		rl.AssertExpectations(t)
-	})
-
-	t.Run("exceeding limit rollback failure is logged but still returns 429", func(t *testing.T) {
-		rl := &mockRateLimiter{}
-		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(3), nil).Once()
-		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(-1)).Return(int64(0), errors.New("redis down")).Once()
-
-		s := &Server{modelRateLimiter: rl}
-		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
-
-		resp := s.enforceModelRPS(context.Background(), "llama", rc)
-		if assert.NotNil(t, resp) {
-			imm := resp.GetImmediateResponse()
-			require.NotNil(t, imm)
-			assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, imm.GetStatus().GetCode())
 		}
 		rl.AssertExpectations(t)
 	})

--- a/pkg/plugins/gateway/gateway_ratelimit_test.go
+++ b/pkg/plugins/gateway/gateway_ratelimit_test.go
@@ -137,15 +137,16 @@ func TestCheckTPM(t *testing.T) {
 	})
 }
 
-func TestCheckModelRPS(t *testing.T) {
+func TestEnforceModelRPS(t *testing.T) {
 	t.Run("nil config profile skips check", func(t *testing.T) {
 		rl := &mockRateLimiter{}
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{}
 
-		resp := s.checkModelRPS(context.Background(), "llama", rc)
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
 		assert.Nil(t, resp)
 		rl.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
+		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("non-positive rps skips check", func(t *testing.T) {
@@ -153,9 +154,10 @@ func TestCheckModelRPS(t *testing.T) {
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 0}}
 
-		resp := s.checkModelRPS(context.Background(), "llama", rc)
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
 		assert.Nil(t, resp)
 		rl.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
+		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("negative rps skips check", func(t *testing.T) {
@@ -163,9 +165,10 @@ func TestCheckModelRPS(t *testing.T) {
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: -1}}
 
-		resp := s.checkModelRPS(context.Background(), "llama", rc)
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
 		assert.Nil(t, resp)
 		rl.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
+		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("get failure returns 500 with model-rps header", func(t *testing.T) {
@@ -175,7 +178,7 @@ func TestCheckModelRPS(t *testing.T) {
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
 
-		resp := s.checkModelRPS(context.Background(), "llama", rc)
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
 		if assert.NotNil(t, resp) {
 			imm := resp.GetImmediateResponse()
 			require.NotNil(t, imm)
@@ -187,16 +190,17 @@ func TestCheckModelRPS(t *testing.T) {
 			}
 		}
 		rl.AssertExpectations(t)
+		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
 	})
 
-	t.Run("exceeding limit returns 429 with model-rps header", func(t *testing.T) {
+	t.Run("exceeding limit returns 429 and does not increment", func(t *testing.T) {
 		rl := &mockRateLimiter{}
 		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(2), nil).Once()
 
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
 
-		resp := s.checkModelRPS(context.Background(), "llama", rc)
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
 		if assert.NotNil(t, resp) {
 			imm := resp.GetImmediateResponse()
 			require.NotNil(t, imm)
@@ -209,50 +213,18 @@ func TestCheckModelRPS(t *testing.T) {
 			}
 		}
 		rl.AssertExpectations(t)
+		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
 	})
 
-	t.Run("below limit returns nil", func(t *testing.T) {
+	t.Run("incr failure returns 500 with incr header", func(t *testing.T) {
 		rl := &mockRateLimiter{}
 		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(1), nil).Once()
-
-		s := &Server{modelRateLimiter: rl}
-		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
-
-		resp := s.checkModelRPS(context.Background(), "llama", rc)
-		assert.Nil(t, resp)
-		rl.AssertExpectations(t)
-	})
-}
-
-func TestIncrModelRPS(t *testing.T) {
-	t.Run("nil config profile skips increment", func(t *testing.T) {
-		rl := &mockRateLimiter{}
-		s := &Server{modelRateLimiter: rl}
-		rc := &types.RoutingContext{}
-
-		resp := s.incrModelRPS(context.Background(), "llama", rc)
-		assert.Nil(t, resp)
-		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
-	})
-
-	t.Run("non-positive rps skips increment", func(t *testing.T) {
-		rl := &mockRateLimiter{}
-		s := &Server{modelRateLimiter: rl}
-		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 0}}
-
-		resp := s.incrModelRPS(context.Background(), "llama", rc)
-		assert.Nil(t, resp)
-		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
-	})
-
-	t.Run("increment failure returns 500 with incr header", func(t *testing.T) {
-		rl := &mockRateLimiter{}
 		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(0), errors.New("redis down")).Once()
 
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
 
-		resp := s.incrModelRPS(context.Background(), "llama", rc)
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
 		if assert.NotNil(t, resp) {
 			imm := resp.GetImmediateResponse()
 			require.NotNil(t, imm)
@@ -266,15 +238,58 @@ func TestIncrModelRPS(t *testing.T) {
 		rl.AssertExpectations(t)
 	})
 
-	t.Run("increment success returns nil", func(t *testing.T) {
+	t.Run("below limit increments and returns nil", func(t *testing.T) {
 		rl := &mockRateLimiter{}
-		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(1), nil).Once()
+		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(1), nil).Once()
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(2), nil).Once()
 
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
 
-		resp := s.incrModelRPS(context.Background(), "llama", rc)
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
 		assert.Nil(t, resp)
+		rl.AssertExpectations(t)
+	})
+}
+
+func TestDecrModelRPS(t *testing.T) {
+	t.Run("nil config profile skips decrement", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{}
+
+		s.decrModelRPS(context.Background(), "llama", rc)
+		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("non-positive rps skips decrement", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 0}}
+
+		s.decrModelRPS(context.Background(), "llama", rc)
+		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("decrement calls incr with -1", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(-1)).Return(int64(0), nil).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
+
+		s.decrModelRPS(context.Background(), "llama", rc)
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("decrement failure is logged and does not panic", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(-1)).Return(int64(0), errors.New("redis down")).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
+
+		s.decrModelRPS(context.Background(), "llama", rc)
 		rl.AssertExpectations(t)
 	})
 }

--- a/pkg/plugins/gateway/gateway_ratelimit_test.go
+++ b/pkg/plugins/gateway/gateway_ratelimit_test.go
@@ -136,73 +136,6 @@ func TestCheckTPM(t *testing.T) {
 	})
 }
 
-func TestCheckModelRPS(t *testing.T) {
-	t.Run("get failure returns internal server error", func(t *testing.T) {
-		rl := &mockRateLimiter{}
-		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(0), errors.New("redis down")).Once()
-
-		s := &Server{modelRateLimiter: rl}
-		code, err := s.checkModelRPS(context.Background(), "llama", 5)
-
-		assert.Equal(t, envoyTypePb.StatusCode_InternalServerError, code)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "fail to get RPS for model: llama")
-		rl.AssertExpectations(t)
-	})
-
-	t.Run("exceeding limit returns too many requests", func(t *testing.T) {
-		rl := &mockRateLimiter{}
-		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(5), nil).Once()
-
-		s := &Server{modelRateLimiter: rl}
-		code, err := s.checkModelRPS(context.Background(), "llama", 5)
-
-		assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, code)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "has exceeded RPS")
-		rl.AssertExpectations(t)
-	})
-
-	t.Run("below limit returns ok", func(t *testing.T) {
-		rl := &mockRateLimiter{}
-		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(4), nil).Once()
-
-		s := &Server{modelRateLimiter: rl}
-		code, err := s.checkModelRPS(context.Background(), "llama", 5)
-
-		assert.Equal(t, envoyTypePb.StatusCode_OK, code)
-		assert.NoError(t, err)
-		rl.AssertExpectations(t)
-	})
-}
-
-func TestIncrModelRPS(t *testing.T) {
-	t.Run("increment failure returns internal server error", func(t *testing.T) {
-		rl := &mockRateLimiter{}
-		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(0), errors.New("redis down")).Once()
-
-		s := &Server{modelRateLimiter: rl}
-		code, err := s.incrModelRPS(context.Background(), "llama")
-
-		assert.Equal(t, envoyTypePb.StatusCode_InternalServerError, code)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "fail to increment RPS for model: llama")
-		rl.AssertExpectations(t)
-	})
-
-	t.Run("increment success returns ok", func(t *testing.T) {
-		rl := &mockRateLimiter{}
-		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(3), nil).Once()
-
-		s := &Server{modelRateLimiter: rl}
-		code, err := s.incrModelRPS(context.Background(), "llama")
-
-		assert.Equal(t, envoyTypePb.StatusCode_OK, code)
-		assert.NoError(t, err)
-		rl.AssertExpectations(t)
-	})
-}
-
 func TestEnforceModelRPS(t *testing.T) {
 	t.Run("nil config profile skips enforcement", func(t *testing.T) {
 		s := &Server{modelRateLimiter: &mockRateLimiter{}}
@@ -220,30 +153,8 @@ func TestEnforceModelRPS(t *testing.T) {
 		assert.Nil(t, resp)
 	})
 
-	t.Run("check failure returns 429 with model-rps header", func(t *testing.T) {
-		rl := &mockRateLimiter{}
-		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(2), nil).Once()
-
-		s := &Server{modelRateLimiter: rl}
-		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
-
-		resp := s.enforceModelRPS(context.Background(), "llama", rc)
-		if assert.NotNil(t, resp) {
-			imm := resp.GetImmediateResponse()
-			assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, imm.GetStatus().GetCode())
-			assert.Contains(t, imm.GetBody(), ErrorCodeRateLimitExceeded)
-			assert.Contains(t, imm.GetBody(), "exceeded RPS")
-			if assert.NotEmpty(t, imm.GetHeaders().GetSetHeaders()) {
-				assert.Equal(t, HeaderErrorModelRPSExceeded, imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetKey())
-				assert.Equal(t, "true", string(imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetRawValue()))
-			}
-		}
-		rl.AssertExpectations(t)
-	})
-
 	t.Run("increment failure returns 500 with incr header", func(t *testing.T) {
 		rl := &mockRateLimiter{}
-		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(1), nil).Once()
 		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(0), errors.New("redis down")).Once()
 
 		s := &Server{modelRateLimiter: rl}
@@ -262,10 +173,44 @@ func TestEnforceModelRPS(t *testing.T) {
 		rl.AssertExpectations(t)
 	})
 
-	t.Run("success returns nil", func(t *testing.T) {
+	t.Run("exceeding limit returns 429 with model-rps header", func(t *testing.T) {
 		rl := &mockRateLimiter{}
-		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(1), nil).Once()
+		// counter was already at limit; after increment it is limit+1
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(3), nil).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
+
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		if assert.NotNil(t, resp) {
+			imm := resp.GetImmediateResponse()
+			assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, imm.GetStatus().GetCode())
+			assert.Contains(t, imm.GetBody(), ErrorCodeRateLimitExceeded)
+			assert.Contains(t, imm.GetBody(), "exceeded RPS")
+			if assert.NotEmpty(t, imm.GetHeaders().GetSetHeaders()) {
+				assert.Equal(t, HeaderErrorModelRPSExceeded, imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetKey())
+				assert.Equal(t, "true", string(imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetRawValue()))
+			}
+		}
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("at-limit increment is accepted", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		// counter moves from 0 to exactly the limit — still within budget
 		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(2), nil).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
+
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		assert.Nil(t, resp)
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("below limit returns nil", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(1), nil).Once()
 
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}

--- a/pkg/plugins/gateway/gateway_ratelimit_test.go
+++ b/pkg/plugins/gateway/gateway_ratelimit_test.go
@@ -24,6 +24,7 @@ import (
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/vllm-project/aibrix/pkg/types"
 )
 
@@ -136,37 +137,52 @@ func TestCheckTPM(t *testing.T) {
 	})
 }
 
-func TestEnforceModelRPS(t *testing.T) {
-	t.Run("nil config profile skips enforcement", func(t *testing.T) {
-		s := &Server{modelRateLimiter: &mockRateLimiter{}}
+func TestCheckModelRPS(t *testing.T) {
+	t.Run("nil config profile skips check", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{}
 
-		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		resp := s.checkModelRPS(context.Background(), "llama", rc)
 		assert.Nil(t, resp)
+		rl.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
 	})
 
-	t.Run("non-positive rps skips enforcement", func(t *testing.T) {
-		s := &Server{modelRateLimiter: &mockRateLimiter{}}
+	t.Run("non-positive rps skips check", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 0}}
 
-		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		resp := s.checkModelRPS(context.Background(), "llama", rc)
 		assert.Nil(t, resp)
+		rl.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
 	})
 
-	t.Run("increment failure returns 500 with incr header", func(t *testing.T) {
+	t.Run("negative rps skips check", func(t *testing.T) {
 		rl := &mockRateLimiter{}
-		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(0), errors.New("redis down")).Once()
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: -1}}
+
+		resp := s.checkModelRPS(context.Background(), "llama", rc)
+		assert.Nil(t, resp)
+		rl.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
+	})
+
+	t.Run("get failure returns 500 with model-rps header", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(0), errors.New("redis down")).Once()
 
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
 
-		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		resp := s.checkModelRPS(context.Background(), "llama", rc)
 		if assert.NotNil(t, resp) {
 			imm := resp.GetImmediateResponse()
+			require.NotNil(t, imm)
 			assert.Equal(t, envoyTypePb.StatusCode_InternalServerError, imm.GetStatus().GetCode())
-			assert.Contains(t, imm.GetBody(), "fail to increment RPS for model: llama")
+			assert.Contains(t, imm.GetBody(), "fail to get RPS for model: llama")
 			if assert.NotEmpty(t, imm.GetHeaders().GetSetHeaders()) {
-				assert.Equal(t, HeaderErrorIncrModelRPS, imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetKey())
+				assert.Equal(t, HeaderErrorModelRPSExceeded, imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetKey())
 				assert.Equal(t, "true", string(imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetRawValue()))
 			}
 		}
@@ -175,15 +191,15 @@ func TestEnforceModelRPS(t *testing.T) {
 
 	t.Run("exceeding limit returns 429 with model-rps header", func(t *testing.T) {
 		rl := &mockRateLimiter{}
-		// counter was already at limit; after increment it is limit+1
-		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(3), nil).Once()
+		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(2), nil).Once()
 
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
 
-		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		resp := s.checkModelRPS(context.Background(), "llama", rc)
 		if assert.NotNil(t, resp) {
 			imm := resp.GetImmediateResponse()
+			require.NotNil(t, imm)
 			assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, imm.GetStatus().GetCode())
 			assert.Contains(t, imm.GetBody(), ErrorCodeRateLimitExceeded)
 			assert.Contains(t, imm.GetBody(), "exceeded RPS")
@@ -195,27 +211,69 @@ func TestEnforceModelRPS(t *testing.T) {
 		rl.AssertExpectations(t)
 	})
 
-	t.Run("at-limit increment is accepted", func(t *testing.T) {
+	t.Run("below limit returns nil", func(t *testing.T) {
 		rl := &mockRateLimiter{}
-		// counter moves from 0 to exactly the limit — still within budget
-		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(2), nil).Once()
+		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(1), nil).Once()
 
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
 
-		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		resp := s.checkModelRPS(context.Background(), "llama", rc)
 		assert.Nil(t, resp)
 		rl.AssertExpectations(t)
 	})
+}
 
-	t.Run("below limit returns nil", func(t *testing.T) {
+func TestIncrModelRPS(t *testing.T) {
+	t.Run("nil config profile skips increment", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{}
+
+		resp := s.incrModelRPS(context.Background(), "llama", rc)
+		assert.Nil(t, resp)
+		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("non-positive rps skips increment", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 0}}
+
+		resp := s.incrModelRPS(context.Background(), "llama", rc)
+		assert.Nil(t, resp)
+		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("increment failure returns 500 with incr header", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(0), errors.New("redis down")).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
+
+		resp := s.incrModelRPS(context.Background(), "llama", rc)
+		if assert.NotNil(t, resp) {
+			imm := resp.GetImmediateResponse()
+			require.NotNil(t, imm)
+			assert.Equal(t, envoyTypePb.StatusCode_InternalServerError, imm.GetStatus().GetCode())
+			assert.Contains(t, imm.GetBody(), "fail to increment RPS for model: llama")
+			if assert.NotEmpty(t, imm.GetHeaders().GetSetHeaders()) {
+				assert.Equal(t, HeaderErrorIncrModelRPS, imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetKey())
+				assert.Equal(t, "true", string(imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetRawValue()))
+			}
+		}
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("increment success returns nil", func(t *testing.T) {
 		rl := &mockRateLimiter{}
 		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(1), nil).Once()
 
 		s := &Server{modelRateLimiter: rl}
 		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
 
-		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		resp := s.incrModelRPS(context.Background(), "llama", rc)
 		assert.Nil(t, resp)
 		rl.AssertExpectations(t)
 	})

--- a/pkg/plugins/gateway/gateway_ratelimit_test.go
+++ b/pkg/plugins/gateway/gateway_ratelimit_test.go
@@ -145,7 +145,6 @@ func TestEnforceModelRPS(t *testing.T) {
 
 		resp := s.enforceModelRPS(context.Background(), "llama", rc)
 		assert.Nil(t, resp)
-		rl.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
 		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
 	})
 
@@ -156,7 +155,6 @@ func TestEnforceModelRPS(t *testing.T) {
 
 		resp := s.enforceModelRPS(context.Background(), "llama", rc)
 		assert.Nil(t, resp)
-		rl.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
 		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
 	})
 
@@ -167,58 +165,11 @@ func TestEnforceModelRPS(t *testing.T) {
 
 		resp := s.enforceModelRPS(context.Background(), "llama", rc)
 		assert.Nil(t, resp)
-		rl.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
-		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
-	})
-
-	t.Run("get failure returns 500 with model-rps header", func(t *testing.T) {
-		rl := &mockRateLimiter{}
-		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(0), errors.New("redis down")).Once()
-
-		s := &Server{modelRateLimiter: rl}
-		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
-
-		resp := s.enforceModelRPS(context.Background(), "llama", rc)
-		if assert.NotNil(t, resp) {
-			imm := resp.GetImmediateResponse()
-			require.NotNil(t, imm)
-			assert.Equal(t, envoyTypePb.StatusCode_InternalServerError, imm.GetStatus().GetCode())
-			assert.Contains(t, imm.GetBody(), "fail to get RPS for model: llama")
-			if assert.NotEmpty(t, imm.GetHeaders().GetSetHeaders()) {
-				assert.Equal(t, HeaderErrorModelRPSExceeded, imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetKey())
-				assert.Equal(t, "true", string(imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetRawValue()))
-			}
-		}
-		rl.AssertExpectations(t)
-		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
-	})
-
-	t.Run("exceeding limit returns 429 and does not increment", func(t *testing.T) {
-		rl := &mockRateLimiter{}
-		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(2), nil).Once()
-
-		s := &Server{modelRateLimiter: rl}
-		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
-
-		resp := s.enforceModelRPS(context.Background(), "llama", rc)
-		if assert.NotNil(t, resp) {
-			imm := resp.GetImmediateResponse()
-			require.NotNil(t, imm)
-			assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, imm.GetStatus().GetCode())
-			assert.Contains(t, imm.GetBody(), ErrorCodeRateLimitExceeded)
-			assert.Contains(t, imm.GetBody(), "exceeded RPS")
-			if assert.NotEmpty(t, imm.GetHeaders().GetSetHeaders()) {
-				assert.Equal(t, HeaderErrorModelRPSExceeded, imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetKey())
-				assert.Equal(t, "true", string(imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetRawValue()))
-			}
-		}
-		rl.AssertExpectations(t)
 		rl.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("incr failure returns 500 with incr header", func(t *testing.T) {
 		rl := &mockRateLimiter{}
-		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(1), nil).Once()
 		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(0), errors.New("redis down")).Once()
 
 		s := &Server{modelRateLimiter: rl}
@@ -238,9 +189,48 @@ func TestEnforceModelRPS(t *testing.T) {
 		rl.AssertExpectations(t)
 	})
 
+	t.Run("exceeding limit returns 429 and decrements counter", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(3), nil).Once()
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(-1)).Return(int64(2), nil).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
+
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		if assert.NotNil(t, resp) {
+			imm := resp.GetImmediateResponse()
+			require.NotNil(t, imm)
+			assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, imm.GetStatus().GetCode())
+			assert.Contains(t, imm.GetBody(), ErrorCodeRateLimitExceeded)
+			assert.Contains(t, imm.GetBody(), "exceeded RPS")
+			if assert.NotEmpty(t, imm.GetHeaders().GetSetHeaders()) {
+				assert.Equal(t, HeaderErrorModelRPSExceeded, imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetKey())
+				assert.Equal(t, "true", string(imm.GetHeaders().GetSetHeaders()[0].GetHeader().GetRawValue()))
+			}
+		}
+		rl.AssertExpectations(t)
+	})
+
+	t.Run("exceeding limit rollback failure is logged but still returns 429", func(t *testing.T) {
+		rl := &mockRateLimiter{}
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(3), nil).Once()
+		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(-1)).Return(int64(0), errors.New("redis down")).Once()
+
+		s := &Server{modelRateLimiter: rl}
+		rc := &types.RoutingContext{ConfigProfile: &types.ResolvedConfigProfile{RequestsPerSecond: 2}}
+
+		resp := s.enforceModelRPS(context.Background(), "llama", rc)
+		if assert.NotNil(t, resp) {
+			imm := resp.GetImmediateResponse()
+			require.NotNil(t, imm)
+			assert.Equal(t, envoyTypePb.StatusCode_TooManyRequests, imm.GetStatus().GetCode())
+		}
+		rl.AssertExpectations(t)
+	})
+
 	t.Run("below limit increments and returns nil", func(t *testing.T) {
 		rl := &mockRateLimiter{}
-		rl.On("Get", mock.Anything, "llama_MODEL_RPS_CURRENT").Return(int64(1), nil).Once()
 		rl.On("Incr", mock.Anything, "llama_MODEL_RPS_CURRENT", int64(1)).Return(int64(2), nil).Once()
 
 		s := &Server{modelRateLimiter: rl}

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -107,8 +107,9 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 		headers = buildEnvoyProxyHeaders(headers, ":path", rewritePath)
 	}
 
-	// Enforce per-model RPS limit from config profile
-	if errRes = s.enforceModelRPS(ctx, model, routingCtx); errRes != nil {
+	// Reject early if the per-model RPS limit is already reached; increment happens
+	// after routing succeeds so failed routing attempts don't consume quota.
+	if errRes = s.checkModelRPS(ctx, model, routingCtx); errRes != nil {
 		return errRes, model, routingCtx, stream, term
 	}
 
@@ -149,6 +150,11 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 
 	routingCtx.RequestEndTime = time.Now()
 	term = s.cache.AddRequestCount(routingCtx, requestID, model)
+
+	// Routing succeeded — now charge the RPS quota.
+	if errRes = s.incrModelRPS(ctx, model, routingCtx); errRes != nil {
+		return errRes, model, routingCtx, stream, term
+	}
 
 	return &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_RequestBody{

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -107,6 +107,11 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 		headers = buildEnvoyProxyHeaders(headers, ":path", rewritePath)
 	}
 
+	// Enforce per-model RPS limit from config profile
+	if errRes = s.enforceModelRPS(ctx, model, routingCtx); errRes != nil {
+		return errRes, model, routingCtx, stream, term
+	}
+
 	if routingAlgorithm == routing.RouterNotSet {
 		if err := s.validateHTTPRouteStatus(ctx, model); err != nil {
 			return buildErrorResponse(envoyTypePb.StatusCode_ServiceUnavailable, err.Error(), ErrorCodeServiceUnavailable, "", HeaderErrorRouting, "true"), model, routingCtx, stream, term

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -107,11 +107,16 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 		headers = buildEnvoyProxyHeaders(headers, ":path", rewritePath)
 	}
 
-	// Reject early if the per-model RPS limit is already reached; increment happens
-	// after routing succeeds so failed routing attempts don't consume quota.
-	if errRes = s.checkModelRPS(ctx, model, routingCtx); errRes != nil {
+	// Enforce per-model RPS limit from config profile
+	if errRes = s.enforceModelRPS(ctx, model, routingCtx); errRes != nil {
 		return errRes, model, routingCtx, stream, term
 	}
+	rpsCharged := true
+	defer func() {
+		if rpsCharged {
+			s.decrModelRPS(ctx, model, routingCtx)
+		}
+	}()
 
 	if routingAlgorithm == routing.RouterNotSet {
 		if err := s.validateHTTPRouteStatus(ctx, model); err != nil {
@@ -148,13 +153,9 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 			"target_pod", targetPodName, "target_pod_ip", targetPodIP, "outstanding_requests", request_count, "routing_time_taken", routingDelay)
 	}
 
+	rpsCharged = false
 	routingCtx.RequestEndTime = time.Now()
 	term = s.cache.AddRequestCount(routingCtx, requestID, model)
-
-	// Routing succeeded — now charge the RPS quota.
-	if errRes = s.incrModelRPS(ctx, model, routingCtx); errRes != nil {
-		return errRes, model, routingCtx, stream, term
-	}
 
 	return &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_RequestBody{

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -107,13 +107,12 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 		headers = buildEnvoyProxyHeaders(headers, ":path", rewritePath)
 	}
 
-	// Enforce per-model RPS limit from config profile
 	if errRes = s.enforceModelRPS(ctx, model, routingCtx); errRes != nil {
 		return errRes, model, routingCtx, stream, term
 	}
-	rpsCharged := true
+	needsRollback := true
 	defer func() {
-		if rpsCharged {
+		if needsRollback {
 			s.decrModelRPS(ctx, model, routingCtx)
 		}
 	}()
@@ -153,7 +152,7 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestID string, req *e
 			"target_pod", targetPodName, "target_pod_ip", targetPodIP, "outstanding_requests", request_count, "routing_time_taken", routingDelay)
 	}
 
-	rpsCharged = false
+	needsRollback = false
 	routingCtx.RequestEndTime = time.Now()
 	term = s.cache.AddRequestCount(routingCtx, requestID, model)
 

--- a/pkg/plugins/gateway/gateway_req_body_test.go
+++ b/pkg/plugins/gateway/gateway_req_body_test.go
@@ -18,6 +18,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/constants"
 	routingalgorithms "github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
@@ -675,4 +677,87 @@ func Test_handleRequestBody(t *testing.T) {
 			mockRouter.AssertExpectations(subtest)
 		})
 	}
+}
+
+func TestHandleRequestBody_ModelRPSNotConsumedOnRoutingFailure(t *testing.T) {
+	routingalgorithms.Init()
+
+	mockCache := &MockCache{Cache: cache.NewForTest()}
+	mockRouter := new(mockRouter)
+	mockModelRL := &mockRateLimiter{}
+
+	mockRouterProvider := func() (types.Router, error) {
+		return mockRouter, nil
+	}
+	routingalgorithms.Register(TestRouterAlgorithm, mockRouterProvider)
+	routingalgorithms.Init()
+
+	// Config profile enables model RPS checks.
+	profileJSON := `{"defaultProfile":"rps-limited","profiles":{"rps-limited":{"requestsPerSecond":5}}}`
+	podList := &utils.PodArray{
+		Pods: []*v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-a",
+					Annotations: map[string]string{
+						constants.ModelAnnoConfig: profileJSON,
+					},
+				},
+				Status: v1.PodStatus{
+					PodIP:      "1.2.3.4",
+					Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-b",
+					Annotations: map[string]string{
+						constants.ModelAnnoConfig: profileJSON,
+					},
+				},
+				Status: v1.PodStatus{
+					PodIP:      "4.5.6.7",
+					Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+				},
+			},
+		},
+	}
+
+	mockCache.On("HasModel", "test-model").Return(true).Once()
+	mockCache.On("ListPodsByModel", "test-model").Return(podList, nil).Once()
+
+	// checkModelRPS should run and allow request.
+	mockModelRL.On("Get", mock.Anything, "test-model_MODEL_RPS_CURRENT").Return(int64(0), nil).Once()
+	// Routing then fails, so incrModelRPS should not execute.
+	mockRouter.On("Route", mock.Anything, mock.Anything).Return("", errors.New("route selection failed")).Once()
+
+	server := &Server{
+		cache:             mockCache,
+		modelRateLimiter:  mockModelRL,
+		gatewayClient:     nil, // not used for explicit routing strategy path
+		requestCountTracker: map[string]int{},
+	}
+
+	req := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestBody{
+			RequestBody: &extProcPb.HttpBody{
+				Body: []byte(`{"model":"test-model","messages":[{"role":"user","content":"test"}]}`),
+			},
+		},
+	}
+
+	routingCtx := types.NewRoutingContext(context.Background(), "", "", "", "test-request-id", "test-user")
+	routingCtx.ReqPath = PathChatCompletions
+	routingCtx.ReqHeaders[HeaderRoutingStrategy] = string(TestRouterAlgorithm)
+
+	resp, _, _, _, term := server.HandleRequestBody(routingCtx, "test-request-id", req, utils.User{Name: "test-user"})
+
+	assert.NotNil(t, resp)
+	assert.Equal(t, envoyTypePb.StatusCode_ServiceUnavailable, resp.GetImmediateResponse().GetStatus().GetCode())
+	assert.Equal(t, int64(0), term, "failed routing path should not add request trace term")
+	mockModelRL.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
+	mockCache.AssertNotCalled(t, "AddRequestCount", mock.Anything, mock.Anything, mock.Anything)
+	mockCache.AssertExpectations(t)
+	mockRouter.AssertExpectations(t)
+	mockModelRL.AssertExpectations(t)
 }

--- a/pkg/plugins/gateway/gateway_req_body_test.go
+++ b/pkg/plugins/gateway/gateway_req_body_test.go
@@ -734,9 +734,9 @@ func TestHandleRequestBody_ModelRPSNotConsumedOnRoutingFailure(t *testing.T) {
 	mockRouter.On("Route", mock.Anything, mock.Anything).Return("", errors.New("route selection failed")).Once()
 
 	server := &Server{
-		cache:             mockCache,
-		modelRateLimiter:  mockModelRL,
-		gatewayClient:     nil, // not used for explicit routing strategy path
+		cache:               mockCache,
+		modelRateLimiter:    mockModelRL,
+		gatewayClient:       nil, // not used for explicit routing strategy path
 		requestCountTracker: map[string]int{},
 	}
 

--- a/pkg/plugins/gateway/gateway_req_body_test.go
+++ b/pkg/plugins/gateway/gateway_req_body_test.go
@@ -726,10 +726,9 @@ func TestHandleRequestBody_ModelRPSNotConsumedOnRoutingFailure(t *testing.T) {
 	mockCache.On("HasModel", "test-model").Return(true).Once()
 	mockCache.On("ListPodsByModel", "test-model").Return(podList, nil).Once()
 
-	// enforceModelRPS should check current usage and then pre-charge (+1).
-	mockModelRL.On("Get", mock.Anything, "test-model_MODEL_RPS_CURRENT").Return(int64(0), nil).Once()
+	// enforceModelRPS atomically pre-charges (+1); routing then fails so the deferred
+	// compensation refunds (-1).
 	mockModelRL.On("Incr", mock.Anything, "test-model_MODEL_RPS_CURRENT", int64(1)).Return(int64(1), nil).Once()
-	// Routing then fails, so deferred compensation should refund (-1).
 	mockModelRL.On("Incr", mock.Anything, "test-model_MODEL_RPS_CURRENT", int64(-1)).Return(int64(0), nil).Once()
 	mockRouter.On("Route", mock.Anything, mock.Anything).Return("", errors.New("route selection failed")).Once()
 

--- a/pkg/plugins/gateway/gateway_req_body_test.go
+++ b/pkg/plugins/gateway/gateway_req_body_test.go
@@ -726,9 +726,11 @@ func TestHandleRequestBody_ModelRPSNotConsumedOnRoutingFailure(t *testing.T) {
 	mockCache.On("HasModel", "test-model").Return(true).Once()
 	mockCache.On("ListPodsByModel", "test-model").Return(podList, nil).Once()
 
-	// checkModelRPS should run and allow request.
+	// enforceModelRPS should check current usage and then pre-charge (+1).
 	mockModelRL.On("Get", mock.Anything, "test-model_MODEL_RPS_CURRENT").Return(int64(0), nil).Once()
-	// Routing then fails, so incrModelRPS should not execute.
+	mockModelRL.On("Incr", mock.Anything, "test-model_MODEL_RPS_CURRENT", int64(1)).Return(int64(1), nil).Once()
+	// Routing then fails, so deferred compensation should refund (-1).
+	mockModelRL.On("Incr", mock.Anything, "test-model_MODEL_RPS_CURRENT", int64(-1)).Return(int64(0), nil).Once()
 	mockRouter.On("Route", mock.Anything, mock.Anything).Return("", errors.New("route selection failed")).Once()
 
 	server := &Server{
@@ -755,7 +757,6 @@ func TestHandleRequestBody_ModelRPSNotConsumedOnRoutingFailure(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.Equal(t, envoyTypePb.StatusCode_ServiceUnavailable, resp.GetImmediateResponse().GetStatus().GetCode())
 	assert.Equal(t, int64(0), term, "failed routing path should not add request trace term")
-	mockModelRL.AssertNotCalled(t, "Incr", mock.Anything, mock.Anything, mock.Anything)
 	mockCache.AssertNotCalled(t, "AddRequestCount", mock.Anything, mock.Anything, mock.Anything)
 	mockCache.AssertExpectations(t)
 	mockRouter.AssertExpectations(t)

--- a/pkg/plugins/gateway/ratelimiter/README.md
+++ b/pkg/plugins/gateway/ratelimiter/README.md
@@ -74,13 +74,17 @@ Keys follow the pattern `aibrix_model:{modelName}_MODEL_RPS_CURRENT:{timebin}`. 
 
 The active profile is selected by passing the `config-profile` request header. If no profile is active or `requestsPerSecond` is unset, the RPS check is skipped entirely.
 
-#### Two-phase enforcement
+#### Enforcement flow
 
-Per-model RPS enforcement is split across two call sites in `HandleRequestBody` to avoid charging quota for requests that fail during routing:
+Per-model RPS enforcement is handled in `HandleRequestBody` via `enforceModelRPS` and a deferred compensation step:
 
-1. **`checkModelRPS`** — called before routing. Uses `Get` to read the current counter and rejects with HTTP 429 if `current >= limit`. Does not write.
-2. **`incrModelRPS`** — called after routing succeeds (after `AddRequestCount`). Uses `Incr` to charge the quota only once a pod has been selected and the request is being forwarded.
+1. **Pre-routing gate (`enforceModelRPS`)** — called before routing. It:
+   - reads current usage with `Get`
+   - rejects with HTTP 429 if `current >= limit`
+   - pre-charges quota with `Incr(..., +1)` when allowed
+2. **Deferred compensation (`decrModelRPS`)** — armed immediately after a successful pre-charge. If routing later fails, the deferred call refunds quota with `Incr(..., -1)`.
+3. **Success path** — after routing succeeds and request accounting is attached, compensation is disabled, so the pre-charge remains counted.
 
-This means requests rejected by routing errors (no available pods, invalid strategy, etc.) do not consume the per-model RPS budget.
+This keeps rejected requests from permanently consuming RPS budget while still enforcing limits early.
 
-**Tradeoff:** the check-then-increment sequence has a small TOCTOU race — concurrent requests that both read the same counter value before either increments can both pass the gate. In practice the race window is a single Redis round-trip and the over-admission is bounded to the number of concurrent inflight requests, which is acceptable for typical RPS values.
+**Tradeoff:** the check-then-increment gate has a small TOCTOU race. Concurrent requests can observe the same pre-increment value and both pass before their increments land. In practice, the race window is one Redis round-trip and over-admission is bounded by concurrent in-flight requests.

--- a/pkg/plugins/gateway/ratelimiter/README.md
+++ b/pkg/plugins/gateway/ratelimiter/README.md
@@ -1,0 +1,75 @@
+# ratelimiter
+
+Package `ratelimiter` provides a distributed, Redis-backed fixed-window rate limiter used by the Aibrix gateway to enforce per-user and per-model request limits across multiple gateway instances.
+
+## Interface
+
+```go
+type RateLimiter interface {
+    Get(ctx context.Context, key string) (int64, error)
+    GetLimit(ctx context.Context, key string) (int64, error)
+    Incr(ctx context.Context, key string, val int64) (int64, error)
+}
+```
+
+| Method     | Description |
+|------------|-------------|
+| `Get`      | Returns the current counter value for a key in the active time window. |
+| `GetLimit` | Returns the configured maximum for a key (used for limit lookups, not window counters). |
+| `Incr`     | Atomically increments the counter by `val` and returns the new value. Sets the key TTL to the window size. |
+
+## Implementations
+
+### `redisRateLimiter` — `NewRedisAccountRateLimiter(name, client, windowSize)`
+
+A fixed-window counter backed by Redis. Suitable for cluster-wide enforcement when multiple gateway replicas share the same Redis instance.
+
+**Key scheme:** `{name}:{key}:{timebin}`
+
+The time bin is computed as:
+
+```
+timebin = (time.Now().Unix() / windowSeconds) % 64
+```
+
+This cycles through 64 buckets, so at most 64 keys exist per logical counter. The TTL on each key is set to `windowSize`, so stale bins expire automatically.
+
+- Minimum `windowSize` is 1 second (smaller values are clamped up).
+- `Incr` uses a Redis pipeline (`INCRBY` + `EXPIRE`) for atomicity within a single round-trip.
+- A missing key (`redis.Nil`) is treated as `0`, not an error.
+
+### `noopRateLimiter` — `NewNoopRateLimiter()`
+
+A no-op implementation that always allows requests. Used when Redis is unavailable (e.g., local development without a Redis sidecar). `GetLimit` returns `math.MaxInt64`.
+
+## Usage in the gateway
+
+Two limiter instances are created at server startup:
+
+| Instance           | Constructor arg `name` | `windowSize` | Purpose                          |
+|--------------------|------------------------|--------------|----------------------------------|
+| `ratelimiter`      | `"aibrix"`             | 1 minute     | Per-user RPM and TPM enforcement |
+| `modelRateLimiter` | `"aibrix_model"`       | 1 second     | Per-model RPS enforcement        |
+
+The separate `name` prefix ensures the two limiters' keys never collide in Redis.
+
+### Per-user limits (RPM / TPM)
+
+Keys follow the pattern `aibrix:{username}_{RPM|TPM}_CURRENT:{timebin}`. Limits are read from the user record resolved during request header processing.
+
+### Per-model RPS
+
+Keys follow the pattern `aibrix_model:{modelName}_MODEL_RPS_CURRENT:{timebin}`. The RPS limit is configured per model via the `requestsPerSecond` field in a config profile:
+
+```json
+{
+  "profiles": {
+    "rps-limited": {
+      "routingStrategy": "least-request",
+      "requestsPerSecond": 1
+    }
+  }
+}
+```
+
+The active profile is selected by passing the `config-profile` request header. If no profile is active or `requestsPerSecond` is unset, the RPS check is skipped entirely.

--- a/pkg/plugins/gateway/ratelimiter/README.md
+++ b/pkg/plugins/gateway/ratelimiter/README.md
@@ -73,3 +73,14 @@ Keys follow the pattern `aibrix_model:{modelName}_MODEL_RPS_CURRENT:{timebin}`. 
 ```
 
 The active profile is selected by passing the `config-profile` request header. If no profile is active or `requestsPerSecond` is unset, the RPS check is skipped entirely.
+
+#### Two-phase enforcement
+
+Per-model RPS enforcement is split across two call sites in `HandleRequestBody` to avoid charging quota for requests that fail during routing:
+
+1. **`checkModelRPS`** — called before routing. Uses `Get` to read the current counter and rejects with HTTP 429 if `current >= limit`. Does not write.
+2. **`incrModelRPS`** — called after routing succeeds (after `AddRequestCount`). Uses `Incr` to charge the quota only once a pod has been selected and the request is being forwarded.
+
+This means requests rejected by routing errors (no available pods, invalid strategy, etc.) do not consume the per-model RPS budget.
+
+**Tradeoff:** the check-then-increment sequence has a small TOCTOU race — concurrent requests that both read the same counter value before either increments can both pass the gate. In practice the race window is a single Redis round-trip and the over-admission is bounded to the number of concurrent inflight requests, which is acceptable for typical RPS values.

--- a/pkg/plugins/gateway/ratelimiter/README.md
+++ b/pkg/plugins/gateway/ratelimiter/README.md
@@ -79,12 +79,10 @@ The active profile is selected by passing the `config-profile` request header. I
 Per-model RPS enforcement is handled in `HandleRequestBody` via `enforceModelRPS` and a deferred compensation step:
 
 1. **Pre-routing gate (`enforceModelRPS`)** — called before routing. It:
-   - reads current usage with `Get`
-   - rejects with HTTP 429 if `current >= limit`
-   - pre-charges quota with `Incr(..., +1)` when allowed
+   - atomically increments the counter with `Incr(..., +1)` and receives the new value
+   - rejects with HTTP 429 and rolls back with `Incr(..., -1)` if `newVal > limit`
+   - allows the request through when `newVal <= limit`
 2. **Deferred compensation (`decrModelRPS`)** — armed immediately after a successful pre-charge. If routing later fails, the deferred call refunds quota with `Incr(..., -1)`.
 3. **Success path** — after routing succeeds and request accounting is attached, compensation is disabled, so the pre-charge remains counted.
 
-This keeps rejected requests from permanently consuming RPS budget while still enforcing limits early.
-
-**Tradeoff:** the check-then-increment gate has a small TOCTOU race. Concurrent requests can observe the same pre-increment value and both pass before their increments land. In practice, the race window is one Redis round-trip and over-admission is bounded by concurrent in-flight requests.
+Using incr-then-check (rather than check-then-increment) means the `INCRBY` is the sole gate. Because Redis processes `INCRBY` atomically, each concurrent caller receives a unique sequential result — eliminating the TOCTOU race that would otherwise allow over-admission during the check→increment window.

--- a/pkg/plugins/gateway/ratelimiter/ratelimiter_test.go
+++ b/pkg/plugins/gateway/ratelimiter/ratelimiter_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimiter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRedisForTest(t *testing.T) *redis.Client {
+	t.Helper()
+
+	client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		_ = client.Close()
+		t.Skip("Redis is not available at localhost:6379")
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+	return client
+}
+
+func TestNoopRateLimiter(t *testing.T) {
+	rl := NewNoopRateLimiter()
+
+	got, err := rl.Get(context.Background(), "any")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got)
+
+	limit, err := rl.GetLimit(context.Background(), "any")
+	require.NoError(t, err)
+	assert.Equal(t, int64(9223372036854775807), limit)
+
+	incr, err := rl.Incr(context.Background(), "any", 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), incr)
+}
+
+func TestNewRedisAccountRateLimiter_ClampsWindowToOneSecond(t *testing.T) {
+	rl := NewRedisAccountRateLimiter("test", nil, 100*time.Millisecond)
+	typed, ok := rl.(*redisRateLimiter)
+	require.True(t, ok)
+	assert.Equal(t, time.Second, typed.windowSize)
+}
+
+func TestRedisRateLimiter_IncrAndGetCurrentWindow(t *testing.T) {
+	client := setupRedisForTest(t)
+	rl := NewRedisAccountRateLimiter("ratelimiter_test", client, time.Second)
+	typed := rl.(*redisRateLimiter)
+
+	ctx := context.Background()
+	key := "userA_RPM_CURRENT"
+	redisKey := typed.genKey(key)
+	t.Cleanup(func() {
+		_ = client.Del(ctx, redisKey).Err()
+	})
+
+	// Missing key should read as 0.
+	initial, err := rl.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), initial)
+
+	afterIncr, err := rl.Incr(ctx, key, 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), afterIncr)
+
+	afterSecondIncr, err := rl.Incr(ctx, key, 2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), afterSecondIncr)
+
+	current, err := rl.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), current)
+}
+
+func TestRedisRateLimiter_GetLimitUsesStaticKey(t *testing.T) {
+	client := setupRedisForTest(t)
+	rl := NewRedisAccountRateLimiter("ratelimiter_test", client, time.Second)
+
+	ctx := context.Background()
+	limitKey := "alice_limit"
+	fullKey := "ratelimiter_test:" + limitKey
+
+	require.NoError(t, client.Set(ctx, fullKey, 42, time.Minute).Err())
+	t.Cleanup(func() {
+		_ = client.Del(ctx, fullKey).Err()
+	})
+
+	got, err := rl.GetLimit(ctx, limitKey)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), got)
+}
+

--- a/pkg/plugins/gateway/ratelimiter/ratelimiter_test.go
+++ b/pkg/plugins/gateway/ratelimiter/ratelimiter_test.go
@@ -149,4 +149,3 @@ func TestRedisRateLimiter_ConcurrentIncrements(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(workers), got, "all concurrent increments should be reflected")
 }
-

--- a/pkg/plugins/gateway/ratelimiter/ratelimiter_test.go
+++ b/pkg/plugins/gateway/ratelimiter/ratelimiter_test.go
@@ -18,6 +18,7 @@ package ratelimiter
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -109,5 +110,43 @@ func TestRedisRateLimiter_GetLimitUsesStaticKey(t *testing.T) {
 	got, err := rl.GetLimit(ctx, limitKey)
 	require.NoError(t, err)
 	assert.Equal(t, int64(42), got)
+}
+
+func TestRedisRateLimiter_ConcurrentIncrements(t *testing.T) {
+	client := setupRedisForTest(t)
+	rl := NewRedisAccountRateLimiter("ratelimiter_test", client, 5*time.Second)
+	typed := rl.(*redisRateLimiter)
+
+	ctx := context.Background()
+	key := "burst_MODEL_RPS_CURRENT"
+	redisKey := typed.genKey(key)
+	t.Cleanup(func() {
+		_ = client.Del(ctx, redisKey).Err()
+	})
+
+	const workers = 64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	errCh := make(chan error, workers)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := rl.Incr(ctx, key, 1)
+			if err != nil {
+				errCh <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	got, err := rl.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(workers), got, "all concurrent increments should be reflected")
 }
 

--- a/pkg/plugins/gateway/types.go
+++ b/pkg/plugins/gateway/types.go
@@ -65,6 +65,10 @@ const (
 	HeaderErrorIncrRPM     = "x-error-incr-rpm"
 	HeaderErrorIncrTPM     = "x-error-incr-tpm"
 
+	// Model RPS Errors
+	HeaderErrorModelRPSExceeded = "x-error-model-rps-exceeded"
+	HeaderErrorIncrModelRPS     = "x-error-incr-model-rps"
+
 	// Rate Limiting defaults
 	DefaultRPM           = 100
 	DefaultTPMMultiplier = 1000

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -398,8 +398,9 @@ func applyConfigProfile(routingCtx *types.RoutingContext, pods []*v1.Pod) {
 		return
 	}
 	routingCtx.ConfigProfile = &types.ResolvedConfigProfile{
-		RoutingStrategy: profile.RoutingStrategy,
-		RoutingConfig:   profile.RoutingConfig,
+		RoutingStrategy:   profile.RoutingStrategy,
+		RoutingConfig:     profile.RoutingConfig,
+		RequestsPerSecond: profile.RequestsPerSecond,
 	}
 }
 

--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -46,8 +46,9 @@ type RequestFeatures []float64
 // Populated from model.aibrix.ai/config annotation based on config-profile header or defaultProfile.
 // Nil when no config is present;
 type ResolvedConfigProfile struct {
-	RoutingStrategy string
-	RoutingConfig   json.RawMessage
+	RoutingStrategy   string
+	RoutingConfig     json.RawMessage
+	RequestsPerSecond int64
 }
 
 // RoutingAlgorithm defines the routing algorithms

--- a/test/e2e/model_rps_limit_test.go
+++ b/test/e2e/model_rps_limit_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModelRPSLimit verifies that the per-model requestsPerSecond limit defined in the
+// model.aibrix.ai/config annotation is enforced by the gateway across all instances.
+//
+// The "rps-limited" profile on qwen3-8b is configured with requestsPerSecond: 1,
+// meaning only 1 request per second is allowed. This is defined in
+// development/app/config/mock/config-profile.yaml.
+func TestModelRPSLimit(t *testing.T) {
+	msg := "rps limit test message"
+
+	// waitForFreshWindow sleeps until the current 1-second Redis window expires,
+	// ensuring the counter is at zero at the start of each sub-test.
+	waitForFreshWindow := func() {
+		time.Sleep(1100 * time.Millisecond)
+	}
+
+	sendRequest := func(t *testing.T, profile string) error {
+		t.Helper()
+		client := createOpenAIClientWithConfigProfile(gatewayURL, apiKey, profile, nil)
+		_, err := client.Chat.Completions.New(context.TODO(), openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage(msg)},
+			Model:    modelNameQwen3,
+		})
+		return err
+	}
+
+	t.Run("first_request_succeeds", func(t *testing.T) {
+		waitForFreshWindow()
+
+		err := sendRequest(t, "rps-limited")
+		require.NoError(t, err, "first request within the RPS limit should succeed")
+	})
+
+	t.Run("second_request_in_same_window_is_rejected", func(t *testing.T) {
+		waitForFreshWindow()
+
+		// First request exhausts the 1 RPS budget.
+		err := sendRequest(t, "rps-limited")
+		require.NoError(t, err, "first request should succeed")
+
+		// Second request in the same 1-second window must be rejected.
+		err = sendRequest(t, "rps-limited")
+		require.Error(t, err, "second request should be rejected after RPS limit is exhausted")
+
+		var apiErr *openai.Error
+		require.True(t, errors.As(err, &apiErr), "error should be an openai API error, got: %v", err)
+		assert.Equal(t, 429, apiErr.StatusCode, "exceeded RPS limit should return HTTP 429")
+	})
+
+	t.Run("requests_succeed_after_window_resets", func(t *testing.T) {
+		waitForFreshWindow()
+
+		// Exhaust the window.
+		err := sendRequest(t, "rps-limited")
+		require.NoError(t, err, "first request should succeed")
+
+		err = sendRequest(t, "rps-limited")
+		require.Error(t, err, "second request should be throttled")
+
+		// Wait for the window to roll over, then verify requests succeed again.
+		waitForFreshWindow()
+
+		err = sendRequest(t, "rps-limited")
+		require.NoError(t, err, "request in the next window should succeed after the counter resets")
+	})
+
+	t.Run("no_rps_limit_without_rps_profile", func(t *testing.T) {
+		// The default profile has no requestsPerSecond, so multiple rapid requests
+		// to the same model must all succeed regardless of how many are sent.
+		for i := 0; i < 3; i++ {
+			err := sendRequest(t, "least-request")
+			require.NoError(t, err, "request %d without RPS profile should succeed", i+1)
+		}
+	})
+}


### PR DESCRIPTION
## Pull Request Description

### Summary
Adds per-model requests-per-second (RPS) rate limiting to the Aibrix gateway. Operators can now configure a `requestsPerSecond` cap on a named config profile. The gateway enforces this cluster-wide using a shared Redis fixed-window counter (1-second window). When Redis is unavailable, the system falls back to the existing no-op limiter to ensure local development remains unaffected.

---

### Changes
* **`ResolvedConfigProfile` / `ModelConfigProfile`**: Added a new `requestsPerSecond` (int64) field propagated from model annotations to the routing context.
* **`gateway.go`**: Initialized a second `RateLimiter` instance (`modelRateLimiter`) with a 1-second window and a distinct `aibrix_model` Redis key prefix.
* **`gateway_ratelimit.go`**: 
    * `enforceModelRPS`: Implements the incr-then-check gate.
    * `decrModelRPS`: Handles deferred compensation.
    * `modelRPSKey`: Centralizes the Redis key formatting.
* **`gateway_req_body.go`**: Integrated `enforceModelRPS` before routing for "fail-fast" behavior. Implemented a `needsRollback` flag to refund quota via `decrModelRPS` if routing fails.
* **`types.go`**: Added error-header constants: `x-error-model-rps-exceeded` and `x-error-incr-model-rps`.
* **`ratelimiter/README.md`**: Updated documentation covering key schemes, rotation, and enforcement flow.
* **Tests**:
    * **Unit**: `gateway_ratelimit_test.go` covers nil profiles, zero RPS, increment failures, and rollback logic.
    * **E2E**: `test/e2e/model_rps_limit_test.go` validates 429 rejections, window resets, and baseline success.

---

### Design Notes
* **Incr-then-check (Race-free enforcement)**: To avoid TOCTOU (time-of-check to time-of-use) windows, the gate uses a single atomic `INCRBY`. If the returned value exceeds the limit, the request is rejected immediately without extra Redis round-trips.
* **Deferred Compensation**: After a successful increment, a `needsRollback` flag is armed. If routing fails, `decrModelRPS` refunds the quota so that failed requests do not consume the RPS budget.

---

### Example Config Profile
```yaml
profiles:
  rps-limited:
    routingStrategy: least-request
    requestsPerSecond: 1
```

---

### Related Issues
Resolves: #2138


**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>