### PR TITLE
fix: update metric name in throughput routing strategy

### DIFF
--- a/pkg/plugins/gateway/algorithms/throughput.go
+++ b/pkg/plugins/gateway/algorithms/throughput.go
@@ -92,7 +92,7 @@ func (r throughputRouter) Route(ctx *types.RoutingContext, readyPodList types.Po
 
 func (r *throughputRouter) SubscribedMetrics() []string {
 	return []string{
-		metrics.AvgPromptThroughputToksPerS,
-		metrics.AvgGenerationThroughputToksPerS,
+		metrics.AvgPromptToksPerReq,
+		metrics.AvgGenerationToksPerReq,
 	}
 }


### PR DESCRIPTION
## Pull Request Description
Sync metrics updated in https://github.com/vllm-project/aibrix/pull/1968
from AvgPromptThroughputToksPerS/AvgGenerationThroughputToksPerS to AvgPromptToksPerReq/AvgGenerationToksPerReq