### PR TITLE
feat: support preserving upstream x-request-id for e2e tracing(#2157)

### DIFF
--- a/config/gateway/gateway.yaml
+++ b/config/gateway/gateway.yaml
@@ -144,4 +144,11 @@ spec:
         connect_timeout: 6s
         lb_policy: CLUSTER_PROVIDED
         dns_lookup_family: V4_ONLY
+  - type: type.googleapis.com/envoy.config.listener.v3.Listener
+    name: aibrix-system/aibrix-eg/http
+    operation:
+      op: add
+      path: /default_filter_chain/filters/0/typed_config/preserve_external_request_id
+      value: false
+
   

--- a/dist/chart/templates/gateway-instance/gateway.yaml
+++ b/dist/chart/templates/gateway-instance/gateway.yaml
@@ -170,4 +170,10 @@ spec:
                 max_connections: {{ .Values.gateway.envoyPatchPolicy.circuitBreakers.maxConnections }}
                 max_requests: {{ .Values.gateway.envoyPatchPolicy.circuitBreakers.maxRequests }}
                 max_pending_requests: {{ .Values.gateway.envoyPatchPolicy.circuitBreakers.maxPendingRequests }}
+    - type: type.googleapis.com/envoy.config.listener.v3.Listener
+      name: {{ .Release.Namespace }}/{{ include "aibrix.fullname" . }}-eg/http
+      operation:
+        op: add
+        path: /default_filter_chain/filters/{{- if gt (int .Values.gateway.clientTrafficPolicy.connection.connectionLimit.value) 0 }}1{{- else }}0{{- end }}/typed_config/preserve_external_request_id
+        value: {{.Values.gateway.envoyPatchPolicy.preserveExternalRequestID}}
 {{- end }}

--- a/dist/chart/templates/metadata-service/deployment.yaml
+++ b/dist/chart/templates/metadata-service/deployment.yaml
@@ -45,6 +45,8 @@ spec:
             - "0.0.0.0"
             - --port
             - "8090"
+            # Keep install-time startup independent from external inference engine wiring.
+            - --disable-batch-api
           ports:
             - containerPort: 8090
           resources: {{ toYaml .Values.metadata.service.container.resources | nindent 12 }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -221,6 +221,7 @@ gateway:
       maxRequests: 1024
       # The maximum number of pending requests to the original destination cluster.
       maxPendingRequests: 1024
+    preserveExternalRequestID: false
 
 metadata:
   serviceAccount:


### PR DESCRIPTION
## Pull Request Description

feat(gateway): support preserving upstream x-request-id for e2e tracing

Introduce the ability to preserve the client-provided x-request-id header
instead of always generating a new UUID, enabling continuous end-to-end
request tracing across multiple gateways.

Changes:
- App-level: Reuse existing x-request-id from upstream if present.
- Envoy-level: Add a configurable EnvoyPatchPolicy to toggle
  `preserve_external_request_id` on the HttpConnectionManager.

## Related Issues
Resolves #2126 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>