### PR TITLE
fix(batch): unblock end-to-end K8s submission path

### DIFF
--- a/python/aibrix/aibrix/batch/job_driver.py
+++ b/python/aibrix/aibrix/batch/job_driver.py
@@ -92,12 +92,12 @@ class JobDriver:
         * Call finalize_job() for Job finalizing. API server runs without scheduler will call this to aggregate outputs.
         """
         self._progress_manager = progress_manager
-        if inference_client is None:
-            raise ValueError(
-                "JobDriver requires an explicit inference_client. Pass "
-                "EchoInferenceEngineClient() for --dry-run or "
-                "ProxyInferenceEngineClient(url) for a real engine."
-            )
+        # ``inference_client`` may be None when the driver is only used
+        # for prepare_job/finalize_job (the K8s metadata-service path —
+        # worker pods do the actual inference). The check is deferred
+        # to _retry_inference_request so the misuse fails at call site
+        # with a clear message instead of silently falling back to a
+        # default client.
         self._inference_client = inference_client
 
         # Per-job token usage accumulators. Populated by inference responses
@@ -482,6 +482,15 @@ class JobDriver:
         """
         request_output = None
         last_error = None
+
+        if self._inference_client is None:
+            raise RuntimeError(
+                "JobDriver was constructed without an inference_client; "
+                "execute_job / execute_worker require one. Pass "
+                "EchoInferenceEngineClient() for --dry-run or "
+                "ProxyInferenceEngineClient(url) for a real engine. "
+                "(prepare_job / finalize_job do not need a client.)"
+            )
 
         for attempt in range(max_retries):
             try:

--- a/python/aibrix/aibrix/batch/job_manager.py
+++ b/python/aibrix/aibrix/batch/job_manager.py
@@ -337,6 +337,22 @@ class JobManager(JobProgressManager):
                     self._job_entity_manager.submit_job(session_id, job_spec)
                 )
 
+                # If the submit task fails before the future is resolved
+                # (e.g. RenderError on a malformed BatchJobSpec), forward
+                # the real exception so wait_for() returns immediately
+                # with a useful error instead of stalling for the full
+                # ``timeout`` seconds. Without this, every render-time
+                # rejection looked like a 408 to the client.
+                def _propagate_submit_failure(t: "asyncio.Task[None]") -> None:
+                    if t.cancelled():
+                        return
+                    exc = t.exception()
+                    if exc is None or job_future.done():
+                        return
+                    job_future.set_exception(exc)
+
+                submit_task.add_done_callback(_propagate_submit_failure)
+
                 # Wait for job ID with timeout
                 try:
                     job_id = await asyncio.wait_for(job_future, timeout=timeout)

--- a/python/aibrix/aibrix/batch/manifest/renderer.py
+++ b/python/aibrix/aibrix/batch/manifest/renderer.py
@@ -236,8 +236,9 @@ class JobManifestRenderer:
     ) -> tuple[ModelDeploymentTemplate, BatchProfile]:
         if not spec.model_template_name:
             raise RenderError(
-                "BatchJobSpec.model_template_name is required for "
-                "ConfigMap-driven rendering"
+                "extra_body.aibrix.model_template.name is required: "
+                "the cluster has no built-in template fallback, so every "
+                "batch must reference a registered ModelDeploymentTemplate"
             )
         # Pinned version => exact match; empty version => latest active.
         if spec.model_template_version:

--- a/python/aibrix/aibrix/metadata/cache/job.py
+++ b/python/aibrix/aibrix/metadata/cache/job.py
@@ -240,6 +240,11 @@ class JobCache(JobEntityManager):
         if not self.batch_v1_api:
             raise RuntimeError("Kubernetes client not available")
 
+        # Initialize before the try so that any exception raised by
+        # _batch_job_spec_to_k8s_job (manifest rendering) doesn't fall
+        # into the outer ``except`` with ``namespace`` unbound, which
+        # masks the real failure with an UnboundLocalError.
+        namespace = "default"
         try:
             # Convert BatchJobSpec to Kubernetes Job manifest
             k8s_job = self._batch_job_spec_to_k8s_job(
@@ -315,6 +320,10 @@ class JobCache(JobEntityManager):
                 error_type=error_type,
                 operation="submit_job",
             )  # type: ignore[call-arg]
+            # Re-raise so JobManager.create_job_with_spec can fail the
+            # waiting future immediately with the real exception (e.g.
+            # RenderError → 400) instead of stalling 30s on a timeout.
+            raise
 
     async def update_job_ready(self, job: BatchJob):
         """Update job by marking it ready info in the persist store.
@@ -346,7 +355,6 @@ class JobCache(JobEntityManager):
                 name=job.metadata.name,
                 namespace=namespace,
                 body=patch_body,
-                async_req=True,
             )
 
             await self._put_to_store(job, op="update_job_ready", propagate=True)
@@ -456,7 +464,6 @@ class JobCache(JobEntityManager):
                 name=job_name,
                 namespace=namespace,
                 body=suspend_patch,
-                async_req=True,
             )
 
             await self._put_to_store(job, op="cancel_job", propagate=True)
@@ -523,7 +530,6 @@ class JobCache(JobEntityManager):
                 name=job_name,
                 namespace=namespace,
                 propagation_policy="Foreground",  # Delete pods too
-                async_req=True,
             )
 
             await self._delete_from_store(job)
@@ -581,10 +587,15 @@ class JobCache(JobEntityManager):
             job_status.in_progress_at is not None
         ), "AssertError: Job must be set as in progress before setting as ready"
 
+        # No ``metadata.resourceVersion`` here on purpose: this patch is
+        # only ever issued by the metadata service immediately after it
+        # creates the Job, so there is no concurrent writer to guard
+        # against. K8s controller-driven status updates race with our
+        # ADDED handler and bump resourceVersion *before* this patch
+        # fires, producing a 409 every time the optimistic check is in
+        # place. Without it, the strategic-merge patch is naturally
+        # idempotent on these fields.
         return {
-            "metadata": {
-                "resourceVersion": job.metadata.resource_version,
-            },
             "spec": {
                 "template": {
                     "metadata": {

--- a/python/aibrix/scripts/batch_api_smoke.py
+++ b/python/aibrix/scripts/batch_api_smoke.py
@@ -223,6 +223,24 @@ def parse_args() -> argparse.Namespace:
         help="Total seconds to wait for a terminal state. Default: %(default)s",
     )
     p.add_argument(
+        "--aibrix-template",
+        default=None,
+        help=(
+            "AIBrix ModelDeploymentTemplate name to attach via "
+            "extra_body.aibrix.model_template. Required in --enable-k8s-job "
+            "mode (no built-in fallback); ignored by standalone --dry-run."
+        ),
+    )
+    p.add_argument(
+        "--aibrix-profile",
+        default=None,
+        help=(
+            "AIBrix BatchProfile name to attach via "
+            "extra_body.aibrix.profile. Falls back to the registry default "
+            "if omitted. Has no effect in standalone mode."
+        ),
+    )
+    p.add_argument(
         "--cancel",
         action="store_true",
         help=(
@@ -320,13 +338,28 @@ def main() -> None:
     step(
         f"Create  POST /v1/batches  endpoint={args.endpoint} "
         f"completion_window={args.completion_window}"
+        + (f"  template={args.aibrix_template}" if args.aibrix_template else "")
+        + (f"  profile={args.aibrix_profile}" if args.aibrix_profile else "")
     )
+
+    # Build extra_body.aibrix only if the user opted into K8s-mode
+    # selectors. Standalone --dry-run servers ignore this block; K8s
+    # servers reject batches without a model_template.
+    create_kwargs: dict = {
+        "input_file_id": input_file.id,
+        "endpoint": args.endpoint,
+        "completion_window": args.completion_window,
+    }
+    aibrix_block: dict = {}
+    if args.aibrix_template:
+        aibrix_block["model_template"] = {"name": args.aibrix_template}
+    if args.aibrix_profile:
+        aibrix_block["profile"] = {"name": args.aibrix_profile}
+    if aibrix_block:
+        create_kwargs["extra_body"] = {"aibrix": aibrix_block}
+
     try:
-        batch = client.batches.create(
-            input_file_id=input_file.id,
-            endpoint=args.endpoint,
-            completion_window=args.completion_window,
-        )
+        batch = client.batches.create(**create_kwargs)
     except APIStatusError as e:
         fail(f"batch creation rejected: {e.status_code} {e.response.text}")
     dump("create response", batch)

--- a/python/aibrix/tests/batch/test_manifest_renderer.py
+++ b/python/aibrix/tests/batch/test_manifest_renderer.py
@@ -308,7 +308,7 @@ class TestRendererValidation:
         r = renderer_factory(templates=[_vllm_template(count=1)], profiles=[_profile()])
         spec = _spec()
         spec.model_template_name = None
-        with pytest.raises(RenderError, match="model_template_name"):
+        with pytest.raises(RenderError, match="model_template.name"):
             r.render(session_id="s1", spec=spec)
 
     def test_template_not_found(self, renderer_factory):


### PR DESCRIPTION
## Pull Request Description
A series of small bugs each broke a different leg of the K8s batch flow. Symptoms: client got "Batch creation timed out" or "Job preparation failed", Job stayed Suspended, no pod ever ran.

* submit_job: namespace assigned inside try and referenced from the except masked real exceptions with UnboundLocalError. Initialize before the try.
* submit_job: caught and logged exceptions instead of re-raising, so the future awaited by JobManager.create_job_with_spec never resolved and the caller saw a 30s timeout. Re-raise after logging.
* JobManager.create_job_with_spec: forward submit_task failures onto the awaited future via add_done_callback so RenderError surfaces as 400 instead of 408.
* update_job_ready: drop optimistic resourceVersion from the patch body. The kopf ADDED handler bumps the version before this patch fires, producing 409 every time. The metadata service is the only writer, so the lock is unnecessary.
* update_job_ready: drop async_req=True from patch_namespaced_job. asyncio.to_thread already off-loops the call, and the ApplyResult was never .get()ed so any K8s error was silently dropped.
* JobDriver: defer the inference_client check from __init__ to _retry_inference_request. The K8s metadata-service callers use only prepare_job/finalize_job, which never invoke inference; requiring a client there was over-application of the no-silent-fallback rule.
* RenderError wording: refer to the API field name (extra_body.aibrix.model_template.name) instead of the internal Python attribute (BatchJobSpec.model_template_name).

## Related Issues
Resolves: #2149 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>