### PR TITLE
console: Dockerfile + default sqlite store + BFF↔MDS HTTP logging

### DIFF
--- a/apps/console/Dockerfile
+++ b/apps/console/Dockerfile
@@ -1,0 +1,38 @@
+# AIBrix Console
+#
+# Multi-stage build that produces a single image containing the Go HTTP+gRPC
+# backend and the React SPA. The Go server serves the SPA from STATIC_FILES_DIR
+# and falls back to index.html for client-side routes.
+#
+# The React SPA is built on the host (Docker doesn't need a Node image) and
+# COPYed in via apps/console/web/build/. Build context must be the repo root.
+#
+# Commands:
+#   (cd apps/console/web && npm install && npm run build)
+#   docker build -f apps/console/Dockerfile -t aibrix/console .
+
+# Stage 1: build the Go binary.
+# golang:1.22 (debian) is intentional — gorm.io/driver/sqlite needs CGO and
+# the alpine variant requires extra build-base apk packages.
+FROM golang:1.22 AS api
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# nozmq: console doesn't need ZeroMQ (gateway-plugins-only feature).
+# CGO_ENABLED=1: required by the SQLite driver used for the dev/file store.
+RUN CGO_ENABLED=1 go build -tags nozmq -o /out/console ./cmd/console
+
+# Stage 2: minimal runtime.
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=api /out/console /app/console
+COPY apps/console/web/build /app/web
+ENV STATIC_FILES_DIR=/app/web \
+    HTTP_ADDR=:8080 \
+    GRPC_ADDR=:50060
+EXPOSE 8080 50060
+ENTRYPOINT ["/app/console"]

--- a/apps/console/api/config/config.go
+++ b/apps/console/api/config/config.go
@@ -29,8 +29,11 @@ const AuthModeDev = "dev"
 // Config holds all configuration for the AIBrix console backend.
 type Config struct {
 	// StoreURI selects the backing store via a URI scheme. Examples:
-	//   memory://
-	//   mysql://user:pass@host:3306/aibrix
+	//   sqlite:/tmp/aibrix-console.db                   (file-backed, dev default)
+	//   sqlite:/var/lib/aibrix/console.db               (file-backed, absolute)
+	//   sqlite::memory:                                 (in-memory SQLite)
+	//   memory://                                       (alias for in-memory SQLite)
+	//   mysql://user:pass@host:3306/aibrix              (production)
 	// Future: postgres://, redis://, mongodb:// — add a case in store.NewFromURI.
 	StoreURI string
 
@@ -139,7 +142,7 @@ func Load() (*Config, error) {
 	}
 
 	return &Config{
-		StoreURI:                            envOrDefault("STORE_URI", "memory://"),
+		StoreURI:                            envOrDefault("STORE_URI", "sqlite:/tmp/aibrix-console.db"),
 		GatewayEndpoint:                     envOrDefault("GATEWAY_ENDPOINT", "http://localhost:8888"),
 		MetadataServiceURL:                  envOrDefault("METADATA_SERVICE_URL", "http://localhost:8090"),
 		DefaultBatchModelDeploymentTemplate: envOrDefault("DEFAULT_BATCH_MODEL_DEPLOYMENT_TEMPLATE", ""),

--- a/apps/console/api/handler/job.go
+++ b/apps/console/api/handler/job.go
@@ -32,8 +32,12 @@ limitations under the License.
 package handler
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -47,6 +51,75 @@ import (
 	"github.com/vllm-project/aibrix/apps/console/api/middleware"
 	"github.com/vllm-project/aibrix/apps/console/api/store"
 )
+
+// loggingTransport dumps every request and response between the BFF and MDS
+// at klog -v=2 (verbose). Errors and non-2xx responses always log at info.
+// Enable with `--v=2` (or env KLOG_V=2) when debugging the OpenAI SDK payloads.
+type loggingTransport struct {
+	base http.RoundTripper
+}
+
+func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	verbose := klog.V(2).Enabled()
+
+	var reqBody []byte
+	if verbose && req.Body != nil {
+		var err error
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("read request body for logging: %w", err)
+		}
+		req.Body = io.NopCloser(bytes.NewReader(reqBody))
+	}
+	if verbose {
+		klog.V(2).Infof("[BFF→MDS] %s %s\n%s", req.Method, req.URL.String(), prettyBody(reqBody))
+	}
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		klog.Warningf("[BFF→MDS] %s %s ERROR %v", req.Method, req.URL.String(), err)
+		return resp, err
+	}
+
+	if resp.StatusCode >= 400 || verbose {
+		respBody, rerr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if rerr != nil {
+			klog.Warningf("[BFF→MDS] %s %s -> %d (read body failed: %v)",
+				req.Method, req.URL.String(), resp.StatusCode, rerr)
+			return resp, nil
+		}
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		if resp.StatusCode >= 400 {
+			klog.Warningf("[BFF→MDS] %s %s -> %d\n%s", req.Method, req.URL.String(), resp.StatusCode, prettyBody(respBody))
+		} else {
+			klog.V(2).Infof("[BFF→MDS] %s %s -> %d\n%s", req.Method, req.URL.String(), resp.StatusCode, prettyBody(respBody))
+		}
+	}
+	return resp, nil
+}
+
+const maxLoggedBodyBytes = 8192
+
+// prettyBody indents JSON for readability and truncates oversized bodies.
+// Non-JSON bodies are returned as-is (also truncated).
+func prettyBody(b []byte) string {
+	if len(b) == 0 {
+		return "(empty)"
+	}
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, b, "", "  "); err == nil {
+		out := pretty.Bytes()
+		if len(out) > maxLoggedBodyBytes {
+			return string(out[:maxLoggedBodyBytes]) + "\n...(truncated)"
+		}
+		return string(out)
+	}
+	if len(b) > maxLoggedBodyBytes {
+		return string(b[:maxLoggedBodyBytes]) + "...(truncated)"
+	}
+	return string(b)
+}
 
 // Console-owned fields we stash on the OpenAI batch.metadata map. Namespaced
 // to keep them out of user-supplied metadata's key space. The bare
@@ -75,9 +148,11 @@ type JobHandler struct {
 func NewJobHandler(s store.Store, metadataServiceURL, defaultModelDeploymentTemplate string, devMode bool) *JobHandler {
 
 	baseURL := strings.TrimRight(metadataServiceURL, "/") + "/v1"
+	httpClient := &http.Client{Transport: &loggingTransport{base: http.DefaultTransport}}
 	client := openai.NewClient(
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("aibrix-console"),
+		option.WithHTTPClient(httpClient),
 	)
 	return &JobHandler{
 		store:                          s,

--- a/apps/console/api/store/demo.go
+++ b/apps/console/api/store/demo.go
@@ -23,7 +23,12 @@ import (
 
 	pb "github.com/vllm-project/aibrix/apps/console/api/gen/console/v1"
 	"github.com/vllm-project/aibrix/apps/console/api/store/models"
+	"gorm.io/gorm/clause"
 )
+
+// onConflictSkip is used by demo seeders so re-running against an existing
+// (e.g. file-backed sqlite) database is a no-op instead of a primary-key failure.
+var onConflictSkip = clause.OnConflict{DoNothing: true}
 
 type apiKeyEntry struct {
 	key    *pb.APIKey
@@ -116,7 +121,7 @@ func (s *GORMStore) loadDemoDeployments() error {
 		if err := dep.FromPB(pbDep); err != nil {
 			return fmt.Errorf("convert demo deployment %s: %w", pbDep.Id, err)
 		}
-		if err := s.db.Create(&dep).Error; err != nil {
+		if err := s.db.Clauses(onConflictSkip).Create(&dep).Error; err != nil {
 			return fmt.Errorf("insert demo deployment %s: %w", dep.ID, err)
 		}
 	}
@@ -172,7 +177,7 @@ func (s *GORMStore) loadDemoJobs() error {
 		if err := job.FromPB(pbJob); err != nil {
 			return fmt.Errorf("convert demo job %s: %w", pbJob.Id, err)
 		}
-		if err := s.db.Create(&job).Error; err != nil {
+		if err := s.db.Clauses(onConflictSkip).Create(&job).Error; err != nil {
 			return fmt.Errorf("insert demo job %s: %w", job.ID, err)
 		}
 	}
@@ -300,7 +305,7 @@ func (s *GORMStore) loadDemoModels() error {
 		if err := model.FromPB(pbModel); err != nil {
 			return fmt.Errorf("convert demo model %s: %w", pbModel.Id, err)
 		}
-		if err := s.db.Create(&model).Error; err != nil {
+		if err := s.db.Clauses(onConflictSkip).Create(&model).Error; err != nil {
 			return fmt.Errorf("insert demo model %s: %w", model.ID, err)
 		}
 	}
@@ -344,7 +349,7 @@ func (s *GORMStore) loadDemoModelDeploymentTemplates() error {
 		if err := tpl.FromPB(pbTpl); err != nil {
 			return fmt.Errorf("convert demo template %s: %w", pbTpl.Id, err)
 		}
-		if err := s.db.Create(&tpl).Error; err != nil {
+		if err := s.db.Clauses(onConflictSkip).Create(&tpl).Error; err != nil {
 			return fmt.Errorf("insert demo template %s: %w", tpl.ID, err)
 		}
 	}
@@ -369,7 +374,7 @@ func (s *GORMStore) loadDemoAPIKeys() error {
 			return fmt.Errorf("convert demo api key %s: %w", entry.key.Id, err)
 		}
 		key.KeyHash = entry.secret
-		if err := s.db.Create(&key).Error; err != nil {
+		if err := s.db.Clauses(onConflictSkip).Create(&key).Error; err != nil {
 			return fmt.Errorf("insert demo api key %s: %w", key.ID, err)
 		}
 	}
@@ -389,7 +394,7 @@ func (s *GORMStore) loadDemoSecrets() error {
 			return fmt.Errorf("convert demo secret %s: %w", entry.secret.Id, err)
 		}
 		secretModel.EncryptedValue = entry.value
-		if err := s.db.Create(&secretModel).Error; err != nil {
+		if err := s.db.Clauses(onConflictSkip).Create(&secretModel).Error; err != nil {
 			return fmt.Errorf("insert demo secret %s: %w", secretModel.ID, err)
 		}
 	}
@@ -411,7 +416,7 @@ func (s *GORMStore) loadDemoQuotas() error {
 		if err := quota.FromPB(pbQuota); err != nil {
 			return fmt.Errorf("convert demo quota %s: %w", pbQuota.Id, err)
 		}
-		if err := s.db.Create(&quota).Error; err != nil {
+		if err := s.db.Clauses(onConflictSkip).Create(&quota).Error; err != nil {
 			return fmt.Errorf("insert demo quota %s: %w", quota.QuotaID, err)
 		}
 	}

--- a/apps/console/api/store/factory.go
+++ b/apps/console/api/store/factory.go
@@ -19,21 +19,34 @@ package store
 import (
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 // NewFromURI dispatches to a Store implementation based on the URI scheme.
-// Supported schemes:
+// Supported forms:
 //
-//	memory://                                          → in-memory (no persistence)
+//	sqlite:/absolute/path.db                           → file-backed SQLite
+//	sqlite:///absolute/path.db                         → same, URL form
+//	sqlite:file:/path/to/db?cache=shared               → raw SQLite driver DSN
 //	mysql://user:pass@host:3306/db?param=value         → MySQL via go-sql-driver/mysql
+//	memory://                                          → in-process in-memory SQLite (test/throwaway)
 //
-// To add a backend (postgres, redis, mongodb, ...) extend the switch below
-// and add a corresponding constructor in this package.
+// The "sqlite:" prefix is stripped and the remainder is forwarded to the
+// SQLite driver verbatim, so any DSN form the driver accepts (file paths,
+// URI-form options) works without bespoke parsing. For in-memory storage
+// use memory:// — production deployments should use sqlite: or mysql://.
 //
 // secretKey is forwarded to backends that encrypt stored secrets at rest.
 func NewFromURI(uri, secretKey string) (Store, error) {
 	if uri == "" {
-		uri = "memory://"
+		uri = "sqlite:/tmp/aibrix-console.db"
+	}
+	if strings.HasPrefix(uri, "sqlite:") {
+		dsn := strings.TrimPrefix(uri, "sqlite:")
+		// sqlite:///abs/path → //abs/path → /abs/path so the URL form and
+		// the raw driver form converge on the same DSN.
+		dsn = strings.TrimPrefix(dsn, "//")
+		return NewSQLiteStore(dsn, secretKey)
 	}
 	u, err := url.Parse(uri)
 	if err != nil {
@@ -45,7 +58,7 @@ func NewFromURI(uri, secretKey string) (Store, error) {
 	case "mysql":
 		return NewMySQLStore(mysqlURIToDSN(u), secretKey)
 	default:
-		return nil, fmt.Errorf("unsupported store scheme %q (URI %q)", u.Scheme, uri)
+		return nil, fmt.Errorf("unsupported store scheme %q (URI %q); use sqlite:, mysql://, or memory://", u.Scheme, uri)
 	}
 }
 

--- a/apps/console/api/store/gorm.go
+++ b/apps/console/api/store/gorm.go
@@ -45,7 +45,7 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// NewMySQLStore creates mysql-backed gorm store.
+// NewMySQLStore creates mysql-backed gorm store with auto-migrations.
 func NewMySQLStore(dsn, encryptionKey string) (*GORMStore, error) {
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
 	if err != nil {
@@ -59,42 +59,63 @@ func NewMySQLStore(dsn, encryptionKey string) (*GORMStore, error) {
 		_ = sqlDB.Close()
 		return nil, fmt.Errorf("failed to ping mysql: %w", err)
 	}
-	store, err := newGORMStore(db, encryptionKey)
+	s, err := newGORMStore(db, encryptionKey)
 	if err != nil {
 		_ = sqlDB.Close()
 		return nil, err
 	}
-	return store, nil
+	if err := s.RunMigrations(); err != nil {
+		_ = sqlDB.Close()
+		return nil, fmt.Errorf("failed to run mysql migrations: %w", err)
+	}
+	return s, nil
 }
 
-// NewSQLiteStore creates sqlite-backed gorm store.
+// NewSQLiteStore creates sqlite-backed gorm store with auto-migrations.
+// Pass ":memory:" or any "...mode=memory..." DSN to get an in-memory database;
+// such DSNs are pinned to a single connection so all queries see the same
+// in-process database.
 func NewSQLiteStore(dsn, encryptionKey string) (*GORMStore, error) {
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to open sqlite: %w", err)
 	}
-	store, err := newGORMStore(db, encryptionKey)
+	sqlDB, err := db.DB()
 	if err != nil {
+		return nil, fmt.Errorf("failed to access sqlite db: %w", err)
+	}
+	if isSQLiteInMemoryDSN(dsn) {
+		// In-memory SQLite databases are per-connection; multiple connections
+		// would each see a different empty DB. Pin to one connection.
+		sqlDB.SetMaxOpenConns(1)
+		sqlDB.SetMaxIdleConns(1)
+	}
+	s, err := newGORMStore(db, encryptionKey)
+	if err != nil {
+		_ = sqlDB.Close()
 		return nil, err
 	}
-	return store, nil
+	if err := s.RunMigrations(); err != nil {
+		_ = sqlDB.Close()
+		return nil, fmt.Errorf("failed to run sqlite migrations: %w", err)
+	}
+	return s, nil
 }
 
+// NewMemoryStore returns an in-memory SQLite store. Convenience wrapper used
+// by the memory:// URI scheme and by tests; equivalent to
+// NewSQLiteStore(":memory:", ...). Production deployments should use a
+// sqlite: file URL or mysql:// instead.
 func NewMemoryStore() *GORMStore {
-	s, err := NewSQLiteStore("file:aibrix-memory?mode=memory&cache=private", strings.Repeat("0", 64))
+	s, err := NewSQLiteStore(":memory:", strings.Repeat("0", 64))
 	if err != nil {
-		panic(fmt.Sprintf("failed to initialize sqlite memory store: %v", err))
-	}
-	sqlDB, err := s.db.DB()
-	if err != nil {
-		panic(fmt.Sprintf("failed to get sqlite db handle: %v", err))
-	}
-	sqlDB.SetMaxOpenConns(1)
-	sqlDB.SetMaxIdleConns(1)
-	if err := s.RunMigrations(); err != nil {
-		panic(fmt.Sprintf("failed to run sqlite migrations: %v", err))
+		panic(fmt.Sprintf("failed to initialize in-memory sqlite store: %v", err))
 	}
 	return s
+}
+
+func isSQLiteInMemoryDSN(dsn string) bool {
+	return strings.Contains(dsn, ":memory:") || strings.Contains(dsn, "mode=memory")
 }
 
 // GORMStore implements Store for mysql/sqlite with shared logic.

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -72,6 +72,20 @@ func main() {
 		}
 	})
 
+	// In dev mode, default klog verbosity to 2 so request/response payloads
+	// to MDS are visible. User can still override with `-v=N`.
+	if cfg.DevMode {
+		vSet := false
+		flag.Visit(func(f *flag.Flag) {
+			if f.Name == "v" {
+				vSet = true
+			}
+		})
+		if !vSet {
+			_ = flag.CommandLine.Set("v", "2")
+		}
+	}
+
 	srv := server.New(cfg)
 
 	// Start gRPC server

--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import json
 import os
 import sys
 from contextlib import asynccontextmanager
 from typing import Any, Dict, Optional
 
 import uvicorn
-from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi import APIRouter, FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from kubernetes import client as k8s_client
 from kubernetes import config
@@ -45,6 +46,46 @@ from aibrix.storage import create_storage
 
 logger = init_logger(__name__)
 router = APIRouter()
+
+_MAX_LOGGED_BODY_BYTES = 8192
+
+
+def _pretty_body(b: bytes) -> str:
+    """Indent JSON bodies for readable traffic dumps; truncate oversized."""
+    if not b:
+        return "(empty)"
+    try:
+        out = json.dumps(json.loads(b), indent=2, ensure_ascii=False)
+    except Exception:  # noqa: BLE001
+        out = b.decode("utf-8", errors="replace")
+    if len(out) > _MAX_LOGGED_BODY_BYTES:
+        return out[:_MAX_LOGGED_BODY_BYTES] + "\n...(truncated)"
+    return out
+
+
+def _emit_traffic(
+    method: str,
+    path: str,
+    req_body: bytes,
+    status: int,
+    resp_body: Optional[bytes],
+    resp_ct: str = "",
+) -> None:
+    """Print one HTTP exchange to stderr in human-readable form.
+
+    Multi-line by design — bypasses structlog so the JSON bodies render with
+    indentation. Off the structured-log path so production filters can ignore.
+    """
+    parts = [f"\n[MDS HTTP] {method} {path} -> {status}"]
+    if req_body:
+        parts.append("--- request ---")
+        parts.append(_pretty_body(req_body))
+    if resp_body is not None:
+        parts.append("--- response ---")
+        parts.append(_pretty_body(resp_body))
+    elif resp_ct:
+        parts.append(f"(response body skipped: content-type={resp_ct})")
+    print("\n".join(parts), file=sys.stderr, flush=True)
 
 
 @router.get("/healthz")
@@ -190,6 +231,41 @@ def build_app(args: argparse.Namespace, params={}):
                 }
             }
         return JSONResponse(status_code=exc.status_code, content=body)
+
+    # HTTP traffic dump for debugging — always on. JSON bodies are pretty-
+    # printed; multipart uploads and file/stream responses skip body capture
+    # to avoid buffering large payloads.
+    @app.middleware("http")
+    async def _log_http_traffic(request: Request, call_next):
+        method = request.method
+        path = request.url.path
+        req_ct = request.headers.get("content-type", "")
+        req_body: bytes = b""
+        if req_ct.startswith("application/json"):
+            try:
+                req_body = await request.body()
+            except Exception:  # noqa: BLE001
+                pass
+
+        response = await call_next(request)
+
+        resp_ct = response.headers.get("content-type", "")
+        if resp_ct.startswith("application/json"):
+            chunks = []
+            async for chunk in response.body_iterator:
+                chunks.append(chunk)
+            resp_body = b"".join(chunks)
+            _emit_traffic(method, path, req_body, response.status_code, resp_body)
+            return Response(
+                content=resp_body,
+                status_code=response.status_code,
+                headers=dict(response.headers),
+                media_type=response.media_type,
+            )
+        _emit_traffic(
+            method, path, req_body, response.status_code, None, resp_ct=resp_ct
+        )
+        return response
 
     # Initialize kopf operator wrapper if K8s jobs are enabled
     if args.enable_k8s_job:


### PR DESCRIPTION
## Pull Request Description
- BFF↔MDS HTTP traffic logging. mainly to expose openai request payload
- Console Dockerfile.** Multi-stage build that compiles the React SPA, builds the Go API, and bundles them into a single runnable image.
- Default dev store to file-backed sqlite

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>