### PR TITLE
chart: add env for controller-manager

### DIFF
--- a/dist/chart/templates/controller-manager/deployment.yaml
+++ b/dist/chart/templates/controller-manager/deployment.yaml
@@ -30,9 +30,10 @@ spec:
         env:
         - name: AIBRIX_GATEWAY_TIMEOUT_SECONDS
           value: "{{ .Values.controllerManager.gatewayTimeoutSeconds }}"
-{{- range $key, $val := .Values.controllerManager.container.envs }}
+{{- $envs := .Values.controllerManager.container.envs }}
+{{- range $key := keys $envs | sortAlpha }}
         - name: {{ $key }}
-          value: "{{ $val }}"
+          value: {{ index $envs $key | quote }}
 {{- end }}
         image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag }}
         imagePullPolicy: {{ .Values.controllerManager.container.image.imagePullPolicy }}

--- a/dist/chart/templates/controller-manager/deployment.yaml
+++ b/dist/chart/templates/controller-manager/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         env:
         - name: AIBRIX_GATEWAY_TIMEOUT_SECONDS
           value: "{{ .Values.controllerManager.gatewayTimeoutSeconds }}"
+{{- range $key, $val := .Values.controllerManager.container.envs }}
+        - name: {{ $key }}
+          value: "{{ $val }}"
+{{- end }}
         image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag }}
         imagePullPolicy: {{ .Values.controllerManager.container.image.imagePullPolicy }}
         name: manager

--- a/dist/chart/templates/controller-manager/deployment.yaml
+++ b/dist/chart/templates/controller-manager/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: "{{ .Values.controllerManager.gatewayTimeoutSeconds }}"
 {{- range $key, $val := .Values.controllerManager.container.envs }}
         - name: {{ $key }}
-          value: "{{ $val }}"
+          value: "{{ $val | quote }}"
 {{- end }}
         image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag }}
         imagePullPolicy: {{ .Values.controllerManager.container.image.imagePullPolicy }}

--- a/dist/chart/templates/controller-manager/deployment.yaml
+++ b/dist/chart/templates/controller-manager/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: "{{ .Values.controllerManager.gatewayTimeoutSeconds }}"
 {{- range $key, $val := .Values.controllerManager.container.envs }}
         - name: {{ $key }}
-          value: "{{ $val | quote }}"
+          value: "{{ $val }}"
 {{- end }}
         image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag }}
         imagePullPolicy: {{ .Values.controllerManager.container.image.imagePullPolicy }}

--- a/dist/chart/values.schema.json
+++ b/dist/chart/values.schema.json
@@ -23,6 +23,14 @@
             },
             "probes": {
               "$ref": "#/$defs/probeConfiguration"
+            },
+            "envs": {
+              "type": "object",
+              "patternProperties": {
+                "^[A-Z_][A-Z0-9_]*$": {
+                  "type": "string"
+                }
+              }
             }
           }
         },

--- a/dist/chart/values.schema.json
+++ b/dist/chart/values.schema.json
@@ -29,7 +29,8 @@
               "patternProperties": {
                 "^[A-Z_][A-Z0-9_]*$": {
                   "type": "string"
-                }
+                },
+              "additionalProperties": false
               }
             }
           }
@@ -77,7 +78,8 @@
                 "^[A-Z_][A-Z0-9_]*$": {
                   "type": "string"
                 }
-              }
+              },
+              "additionalProperties": false
             }
           }
         },

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -33,8 +33,12 @@ controllerManager:
           port: 8081
         initialDelaySeconds: 5
         periodSeconds: 10
-    envs:
-      AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS: "50"
+    envs: {}
+      # AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS: "50"  # Uncomment to tune for high-latency or low-traffic environments
+  # Sets the AIBRIX_GATEWAY_TIMEOUT_SECONDS environment variable.
+  # NOTE: This is managed exclusively via this field. Do NOT add
+  # AIBRIX_GATEWAY_TIMEOUT_SECONDS to the 'envs' map below,
+  # as it will result in duplicate environment variables in the manifest.
   gatewayTimeoutSeconds: 120
   serviceAccount:
     create: true

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -33,6 +33,8 @@ controllerManager:
           port: 8081
         initialDelaySeconds: 5
         periodSeconds: 10
+    envs:
+      AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS: "50"
   gatewayTimeoutSeconds: 120
   serviceAccount:
     create: true


### PR DESCRIPTION
## Pull Request Description
according to #1349, now controller-manager will curl /metrics on vllm pods by interval `AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS` in `pkg/cache/cache_metrics.go`, so we need to add env in chart to control that

- cmd/controllers/main.go
```
	if features.IsControllerEnabled(features.ModelAdapterController) {
		// cache is enabled for model adapter scheduling.
		cache.InitWithOptions(config, stopCh, cache.InitOptions{})
		// All options default to zero values (false, nil, nil)
	}
```

- and ModelAdapterController is enabled by default
```
// EnableAllControllers is used to enable all known controllers.
func EnableAllControllers() {
	// This should be updated to reflect all available controllers.
	EnabledControllers[PodAutoscalerController] = true
	EnabledControllers[ModelAdapterController] = true
	EnabledControllers[DistributedInferenceController] = true
	EnabledControllers[ModelRouteController] = true
	EnabledControllers[KVCacheController] = true
	EnabledControllers[StormServiceController] = true
}
```
