### PR TITLE
feat: replace k8s annotation with data store as source of truth

### DIFF
--- a/python/aibrix/aibrix/batch/job_entity/k8s_transformer.py
+++ b/python/aibrix/aibrix/batch/job_entity/k8s_transformer.py
@@ -416,25 +416,35 @@ class BatchJobTransformer:
         A special case is cancelling in progress, where state is finalizing, but we need to confirm the
         finalizing time by check the time the job is suspended.
 
+        As of A.2 the JOB_STATE annotation is no longer authoritative
+        and is generally absent. When it is missing, fall through to the
+        K8s-native condition signal: a terminal condition implies
+        FINALIZING; otherwise the Job is CREATED. The kopf-driven
+        ``active_jobs`` view is reconciled with the BatchJobStore via a
+        monotonicity check in ``job_updated_handler``, so this fallback
+        only ever lifts state — it never regresses one.
+
         Returns:
             state: BatchJobState
             finalizing_time: datetime, optional
         """
-        # If state available, respect it.
         state_value = annotations.get(JobAnnotationKey.JOB_STATE.value)
         if state_value:
             state = BatchJobState(state_value)
             if state not in [BatchJobState.IN_PROGRESS, BatchJobState.FINALIZING]:
                 return state, None
-        else:
-            state = BatchJobState.CREATED
-            return state, None
+            if conditions and len(conditions) > 0:
+                return BatchJobState.FINALIZING, conditions[0].last_transition_time
+            return BatchJobState.IN_PROGRESS, None
 
-        # 1. If ConditionTypes are available, the state should always be FINALIZING
+        # JOB_STATE annotation absent (PR4 slim mode): rely solely on
+        # K8s-native conditions. A terminal condition (Complete / Failed
+        # / Suspended) means the underlying Job has stopped advancing on
+        # its own and the AIBrix state machine is at FINALIZING; without
+        # any condition we assume CREATED.
         if conditions and len(conditions) > 0:
             return BatchJobState.FINALIZING, conditions[0].last_transition_time
-
-        return BatchJobState.IN_PROGRESS, None
+        return BatchJobState.CREATED, None
 
     @classmethod
     def _safe_get_attr(cls, obj: Any, attr: str, default: Any = None) -> Any:

--- a/python/aibrix/aibrix/batch/runtime_updater/__init__.py
+++ b/python/aibrix/aibrix/batch/runtime_updater/__init__.py
@@ -1,0 +1,36 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime-side state projection for BatchJobs.
+
+A ``JobStateRuntimeUpdater`` keeps a small, denormalized view of the
+authoritative BatchJob document on whatever runtime executes the job
+(K8s Job annotations, RunPod tags, EC2 tags, ...). The runtime view is
+best-effort and operator-facing only; it is never read back as the
+source of truth — the BatchJobStore remains authoritative.
+
+Note: this layer is provisional. Once the provisioner abstraction
+lands, naming and responsibilities here may shift to align with that
+boundary.
+"""
+
+from aibrix.batch.runtime_updater.base import (
+    JobStateRuntimeUpdater,
+    NoOpJobStateRuntimeUpdater,
+)
+
+__all__ = [
+    "JobStateRuntimeUpdater",
+    "NoOpJobStateRuntimeUpdater",
+]

--- a/python/aibrix/aibrix/batch/runtime_updater/base.py
+++ b/python/aibrix/aibrix/batch/runtime_updater/base.py
@@ -1,0 +1,54 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from abc import ABC, abstractmethod
+
+from aibrix.batch.job_entity.batch_job import BatchJob
+
+logger = logging.getLogger(__name__)
+
+
+class JobStateRuntimeUpdater(ABC):
+    """Update runtime-side metadata to reflect the authoritative BatchJob.
+
+    Implementations write a small projection of BatchJob state onto the
+    runtime that executes the job: K8s Job annotations, RunPod tags, EC2
+    tags, etc. This view is for operator UX and reconciliation/debug; it
+    is never read back as a source of truth — the ``BatchJobStore``
+    remains authoritative.
+
+    Failures are best-effort: implementations should log and swallow
+    transient errors rather than propagate them, so that a successful
+    store write is not rolled back by a failed runtime update. Callers
+    are expected to invoke ``update`` *after* a successful store write.
+
+    Note: this abstraction is provisional and may be folded into the
+    provisioner layer once that abstraction settles.
+    """
+
+    @abstractmethod
+    async def update(self, job: BatchJob) -> None:
+        """Update runtime-side metadata to match ``job``. Best-effort."""
+
+
+class NoOpJobStateRuntimeUpdater(JobStateRuntimeUpdater):
+    """Updater that drops all writes.
+
+    Useful for tests and providers without runtime-side metadata
+    (e.g., bare worker pools).
+    """
+
+    async def update(self, job: BatchJob) -> None:
+        return None

--- a/python/aibrix/aibrix/batch/store/__init__.py
+++ b/python/aibrix/aibrix/batch/store/__init__.py
@@ -1,0 +1,32 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BatchJob document store.
+
+Domain-level abstraction over BatchJob persistence. Callers work with typed
+``BatchJob`` objects; key conventions, serialization, and (future) CAS live
+behind the ``BatchJobStore`` interface so that swapping the underlying
+backend (object storage, DB, ...) does not leak into call sites.
+"""
+
+from aibrix.batch.store.base import BatchJobNotFoundError, BatchJobStore
+from aibrix.batch.store.memory import InMemoryBatchJobStore
+from aibrix.batch.store.object_store import ObjectBatchJobStore
+
+__all__ = [
+    "BatchJobNotFoundError",
+    "BatchJobStore",
+    "InMemoryBatchJobStore",
+    "ObjectBatchJobStore",
+]

--- a/python/aibrix/aibrix/batch/store/base.py
+++ b/python/aibrix/aibrix/batch/store/base.py
@@ -1,0 +1,80 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import Awaitable, Callable, Optional
+
+from aibrix.batch.job_entity.batch_job import BatchJob
+
+
+class BatchJobNotFoundError(KeyError):
+    """Raised when a BatchJob document is not found in the store."""
+
+    def __init__(self, batch_id: str):
+        super().__init__(batch_id)
+        self.batch_id = batch_id
+
+
+class BatchJobStore(ABC):
+    """Typed document store for ``BatchJob`` state.
+
+    Implementations own the storage layout (key path, serialization format)
+    and the consistency model. The interface intentionally hides bytes,
+    paths, and content-type concerns from callers.
+
+    Concurrency model: all implementations currently use last-writer-wins
+    (LWW) on ``put`` — the most recent writer wins, prior writes can be
+    silently overwritten. This is acceptable today because the controller
+    is a single writer for state-machine transitions and the worker only
+    appends usage which is idempotent on ``custom_id``.
+
+    TODO(A.2 follow-up): introduce optimistic concurrency control via an
+    ETag / version token returned by ``get`` and required by ``put`` so
+    that concurrent writers cannot silently clobber each other. The
+    interface will grow a ``put(..., expected_version=...)`` parameter and
+    raise ``BatchJobConflictError`` on mismatch.
+    """
+
+    @abstractmethod
+    async def get(self, batch_id: str) -> Optional[BatchJob]:
+        """Return the stored BatchJob, or ``None`` if absent."""
+
+    @abstractmethod
+    async def put(self, batch_id: str, job: BatchJob) -> None:
+        """Persist ``job`` under ``batch_id`` (last-writer-wins)."""
+
+    @abstractmethod
+    async def delete(self, batch_id: str) -> None:
+        """Remove the BatchJob document. No-op if it does not exist."""
+
+    async def update(
+        self,
+        batch_id: str,
+        mutator: Callable[[BatchJob], Awaitable[BatchJob]],
+    ) -> Optional[BatchJob]:
+        """Read-modify-write convenience helper.
+
+        Reads the current document, passes it to ``mutator``, and writes
+        back the returned BatchJob. Returns the written BatchJob, or
+        ``None`` if no document exists for ``batch_id``.
+
+        TODO(A.2 follow-up): once CAS lands, this becomes a retry loop on
+        version conflicts. Today it is a plain LWW write.
+        """
+        current = await self.get(batch_id)
+        if current is None:
+            return None
+        updated = await mutator(current)
+        await self.put(batch_id, updated)
+        return updated

--- a/python/aibrix/aibrix/batch/store/memory.py
+++ b/python/aibrix/aibrix/batch/store/memory.py
@@ -1,0 +1,46 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from typing import Optional
+
+from aibrix.batch.job_entity.batch_job import BatchJob
+from aibrix.batch.store.base import BatchJobStore
+
+
+class InMemoryBatchJobStore(BatchJobStore):
+    """Process-local BatchJobStore for tests and single-node setups.
+
+    Uses ``BatchJob.model_copy(deep=True)`` on both ingress and egress so
+    callers cannot mutate stored state by holding a reference. A single
+    asyncio lock serializes writes to keep semantics close to the future
+    CAS-backed store.
+    """
+
+    def __init__(self) -> None:
+        self._jobs: dict[str, BatchJob] = {}
+        self._lock = asyncio.Lock()
+
+    async def get(self, batch_id: str) -> Optional[BatchJob]:
+        async with self._lock:
+            job = self._jobs.get(batch_id)
+            return job.model_copy(deep=True) if job is not None else None
+
+    async def put(self, batch_id: str, job: BatchJob) -> None:
+        async with self._lock:
+            self._jobs[batch_id] = job.model_copy(deep=True)
+
+    async def delete(self, batch_id: str) -> None:
+        async with self._lock:
+            self._jobs.pop(batch_id, None)

--- a/python/aibrix/aibrix/batch/store/object_store.py
+++ b/python/aibrix/aibrix/batch/store/object_store.py
@@ -1,0 +1,79 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from aibrix.batch.job_entity.batch_job import BatchJob
+from aibrix.batch.store.base import BatchJobStore
+from aibrix.storage.base import BaseStorage
+
+_DEFAULT_PREFIX = "batches"
+_METADATA_FILE = "metadata.json"
+_CONTENT_TYPE = "application/json"
+
+
+class ObjectBatchJobStore(BatchJobStore):
+    """BatchJobStore backed by an :class:`aibrix.storage.BaseStorage`.
+
+    Layout:
+
+        {prefix}/{batch_id}/metadata.json
+
+    Serialization uses ``by_alias=True`` so the on-disk JSON keys match
+    the API/CRD shape (``typeMeta``, ``jobID``, ``createdAt``, ...) rather
+    than the Python snake_case attribute names — the same shape callers
+    will eventually parse from K8s objects or external tooling.
+    ``exclude_none=True`` keeps optional unset fields (notably
+    ``status.usage`` before the worker reports tokens) absent on disk
+    rather than serialized as ``null``.
+
+    Concurrency: last-writer-wins. ``BaseStorage.put_object`` does not
+    expose ETag-based conditional writes today, so two concurrent writers
+    can clobber each other. The controller is the single writer for
+    state-machine transitions and the worker appends idempotent usage, so
+    LWW is sufficient for now. See ``BatchJobStore`` docstring for the
+    planned CAS upgrade.
+    """
+
+    def __init__(
+        self,
+        storage: BaseStorage,
+        prefix: str = _DEFAULT_PREFIX,
+    ) -> None:
+        self._storage = storage
+        self._prefix = prefix.strip("/")
+
+    def _key(self, batch_id: str) -> str:
+        return f"{self._prefix}/{batch_id}/{_METADATA_FILE}"
+
+    async def get(self, batch_id: str) -> Optional[BatchJob]:
+        try:
+            raw = await self._storage.get_object(self._key(batch_id))
+        except FileNotFoundError:
+            return None
+        return BatchJob.model_validate_json(raw)
+
+    async def put(self, batch_id: str, job: BatchJob) -> None:
+        payload = job.model_dump_json(by_alias=True, exclude_none=True).encode("utf-8")
+        await self._storage.put_object(
+            self._key(batch_id),
+            payload,
+            content_type=_CONTENT_TYPE,
+        )
+
+    async def delete(self, batch_id: str) -> None:
+        try:
+            await self._storage.delete_object(self._key(batch_id))
+        except FileNotFoundError:
+            return

--- a/python/aibrix/aibrix/envs.py
+++ b/python/aibrix/aibrix/envs.py
@@ -107,6 +107,15 @@ STORAGE_REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
 STORAGE_REDIS_DB = int(os.getenv("REDIS_DB", 0))
 STORAGE_REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")
 
+# Batch job state document store (A.2).
+# When enabled, JobCache writes every BatchJob status mutation to a
+# document in object storage and the metadata API serves point reads
+# from it. K8s Job annotations no longer carry runtime status; only
+# the immutable spec annotations the worker reads via the downward API
+# remain. Off means status stays purely in the JobManager in-process
+# pool (legacy single-replica behavior).
+BATCH_JOB_STORE_ENABLED = _is_true(os.getenv("AIBRIX_BATCH_JOB_STORE_ENABLED", "0"))
+
 # Metric Standardizing Related Config
 # Scrape config
 METRIC_SCRAPE_PATH = os.getenv("METRIC_SCRAPE_PATH", "/metrics")

--- a/python/aibrix/aibrix/metadata/api/v1/batch.py
+++ b/python/aibrix/aibrix/metadata/api/v1/batch.py
@@ -34,6 +34,7 @@ from aibrix.batch.job_entity import (
     CompletionWindow,
 )
 from aibrix.batch.manifest import RenderError
+from aibrix.batch.store import BatchJobStore
 from aibrix.batch.template import (
     ProfileOverridesSpec,
     ProfileRegistry,
@@ -712,6 +713,29 @@ async def create_batch(request: Request, batch_spec: BatchSpec) -> BatchResponse
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+async def _resolve_batch_job(request: Request, batch_id: str) -> Optional[BatchJob]:
+    """Resolve a BatchJob by id, store-first with JobManager fallback.
+
+    When ``app.state.batch_job_store`` is configured (A.2 read-flip phase),
+    the store is the source of truth and is consulted first. The fallback
+    to ``JobManager.get_job`` covers the brief window between K8s
+    ``create_namespaced_job`` returning and the kopf ADDED handler
+    persisting the document, since the metadata service seeds the
+    JobManager pool synchronously on POST.
+
+    When the store is not configured, behavior is identical to reading
+    from JobManager directly.
+    """
+    store: Optional[BatchJobStore] = getattr(request.app.state, "batch_job_store", None)
+    if store is not None:
+        job = await store.get(batch_id)
+        if job is not None:
+            return job
+
+    batch_driver: BatchDriver = request.app.state.batch_driver
+    return await batch_driver.run_coroutine(batch_driver.job_manager.get_job(batch_id))
+
+
 @router.get("/{batch_id}")
 async def get_batch(request: Request, batch_id: str) -> BatchResponse:
     """Retrieve a batch by ID.
@@ -720,15 +744,9 @@ async def get_batch(request: Request, batch_id: str) -> BatchResponse:
     request counts, and timestamps.
     """
     try:
-        # Get job controller from app state
-        batch_driver: BatchDriver = request.app.state.batch_driver
-
         logger.debug("Retrieving batch", batch_id=batch_id)  # type: ignore[call-arg]
 
-        # Get job from manager
-        job = await batch_driver.run_coroutine(
-            batch_driver.job_manager.get_job(batch_id)
-        )
+        job = await _resolve_batch_job(request, batch_id)
         if not job:
             logger.warning("Batch not found", batch_id=batch_id)  # type: ignore[call-arg]
             raise HTTPException(status_code=404, detail="Batch not found")
@@ -757,15 +775,15 @@ async def cancel_batch(request: Request, batch_id: str) -> BatchResponse:
 
         logger.info("Cancelling batch", batch_id=batch_id)  # type: ignore[call-arg]
 
-        # Check if job exists
-        job = await batch_driver.run_coroutine(
-            batch_driver.job_manager.get_job(batch_id)
-        )
+        # Check if job exists (store-first read).
+        job = await _resolve_batch_job(request, batch_id)
         if not job:
             logger.warning("Batch not found for cancellation", batch_id=batch_id)  # type: ignore[call-arg]
             raise HTTPException(status_code=404, detail="Batch not found")
 
-        # Cancel the job
+        # Cancel the job. JobManager.cancel_job drives the K8s suspend
+        # patch and the status write to the BatchJobStore via
+        # JobCache._put_to_store.
         success = await batch_driver.run_coroutine(
             batch_driver.job_manager.cancel_job(batch_id)
         )
@@ -773,10 +791,8 @@ async def cancel_batch(request: Request, batch_id: str) -> BatchResponse:
             logger.warning("Failed to cancel batch", batch_id=batch_id)  # type: ignore[call-arg]
             raise HTTPException(status_code=400, detail="Batch cannot be cancelled")
 
-        # Get updated job status
-        updated_job = await batch_driver.run_coroutine(
-            batch_driver.job_manager.get_job(batch_id)
-        )
+        # Get updated job status (store-first again).
+        updated_job = await _resolve_batch_job(request, batch_id)
         if not updated_job:
             logger.error("Job not found after cancellation", batch_id=batch_id)  # type: ignore[call-arg]
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -812,9 +828,13 @@ async def list_batches(
 
         logger.debug("Listing batches", after=after, limit=limit)  # type: ignore[call-arg]
 
-        # Get all jobs from the manager
-        # Note: This is a simple implementation. In production, you'd want
-        # proper pagination and filtering in the JobManager
+        # List still goes through JobManager. Adding a list_by_prefix to
+        # BatchJobStore would require either an eagerly-maintained index
+        # (Redis ZSET keyed by created_at) or an S3 list-objects walk;
+        # the latter does not fit the current cursor-based pagination
+        # cheaply. Point reads already serve from the store, so the
+        # tradeoff only hurts the rare list call.
+        # TODO(A.2 follow-up): wire list to BatchJobStore via an index.
         all_jobs: List[BatchJob] = await batch_driver.run_coroutine(
             batch_driver.job_manager.list_jobs()
         )

--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -25,6 +25,7 @@ from kubernetes import config
 from aibrix import envs
 from aibrix.batch import BatchDriver
 from aibrix.batch.job_entity import JobEntityManager
+from aibrix.batch.store import BatchJobStore, ObjectBatchJobStore
 from aibrix.batch.template import (
     k8s_profile_registry,
     k8s_template_registry,
@@ -199,10 +200,29 @@ def build_app(args: argparse.Namespace, params={}):
             app.state.template_registry = template_registry
             app.state.profile_registry = profile_registry
 
+            batch_job_store: Optional[BatchJobStore] = None
+            if envs.BATCH_JOB_STORE_ENABLED:
+                # Reuse the same backing storage as batch payloads. The
+                # store namespaces its keys under ``batches/`` so it does
+                # not collide with payload files (root-level) or metastore
+                # locks (``batch:...`` colon-prefixed).
+                batch_job_store = ObjectBatchJobStore(
+                    create_storage(settings.STORAGE_TYPE, **params)
+                )
+                logger.info(  # type: ignore[call-arg]
+                    "BatchJobStore enabled",
+                    storage_type=settings.STORAGE_TYPE.value,
+                )
+
             job_entity_manager = JobCache(
                 template_registry=template_registry,
                 profile_registry=profile_registry,
+                batch_job_store=batch_job_store,
             )
+            # Expose the store so API handlers can read from it
+            # directly. When None, handlers fall through to the
+            # JobManager in-memory pool (legacy mode).
+            app.state.batch_job_store = batch_job_store
         app.state.batch_driver = BatchDriver(
             job_entity_manager,
             storage_type=settings.STORAGE_TYPE,

--- a/python/aibrix/aibrix/metadata/cache/job.py
+++ b/python/aibrix/aibrix/metadata/cache/job.py
@@ -24,13 +24,12 @@ from aibrix.batch.job_entity import (
     BatchJobSpec,
     BatchJobState,
     BatchJobStatus,
-    BatchJobTransformer,
-    ConditionType,
     JobAnnotationKey,
     JobEntityManager,
     k8s_job_to_batch_job,
 )
 from aibrix.batch.manifest import JobManifestRenderer
+from aibrix.batch.store import BatchJobStore
 from aibrix.batch.template import ProfileRegistry, TemplateRegistry
 from aibrix.logger import init_logger
 
@@ -70,6 +69,7 @@ class JobCache(JobEntityManager):
         self,
         template_registry: TemplateRegistry,
         profile_registry: ProfileRegistry,
+        batch_job_store: Optional[BatchJobStore] = None,
     ) -> None:
         """Initialize the job cache.
 
@@ -78,6 +78,18 @@ class JobCache(JobEntityManager):
                 Caller must have invoked reload() at least once.
             profile_registry: Loaded BatchProfile registry. Caller must
                 have invoked reload() at least once.
+            batch_job_store: Optional document store that owns BatchJob
+                runtime status (state, conditions, request counts,
+                timestamps, errors, usage). When provided, every status
+                mutation is written here and the metadata API serves
+                point reads from it; K8s Job annotations carry only the
+                immutable spec the worker reads via downward API.
+                Status-write failures are propagated by ``_put_to_store``
+                so callers (including the synchronous /cancel path) see
+                store outages instead of silently leaving the in-memory
+                view ahead of disk. The kopf ADDED seed write keeps the
+                default swallow because the next event re-emits the
+                document.
 
         The legacy hardcoded ``k8s_job_template.yaml`` and
         ``k8s_job_*_patch.yaml`` files are no longer used; manifest
@@ -86,6 +98,11 @@ class JobCache(JobEntityManager):
         """
         # Cache of BatchJob objects keyed by batch ID (K8s UID)
         self.active_jobs: Dict[str, BatchJob] = {}
+
+        # Optional document store; when set, owns the runtime status
+        # half of the BatchJob and is the authoritative source for the
+        # metadata API.
+        self._batch_job_store = batch_job_store
 
         # Register this instance as the global job cache for kopf handlers
         set_global_job_cache(self)
@@ -119,6 +136,60 @@ class JobCache(JobEntityManager):
     def is_scheduler_enabled(self) -> bool:
         """Check if JobEntityManager has own scheduler enabled."""
         return True
+
+    async def _put_to_store(
+        self, job: BatchJob, *, op: str, propagate: bool = False
+    ) -> None:
+        """Persist a BatchJob status mutation to the document store.
+
+        No-op when the store is not configured (legacy mode).
+
+        Status-write callers (``update_job_status``, ``update_job_ready``,
+        ``cancel_job``) pass ``propagate=True`` because the store is the
+        only persistent record of those mutations: a swallowed failure
+        would leave ``active_jobs`` ahead of disk and surface as stale
+        reads after a restart. Eventual-consistency callers (the kopf
+        ADDED handler that seeds the initial document) keep the default
+        ``propagate=False`` since a missed write will be retried the
+        next time kopf re-emits the event.
+
+        ``op`` tags the originating operation for log correlation.
+        """
+        if self._batch_job_store is None:
+            return
+        batch_id = job.status.job_id
+        try:
+            await self._batch_job_store.put(batch_id, job)
+        except Exception as e:
+            logger.warning(  # type: ignore[call-arg]
+                "BatchJobStore write failed",
+                job_id=batch_id,
+                op=op,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            if propagate:
+                raise
+
+    async def _delete_from_store(self, job: BatchJob) -> None:
+        """Remove a BatchJob document from the store.
+
+        Best-effort cleanup that follows a real K8s ``delete`` op; the
+        K8s deletion is the authoritative signal, the store entry is a
+        leaked artifact at worst. Errors are logged and swallowed.
+        """
+        if self._batch_job_store is None:
+            return
+        batch_id = job.status.job_id
+        try:
+            await self._batch_job_store.delete(batch_id)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(  # type: ignore[call-arg]
+                "BatchJobStore delete failed",
+                job_id=batch_id,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
 
     # Implementation of JobEntityManager abstract methods
     def get_job(self, job_id: str) -> Optional[BatchJob]:
@@ -277,6 +348,8 @@ class JobCache(JobEntityManager):
                 async_req=True,
             )
 
+            await self._put_to_store(job, op="update_job_ready", propagate=True)
+
         except ApiException as e:
             if e.status == 409:
                 logger.warning(  # type: ignore[call-arg]
@@ -309,94 +382,38 @@ class JobCache(JobEntityManager):
             raise
 
     async def update_job_status(self, job: BatchJob):
-        """Update job status by persisting status information as annotations.
+        """Persist a job status mutation.
 
-        Args:
-            job (BatchJob): Job with updated status to persist.
+        Status (state, conditions, request_counts, timestamps, errors,
+        usage) is owned by the BatchJobStore as of A.2. K8s annotations
+        on the Job object are no longer written for status — they are a
+        projection that ``kubectl describe`` no longer sees.
 
-        This method persists critical job status information including:
-        - Finalized state
-        - Conditions (completed, failed, cancelled)
-        - Request counts
-        - Timestamps (in_progress_at, completed_at, failed_at, cancelled_at, etc.)
+        Because we no longer trigger a K8s MODIFIED via an annotation
+        patch, the kopf-driven JobCache refresh path does not fire for
+        pure status updates; this method updates ``active_jobs`` and
+        invokes ``job_updated`` directly so the JobManager pool stays
+        in sync with the new status.
         """
-        if not self.batch_v1_api:
-            raise RuntimeError("Kubernetes client not available")
+        # Snapshot the previous view for the callback diff before we
+        # overwrite the cache. The callback expects (old, new); a None
+        # old indicates this is the first time we see the job.
+        batch_id = job.status.job_id
+        old = self.active_jobs.get(batch_id)
 
-        patch_body: Any = None
-        try:
-            # Create status annotations from job status
-            status_annotations = BatchJobTransformer.create_status_annotations(
-                job.status
-            )
+        await self._put_to_store(job, op="update_job_status", propagate=True)
+        self.active_jobs[batch_id] = job
 
-            if not status_annotations:
-                logger.debug("No status annotations to persist", job_id=job.job_id)  # type: ignore[call-arg]
-                return
-
-            # Create patch body to update pod template annotations
-            patch_body = {
-                "metadata": {
-                    "resourceVersion": job.metadata.resource_version,
-                    "annotations": status_annotations,
-                }
-            }
-
-            namespace = job.metadata.namespace or "default"
-
-            logger.info(  # type: ignore[call-arg]
-                "Executing job status update",
-                job_name=job.metadata.name,
-                namespace=namespace,
-                job_id=job.job_id,
-                patch=patch_body,
-            )
-
-            await asyncio.to_thread(
-                self.batch_v1_api.patch_namespaced_job,
-                name=job.metadata.name,
-                namespace=namespace,
-                body=patch_body,
-                async_req=True,
-            )
-
-        except ApiException as e:
-            if e.status == 409:
-                logger.warning(  # type: ignore[call-arg]
-                    "Job status changed",
-                    job=job.metadata.name,
-                    namespace=namespace,
-                    job_id=job.job_id,
-                )
-                raise
-            else:
-                logger.error(  # type: ignore[call-arg]
-                    "Failed to persist job status to Kubernetes",
-                    job_name=job.metadata.name,
-                    namespace=job.metadata.namespace or "default",
-                    job_id=job.job_id,
-                    error=str(e),
-                    status_code=e.status,
-                    reason=e.reason,
-                )
-                raise
-        except Exception as e:
-            logger.error(  # type: ignore[call-arg]
-                "Unexpected error persisting job status",
-                job_name=job.metadata.name,
-                namespace=job.metadata.namespace or "default",
-                job_id=job.job_id,
-                error=str(e),
-                patch=str(patch_body),
-                operation="update_job_status",
-            )
-            raise
+        if old is not None:
+            await self.job_updated(old, job)
 
     async def cancel_job(self, job: BatchJob) -> None:
-        """Cancel job by suspending it and persisting cancellation status.
+        """Cancel a job by suspending the K8s Job and recording status.
 
-        Args:
-            job_id: Job ID (batch ID) to cancel.
+        The K8s side only sees ``spec.suspend = True``; cancellation /
+        failure status is written to the BatchJobStore (and reflected in
+        ``active_jobs``). Status annotations on the K8s Job are no
+        longer written.
 
         Raises:
             RuntimeError: If Kubernetes client is not available.
@@ -416,25 +433,9 @@ class JobCache(JobEntityManager):
         job_name = job.metadata.name
 
         try:
-            # Prepare base annotations
-            annotations_patch = BatchJobTransformer.create_status_annotations(
-                job.status
-            )
-            # Set condition after update based on error or not.
-            if job.status.errors is None:
-                annotations_patch[JobAnnotationKey.CONDITION.value] = (
-                    ConditionType.CANCELLED.value
-                )
-            else:
-                annotations_patch[JobAnnotationKey.CONDITION.value] = (
-                    ConditionType.FAILED.value
-                )
-
-            # Persist conditions (failed, cancelled)
             suspend_patch = {
                 "metadata": {
                     "resourceVersion": job.metadata.resource_version,
-                    "annotations": annotations_patch,
                 },
                 "spec": {
                     "suspend": True  # Suspend the Kubernetes Job (instead of deleting)
@@ -456,6 +457,8 @@ class JobCache(JobEntityManager):
                 body=suspend_patch,
                 async_req=True,
             )
+
+            await self._put_to_store(job, op="cancel_job", propagate=True)
 
         except ApiException as e:
             if e.status == 404:
@@ -522,6 +525,8 @@ class JobCache(JobEntityManager):
                 async_req=True,
             )
 
+            await self._delete_from_store(job)
+
             logger.info(  # type: ignore[call-arg]
                 "Job deletion requested in Kubernetes",
                 job_id=job.job_id,
@@ -558,25 +563,26 @@ class JobCache(JobEntityManager):
             raise
 
     def _ready_batch_job_to_k8s_job_patch(self, job: BatchJob) -> Dict[str, Any]:
-        """Convert BatchJob to Kubernetes Job patch manifest. Only annotations will be patched.
+        """Build the K8s Job patch that flips a prepared batch into running.
 
-        Args:
-            job_spec: BatchJob to convert.
+        The patch carries only what K8s itself needs to act on:
 
-        Returns:
-            patch body object.
+        * ``spec.suspend = False`` to release the Job.
+        * Pod template annotations holding the output / error file IDs
+          the worker reads via the downward API at startup.
+
+        Job-level status annotations (state, conditions, counts, etc.)
+        are owned by the BatchJobStore in A.2 and are no longer mirrored
+        here.
         """
-        # Use pre-loaded template (deep copy to avoid modifying the original)
         job_status: BatchJobStatus = job.status
         assert (
             job_status.in_progress_at is not None
         ), "AssertError: Job must be set as in progress before setting as ready"
 
-        patch_annotations = BatchJobTransformer.create_status_annotations(job_status)
-        patch_body = {
+        return {
             "metadata": {
                 "resourceVersion": job.metadata.resource_version,
-                "annotations": patch_annotations,
             },
             "spec": {
                 "template": {
@@ -592,7 +598,6 @@ class JobCache(JobEntityManager):
                 "suspend": False,
             },
         }
-        return patch_body
 
     def _batch_job_spec_to_k8s_job(
         self,
@@ -634,6 +639,27 @@ class JobCache(JobEntityManager):
 
 
 logger.info("kopf job handlers imported")
+
+
+# Monotonic ordering of BatchJob states. Used by the kopf-driven
+# ``job_updated_handler`` to decide whether a fresh K8s-extracted view
+# may overwrite the in-memory cache: as of PR4 the K8s Job no longer
+# carries authoritative status annotations, so a transformer rebuild
+# triggered by an unrelated K8s mutation (e.g. ``spec.suspend = False``)
+# may yield a lower-state BatchJob. Allowing that through would regress
+# the cache and the JobManager pool behind it.
+_STATE_RANK: Dict[BatchJobState, int] = {
+    BatchJobState.CREATED: 0,
+    BatchJobState.VALIDATING: 1,
+    BatchJobState.IN_PROGRESS: 2,
+    BatchJobState.CANCELLING: 3,
+    BatchJobState.FINALIZING: 4,
+    BatchJobState.FINALIZED: 5,
+}
+
+
+def _state_rank(state: BatchJobState) -> int:
+    return _STATE_RANK.get(state, -1)
 
 
 # Standalone kopf handlers that work with the global JobCache instance
@@ -686,6 +712,11 @@ async def job_created_handler(body: Any, **kwargs: Any) -> None:
             if await job_cache.job_committed(batch_job):
                 # Store in cache
                 job_cache.active_jobs[job_id] = batch_job
+                # Seed the initial document. The K8s ADDED event is
+                # the first time anything outside K8s sees this job, so
+                # the store had no prior entry; subsequent status
+                # mutations also flow through _put_to_store.
+                await job_cache._put_to_store(batch_job, op="job_created")
             else:
                 await job_cache.delete_job(batch_job)
         except Exception as e:
@@ -727,6 +758,25 @@ async def job_updated_handler(body: Any, **kwargs: Any) -> None:
         old_batch_job = job_cache.active_jobs.get(job_id)
         if old_batch_job is None:
             logger.warning("Job updating ignored due to job not found", job_id=job_id)  # type: ignore[call-arg]
+            return
+
+        # PR4 monotonicity: status annotations are no longer the source
+        # of truth, so this kopf event may carry a lower-state view than
+        # the cache (e.g. update_job_ready patches only spec.suspend, so
+        # the transformer derives state=CREATED from the absent
+        # JOB_STATE annotation while the cache already holds
+        # IN_PROGRESS). Drop such echo events outright; the internally
+        # driven update path (JobCache.update_job_status) keeps both the
+        # cache and the BatchJobStore current.
+        if _state_rank(new_batch_job.status.state) < _state_rank(
+            old_batch_job.status.state
+        ):
+            logger.debug(  # type: ignore[call-arg]
+                "Skipping kopf-driven update; cached state is more advanced",
+                job_id=job_id,
+                cached_state=old_batch_job.status.state.value,
+                k8s_view_state=new_batch_job.status.state.value,
+            )
             return
 
         logger.info(

--- a/python/aibrix/tests/batch/test_batch_api_read_flip.py
+++ b/python/aibrix/tests/batch/test_batch_api_read_flip.py
@@ -1,0 +1,175 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the metadata API read-flip helper.
+
+Exercises ``aibrix.metadata.api.v1.batch._resolve_batch_job`` directly
+with stubbed app state, so the test does not need a running FastAPI
+TestClient or a real ``BatchDriver``. The point is to pin down the
+store-first-with-JobManager-fallback contract that closes the
+submit -> kopf ADDED window.
+"""
+
+import os
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Optional
+
+# Set required environment variable before importing
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing")
+
+import pytest
+
+from aibrix.batch.job_entity.batch_job import (
+    BatchJob,
+    BatchJobEndpoint,
+    BatchJobSpec,
+    BatchJobState,
+    BatchJobStatus,
+    CompletionWindow,
+    ObjectMeta,
+    RequestCountStats,
+    TypeMeta,
+)
+from aibrix.batch.store import InMemoryBatchJobStore
+from aibrix.metadata.api.v1.batch import _resolve_batch_job
+
+
+def _make_job(batch_id: str) -> BatchJob:
+    return BatchJob(
+        typeMeta=TypeMeta(apiVersion="batch/v1", kind="Job"),
+        metadata=ObjectMeta(
+            name="test-job",
+            namespace="default",
+            uid=str(uuid.uuid4()),
+            creationTimestamp=datetime.now(timezone.utc),
+            resourceVersion="1",
+            deletionTimestamp=None,
+        ),
+        spec=BatchJobSpec(
+            input_file_id="file-input",
+            endpoint=BatchJobEndpoint.CHAT_COMPLETIONS.value,
+            completion_window=CompletionWindow.TWENTY_FOUR_HOURS.expires_at(),
+        ),
+        status=BatchJobStatus(
+            jobID=batch_id,
+            state=BatchJobState.IN_PROGRESS,
+            createdAt=datetime.now(timezone.utc),
+            requestCounts=RequestCountStats(
+                total=10, launched=0, completed=2, failed=0
+            ),
+        ),
+    )
+
+
+class _StubJobManager:
+    def __init__(self, jobs: dict):
+        self._jobs = jobs
+
+    async def get_job(self, batch_id: str) -> Optional[BatchJob]:
+        return self._jobs.get(batch_id)
+
+
+class _StubBatchDriver:
+    """Mimics enough of BatchDriver for the helper's fallback path.
+
+    ``run_coroutine`` on the real driver schedules the coroutine on a
+    dedicated event loop; for a unit test the same coroutine can be
+    awaited inline.
+    """
+
+    def __init__(self, jobs: dict):
+        self.job_manager = _StubJobManager(jobs)
+
+    async def run_coroutine(self, coro):
+        return await coro
+
+
+def _make_request(*, store=None, manager_jobs: Optional[dict] = None):
+    state = SimpleNamespace(
+        batch_driver=_StubBatchDriver(manager_jobs or {}),
+    )
+    if store is not None:
+        state.batch_job_store = store
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+@pytest.mark.asyncio
+async def test_store_hit_returns_store_document():
+    store = InMemoryBatchJobStore()
+    job = _make_job("batch-store-hit")
+    await store.put("batch-store-hit", job)
+
+    # JobManager has nothing — proves we did not fall through.
+    request = _make_request(store=store, manager_jobs={})
+
+    result = await _resolve_batch_job(request, "batch-store-hit")
+    assert result is not None
+    assert result.status.job_id == "batch-store-hit"
+
+
+@pytest.mark.asyncio
+async def test_store_miss_falls_back_to_job_manager():
+    """Covers the K8s submit -> kopf ADDED gap where the store has not
+    yet observed the new job but the metadata service already seeded its
+    JobManager pool synchronously on POST."""
+    store = InMemoryBatchJobStore()
+    job = _make_job("batch-gap")
+    request = _make_request(store=store, manager_jobs={"batch-gap": job})
+
+    result = await _resolve_batch_job(request, "batch-gap")
+    assert result is not None
+    assert result.status.job_id == "batch-gap"
+
+
+@pytest.mark.asyncio
+async def test_store_not_configured_uses_job_manager():
+    job = _make_job("batch-no-store")
+    request = _make_request(store=None, manager_jobs={"batch-no-store": job})
+
+    result = await _resolve_batch_job(request, "batch-no-store")
+    assert result is not None
+    assert result.status.job_id == "batch-no-store"
+
+
+@pytest.mark.asyncio
+async def test_both_miss_returns_none():
+    store = InMemoryBatchJobStore()
+    request = _make_request(store=store, manager_jobs={})
+
+    result = await _resolve_batch_job(request, "batch-missing")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_store_takes_precedence_over_job_manager():
+    """If the store has an updated copy and JobManager has stale state,
+    the read returns the store's view — that is the whole point of the
+    read flip."""
+    store = InMemoryBatchJobStore()
+    fresh = _make_job("batch-fresh")
+    fresh.status.state = BatchJobState.FINALIZED
+    fresh.status.request_counts.completed = 10
+    await store.put("batch-fresh", fresh)
+
+    stale = _make_job("batch-fresh")
+    stale.status.state = BatchJobState.IN_PROGRESS
+    stale.status.request_counts.completed = 5
+    request = _make_request(store=store, manager_jobs={"batch-fresh": stale})
+
+    result = await _resolve_batch_job(request, "batch-fresh")
+    assert result is not None
+    assert result.status.state == BatchJobState.FINALIZED
+    assert result.status.request_counts.completed == 10

--- a/python/aibrix/tests/batch/test_batch_job_store.py
+++ b/python/aibrix/tests/batch/test_batch_job_store.py
@@ -1,0 +1,191 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from aibrix.batch.job_entity.batch_job import (
+    BatchJob,
+    BatchJobEndpoint,
+    BatchJobSpec,
+    BatchJobState,
+    BatchJobStatus,
+    CompletionWindow,
+    ObjectMeta,
+    RequestCountStats,
+    TypeMeta,
+)
+from aibrix.batch.store import (
+    BatchJobStore,
+    InMemoryBatchJobStore,
+    ObjectBatchJobStore,
+)
+from aibrix.storage.local import LocalStorage
+
+
+def _make_job(
+    job_id: str = "job-1",
+    state: BatchJobState = BatchJobState.CREATED,
+    completed: int = 0,
+) -> BatchJob:
+    return BatchJob(
+        typeMeta=TypeMeta(apiVersion="batch/v1", kind="Job"),
+        metadata=ObjectMeta(
+            name=f"test-{job_id}",
+            namespace="default",
+            uid=str(uuid.uuid4()),
+            creationTimestamp=datetime.now(timezone.utc),
+            resourceVersion=None,
+            deletionTimestamp=None,
+        ),
+        spec=BatchJobSpec(
+            input_file_id="file-input",
+            endpoint=BatchJobEndpoint.CHAT_COMPLETIONS.value,
+            completion_window=CompletionWindow.TWENTY_FOUR_HOURS.expires_at(),
+        ),
+        status=BatchJobStatus(
+            jobID=job_id,
+            state=state,
+            createdAt=datetime.now(timezone.utc),
+            requestCounts=RequestCountStats(
+                total=10, launched=0, completed=completed, failed=0
+            ),
+        ),
+    )
+
+
+@pytest.fixture(params=["memory", "object"])
+def store(request, tmp_path) -> BatchJobStore:
+    if request.param == "memory":
+        return InMemoryBatchJobStore()
+    return ObjectBatchJobStore(LocalStorage(base_path=str(tmp_path)))
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(store: BatchJobStore):
+    assert await store.get("does-not-exist") is None
+
+
+@pytest.mark.asyncio
+async def test_put_then_get_round_trip(store: BatchJobStore):
+    job = _make_job("job-rt", state=BatchJobState.IN_PROGRESS, completed=3)
+    await store.put("job-rt", job)
+
+    fetched = await store.get("job-rt")
+    assert fetched is not None
+    assert fetched.status.job_id == "job-rt"
+    assert fetched.status.state == BatchJobState.IN_PROGRESS
+    assert fetched.status.request_counts.completed == 3
+
+
+@pytest.mark.asyncio
+async def test_put_overwrites_lww(store: BatchJobStore):
+    job = _make_job("job-ow", completed=1)
+    await store.put("job-ow", job)
+
+    job_v2 = _make_job("job-ow", state=BatchJobState.FINALIZED, completed=10)
+    await store.put("job-ow", job_v2)
+
+    fetched = await store.get("job-ow")
+    assert fetched is not None
+    assert fetched.status.state == BatchJobState.FINALIZED
+    assert fetched.status.request_counts.completed == 10
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_is_noop(store: BatchJobStore):
+    await store.delete("never-existed")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_delete_then_get_returns_none(store: BatchJobStore):
+    job = _make_job("job-del")
+    await store.put("job-del", job)
+    await store.delete("job-del")
+    assert await store.get("job-del") is None
+
+
+@pytest.mark.asyncio
+async def test_update_helper_mutates_and_persists(store: BatchJobStore):
+    job = _make_job("job-up", completed=0)
+    await store.put("job-up", job)
+
+    async def bump(current: BatchJob) -> BatchJob:
+        current.status.request_counts.completed = 7
+        current.status.state = BatchJobState.IN_PROGRESS
+        return current
+
+    result = await store.update("job-up", bump)
+    assert result is not None
+    assert result.status.request_counts.completed == 7
+
+    fetched = await store.get("job-up")
+    assert fetched is not None
+    assert fetched.status.request_counts.completed == 7
+    assert fetched.status.state == BatchJobState.IN_PROGRESS
+
+
+@pytest.mark.asyncio
+async def test_update_helper_returns_none_when_missing(store: BatchJobStore):
+    async def bump(current: BatchJob) -> BatchJob:
+        return current  # pragma: no cover - should not be called
+
+    assert await store.update("missing", bump) is None
+
+
+@pytest.mark.asyncio
+async def test_in_memory_isolates_callers_from_mutation():
+    """Holding a reference to a previously-put job must not let a caller
+    mutate stored state — store must deep-copy on the boundary."""
+    store = InMemoryBatchJobStore()
+    job = _make_job("job-iso", completed=1)
+    await store.put("job-iso", job)
+
+    # Mutate the local reference — should not bleed into the store.
+    job.status.request_counts.completed = 999
+
+    fetched = await store.get("job-iso")
+    assert fetched is not None
+    assert fetched.status.request_counts.completed == 1
+
+    # Mutating the fetched copy must not bleed back either.
+    fetched.status.request_counts.completed = 42
+    again = await store.get("job-iso")
+    assert again is not None
+    assert again.status.request_counts.completed == 1
+
+
+@pytest.mark.asyncio
+async def test_object_store_writes_under_prefix_path(tmp_path):
+    storage = LocalStorage(base_path=str(tmp_path))
+    store = ObjectBatchJobStore(storage, prefix="custom/batches")
+    await store.put("job-key", _make_job("job-key"))
+
+    expected = tmp_path / "custom" / "batches" / "job-key" / "metadata.json"
+    assert expected.exists(), f"expected metadata.json at {expected}"
+
+
+@pytest.mark.asyncio
+async def test_object_store_excludes_none_fields(tmp_path):
+    """Optional unset fields (e.g. status.usage before worker reports) must
+    serialize as absent, not as ``null``, to keep the document compact and
+    forward-compatible."""
+    storage = LocalStorage(base_path=str(tmp_path))
+    store = ObjectBatchJobStore(storage)
+    await store.put("job-en", _make_job("job-en"))
+
+    raw = (tmp_path / "batches" / "job-en" / "metadata.json").read_bytes()
+    assert b"null" not in raw

--- a/python/aibrix/tests/batch/test_job_cache_store.py
+++ b/python/aibrix/tests/batch/test_job_cache_store.py
@@ -1,0 +1,390 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for JobCache integration with the BatchJobStore.
+
+These tests exercise ``JobCache._put_to_store`` and ``_delete_from_store``
+directly so we can pin the store contract (LWW write, idempotent
+delete, no-op when the store is unconfigured, error swallowing on
+write) without standing up a kubernetes client mock. The higher-level
+flow tests for ``update_job_status`` and the kopf monotonicity rule
+live further below in this file.
+"""
+
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+# Set required environment variable before importing
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing")
+
+import pytest
+
+from aibrix.batch.job_entity.batch_job import (
+    BatchJob,
+    BatchJobEndpoint,
+    BatchJobSpec,
+    BatchJobState,
+    BatchJobStatus,
+    CompletionWindow,
+    ObjectMeta,
+    RequestCountStats,
+    TypeMeta,
+)
+from aibrix.batch.store import BatchJobStore, InMemoryBatchJobStore
+from aibrix.batch.template import local_profile_registry, local_template_registry
+from aibrix.metadata.cache.job import JobCache
+
+_FIXTURE = Path(__file__).parent / "testdata" / "template_configmaps_unittest.yaml"
+
+
+def _make_job(batch_id: str = "batch-1") -> BatchJob:
+    return BatchJob(
+        typeMeta=TypeMeta(apiVersion="batch/v1", kind="Job"),
+        metadata=ObjectMeta(
+            name="test-job",
+            namespace="default",
+            uid=str(uuid.uuid4()),
+            creationTimestamp=datetime.now(timezone.utc),
+            resourceVersion="1",
+            deletionTimestamp=None,
+        ),
+        spec=BatchJobSpec(
+            input_file_id="file-input",
+            endpoint=BatchJobEndpoint.CHAT_COMPLETIONS.value,
+            completion_window=CompletionWindow.TWENTY_FOUR_HOURS.expires_at(),
+        ),
+        status=BatchJobStatus(
+            jobID=batch_id,
+            state=BatchJobState.IN_PROGRESS,
+            createdAt=datetime.now(timezone.utc),
+            requestCounts=RequestCountStats(
+                total=10, launched=0, completed=2, failed=0
+            ),
+        ),
+    )
+
+
+def _make_cache(store: Optional[BatchJobStore]) -> JobCache:
+    template_registry = local_template_registry(_FIXTURE)
+    profile_registry = local_profile_registry(_FIXTURE)
+    template_registry.reload()
+    profile_registry.reload()
+    return JobCache(
+        template_registry=template_registry,
+        profile_registry=profile_registry,
+        batch_job_store=store,
+    )
+
+
+@pytest.mark.asyncio
+async def test_put_to_store_writes_when_store_configured():
+    store = InMemoryBatchJobStore()
+    cache = _make_cache(store)
+
+    job = _make_job("batch-1")
+    await cache._put_to_store(job, op="update_job_status")
+
+    fetched = await store.get("batch-1")
+    assert fetched is not None
+    assert fetched.status.state == BatchJobState.IN_PROGRESS
+    assert fetched.status.request_counts.completed == 2
+
+
+@pytest.mark.asyncio
+async def test_put_to_store_is_noop_when_store_is_none():
+    cache = _make_cache(None)
+    # Must not raise, must not error.
+    await cache._put_to_store(_make_job(), op="update_job_status")
+
+
+@pytest.mark.asyncio
+async def test_delete_from_store_removes_document():
+    store = InMemoryBatchJobStore()
+    cache = _make_cache(store)
+
+    job = _make_job("batch-del")
+    await cache._put_to_store(job, op="update_job_ready")
+    assert await store.get("batch-del") is not None
+
+    await cache._delete_from_store(job)
+    assert await store.get("batch-del") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_from_store_is_noop_when_store_is_none():
+    cache = _make_cache(None)
+    await cache._delete_from_store(_make_job())
+
+
+class _FailingStore(BatchJobStore):
+    """BatchJobStore that fails every write/delete, used to pin error
+    semantics on the JobCache helpers."""
+
+    async def get(self, batch_id):
+        return None
+
+    async def put(self, batch_id, job):
+        raise RuntimeError("simulated store outage")
+
+    async def delete(self, batch_id):
+        raise RuntimeError("simulated store outage")
+
+
+@pytest.mark.asyncio
+async def test_put_to_store_default_swallows_failures(caplog):
+    """Default behavior (no ``propagate`` flag) swallows store errors.
+    Reserved for the kopf seed write where the next event will retry;
+    status-mutation callers must opt into propagation explicitly."""
+    cache = _make_cache(_FailingStore())
+    await cache._put_to_store(_make_job("batch-fail"), op="job_created")
+
+
+@pytest.mark.asyncio
+async def test_put_to_store_propagates_when_requested():
+    """Status-mutation callers (update_job_status / update_job_ready /
+    cancel_job) pass ``propagate=True`` because the store is the only
+    persistent record; a swallowed failure would leave active_jobs
+    ahead of disk and surface as stale reads after restart."""
+    cache = _make_cache(_FailingStore())
+    with pytest.raises(RuntimeError, match="simulated store outage"):
+        await cache._put_to_store(
+            _make_job("batch-fail"), op="update_job_status", propagate=True
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_from_store_swallows_failures():
+    """Delete is best-effort: the K8s ``delete_namespaced_job`` op is
+    the authoritative deletion signal, so a store delete failure leaks
+    a stale document at worst."""
+    cache = _make_cache(_FailingStore())
+    await cache._delete_from_store(_make_job("batch-fail"))
+
+
+@pytest.mark.asyncio
+async def test_subsequent_puts_overwrite_via_lww():
+    store = InMemoryBatchJobStore()
+    cache = _make_cache(store)
+
+    job = _make_job("batch-lww")
+    await cache._put_to_store(job, op="update_job_status")
+
+    job.status.request_counts.completed = 9
+    job.status.state = BatchJobState.FINALIZED
+    await cache._put_to_store(job, op="update_job_status")
+
+    fetched = await store.get("batch-lww")
+    assert fetched is not None
+    assert fetched.status.state == BatchJobState.FINALIZED
+    assert fetched.status.request_counts.completed == 9
+
+
+@pytest.mark.asyncio
+async def test_update_job_status_writes_store_and_cache_no_k8s():
+    """As of PR4, update_job_status no longer issues a K8s patch. The
+    BatchJobStore is the source of truth and active_jobs is updated
+    directly so the JobManager pool stays in sync without waiting for a
+    kopf MODIFIED echo."""
+    store = InMemoryBatchJobStore()
+    cache = _make_cache(store)
+    # Replace the K8s client with one that fails on any call so the test
+    # asserts no K8s round-trip is attempted.
+
+    class _ExplodingApi:
+        def patch_namespaced_job(self, *args, **kwargs):
+            raise AssertionError("update_job_status must not call K8s")
+
+    cache.batch_v1_api = _ExplodingApi()
+
+    job = _make_job("batch-update")
+    await cache.update_job_status(job)
+
+    assert (await store.get("batch-update")) is not None
+    assert "batch-update" in cache.active_jobs
+    assert cache.active_jobs["batch-update"].status.state == BatchJobState.IN_PROGRESS
+
+
+@pytest.mark.asyncio
+async def test_update_job_status_fires_job_updated_callback():
+    """The callback is how JobManager moves a job between its pending /
+    in_progress / done pools. Without a kopf MODIFIED to trigger it
+    after we dropped the annotation patch, JobCache must invoke it."""
+    store = InMemoryBatchJobStore()
+    cache = _make_cache(store)
+
+    received: list = []
+
+    async def _on_updated(old, new):
+        received.append((old.status.state, new.status.state))
+        return True
+
+    cache.on_job_updated(_on_updated)
+
+    initial = _make_job("batch-cb")
+    initial.status.state = BatchJobState.IN_PROGRESS
+    cache.active_jobs["batch-cb"] = initial
+
+    advanced = _make_job("batch-cb")
+    advanced.status.state = BatchJobState.FINALIZED
+
+    await cache.update_job_status(advanced)
+
+    assert received == [(BatchJobState.IN_PROGRESS, BatchJobState.FINALIZED)]
+
+
+@pytest.mark.asyncio
+async def test_update_job_status_raises_and_does_not_advance_cache_on_store_failure():
+    """When the store is unreachable, update_job_status must raise and
+    leave ``active_jobs`` at its previous value. Otherwise the
+    in-memory view would advance past the persistent record and the
+    next API read (which prefers the store) would silently regress."""
+    cache = _make_cache(_FailingStore())
+
+    initial = _make_job("batch-fail")
+    initial.status.state = BatchJobState.IN_PROGRESS
+    cache.active_jobs["batch-fail"] = initial
+
+    advanced = _make_job("batch-fail")
+    advanced.status.state = BatchJobState.FINALIZED
+
+    with pytest.raises(RuntimeError, match="simulated store outage"):
+        await cache.update_job_status(advanced)
+
+    # Cache must still hold the pre-failure view.
+    assert cache.active_jobs["batch-fail"].status.state == BatchJobState.IN_PROGRESS
+
+
+@pytest.mark.asyncio
+async def test_update_job_status_first_seen_skips_callback():
+    """First-time observation has no ``old`` to diff against; the
+    callback is reserved for genuine transitions."""
+    store = InMemoryBatchJobStore()
+    cache = _make_cache(store)
+
+    received: list = []
+
+    async def _on_updated(old, new):  # pragma: no cover - asserted not called
+        received.append((old, new))
+        return True
+
+    cache.on_job_updated(_on_updated)
+
+    job = _make_job("batch-first")
+    await cache.update_job_status(job)
+
+    assert received == []
+    assert "batch-first" in cache.active_jobs
+
+
+# ---------------------------------------------------------------------------
+# Kopf monotonicity rule.
+#
+# K8s annotations are no longer authoritative for status. A non-status
+# K8s patch (e.g. ``update_job_ready`` flipping ``spec.suspend = False``)
+# still fires kopf MODIFIED, which re-runs the transformer with absent
+# JOB_STATE annotations and produces a CREATED-state BatchJob. The
+# kopf-driven cache update must drop such echoes so it never regresses
+# below the state JobCache wrote directly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kopf_update_skips_when_cached_state_is_more_advanced(monkeypatch):
+    from aibrix.metadata.cache import job as job_module
+
+    captured = {"updated": False}
+
+    class _StubMeta:
+        name = "n"
+        namespace = "default"
+        resource_version = "1"
+
+    class _StubStatus:
+        def __init__(self, state):
+            self.state = state
+            self.job_id = "uid-skip"
+
+    class _StubJob:
+        def __init__(self, state):
+            self.status = _StubStatus(state)
+            self.metadata = _StubMeta()
+
+    class _StubCache:
+        def __init__(self):
+            self.active_jobs = {"uid-skip": _StubJob(BatchJobState.IN_PROGRESS)}
+
+        async def job_updated(self, old, new):  # pragma: no cover - asserted not called
+            captured["updated"] = True
+            return True
+
+    stub = _StubCache()
+    monkeypatch.setattr(job_module, "get_global_job_cache", lambda: stub)
+    monkeypatch.setattr(
+        job_module, "k8s_job_to_batch_job", lambda body: _StubJob(BatchJobState.CREATED)
+    )
+
+    body = type("B", (), {"metadata": type("M", (), {"uid": "uid-skip"})()})()
+    await job_module.job_updated_handler(body)
+
+    assert stub.active_jobs["uid-skip"].status.state == BatchJobState.IN_PROGRESS
+    assert captured["updated"] is False
+
+
+@pytest.mark.asyncio
+async def test_kopf_update_propagates_when_state_advances(monkeypatch):
+    """A FINALIZING (or higher) view derived from K8s native conditions
+    must propagate; that is the whole reason the kopf path stays alive
+    after we stopped writing status annotations."""
+    from aibrix.metadata.cache import job as job_module
+
+    received: list = []
+
+    class _StubMeta:
+        name = "n"
+        namespace = "default"
+        resource_version = "1"
+
+    class _StubStatus:
+        def __init__(self, state):
+            self.state = state
+            self.job_id = "uid-adv"
+
+    class _StubJob:
+        def __init__(self, state):
+            self.status = _StubStatus(state)
+            self.metadata = _StubMeta()
+
+    cached_job = _StubJob(BatchJobState.IN_PROGRESS)
+    new_job = _StubJob(BatchJobState.FINALIZING)
+
+    class _StubCache:
+        def __init__(self):
+            self.active_jobs = {"uid-adv": cached_job}
+
+        async def job_updated(self, old, new):
+            received.append((old.status.state, new.status.state))
+            return True
+
+    stub = _StubCache()
+    monkeypatch.setattr(job_module, "get_global_job_cache", lambda: stub)
+    monkeypatch.setattr(job_module, "k8s_job_to_batch_job", lambda body: new_job)
+
+    body = type("B", (), {"metadata": type("M", (), {"uid": "uid-adv"})()})()
+    await job_module.job_updated_handler(body)
+
+    assert received == [(BatchJobState.IN_PROGRESS, BatchJobState.FINALIZING)]
+    assert stub.active_jobs["uid-adv"].status.state == BatchJobState.FINALIZING

--- a/python/aibrix/tests/batch/test_k8s_job_transformer.py
+++ b/python/aibrix/tests/batch/test_k8s_job_transformer.py
@@ -1176,3 +1176,71 @@ def test_unknown_conditions_ignored():
 
     condition = batch_job.status.conditions[0]
     assert condition.type == ConditionType.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# State derivation when JOB_STATE annotation is absent.
+#
+# K8s Job annotations are no longer the authoritative carrier of batch
+# status, so the transformer must rebuild a sane BatchJob purely from
+# K8s-native conditions when the JOB_STATE annotation is missing.
+# ---------------------------------------------------------------------------
+
+
+def test_state_falls_back_to_created_when_annotation_absent_and_no_conditions():
+    """No JOB_STATE annotation and no terminal K8s condition: the
+    steady-state observation for a just-created Job. Must yield
+    CREATED rather than crash or invent a transient state."""
+    from aibrix.batch.job_entity.k8s_transformer import BatchJobTransformer
+
+    state, ts = BatchJobTransformer._map_k8s_phase_to_batch_state(
+        annotations={}, conditions=None
+    )
+    assert state == BatchJobState.CREATED
+    assert ts is None
+
+
+def test_state_advances_to_finalizing_when_terminal_condition_appears():
+    """A terminal K8s condition (Complete / Failed / Suspended) must
+    surface as FINALIZING regardless of whether the JOB_STATE
+    annotation is present. This is what closes the gap between K8s
+    native progress and the BatchJob state machine once the annotation
+    echo is no longer driving updates."""
+    from aibrix.batch.job_entity.k8s_transformer import BatchJobTransformer
+
+    cond = SimpleNamespace(last_transition_time="2024-01-01T00:00:00Z")
+    state, ts = BatchJobTransformer._map_k8s_phase_to_batch_state(
+        annotations={}, conditions=[cond]
+    )
+    assert state == BatchJobState.FINALIZING
+    assert ts == cond.last_transition_time
+
+
+def test_explicit_terminal_annotation_still_wins_over_fallback():
+    """A terminal JOB_STATE annotation (rare; legacy or
+    third-party-managed Job) must be respected; the K8s-condition
+    fallback only kicks in when the annotation is missing."""
+    from aibrix.batch.job_entity import JobAnnotationKey
+    from aibrix.batch.job_entity.k8s_transformer import BatchJobTransformer
+
+    state, _ = BatchJobTransformer._map_k8s_phase_to_batch_state(
+        annotations={JobAnnotationKey.JOB_STATE.value: BatchJobState.FINALIZED.value},
+        conditions=None,
+    )
+    assert state == BatchJobState.FINALIZED
+
+
+def test_in_progress_annotation_with_conditions_advances_to_finalizing():
+    """Pre-existing path: an IN_PROGRESS annotation with a terminal
+    condition advances to FINALIZING. Pinned here to guard against the
+    fallback inadvertently shadowing the annotated path."""
+    from aibrix.batch.job_entity import JobAnnotationKey
+    from aibrix.batch.job_entity.k8s_transformer import BatchJobTransformer
+
+    cond = SimpleNamespace(last_transition_time="2024-01-01T00:00:00Z")
+    state, ts = BatchJobTransformer._map_k8s_phase_to_batch_state(
+        annotations={JobAnnotationKey.JOB_STATE.value: BatchJobState.IN_PROGRESS.value},
+        conditions=[cond],
+    )
+    assert state == BatchJobState.FINALIZING
+    assert ts == cond.last_transition_time

--- a/python/aibrix/tests/batch/test_runtime_updater.py
+++ b/python/aibrix/tests/batch/test_runtime_updater.py
@@ -1,0 +1,85 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from aibrix.batch.job_entity.batch_job import (
+    BatchJob,
+    BatchJobEndpoint,
+    BatchJobSpec,
+    BatchJobState,
+    BatchJobStatus,
+    CompletionWindow,
+    ObjectMeta,
+    RequestCountStats,
+    TypeMeta,
+)
+from aibrix.batch.runtime_updater import (
+    JobStateRuntimeUpdater,
+    NoOpJobStateRuntimeUpdater,
+)
+
+
+def _make_job() -> BatchJob:
+    return BatchJob(
+        typeMeta=TypeMeta(apiVersion="batch/v1", kind="Job"),
+        metadata=ObjectMeta(
+            name="test-job",
+            namespace="default",
+            uid=str(uuid.uuid4()),
+            creationTimestamp=datetime.now(timezone.utc),
+            resourceVersion=None,
+            deletionTimestamp=None,
+        ),
+        spec=BatchJobSpec(
+            input_file_id="file-input",
+            endpoint=BatchJobEndpoint.CHAT_COMPLETIONS.value,
+            completion_window=CompletionWindow.TWENTY_FOUR_HOURS.expires_at(),
+        ),
+        status=BatchJobStatus(
+            jobID="job-1",
+            state=BatchJobState.IN_PROGRESS,
+            createdAt=datetime.now(timezone.utc),
+            requestCounts=RequestCountStats(total=1, launched=0, completed=0, failed=0),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_noop_updater_swallows_calls():
+    updater = NoOpJobStateRuntimeUpdater()
+    await updater.update(_make_job())  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_runtime_updater_is_abstract():
+    with pytest.raises(TypeError):
+        JobStateRuntimeUpdater()  # type: ignore[abstract]
+
+
+@pytest.mark.asyncio
+async def test_custom_updater_receives_job():
+    seen: list[BatchJob] = []
+
+    class _Recording(JobStateRuntimeUpdater):
+        async def update(self, job: BatchJob) -> None:
+            seen.append(job)
+
+    updater = _Recording()
+    job = _make_job()
+    await updater.update(job)
+    assert seen == [job]


### PR DESCRIPTION
## Pull Request Description

  - add BatchJobStore and JobStateRuntimeUpdater abstractions
  - shadow-write BatchJob state to BatchJobStore
  - serve /v1/batches/{id} from BatchJobStore when enabled
  - stop mirroring runtime status onto K8s Job annotations
  - rename _shadow_put/_shadow_delete and refresh stale wording
  - rename test_job_cache_shadow_store.py to test_job_cache_store.py

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>