### PR TITLE
chart: add router idleTimeout in chart

### DIFF
--- a/dist/chart/templates/gateway-instance/gateway.yaml
+++ b/dist/chart/templates/gateway-instance/gateway.yaml
@@ -146,6 +146,7 @@ spec:
           route:
             cluster: original_destination_cluster
             timeout: {{ .Values.gateway.envoyPatchPolicy.route.timeout }}
+            idle_timeout: {{ .Values.gateway.envoyPatchPolicy.route.idleTimeout }}
           typed_per_filter_config:
             "envoy.filters.http.ext_proc/envoyextensionpolicy/{{ .Release.Namespace }}/{{ include "aibrix.fullname" . }}-gateway-plugins-extension-policy/extproc/0":
               "@type": "type.googleapis.com/envoy.config.route.v3.FilterConfig"

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -214,6 +214,7 @@ gateway:
     route:
       timeout: 120s          # e.g., "120s" or "2m"
       connectTimeout: 6s     # e.g., "6s"
+      idleTimeout: 300s      # e.g., "300s" or "5m"
     circuitBreakers:
       # The maximum number of connections for the original destination cluster.
       maxConnections: 1024


### PR DESCRIPTION
## Pull Request Description

Added idle_timeout configuration. This allows us to explicitly control the connection lifecycle for idle streams. ensuring better stability for idle connections

according to envoy docs, the defualt value depends on steam_idle_timeout

<img width="958" height="414" alt="image" src="https://github.com/user-attachments/assets/dab76da7-f782-49c3-a490-c03578c20320" />


- in `deployment/standalone/configs/envoy.yaml`, steam_idle_timeout and idle_timeout is set to 300s, so i give it 300s to default value in chart
```
      filter_chains:
        - filters:
            - name: envoy.filters.network.http_connection_manager
              typed_config:
                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                stat_prefix: ingress_http
                codec_type: AUTO

                # Enable streaming for LLM responses
                stream_idle_timeout: 300s
                request_timeout: 600s

############################################
                route_config:
                  name: local_route
                  virtual_hosts:
                    - name: aibrix_api
                      domains: ["*"]
                      routes:
                        - match:
                            prefix: "/v1/chat/completions"
                          route:
                            cluster: vllm_backend
                            timeout: 600s
                            idle_timeout: 300s

                        - match:
                            prefix: "/v1/messages"
                          route:
                            cluster: vllm_backend
                            timeout: 600s
                            idle_timeout: 300s

                        - match:
                            prefix: "/v1/completions"
                          route:
                            cluster: vllm_backend
                            timeout: 600s
                            idle_timeout: 300s

                        - match:
                            prefix: "/v1/embeddings"
                          route:
                            cluster: vllm_backend
                            timeout: 120s
```

