### PR TITLE
[Bugfix]: Remove min_tokens from PD prefill requests to avoid vLLM validation failure

### DIFF
--- a/pkg/plugins/gateway/algorithms/pd_prefill_request.go
+++ b/pkg/plugins/gateway/algorithms/pd_prefill_request.go
@@ -270,6 +270,7 @@ func (r *pdRouter) preparePrefillPayload(routingCtx *types.RoutingContext, pod *
 	}
 	completionRequest["stream"] = false
 	delete(completionRequest, "stream_options")
+	delete(completionRequest, "min_tokens")
 
 	return sonic.Marshal(completionRequest)
 }


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue encountered during PD-disaggregation benchmarking with vLLM-compatible requests.
<img width="684" height="336" alt="image" src="https://github.com/user-attachments/assets/5a23d9bb-f0ed-44bf-8209-424fd41d135c" />

During performance testing, requests containing:
```
"min_tokens": 1024
```
could fail during the prefill stage in PD-disaggregation mode.

The failure is triggered by the following validation logic in vLLM:

```
if self.max_tokens is not None and self.min_tokens > self.max_tokens:
    raise ValueError(
        f"min_tokens must be less than or equal to "
        f"max_tokens={self.max_tokens}, got {self.min_tokens}."
    )
```

In the PD-disaggregation prefill request path, min_tokens is not required and may become inconsistent with rewritten request parameters, causing unnecessary request failures.

This PR removes min_tokens from the prefill request before forwarding:

```
delete(completionRequest, "min_tokens")
```
This change ensures compatibility with PD-disaggregation prefill flows and avoids invalid parameter validation errors during benchmarking and production inference workloads.