### PR TITLE
fix(console): update key to snake_case

### DIFF
--- a/apps/console/api/handler/job.go
+++ b/apps/console/api/handler/job.go
@@ -214,11 +214,10 @@ func (h *JobHandler) CreateJob(ctx context.Context, req *pb.CreateJobRequest) (*
 		if tpl := h.resolveTemplate(ctx, templateName, req.ModelTemplateVersion); tpl != nil {
 			modelID = tpl.ModelId
 			if tpl.Spec != nil {
-				// protojson preserves proto3 wire conventions (enums as
-				// strings, snake_case field names) that the Python pydantic
-				// consumer expects; encoding/json would emit Go field names
-				// and int enums.
-				if specBytes, err := protojson.Marshal(tpl.Spec); err == nil {
+				// UseProtoNames keeps snake_case proto field names (engine_args,
+				// model_source, ...) that the Python pydantic consumer expects;
+				// default protojson uses lowerCamelCase. Enums still serialize as strings.
+				if specBytes, err := (protojson.MarshalOptions{UseProtoNames: true}).Marshal(tpl.Spec); err == nil {
 					modelTemplate.Spec = specBytes
 				} else {
 					klog.Warningf("marshal template spec %q/%q: %v", templateName, req.ModelTemplateVersion, err)


### PR DESCRIPTION
## Pull Request Description
make sure we use snake_case keys rather than camelCase keys in the model template spec

Right now, there are mixed key formats in the aibrix-extra-body and would like to make all the keys using the snake_case. The modelSource, engineArgs, supportedEndpoints, deploymentMode use camelCase and other keys use the snake_case.

The following is an example of the current extra-body

```
      "aibrix": {
        "job_id": "job_f5b298e2-29be-49c8-bbf8-2b5caaa2fb92",
        "planner_decision": {
          "provision_id": "ae5608f6-db6e-4372-ac2f-25a55964cdf2",
          "provision_resource_deadline": null,
          "resource_details": null
        },
        "model_template": {
          "name": "ning-test2",
          "version": "v1.0.0",
          "spec": {
            "engine": {
              "type": "vllm",
              "invocation": "http_server"
            },
            "modelSource": {
              "type": "local",
              "uri": "test"
            },
            "accelerator": {
              "type": "H100-PCIe",
              "count": 1,
              "interconnect": "pcie",
              "vramGb": 80
            },
            "parallelism": {
              "tp": 1,
              "pp": 1,
              "dp": 1
            },
            "engineArgs": {
              "enable_chunked_prefill": "true",
              "enable_prefix_caching": "true",
              "gpu_memory_utilization": "0.88",
              "max_model_len": "4",
              "max_num_batched_tokens": "10000",
              "test_flag_1": "43"
            },
            "quantization": {},
            "supportedEndpoints": [
              "/v1/chat/completions"
            ],
            "deploymentMode": "dedicated"
          },
          "overrides": null
        },
        "profile": null
      }
    }
```