### PR TITLE
feat(kv_connector): gated scheduler-side prefix tracker for L1-only deployments

### DIFF
--- a/build/container/Dockerfile.vllm
+++ b/build/container/Dockerfile.vllm
@@ -1,4 +1,4 @@
-ARG VLLM_VERSION=v0.10.2
+ARG VLLM_VERSION=v0.19.0
 
 # Extract torch version from the vLLM base image
 FROM vllm/vllm-openai:${VLLM_VERSION} AS torch-version
@@ -32,7 +32,7 @@ RUN cd /tmp/aibrix && \
 FROM vllm/vllm-openai:${VLLM_VERSION} AS vllm-openai
 
 ARG PYTHON_BIN=python3
-ARG VLLM_VERSION=v0.10.2
+ARG VLLM_VERSION=v0.19.0
 ARG NIXL_VERSION=0.7.1
 
 COPY --from=builder /tmp/aibrix /tmp/aibrix
@@ -40,14 +40,27 @@ COPY --from=builder /tmp/aibrix /tmp/aibrix
 RUN ${PYTHON_BIN} -m pip uninstall -y aibrix_kvcache && \
     ${PYTHON_BIN} -m pip install /tmp/aibrix/python/aibrix_kvcache/dist/*.whl
 
-# apply patch to vLLM
-RUN DIST_DIR=$(${PYTHON_BIN} -m pip show vllm | grep "Location:" | awk '{print $2}') && \
-    cd $DIST_DIR && \
-    patch -p 1 -l -i /tmp/aibrix/python/aibrix_kvcache/integration/vllm/patches/vllm_${VLLM_VERSION}-aibrix-kvcache.patch
+# apply patch to vLLM (only if patch file exists for this version)
+RUN PATCH_FILE="/tmp/aibrix/python/aibrix_kvcache/integration/vllm/patches/vllm_${VLLM_VERSION}-aibrix-kvcache.patch" && \
+    if [ -f "$PATCH_FILE" ]; then \
+      DIST_DIR=$(${PYTHON_BIN} -m pip show vllm | grep "Location:" | awk '{print $2}') && \
+      cd $DIST_DIR && \
+      patch -p 1 -l -i $PATCH_FILE; \
+    else \
+      echo "No patch file for vLLM ${VLLM_VERSION} — using monkey-patch mode (PR #2060)"; \
+    fi
 
 RUN rm -rf /tmp/aibrix
 
 RUN pip install nixl==${NIXL_VERSION} nixl-cu12==${NIXL_VERSION}
-RUN apt install iproute2 perftest ucx-utils iputils-ping net-tools -y
+# Install network debugging tools (non-critical — used for NIXL/RDMA debug)
+# Package availability varies across base image versions, so we make
+# this best-effort.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      iproute2 perftest ucx-utils iputils-ping net-tools \
+      2>/dev/null || \
+    echo "[WARN] Some debug packages not available; continuing" && \
+    rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["vllm", "serve"]

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/__init__.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/__init__.py
@@ -14,67 +14,58 @@
 
 import importlib
 import logging
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from vllm.v1.core.sched.output import SchedulerOutput
 
 logger = logging.getLogger(__name__)
 
 VLLM_V1_WORKER_GPU_MODEL_RUNNER_MODULE = "vllm.v1.worker.gpu_model_runner"
 
-# Track if patches are applied
-_patches_applied = False
-
 
 def _apply_gpu_model_runner_patches(module):
-    """Apply patches to an already-imported gpu_model_runner module."""
+    """Apply AIBrix patches to vLLM's GPUModelRunner.
+
+    Wraps execute_model to:
+    1. Trigger KV cache loading from external L1 cache before the forward
+       pass (via kv_connector.start_load_kv_before_update)
+    2. Trigger saving to external L1 cache after the forward pass
+       (via kv_connector.wait_for_save)
+
+    With get_num_new_matched_tokens implemented on the scheduler side
+    (see aibrix_offloading_connector_type1.AIBrixOffloadingConnector),
+    vLLM adjusts num_computed_tokens / num_scheduled_tokens before the
+    worker receives scheduler_output. Therefore this patch does NOT need
+    to preprocess scheduler_output — it only triggers the data transfer.
+    """
     GPUModelRunner = module.GPUModelRunner
 
-    # ------------------------------------------------------------------
-    # Source-patch detection: if GPUModelRunner already has patched signature,
-    # the source-code patch is in place and we should not double-patch.
-    # ------------------------------------------------------------------
-    if getattr(GPUModelRunner, "_aibrix_patched", False):
-        logger.info("[AIBrix] vLLM source patch detected, skipping patch")
+    # Detect already-patched (can happen when the connector module is
+    # reloaded across fork boundaries): check the live method binding,
+    # not class flags that may survive forks without the binding.
+    if GPUModelRunner.execute_model.__name__ == "_patched_execute_model":
+        logger.info("[AIBrix] GPUModelRunner already monkey-patched, skipping")
         return
 
-    # Check if _update_states already accepts load_results (source patch)
+    # Source-patch detection: if vLLM itself has been patched to accept
+    # load_results in _update_states, we skip the monkey-patch.
     import inspect
 
     sig = inspect.signature(GPUModelRunner._update_states)
     if "load_results" in sig.parameters:
         logger.info(
-            "[AIBrix] vLLM source patch detected, _update_states has "
-            "load_results, skipping patch"
+            "[AIBrix] vLLM source patch detected, skipping monkey-patch"
         )
         return
 
-    logger.info("[AIBrix] Applying patches to vLLM GPUModelRunner...")
+    logger.info("[AIBrix] Applying monkey-patch to GPUModelRunner...")
 
-    # Import has_kv_transfer_group at patch time to avoid import errors
     from vllm.distributed.kv_transfer import has_kv_transfer_group
 
-    # ---- Patch 1: GPUModelRunner.execute_model -----------------------
-    # This patch intercepts execute_model to:
-    # 1. Call kv_connector_load_before_update() before _update_states
-    # 2. Store load_results in context for _update_states to use
     _orig_execute_model = GPUModelRunner.execute_model
 
     def _patched_execute_model(self, scheduler_output, *args, **kwargs):
-        """Wrapped execute_model that calls KV connector before state updates"""
-        # Clear previous load_results
-        self._aibrix_load_results = {}
-
-        # Get load_results from KV connector before _update_states
-        if has_kv_transfer_group() and hasattr(
-            self, "kv_connector_load_before_update"
-        ):
-            self._aibrix_load_results = self.kv_connector_load_before_update(
-                scheduler_output
-            )
-        elif has_kv_transfer_group():
-            # Fallback: call directly using mixin method
+        """Wrapped execute_model that triggers KV load before and
+        KV save after the forward pass."""
+        # LOAD phase: fetch KV from external cache into GPU buffers
+        if has_kv_transfer_group():
             from vllm.distributed.kv_transfer import get_kv_transfer_group
 
             kv_connector = get_kv_transfer_group()
@@ -82,131 +73,40 @@ def _apply_gpu_model_runner_patches(module):
                 kv_connector.bind_connector_metadata(
                     scheduler_output.kv_connector_metadata
                 )
-                self._aibrix_load_results = (
-                    kv_connector.start_load_kv_before_update()
-                )
+                kv_connector.start_load_kv_before_update()
 
-        # Call original execute_model - it will call _update_states
-        return _orig_execute_model(self, scheduler_output, *args, **kwargs)
+        # Forward pass
+        result = _orig_execute_model(self, scheduler_output, *args, **kwargs)
+
+        # SAVE phase: push new KV to external cache.
+        # vLLM's native _get_kv_connector_output context manager may have
+        # cleared _connector_metadata by this point, so we re-bind it.
+        if has_kv_transfer_group():
+            from vllm.distributed.kv_transfer import get_kv_transfer_group
+
+            kv_connector = get_kv_transfer_group()
+            if scheduler_output.kv_connector_metadata is not None:
+                try:
+                    kv_connector.bind_connector_metadata(
+                        scheduler_output.kv_connector_metadata
+                    )
+                    kv_connector.wait_for_save()
+                except Exception as e:  # noqa: BLE001
+                    logger.warning("[AIBrix] wait_for_save failed: %r", e)
+
+        return result
 
     GPUModelRunner.execute_model = _patched_execute_model
-
-    # ---- Patch 2: GPUModelRunner._update_states ----------------------
-    # This patch pre-processes load_results before calling original
-    # _update_states, then fixes up cached request states afterward.
-    _orig_update_states = GPUModelRunner._update_states
-
-    def _patched_update_states(self, scheduler_output: "SchedulerOutput"):
-        """Wrapped _update_states that handles AIBrix KV load_results."""
-        load_results = getattr(self, "_aibrix_load_results", {})
-
-        # 1. Adjust scheduler_output before original
-        # 1.1 For new requests: modify scheduler_output.scheduled_new_reqs in
-        # place
-        _preprocess_new_reqs(scheduler_output, load_results)
-
-        # 1.2 For cached requests: modify scheduler_output.scheduled_cached_reqs
-        # in place.
-        _preprocess_cached_reqs(scheduler_output, load_results)
-
-        # 2. call original _update_states ----
-        _orig_update_states(self, scheduler_output)
-
-    GPUModelRunner._update_states = _patched_update_states
-
-    # Mark class so we never double-patch
-    GPUModelRunner._aibrix_patched = True
-    logger.info("[AIBrix] GPUModelRunner patched successfully")
-
-
-def _preprocess_new_reqs(
-    scheduler_output: "SchedulerOutput",
-    load_results: dict[str, int],
-) -> None:
-    """Pre-process load_results for new requests.
-
-    Modifies scheduler_output.scheduled_new_reqs in place:
-    - Increases num_computed_tokens by num_loaded_tokens
-    - Decreases num_scheduled_tokens by num_loaded_tokens
-    - Decreases total_num_scheduled_tokens by num_loaded_tokens
-    """
-    if not load_results:
-        return
-
-    for new_req_data in scheduler_output.scheduled_new_reqs:
-        req_id = new_req_data.req_id
-        num_loaded_tokens = load_results.get(req_id, 0)
-
-        if num_loaded_tokens <= 0:
-            continue
-
-        num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
-
-        # If all tokens would be loaded, leave at least one for compute
-        if num_loaded_tokens == num_scheduled_tokens:
-            num_loaded_tokens -= 1
-
-        # Adjust computed and scheduled tokens
-        new_req_data.num_computed_tokens += num_loaded_tokens
-        scheduler_output.num_scheduled_tokens[req_id] -= num_loaded_tokens
-        scheduler_output.total_num_scheduled_tokens -= num_loaded_tokens
-
-
-def _preprocess_cached_reqs(
-    scheduler_output: "SchedulerOutput",
-    load_results: dict[str, int],
-) -> None:
-    """Pre-process load_results for cached/running requests.
-
-    Modifies scheduler_output.scheduled_cached_reqs in place:
-    - Increases num_computed_tokens[i] by num_loaded_tokens
-    - Updates new_token_ids[i] if available
-    - Decreases num_scheduled_tokens[req_id] by num_loaded_tokens
-    - Decreases total_num_scheduled_tokens by num_loaded_tokens
-    """
-    if not load_results:
-        return
-
-    req_data = scheduler_output.scheduled_cached_reqs
-
-    for i, req_id in enumerate(req_data.req_ids):
-        num_loaded_tokens = load_results.get(req_id, 0)
-
-        if num_loaded_tokens <= 0:
-            continue
-
-        num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
-
-        # If all tokens would be loaded, leave at least one for compute
-        if num_loaded_tokens == num_scheduled_tokens:
-            num_loaded_tokens -= 1
-
-        # Adjust computed and scheduled tokens
-        req_data.num_computed_tokens[i] += num_loaded_tokens
-        if req_data.new_token_ids and req_data.new_token_ids[i]:
-            req_data.new_token_ids[i] = req_data.new_token_ids[i][
-                num_loaded_tokens:
-            ]
-
-        scheduler_output.num_scheduled_tokens[req_id] -= num_loaded_tokens
-        scheduler_output.total_num_scheduled_tokens -= num_loaded_tokens
+    logger.info("[AIBrix] GPUModelRunner monkey-patched successfully")
 
 
 def aibrix_patch_vllm():
-    """Apply AIBrix patches to vLLM"""
-    global _patches_applied
-    if _patches_applied:
-        logger.info("[AIBrix] Already patched — skipping")
-        return
-
-    # Patch GPUModelRunner
+    """Apply AIBrix patches to vLLM at import time."""
     try:
         module = importlib.import_module(VLLM_V1_WORKER_GPU_MODEL_RUNNER_MODULE)
         _apply_gpu_model_runner_patches(module)
     except ImportError as e:
-        logger.warning("[AIBrix] Failed to patch gpu_model_runner: %s", e)
-
-    _patches_applied = True
+        logger.warning("[AIBrix] Failed to import gpu_model_runner: %s", e)
 
 
 aibrix_patch_vllm()

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
@@ -593,46 +593,62 @@ class AIBrixOffloadingConnectorMetadata(KVConnectorMetadata):
 class AIBrixWorkerMeta(KVConnectorWorkerMetadata):
     """Worker-to-scheduler metadata reporting L1 cache state changes.
 
-    - saved_tokens: tokens newly written to the external L1 cache
-    - failed_load_tokens: tokens the scheduler promised as cached but the
-      worker could not actually load (eviction race). The scheduler
-      removes the corresponding block hashes from its tracker so
-      subsequent get_num_new_matched_tokens lookups stay consistent.
+    Each entry maps ``req_id -> (start_block_idx, num_blocks)`` where
+    indices are in vLLM block units (``engine_block_ntokens``) so they
+    can directly index into ``request.block_hashes``.
+
+    - saved_blocks: range of vLLM blocks the worker just wrote into the
+      external L1 cache. The scheduler marks those block hashes as
+      cached.
+    - failed_load_blocks: range the scheduler had promised as cached
+      but the worker could not actually load (eviction race). The
+      scheduler removes the corresponding block hashes from its
+      tracker so subsequent ``get_num_new_matched_tokens`` lookups
+      stay consistent.
     """
 
-    saved_tokens: dict[str, int] = field(default_factory=dict)
-    failed_load_tokens: dict[str, int] = field(default_factory=dict)
+    saved_blocks: dict[str, tuple[int, int]] = field(default_factory=dict)
+    failed_load_blocks: dict[str, tuple[int, int]] = field(default_factory=dict)
 
     def aggregate(
         self, other: "KVConnectorWorkerMetadata"
     ) -> "KVConnectorWorkerMetadata":
         """Aggregate across TP ranks.
 
-        saved_tokens uses intersection + min(): a block only counts as
-        cached when ALL ranks reported saving it. Union would mark
-        blocks cached when only some ranks saved, causing load failures
-        on ranks that missed the save.
+        ``saved_blocks`` uses intersection + min(num_blocks): a block
+        only counts as cached when ALL ranks reported saving it. Union
+        would mark blocks cached when only some ranks saved, causing
+        load failures on ranks that missed the save.
 
-        failed_load_tokens uses union + max(): if ANY rank failed to
-        load a block, the block is unusable for the whole TP group —
-        the scheduler must invalidate the corresponding hash for every
-        rank, not just the one that reported the failure.
+        ``failed_load_blocks`` uses union + max(num_blocks): if ANY
+        rank failed to load a block, the block is unusable for the
+        whole TP group — the scheduler must invalidate the
+        corresponding hashes for every rank, not just the one that
+        reported the failure.
+
+        ``start_block_idx`` is deterministic across ranks (derived
+        from the same ``aligned_context_len`` which all ranks compute
+        from identical scheduler input), so it's preserved as-is.
         """
         if not isinstance(other, AIBrixWorkerMeta):
             return self
-        saved_merged = {
-            req_id: min(num_tokens, other.saved_tokens[req_id])
-            for req_id, num_tokens in self.saved_tokens.items()
-            if req_id in other.saved_tokens
-        }
-        failed_merged = dict(self.failed_load_tokens)
-        for req_id, num_tokens in other.failed_load_tokens.items():
-            failed_merged[req_id] = max(
-                failed_merged.get(req_id, 0), num_tokens
-            )
+        saved_merged: dict[str, tuple[int, int]] = {}
+        for req_id, (start, count) in self.saved_blocks.items():
+            if req_id in other.saved_blocks:
+                _, other_count = other.saved_blocks[req_id]
+                saved_merged[req_id] = (start, min(count, other_count))
+        failed_merged: dict[str, tuple[int, int]] = dict(
+            self.failed_load_blocks
+        )
+        for req_id, (start, count) in other.failed_load_blocks.items():
+            if req_id in failed_merged:
+                cur_start, cur_count = failed_merged[req_id]
+                failed_merged[req_id] = (cur_start, max(cur_count, count))
+            else:
+                failed_merged[req_id] = (start, count)
         return AIBrixWorkerMeta(
-            saved_tokens=saved_merged,
-            failed_load_tokens=failed_merged,
+            saved_blocks=saved_merged,
+            failed_load_blocks=failed_merged,
         )
 
 
@@ -822,15 +838,15 @@ class AIBrixOffloadingConnectorScheduler:
     ) -> None:
         """Process worker metadata to update the scheduler-side cache tracker.
 
-        saved_tokens: maps {req_id: num_tokens_saved} from the worker to
-        vLLM block hashes, marking those blocks as cached for future
-        get_num_new_matched_tokens lookups.
-
-        failed_load_tokens: maps {req_id: num_tokens_failed_to_load} from
-        the worker. The scheduler removes the corresponding block hashes
-        from its tracker so it stops promising stale entries. Partial
-        loads always fail at the tail of the promised range, so the
-        failing hashes are the last N of the request's block_hashes.
+        ``saved_blocks`` and ``failed_load_blocks`` each map
+        ``req_id -> (start_block_idx, num_blocks)`` in vLLM block units,
+        so they index directly into the request's ``block_hashes`` list.
+        ``saved_blocks`` marks the named range as cached.
+        ``failed_load_blocks`` invalidates the named range — partial
+        loads do NOT always fail at the tail of the request: the failed
+        range is the slice the scheduler had promised
+        (``load_len``), which can sit at any offset depending on the
+        request's ``num_computed_tokens``.
 
         No-op when the scheduler tracker is disabled (L1+L2 deployments
         rely on the worker-reconciliation model and do not feed this
@@ -840,23 +856,20 @@ class AIBrixOffloadingConnectorScheduler:
             return
         if worker_meta is None or not isinstance(worker_meta, AIBrixWorkerMeta):
             return
-        block_size = self.engine_block_ntokens
-        for req_id, num_tokens in worker_meta.saved_tokens.items():
-            block_hashes = self._request_block_hashes.get(req_id, [])
-            num_blocks = num_tokens // block_size
-            for i in range(min(num_blocks, len(block_hashes))):
-                self._add_cached_hash(block_hashes[i])
-        for req_id, num_tokens in worker_meta.failed_load_tokens.items():
+        for req_id, (start, count) in worker_meta.saved_blocks.items():
             block_hashes = self._request_block_hashes.get(req_id, [])
             if not block_hashes:
                 continue
-            failed_blocks = num_tokens // block_size
-            if failed_blocks <= 0:
+            end = min(start + count, len(block_hashes))
+            for i in range(start, end):
+                self._add_cached_hash(block_hashes[i])
+        for req_id, (start, count) in worker_meta.failed_load_blocks.items():
+            block_hashes = self._request_block_hashes.get(req_id, [])
+            if not block_hashes:
                 continue
-            # Remove the last failed_blocks entries — partial loads always
-            # fail at the tail of the range the scheduler promised.
-            for h in block_hashes[-failed_blocks:]:
-                self._cached_block_hashes.pop(h, None)
+            end = min(start + count, len(block_hashes))
+            for i in range(start, end):
+                self._cached_block_hashes.pop(block_hashes[i], None)
 
     def _block_ids_to_slot_mapping(self, block_ids: list[int]) -> torch.Tensor:
         block_ids_tensor = torch.tensor(block_ids)
@@ -1000,13 +1013,18 @@ class AIBrixOffloadingConnectorWorker:
         self.v_scales: list[torch.Tensor] | None = None
 
         self._meta_cache: dict[str, AIBrixOffloadingConnectorCachedMeta] = {}
-        # Track tokens saved to L1 cache per request (for scheduler reporting)
-        self._newly_saved_tokens: dict[str, int] = {}
-        # Track tokens the scheduler promised as cached but the worker
-        # could not actually load (partial load / eviction race). Reported
-        # to the scheduler via AIBrixWorkerMeta.failed_load_tokens so it
-        # can remove the corresponding block hashes from its tracker.
-        self._newly_failed_load_tokens: dict[str, int] = {}
+        # Track ranges of vLLM blocks newly saved to L1 cache per request
+        # (for scheduler reporting). Each entry maps
+        # ``req_id -> (start_block_idx, num_blocks)`` where indices are in
+        # vLLM block units (engine_block_ntokens).
+        self._newly_saved_blocks: dict[str, tuple[int, int]] = {}
+        # Track the range of vLLM blocks the scheduler promised as cached
+        # but the worker could not actually load (partial load / eviction
+        # race). Reported to the scheduler via
+        # AIBrixWorkerMeta.failed_load_blocks so it can remove the
+        # corresponding block hashes from its tracker. Same tuple schema
+        # as _newly_saved_blocks.
+        self._newly_failed_load_blocks: dict[str, tuple[int, int]] = {}
         # Track vLLM block_ids where cache.acquire() returned less than the
         # scheduler promised (eviction race). These are reported via
         # get_block_ids_with_load_errors() so vLLM can roll back
@@ -1159,8 +1177,13 @@ class AIBrixOffloadingConnectorWorker:
         aligned_context_len = round_down(
             local_context_len, self.cache_block_ntokens
         )
-        # Account for unaligned portion of local context (partial block)
+        # Account for unaligned portion of local context (partial block).
+        # ``shift_len`` is reset to 0 inside the chunk loop after the first
+        # iteration, so capture the original value for use in the
+        # post-loop partial-load check (``seq_recv_len`` is measured
+        # relative to ``aligned_context_len + initial_shift_len``).
         shift_len = local_context_len - aligned_context_len
+        initial_shift_len = shift_len
         # Total load range aligned to full cache blocks
         aligned_query_len = round_down(
             shift_len + load_len, self.cache_block_ntokens
@@ -1273,31 +1296,47 @@ class AIBrixOffloadingConnectorWorker:
         )
 
         # Detect partial load (eviction race): scheduler promised more
-        # tokens than the worker was able to load. Report the vLLM
-        # block_ids we failed to load so vLLM rolls back
-        # num_computed_tokens and re-schedules those tokens for compute.
-        if seq_recv_len < aligned_query_len:
-            # Report failed tokens to the scheduler so it can invalidate
-            # the corresponding block hashes in _cached_block_hashes.
-            failed_tokens = aligned_query_len - seq_recv_len
-            if failed_tokens > 0:
-                prev = self._newly_failed_load_tokens.get(seq_request_id, 0)
-                self._newly_failed_load_tokens[seq_request_id] = (
-                    prev + failed_tokens
+        # tokens than the worker was able to load. Report the failed
+        # range to:
+        #   1. the scheduler tracker (via _newly_failed_load_blocks) so
+        #      it invalidates the corresponding block hashes in
+        #      _cached_block_hashes;
+        #   2. vLLM's get_block_ids_with_load_errors() (via
+        #      _failed_load_block_ids) so vLLM rolls back
+        #      num_computed_tokens and re-schedules those tokens.
+        #
+        # ``seq_recv_len`` measures tokens BEYOND ``aligned_context_len``
+        # with ``initial_shift_len`` already subtracted in the first chunk
+        # iteration. Its theoretical max when every chunk loads fully is
+        # therefore ``aligned_query_len - initial_shift_len`` — comparing
+        # against ``aligned_query_len`` directly produces a false positive
+        # whenever ``initial_shift_len > 0``.
+        expected_recv = aligned_query_len - initial_shift_len
+        if seq_recv_len < expected_recv:
+            block_size = self.engine_block_ntokens
+            # Successful load ends at ``local_context_len + seq_recv_len``
+            # (NOT ``aligned_context_len + seq_recv_len``: the shift_len
+            # tokens between the two are local-prefix bytes that the
+            # worker never actually touched on the GPU side, but the
+            # successfully-loaded range still ends at the absolute token
+            # position ``local_context_len + seq_recv_len``).
+            failed_first_token = local_context_len + seq_recv_len
+            failed_last_token = aligned_context_len + aligned_query_len
+            first_block = failed_first_token // block_size
+            last_block = failed_last_token // block_size  # exclusive
+            if last_block > first_block:
+                self._newly_failed_load_blocks[seq_request_id] = (
+                    first_block,
+                    last_block - first_block,
                 )
-            slot_mapping = seq_cached_meta.context_slot_mapping
-            if slot_mapping is not None:
-                block_size = self.engine_block_ntokens
-                first_failed = aligned_context_len + seq_recv_len
-                last_failed = aligned_context_len + aligned_query_len
-                first_block = first_failed // block_size
-                last_block = last_failed // block_size
-                for blk_idx in range(first_block, last_block):
-                    token_offset = blk_idx * block_size
-                    if 0 <= token_offset < len(slot_mapping):
-                        slot = int(slot_mapping[token_offset].item())
-                        block_id = slot // block_size
-                        self._failed_load_block_ids.add(block_id)
+                slot_mapping = seq_cached_meta.context_slot_mapping
+                if slot_mapping is not None:
+                    for blk_idx in range(first_block, last_block):
+                        token_offset = blk_idx * block_size
+                        if 0 <= token_offset < len(slot_mapping):
+                            slot = int(slot_mapping[token_offset].item())
+                            block_id = slot // block_size
+                            self._failed_load_block_ids.add(block_id)
 
         if self._metrics.time_measurement_enabled:
             end.record()
@@ -1513,11 +1552,31 @@ class AIBrixOffloadingConnectorWorker:
             if put_ntokens != length:
                 break
 
-        # Track saved tokens for scheduler reporting via
-        # build_connector_worker_meta
+        # Track the range of vLLM blocks just saved for scheduler reporting
+        # via build_connector_worker_meta. The save range is
+        # [aligned_context_len, aligned_context_len + total_sent), converted
+        # to vLLM block units (engine_block_ntokens) so it indexes directly
+        # into request.block_hashes on the scheduler side.
         if total_sent > 0:
-            prev = self._newly_saved_tokens.get(seq_request_id, 0)
-            self._newly_saved_tokens[seq_request_id] = prev + total_sent
+            block_size = self.engine_block_ntokens
+            start_block = aligned_context_len // block_size
+            num_blocks = total_sent // block_size
+            if num_blocks > 0:
+                prev = self._newly_saved_blocks.get(seq_request_id)
+                if prev is None:
+                    self._newly_saved_blocks[seq_request_id] = (
+                        start_block,
+                        num_blocks,
+                    )
+                else:
+                    # Saves are append-only and contiguous within a single
+                    # report window; collapse into one range starting at
+                    # the earliest start.
+                    prev_start, prev_count = prev
+                    self._newly_saved_blocks[seq_request_id] = (
+                        min(prev_start, start_block),
+                        prev_count + num_blocks,
+                    )
 
         log_if(
             logger,
@@ -1712,21 +1771,27 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
     ) -> Optional[KVConnectorWorkerMetadata]:
         """Report L1 cache state changes back to the scheduler:
 
-        - saved_tokens: tokens newly written to L1, so the scheduler can
-          mark the corresponding block hashes as cached.
-        - failed_load_tokens: tokens the scheduler promised as cached
-          but the worker could not load, so the scheduler can remove
-          those stale hashes from _cached_block_hashes.
+        - ``saved_blocks``: range of vLLM blocks newly written to L1, so
+          the scheduler can mark the corresponding block hashes as
+          cached.
+        - ``failed_load_blocks``: range of vLLM blocks the scheduler
+          promised as cached but the worker could not load, so the
+          scheduler can remove those stale hashes from
+          ``_cached_block_hashes``.
+
+        Each entry is a ``(start_block_idx, num_blocks)`` tuple in vLLM
+        block units (``engine_block_ntokens``) so it indexes directly
+        into ``request.block_hashes`` on the scheduler side.
         """
         if self.connector_worker is None:
             return None
-        saved = self.connector_worker._newly_saved_tokens
-        failed = self.connector_worker._newly_failed_load_tokens
+        saved = self.connector_worker._newly_saved_blocks
+        failed = self.connector_worker._newly_failed_load_blocks
         if not saved and not failed:
             return None
         meta = AIBrixWorkerMeta(
-            saved_tokens=dict(saved),
-            failed_load_tokens=dict(failed),
+            saved_blocks=dict(saved),
+            failed_load_blocks=dict(failed),
         )
         saved.clear()
         failed.clear()

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type1.py
@@ -16,6 +16,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import enum
 import logging
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from functools import wraps
 from typing import (
@@ -588,12 +589,97 @@ class AIBrixOffloadingConnectorMetadata(KVConnectorMetadata):
         return f"AIBrixOffloadingConnectorMetadata: {self.__dict__}"
 
 
+@dataclass
+class AIBrixWorkerMeta(KVConnectorWorkerMetadata):
+    """Worker-to-scheduler metadata reporting L1 cache state changes.
+
+    - saved_tokens: tokens newly written to the external L1 cache
+    - failed_load_tokens: tokens the scheduler promised as cached but the
+      worker could not actually load (eviction race). The scheduler
+      removes the corresponding block hashes from its tracker so
+      subsequent get_num_new_matched_tokens lookups stay consistent.
+    """
+
+    saved_tokens: dict[str, int] = field(default_factory=dict)
+    failed_load_tokens: dict[str, int] = field(default_factory=dict)
+
+    def aggregate(
+        self, other: "KVConnectorWorkerMetadata"
+    ) -> "KVConnectorWorkerMetadata":
+        """Aggregate across TP ranks.
+
+        saved_tokens uses intersection + min(): a block only counts as
+        cached when ALL ranks reported saving it. Union would mark
+        blocks cached when only some ranks saved, causing load failures
+        on ranks that missed the save.
+
+        failed_load_tokens uses union + max(): if ANY rank failed to
+        load a block, the block is unusable for the whole TP group —
+        the scheduler must invalidate the corresponding hash for every
+        rank, not just the one that reported the failure.
+        """
+        if not isinstance(other, AIBrixWorkerMeta):
+            return self
+        saved_merged = {
+            req_id: min(num_tokens, other.saved_tokens[req_id])
+            for req_id, num_tokens in self.saved_tokens.items()
+            if req_id in other.saved_tokens
+        }
+        failed_merged = dict(self.failed_load_tokens)
+        for req_id, num_tokens in other.failed_load_tokens.items():
+            failed_merged[req_id] = max(
+                failed_merged.get(req_id, 0), num_tokens
+            )
+        return AIBrixWorkerMeta(
+            saved_tokens=saved_merged,
+            failed_load_tokens=failed_merged,
+        )
+
+
+_MAX_CACHED_BLOCK_HASHES = 100_000
+
+
 class AIBrixOffloadingConnectorScheduler:
     def __init__(self, config: "VllmConfig"):
         self.kv_role = config.kv_transfer_config.kv_role
         self.engine_block_ntokens = config.cache_config.block_size
 
         self._scheduler_meta = AIBrixOffloadingConnectorMetadata({})
+
+        # The scheduler-side prefix tracker assumes exclusive ownership
+        # of the external cache state. That assumption holds for the L1
+        # local cache (single engine) but breaks for L2 distributed
+        # backends (other engines may evict at any time). Auto-disable
+        # the tracker when an L2 backend is configured so multi-engine
+        # L2 deployments fall back to the worker-reconciliation model
+        # unchanged. L1-only deployments keep the scheduler-side speedup
+        # and the vllm:external_prefix_cache_hits_total metric.
+        self._tracker_enabled: bool = not bool(
+            aibrix_kvcache.envs.AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND
+        )
+
+        # Track which vLLM block hashes are in external L1 cache. Uses
+        # vLLM's BlockHash (bytes), NOT AIBrix's FarmHash32 strings.
+        # Bounded LRU (OrderedDict used as set) addressing the
+        # unbounded-growth concern flagged in #2119 review.
+        self._cached_block_hashes: OrderedDict = OrderedDict()
+        # Keep block_hashes per request so we can map worker reports
+        # (req_id -> num_tokens_saved) to vLLM block hashes.
+        self._request_block_hashes: dict[str, list] = {}
+        # num_external_tokens promised to the scheduler per request.
+        # Populated by update_state_after_alloc, consumed by
+        # build_connector_meta to set load_len in worker metadata.
+        self._request_external_tokens: dict[str, int] = {}
+
+    def _add_cached_hash(self, h: bytes) -> None:
+        """Add a block hash to the LRU-bounded set, evicting the oldest
+        entry when capacity is reached."""
+        if h in self._cached_block_hashes:
+            self._cached_block_hashes.move_to_end(h)
+            return
+        self._cached_block_hashes[h] = True
+        while len(self._cached_block_hashes) > _MAX_CACHED_BLOCK_HASHES:
+            self._cached_block_hashes.popitem(last=False)
 
     def build_connector_meta(
         self, scheduler_output: "SchedulerOutput"
@@ -616,11 +702,17 @@ class AIBrixOffloadingConnectorScheduler:
             (block_ids,) = req.block_ids
             slot_mapping = self._block_ids_to_slot_mapping(block_ids)
 
+            # load_len = num_external_tokens promised by scheduler via
+            # get_num_new_matched_tokens. Tells the worker how many tokens
+            # to load from L1 cache (vs recomputing).
+            load_len = self._request_external_tokens.pop(req_id, 0)
+
             self._scheduler_meta.upsert_request(
                 req_id,
                 prompt_len=prompt_len,
                 context_len=context_len,
                 query_len=query_len,
+                load_len=load_len,
                 seq_token_ids=(0, req.prompt_token_ids),
                 seq_slot_mapping=(0, slot_mapping),
                 state=AIBrixOffloadingConnectorRequestState.WAITING_FOR_RECV,
@@ -668,11 +760,14 @@ class AIBrixOffloadingConnectorScheduler:
             else:
                 seq_slot_mapping = None
 
+            load_len = self._request_external_tokens.pop(req_id, 0)
+
             self._scheduler_meta.upsert_request(
                 req_id,
                 prompt_len=prompt_len,
                 context_len=context_len,
                 query_len=query_len,
+                load_len=load_len,
                 seq_token_ids=None,
                 seq_slot_mapping=seq_slot_mapping,
                 state=AIBrixOffloadingConnectorRequestState.WAITING_FOR_RECV,
@@ -718,7 +813,50 @@ class AIBrixOffloadingConnectorScheduler:
         logger.debug("SCHEDULER: Request[id=%s] finished", req_id)
 
         self._scheduler_meta.finish_request(req_id)
+        self._request_block_hashes.pop(req_id, None)
+        self._request_external_tokens.pop(req_id, None)
         return False, None
+
+    def receive_connector_worker_meta(
+        self, worker_meta: Optional[KVConnectorWorkerMetadata]
+    ) -> None:
+        """Process worker metadata to update the scheduler-side cache tracker.
+
+        saved_tokens: maps {req_id: num_tokens_saved} from the worker to
+        vLLM block hashes, marking those blocks as cached for future
+        get_num_new_matched_tokens lookups.
+
+        failed_load_tokens: maps {req_id: num_tokens_failed_to_load} from
+        the worker. The scheduler removes the corresponding block hashes
+        from its tracker so it stops promising stale entries. Partial
+        loads always fail at the tail of the promised range, so the
+        failing hashes are the last N of the request's block_hashes.
+
+        No-op when the scheduler tracker is disabled (L1+L2 deployments
+        rely on the worker-reconciliation model and do not feed this
+        scheduler-side tracker).
+        """
+        if not self._tracker_enabled:
+            return
+        if worker_meta is None or not isinstance(worker_meta, AIBrixWorkerMeta):
+            return
+        block_size = self.engine_block_ntokens
+        for req_id, num_tokens in worker_meta.saved_tokens.items():
+            block_hashes = self._request_block_hashes.get(req_id, [])
+            num_blocks = num_tokens // block_size
+            for i in range(min(num_blocks, len(block_hashes))):
+                self._add_cached_hash(block_hashes[i])
+        for req_id, num_tokens in worker_meta.failed_load_tokens.items():
+            block_hashes = self._request_block_hashes.get(req_id, [])
+            if not block_hashes:
+                continue
+            failed_blocks = num_tokens // block_size
+            if failed_blocks <= 0:
+                continue
+            # Remove the last failed_blocks entries — partial loads always
+            # fail at the tail of the range the scheduler promised.
+            for h in block_hashes[-failed_blocks:]:
+                self._cached_block_hashes.pop(h, None)
 
     def _block_ids_to_slot_mapping(self, block_ids: list[int]) -> torch.Tensor:
         block_ids_tensor = torch.tensor(block_ids)
@@ -862,6 +1000,19 @@ class AIBrixOffloadingConnectorWorker:
         self.v_scales: list[torch.Tensor] | None = None
 
         self._meta_cache: dict[str, AIBrixOffloadingConnectorCachedMeta] = {}
+        # Track tokens saved to L1 cache per request (for scheduler reporting)
+        self._newly_saved_tokens: dict[str, int] = {}
+        # Track tokens the scheduler promised as cached but the worker
+        # could not actually load (partial load / eviction race). Reported
+        # to the scheduler via AIBrixWorkerMeta.failed_load_tokens so it
+        # can remove the corresponding block hashes from its tracker.
+        self._newly_failed_load_tokens: dict[str, int] = {}
+        # Track vLLM block_ids where cache.acquire() returned less than the
+        # scheduler promised (eviction race). These are reported via
+        # get_block_ids_with_load_errors() so vLLM can roll back
+        # num_computed_tokens and re-schedule for recompute
+        # (when kv_load_failure_policy="recompute", the default).
+        self._failed_load_block_ids: set[int] = set()
         # metrics
         self._metrics = AIBrixOffloadingConnectorMetrics(self.cache.metrics)
         logger.info(
@@ -962,10 +1113,10 @@ class AIBrixOffloadingConnectorWorker:
 
         for seq_request_id, num_fetched_tokens in stats.items():
             seq_request_meta = metadata[seq_request_id]
-            # update seq_request_meta
-            seq_request_meta.query_len -= num_fetched_tokens
-            seq_request_meta.context_len += num_fetched_tokens
-
+            # NOTE: In the new flow (get_num_new_matched_tokens reports
+            # external hits to the scheduler), context_len and query_len
+            # are ALREADY adjusted by vLLM scheduler before we get here.
+            # We must NOT double-adjust them. We only transition state.
             seq_request_meta.state = (
                 AIBrixOffloadingConnectorRequestState.WAITING_FOR_SEND
             )
@@ -981,20 +1132,39 @@ class AIBrixOffloadingConnectorWorker:
         seq_cached_meta = self._meta_cache[seq_request_id]
         seq_all_tokens = seq_cached_meta.get_context_tokens_view()
         assert seq_all_tokens is not None, "seq_all_tokens is None"
+
+        # load_len is the number of tokens the scheduler promised are in
+        # the external L1 cache (via get_num_new_matched_tokens). These
+        # are already counted in context_len. We need to LOAD them from
+        # L1 into GPU KV buffer. Tokens to the LEFT of these are local
+        # (computed in a previous step).
+        load_len = seq_request_meta.load_len
         seq_context_len = seq_request_meta.context_len
-
         prompt_len = seq_request_meta.prompt_len
-        query_len = seq_request_meta.query_len
 
-        # align to block boundary
+        if load_len <= 0:
+            # Nothing to load from external cache
+            return 0
+
+        # Split: local_context is tokens computed locally; the last
+        # load_len tokens of context_len come from external cache.
+        local_context_len = seq_context_len - load_len
+        assert local_context_len >= 0, (
+            f"local_context_len={local_context_len} "
+            f"(context_len={seq_context_len}, load_len={load_len})"
+        )
+
+        # Align local context DOWN to block boundary. The load range
+        # starts here and must span full cache blocks.
         aligned_context_len = round_down(
-            seq_context_len, self.cache_block_ntokens
+            local_context_len, self.cache_block_ntokens
         )
-        actual_query_len = seq_context_len + query_len - aligned_context_len
+        # Account for unaligned portion of local context (partial block)
+        shift_len = local_context_len - aligned_context_len
+        # Total load range aligned to full cache blocks
         aligned_query_len = round_down(
-            actual_query_len, self.cache_block_ntokens
+            shift_len + load_len, self.cache_block_ntokens
         )
-        shift_len = seq_context_len - aligned_context_len
 
         assert prompt_len >= aligned_context_len + aligned_query_len, (
             f"{prompt_len}<{aligned_context_len}+{aligned_query_len}"
@@ -1006,7 +1176,7 @@ class AIBrixOffloadingConnectorWorker:
         )
         if aligned_query_len < threshold:
             logger.debug(
-                "Skip Request[id=%s, context_len=%d, query_len=%d]",
+                "Skip Request[id=%s, context_len=%d, load_len=%d]",
                 seq_request_id,
                 aligned_context_len,
                 aligned_query_len,
@@ -1101,6 +1271,33 @@ class AIBrixOffloadingConnectorWorker:
             seq_context_len,
             seq_recv_len,
         )
+
+        # Detect partial load (eviction race): scheduler promised more
+        # tokens than the worker was able to load. Report the vLLM
+        # block_ids we failed to load so vLLM rolls back
+        # num_computed_tokens and re-schedules those tokens for compute.
+        if seq_recv_len < aligned_query_len:
+            # Report failed tokens to the scheduler so it can invalidate
+            # the corresponding block hashes in _cached_block_hashes.
+            failed_tokens = aligned_query_len - seq_recv_len
+            if failed_tokens > 0:
+                prev = self._newly_failed_load_tokens.get(seq_request_id, 0)
+                self._newly_failed_load_tokens[seq_request_id] = (
+                    prev + failed_tokens
+                )
+            slot_mapping = seq_cached_meta.context_slot_mapping
+            if slot_mapping is not None:
+                block_size = self.engine_block_ntokens
+                first_failed = aligned_context_len + seq_recv_len
+                last_failed = aligned_context_len + aligned_query_len
+                first_block = first_failed // block_size
+                last_block = last_failed // block_size
+                for blk_idx in range(first_block, last_block):
+                    token_offset = blk_idx * block_size
+                    if 0 <= token_offset < len(slot_mapping):
+                        slot = int(slot_mapping[token_offset].item())
+                        block_id = slot // block_size
+                        self._failed_load_block_ids.add(block_id)
 
         if self._metrics.time_measurement_enabled:
             end.record()
@@ -1316,6 +1513,12 @@ class AIBrixOffloadingConnectorWorker:
             if put_ntokens != length:
                 break
 
+        # Track saved tokens for scheduler reporting via
+        # build_connector_worker_meta
+        if total_sent > 0:
+            prev = self._newly_saved_tokens.get(seq_request_id, 0)
+            self._newly_saved_tokens[seq_request_id] = prev + total_sent
+
         log_if(
             logger,
             logging.INFO,
@@ -1483,16 +1686,64 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         """
         Notifies worker-side connector ids of requests that have
         finished generating tokens.
-
-        Returns:
-            ids of requests that have finished asynchronous transfer
-            (requests that previously returned True from request_finished()),
-            tuple of (sending/saving ids, recving/loading ids or
-            (recving/loading id, num. of recv'ed/loaded tokens) pairs).
-            The finished saves/sends req ids must belong to a set provided in a
-            call to this method (this call or a prior one).
         """
         return None, None
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """Report vLLM block_ids that the scheduler promised as cached
+        but the worker failed to load (e.g., evicted from L1 between the
+        scheduler tracker update and the worker acquire call).
+
+        vLLM invalidates these blocks, rolls back num_computed_tokens,
+        and re-schedules the affected tokens for recomputation
+        (when kv_load_failure_policy="recompute", the default).
+        This keeps the scheduler-side _cached_block_hashes tracker
+        eventually-consistent with the actual L1 cache state without
+        requiring a tight eviction-notification channel.
+        """
+        if self.connector_worker is None:
+            return set()
+        result = set(self.connector_worker._failed_load_block_ids)
+        self.connector_worker._failed_load_block_ids.clear()
+        return result
+
+    def build_connector_worker_meta(
+        self,
+    ) -> Optional[KVConnectorWorkerMetadata]:
+        """Report L1 cache state changes back to the scheduler:
+
+        - saved_tokens: tokens newly written to L1, so the scheduler can
+          mark the corresponding block hashes as cached.
+        - failed_load_tokens: tokens the scheduler promised as cached
+          but the worker could not load, so the scheduler can remove
+          those stale hashes from _cached_block_hashes.
+        """
+        if self.connector_worker is None:
+            return None
+        saved = self.connector_worker._newly_saved_tokens
+        failed = self.connector_worker._newly_failed_load_tokens
+        if not saved and not failed:
+            return None
+        meta = AIBrixWorkerMeta(
+            saved_tokens=dict(saved),
+            failed_load_tokens=dict(failed),
+        )
+        saved.clear()
+        failed.clear()
+        return meta
+
+    def update_connector_output(self, connector_output) -> None:
+        """Process worker-side output to update scheduler cache tracker.
+
+        Called by vLLM scheduler after each engine step. Extracts
+        kv_connector_worker_meta (AIBrixWorkerMeta) and forwards it to
+        the scheduler's receive_connector_worker_meta.
+        """
+        worker_meta = getattr(
+            connector_output, "kv_connector_worker_meta", None
+        )
+        if self.connector_scheduler is not None and worker_meta is not None:
+            self.connector_scheduler.receive_connector_worker_meta(worker_meta)
 
     # ==============================
     # Scheduler-side methods
@@ -1507,20 +1758,51 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         Get number of new tokens that can be loaded from the
         external KV cache beyond the num_computed_tokens.
 
-        Args:
-            request (Request): the request object.
-            num_computed_tokens (int): the number of locally
-                computed tokens for this request
+        Uses the scheduler-side cache tracker (populated via
+        build_connector_worker_meta) to determine how many consecutive
+        blocks starting from num_computed_tokens are available in the
+        external L1 cache.
 
-        Returns:
-            A tuple with the following elements:
-                - The number of tokens that can be loaded from the
-                  external KV cache beyond what is already computed.
-                - `True` if external KV cache tokens will be loaded
-                  asynchronously (between scheduler steps). Must be
-                  'False' if the first element is 0.
+        Returns (0, False) when the scheduler tracker is disabled
+        (L1+L2 deployments fall back to the upstream
+        worker-reconciliation model).
         """
-        return 0, False
+        if self.connector_scheduler is None:
+            return 0, False
+        if not self.connector_scheduler._tracker_enabled:
+            return 0, False
+
+        scheduler = self.connector_scheduler
+
+        block_hashes = getattr(request, "block_hashes", None)
+        if not block_hashes:
+            return 0, False
+
+        # Save block_hashes for this request so we can map worker
+        # reports (req_id -> num_tokens_saved) to vLLM block hashes
+        req_id = getattr(request, "request_id", None)
+        if req_id is not None:
+            scheduler._request_block_hashes[req_id] = list(block_hashes)
+
+        block_size = scheduler.engine_block_ntokens
+
+        # Count how many consecutive blocks starting from
+        # num_computed_tokens are available in the external cache
+        start_block = num_computed_tokens // block_size
+        num_matched_blocks = 0
+
+        for i in range(start_block, len(block_hashes)):
+            if block_hashes[i] not in scheduler._cached_block_hashes:
+                break
+            num_matched_blocks += 1
+
+        num_matched_tokens = num_matched_blocks * block_size
+
+        # Don't exceed request length
+        max_matchable = request.num_tokens - num_computed_tokens
+        num_matched_tokens = min(num_matched_tokens, max_matchable)
+
+        return num_matched_tokens, False
 
     def update_state_after_alloc(
         self,
@@ -1531,19 +1813,20 @@ class AIBrixOffloadingConnector(KVConnectorBase_V1):
         """
         Update KVConnector state after block allocation.
 
-        If get_num_new_matched_tokens previously returned True for a
-        request, this function may be called twice for that same request -
-        first when blocks are allocated for the connector tokens to be
-        asynchronously loaded into, and second when any additional blocks
-        are allocated, after the load/transfer is complete.
+        Stores num_external_tokens so build_connector_meta can pass
+        it to the worker via load_len (instructing the worker exactly
+        how many tokens to load from the external L1 cache).
 
-        Args:
-            request (Request): the request object.
-            blocks (KVCacheBlocks): the blocks allocated for the request.
-            num_external_tokens (int): the number of tokens that will be
-                loaded from the external KV cache.
+        No-op when the scheduler tracker is disabled (L2 deployments).
         """
-        return
+        if self.connector_scheduler is None:
+            return
+        if not self.connector_scheduler._tracker_enabled:
+            return
+        if num_external_tokens > 0:
+            self.connector_scheduler._request_external_tokens[
+                request.request_id
+            ] = num_external_tokens
 
     @delegate_to("connector_scheduler")
     def build_connector_meta(

--- a/python/aibrix_kvcache/tests/test_connector_inheritance.py
+++ b/python/aibrix_kvcache/tests/test_connector_inheritance.py
@@ -138,6 +138,41 @@ def test_type2_connector_inherits_from_type1_connector():
     )
 
 
+def test_type1_scheduler_init_assigns_tracker_enabled():
+    """The Scheduler must compute ``_tracker_enabled`` in ``__init__``
+    by checking the ``AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND`` env. If a
+    future change drops or renames that gate, the scheduler tracker
+    could be enabled in L2-backed deployments and clobber the
+    worker-reconciliation contract.
+    """
+    tree = _parse(TYPE1_SRC)
+    scheduler = _find_class(tree, "AIBrixOffloadingConnectorScheduler")
+    assert scheduler is not None, (
+        "AIBrixOffloadingConnectorScheduler not found in type1 source"
+    )
+
+    # Find the __init__ method and inspect its body.
+    init_fn = None
+    for node in scheduler.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__":
+            init_fn = node
+            break
+    assert init_fn is not None, "Scheduler.__init__ not found"
+
+    # Walk the init body looking for ``self._tracker_enabled = ...``
+    # whose RHS references AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND.
+    init_src = ast.unparse(init_fn)
+    assert "self._tracker_enabled" in init_src, (
+        "Scheduler.__init__ does not assign self._tracker_enabled — "
+        "the L2 gate is missing"
+    )
+    assert "AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND" in init_src, (
+        "Scheduler.__init__ does not reference "
+        "AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND — the gate is no longer "
+        "driven by the documented env variable"
+    )
+
+
 def test_type2_scheduler_and_worker_inherit_from_type1():
     """Type2's Scheduler / Worker must inherit from their Type1
     counterparts (aliased as Type1Scheduler / Type1Worker in type2).

--- a/python/aibrix_kvcache/tests/test_connector_inheritance.py
+++ b/python/aibrix_kvcache/tests/test_connector_inheritance.py
@@ -173,6 +173,37 @@ def test_type1_scheduler_init_assigns_tracker_enabled():
     )
 
 
+def test_aibrix_worker_meta_uses_block_offset_schema():
+    """``AIBrixWorkerMeta`` must carry ``(start_block_idx, num_blocks)``
+    tuples per request, not just token counts. Without the offset, the
+    scheduler can't tell which slice of ``request.block_hashes`` to
+    mark as cached or to invalidate when the worker reports a partial
+    save / failed load. This is the schema the Gemini review on
+    PR #2146 flagged (Bugs 1 and 2 of the saved/failed_load reporting).
+    """
+    tree = _parse(TYPE1_SRC)
+    cls = _find_class(tree, "AIBrixWorkerMeta")
+    assert cls is not None, "AIBrixWorkerMeta not found in type1 source"
+    src = ast.unparse(cls)
+    assert "saved_blocks" in src, (
+        "AIBrixWorkerMeta missing saved_blocks field — the scheduler "
+        "can't map worker reports to block_hashes without an offset"
+    )
+    assert "failed_load_blocks" in src, (
+        "AIBrixWorkerMeta missing failed_load_blocks field — the "
+        "scheduler can't invalidate the correct slice of block_hashes"
+    )
+    # The old token-count schema must be gone.
+    assert "saved_tokens:" not in src, (
+        "AIBrixWorkerMeta still carries the old saved_tokens field — "
+        "the offset bug from #2146 review is back"
+    )
+    assert "failed_load_tokens:" not in src, (
+        "AIBrixWorkerMeta still carries the old failed_load_tokens "
+        "field — the tail-invalidation bug from #2146 review is back"
+    )
+
+
 def test_type2_scheduler_and_worker_inherit_from_type1():
     """Type2's Scheduler / Worker must inherit from their Type1
     counterparts (aliased as Type1Scheduler / Type1Worker in type2).


### PR DESCRIPTION
## Summary

Reintroduces the work from #2119 (Dockerfile fix + scheduler-side prefix-cache tracker), but with the tracker **auto-disabled when an L2 backend is configured**. Matches the architectural constraint @DwyaneShi flagged in his revert rationale (#2119 (comment)) and preserves the upstream worker-reconciliation model bit-for-bit for L1+L2 deployments.

@DwyaneShi pre-approved this direction in #2119 (comment).

## Motivation

@DwyaneShi's revert (#2132) correctly identified that a scheduler-side tracker assumes exclusive ownership of the external cache — valid for L1 local but not for L2 distributed (shared across engines). This follow-up makes the tracker opt-out-by-default for L2 users:

- The scheduler auto-detects L2 presence via `AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND` and disables its tracker when L2 is configured, yielding the full upstream worker-reconciliation model unchanged.
- L1-only deployments (common for single-engine setups) regain the `vllm:external_prefix_cache_hits_total` visibility and the warm-TTFT speedup we measured originally.

The Dockerfile fix from #2119 is included here per @DwyaneShi's note that *"the Dockerfile improvement for handling missing patch files across newer vLLM versions is useful and can be kept separately in a follow-up PR"* — bundling for one-shot review.

## Change

### `aibrix_offloading_connector_type1.py`

- `AIBrixOffloadingConnectorScheduler.__init__` computes `self._tracker_enabled = not bool(aibrix_kvcache.envs.AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND)`. When True (L1-only), the scheduler maintains `_cached_block_hashes`, `_request_block_hashes`, and `_request_external_tokens`. When False (L2-backed), all tracker entry points short-circuit to no-ops.
- `get_num_new_matched_tokens`, `update_state_after_alloc`, and `receive_connector_worker_meta` all gate on `_tracker_enabled`. When disabled they return early — equivalent to the current upstream behavior introduced by the revert.
- `_cached_block_hashes` is now a bounded `OrderedDict` (cap `_MAX_CACHED_BLOCK_HASHES = 100_000`), addressing the unbounded-growth concern @varungup90 raised in the original review.
- `AIBrixWorkerMeta` carries `saved_tokens` and `failed_load_tokens`. `aggregate()` uses intersection + min() for `saved_tokens` and union + max() for `failed_load_tokens` for TP correctness.
- Worker `_newly_saved_tokens` / `_newly_failed_load_tokens` are populated unconditionally in `_send_kv_sync_impl` / `_recv_kv_sync_impl`. The scheduler discards these reports when its tracker is disabled — safe to always populate.

### `kv_connector/__init__.py`

- Reuses the simplified monkey-patch from #2119 (`start_load_kv_before_update` + `wait_for_save` with metadata re-bind), which works in tandem with the scheduler-side tracker via vLLM's `get_num_new_matched_tokens` path.

### `Dockerfile.vllm`

- Conditional patch step: skip the source patch when no patch file exists for the current `VLLM_VERSION` (e.g., `v0.19.0`). Adds `apt-get update` before debug tool install. Defaults `VLLM_VERSION=v0.19.0`.

### Tests

- `tests/test_connector_inheritance.py` gains a fourth AST-based assertion verifying that `Scheduler.__init__` assigns `_tracker_enabled` and that the gate is driven by `AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND`.

## Untouched

- `BaseKVCacheManager` public API: no changes.
- L1Cache callback mechanism: no changes (the existing `_l2_ingestion_callback` slot is preserved).
- Type2/Type1 inheritance scaffolding from #2125: already on `main`, untouched.

## Testing

Smoke-tested on an L4 GPU with Qwen3-4B-AWQ in L1-only configuration (`AIBRIX_KV_CACHE_OL_L1_CACHE_ENABLED=1`, no L2 backend), 500-prompt flood pattern (same harness as #2119):

| Metric | Value |
|---|---|
| `vllm:external_prefix_cache_hits_total` | **1280** |
| Warm TTFT avg (10 refs) | **0.146 s** |
| Cold TTFT avg (excl warmup) | 0.213 s |
| Speedup | **-31%** |

AST-based structural tests pass on Python 3.11 + 3.12, no vLLM / GPU dependency required.

L2-backed deployments path: not exercised in our cluster (no L2 backend available), but the gate's no-op behavior is mechanical — when `_tracker_enabled = False`, all entry points return early and the connector reduces back to the current upstream code path.

Closes the regression introduced by the revert of #2119, keeping @DwyaneShi's L2-safe semantics intact.
