### PR TITLE
optimize: gateway-plugin cpu usage optimize when stream is true #2196

### DIFF
--- a/apps/console/api/planner/api/jobs.go
+++ b/apps/console/api/planner/api/jobs.go
@@ -93,4 +93,3 @@ type ModelTemplateRef struct {
 	Name    string `json:"name"`
 	Version string `json:"version,omitempty"`
 }
-

--- a/pkg/plugins/gateway/gateway_rsp_body.go
+++ b/pkg/plugins/gateway/gateway_rsp_body.go
@@ -20,16 +20,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"math"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/bytedance/sonic"
-	"github.com/openai/openai-go/v3"
-	"github.com/openai/openai-go/v3/packages/ssestream"
+	"github.com/tidwall/gjson"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
@@ -80,31 +77,47 @@ func (s *Server) HandleResponseBody(ctx context.Context, requestID string, req *
 	}()
 
 	if stream {
-		t := &http.Response{
-			Body: io.NopCloser(bytes.NewReader(b.ResponseBody.GetBody())),
-		}
-		streaming := ssestream.NewStream[openai.ChatCompletionChunk](ssestream.NewDecoder(t), nil)
-		defer func() {
-			_ = streaming.Close()
-		}()
-		for streaming.Next() {
-			evt := streaming.Current()
-			if len(evt.Choices) == 0 {
-				// Do not overwrite model, res can be empty.
-				promptTokens = evt.Usage.PromptTokens
-				totalTokens = evt.Usage.TotalTokens
-				completionTokens = evt.Usage.CompletionTokens
+		bodyBytes := b.ResponseBody.GetBody()
+
+		// Pre-filter to avoid processing if "usage" isn't present
+		if bytes.Contains(bodyBytes, []byte(`"usage"`)) {
+			remaining := bodyBytes
+
+			for len(remaining) > 0 {
+				var line []byte
+				// Manually find the newline to avoid the allocations of bytes.Split
+				if idx := bytes.IndexByte(remaining, '\n'); idx >= 0 {
+					line = remaining[:idx]
+					remaining = remaining[idx+1:]
+				} else {
+					line = remaining
+					remaining = nil
+				}
+				line = bytes.TrimSpace(line)
+
+				// Look for the SSE data prefix
+				if bytes.HasPrefix(line, []byte("data:")) {
+					// Slice the "data:" prefix (zero allocation)
+					jsonBytes := bytes.TrimSpace(line[5:])
+
+					// Check for the end of the stream
+					if bytes.Equal(jsonBytes, []byte("[DONE]")) {
+						continue
+					}
+
+					// use gjson.GetBytes accelerate
+					usageResult := gjson.GetBytes(jsonBytes, "usage")
+					if usageResult.Exists() && usageResult.IsObject() {
+						promptTokens = usageResult.Get("prompt_tokens").Int()
+						completionTokens = usageResult.Get("completion_tokens").Int()
+						totalTokens = usageResult.Get("total_tokens").Int()
+					}
+				}
 			}
-		}
-		if err := streaming.Err(); err != nil {
-			klog.ErrorS(err, "error to unmarshal response", "requestID", requestID, "responseBody", string(b.ResponseBody.GetBody()))
-			complete = true
-			return generateErrorResponse(
-				envoyTypePb.StatusCode_InternalServerError,
-				[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
-					Key: HeaderErrorStreaming, RawValue: []byte("true"),
-				}}},
-				err.Error(), "", ""), complete
+			// observability log
+			if promptTokens == 0 && totalTokens == 0 {
+				klog.Warningf("usage string detected but no valid tokens parsed, requestID: %s", requestID)
+			}
 		}
 	} else {
 		if isLanguageRequest(routerCtx.ReqPath) {

--- a/pkg/plugins/gateway/gateway_rsp_body.go
+++ b/pkg/plugins/gateway/gateway_rsp_body.go
@@ -79,7 +79,10 @@ func (s *Server) HandleResponseBody(ctx context.Context, requestID string, req *
 	if stream {
 		bodyBytes := b.ResponseBody.GetBody()
 
-		// Pre-filter to avoid processing if "usage" isn't present
+		// The previous implementation unmarshalled every single SSE chunk into a struct (openai.ChatCompletionChunk).
+		// This caused significant CPU overhead and high GC pressure under heavy concurrency.
+		// The new implementation uses zero-allocation  byte scanning and pre-filtering,
+		// selectively extracting only the "usage" metadata via gjson for the final chunks.
 		if bytes.Contains(bodyBytes, []byte(`"usage"`)) {
 			remaining := bodyBytes
 
@@ -93,6 +96,9 @@ func (s *Server) HandleResponseBody(ctx context.Context, requestID string, req *
 					line = remaining
 					remaining = nil
 				}
+
+				// Handle SSE \r\n line endings. bytes.TrimSpace safely strips trailing \r
+				// as well as any leading/trailing whitespace.
 				line = bytes.TrimSpace(line)
 
 				// Look for the SSE data prefix
@@ -105,18 +111,33 @@ func (s *Server) HandleResponseBody(ctx context.Context, requestID string, req *
 						continue
 					}
 
-					// use gjson.GetBytes accelerate
+					// While gjson.ValidBytes is O(N), it does not degrade gateway throughput.
+					// Guarded by the bytes.Contains pre-filter, it bypasses the hot path of streaming standard text
+					// and only executes on final chunks, ensuring strict correctness.
+					if !gjson.ValidBytes(jsonBytes) {
+						complete = true
+						return generateErrorResponse(
+							envoyTypePb.StatusCode_InternalServerError,
+							[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
+								Key: HeaderErrorStreaming, RawValue: []byte("true"),
+							}}},
+							"malformed JSON in SSE stream", "", ""), complete
+					}
+
+					// gjson avoids full deserialization by only extracting the usage field.
 					usageResult := gjson.GetBytes(jsonBytes, "usage")
 					if usageResult.Exists() && usageResult.IsObject() {
+						// Assumption: The upstream sends the usage object only in the final chunk
+						// (standard vLLM/OpenAI behavior). We overwrite/set the values here.
 						promptTokens = usageResult.Get("prompt_tokens").Int()
 						completionTokens = usageResult.Get("completion_tokens").Int()
 						totalTokens = usageResult.Get("total_tokens").Int()
 					}
 				}
 			}
-			// observability log
+			// warnings when "usage" is triggered by a false positive in generated content.
 			if promptTokens == 0 && totalTokens == 0 {
-				klog.Warningf("usage string detected but no valid tokens parsed, requestID: %s", requestID)
+				klog.V(4).Infof("usage string detected but no valid tokens parsed (likely generated text), requestID: %s", requestID)
 			}
 		}
 	} else {

--- a/pkg/plugins/gateway/gateway_rsp_body_test.go
+++ b/pkg/plugins/gateway/gateway_rsp_body_test.go
@@ -519,3 +519,107 @@ func TestHandleResponseBody_DoesNotDuplicateTrace(t *testing.T) {
 	assert.True(t, complete)
 	mockCache.AssertNotCalled(t, "DoneRequestTrace", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
+
+func TestHandleResponseBody_SSEParsing(t *testing.T) {
+	tests := []struct {
+		name             string
+		body             []byte
+		promptTokens     int64
+		completionTokens int64
+		totalTokens      int64
+		expectError      bool
+	}{
+		{
+			name:             "Normal usage chunk with \\n",
+			body:             []byte("data: {\"id\": \"1\", \"usage\": {\"prompt_tokens\": 10, \"completion_tokens\": 20, \"total_tokens\": 30}}\n\n"),
+			promptTokens:     10,
+			completionTokens: 20,
+			totalTokens:      30,
+			expectError:      false,
+		},
+		{
+			name:             "Normal usage chunk with \\r\\n",
+			body:             []byte("data: {\"id\": \"2\", \"usage\": {\"prompt_tokens\": 5, \"completion_tokens\": 5, \"total_tokens\": 10}}\r\n\r\n"),
+			promptTokens:     5,
+			completionTokens: 5,
+			totalTokens:      10,
+			expectError:      false,
+		},
+		{
+			name:             "DONE terminator",
+			body:             []byte("data: [DONE]\n\n"),
+			promptTokens:     0,
+			completionTokens: 0,
+			totalTokens:      0,
+			expectError:      false,
+		},
+		{
+			name:             "Malformed JSON payload is passed through transparently",
+			body:             []byte("data: {\"id\": \"1\", \"usage\": { broken json \n\n"),
+			promptTokens:     0,
+			completionTokens: 0,
+			totalTokens:      0,
+			expectError:      true,
+		},
+		{
+			name:             "False positive 'usage' text in response",
+			body:             []byte("data: {\"id\": \"1\", \"choices\": [{\"delta\": {\"content\": \"Here is the usage example\"}}]}\n\n"),
+			promptTokens:     0,
+			completionTokens: 0,
+			totalTokens:      0,
+			expectError:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCache := &MockCache{Cache: cache.NewForTest()}
+			mockCache.On("DoneRequestTrace", mock.Anything, "test-req-id", "test-model", tt.promptTokens, tt.completionTokens, int64(0)).Maybe()
+
+			server := &Server{
+				cache: mockCache,
+			}
+
+			routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", "test-req-id", "")
+			routerCtx.ReqPath = PathChatCompletions
+			routerCtx.RequestTime = time.Now()
+
+			req := &extProcPb.ProcessingRequest{
+				Request: &extProcPb.ProcessingRequest_ResponseBody{
+					ResponseBody: &extProcPb.HttpBody{
+						Body:        tt.body,
+						EndOfStream: true, // assume this is last chunk
+					},
+				},
+			}
+
+			// stream=true
+			resp, complete := server.HandleResponseBody(routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", true, 0, false)
+
+			if tt.expectError {
+				assert.True(t, complete)
+				assert.NotNil(t, resp)
+
+				immediateRes := resp.GetImmediateResponse()
+				assert.NotNil(t, immediateRes, "Expected ImmediateResponse on error, but got nil. Response: %v", resp)
+
+				hasErrorHeader := false
+				if immediateRes.GetHeaders() != nil {
+					for _, header := range immediateRes.GetHeaders().GetSetHeaders() {
+						if header.Header.Key == HeaderErrorStreaming {
+							hasErrorHeader = true
+							break
+						}
+					}
+				}
+				assert.True(t, hasErrorHeader, "Expected HeaderErrorStreaming to be set on error")
+			} else {
+				assert.True(t, complete)
+				assert.NotNil(t, resp)
+				assert.NotNil(t, resp.GetResponseBody(), "Expected ResponseBody on success")
+			}
+
+			mockCache.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: rayne-Li <lizhy1@chinatelecom.cn>

## Pull Request Description
optimize cpu usage by reduce memory alloc and gc, use gjson instead avoid fully unmarshall resp when stream=True

when 1000QPS with total 5000 request

- before: cpu: 32C, after: 17c

- before cpu-pprof: 
<img width="1714" height="853" alt="image" src="https://github.com/user-attachments/assets/c8ed29ae-1cdd-4f09-86fc-2bdff648cd1a" />


- before mem-pprof
<img width="2742" height="1478" alt="image" src="https://github.com/user-attachments/assets/f61b2ebb-0d75-447b-894f-2480ea2f359c" />

- after mem-pprof
<img width="2334" height="1414" alt="image" src="https://github.com/user-attachments/assets/f86b8c2d-bffb-4a0d-ab3b-139cbacb59a1" />


- diff
<img width="2754" height="1518" alt="image" src="https://github.com/user-attachments/assets/9829f890-6496-49a4-a84e-5e1c17a88c00" />
