### PR TITLE
bugfix: add completed check after process envoy request

### DIFF
--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -125,6 +125,11 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		ctx:       srv.Context(),
 		requestID: uuid.New().String(),
 	}
+	defer func() {
+		if st.routerCtx != nil {
+			st.routerCtx.Delete()
+		}
+	}()
 
 	klog.InfoS("processing request", "requestID", st.requestID)
 	labels := map[string]string{"pod_name": podName}
@@ -202,7 +207,7 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 		default:
 		}
 
-		// EOF at completion is normal
+		// Fallback: if proactive exit in Process was skipped (should not happen normally)
 		if st.completed {
 			if st.model != "" {
 				s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, "gateway_request_success", "200")
@@ -328,9 +333,6 @@ func (s *Server) sendProcessingResponse(srv extProcPb.ExternalProcessor_ProcessS
 		klog.ErrorS(err, "gateway fail to send response to envoy-proxy", "requestID", st.requestID)
 		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "send_envoy_proxy", "499")
 		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
-		if st.routerCtx != nil {
-			st.routerCtx.Delete()
-		}
 
 		if errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "EOF") {
 			klog.Warning("Stream already closed by client", "requestID", st.requestID)

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -134,6 +134,16 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		if err := s.processOnce(srv, st); err != nil {
 			return err
 		}
+		// Proactively break the loop if the response is fully processed.
+		// This allows Envoy to gracefully close the stream and send 0\r\n\r\n.
+		if st.completed {
+			klog.V(4).InfoS("request actively finished, breaking ext_proc stream", "requestID", st.requestID)
+			if st.model != "" {
+				s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, "gateway_request_success", "200")
+			}
+			s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+			return nil
+		}
 	}
 }
 

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -125,11 +125,6 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		ctx:       srv.Context(),
 		requestID: uuid.New().String(),
 	}
-	defer func() {
-		if st.routerCtx != nil {
-			st.routerCtx.Delete()
-		}
-	}()
 
 	klog.InfoS("processing request", "requestID", st.requestID)
 	labels := map[string]string{"pod_name": podName}
@@ -333,6 +328,11 @@ func (s *Server) sendProcessingResponse(srv extProcPb.ExternalProcessor_ProcessS
 		klog.ErrorS(err, "gateway fail to send response to envoy-proxy", "requestID", st.requestID)
 		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "send_envoy_proxy", "499")
 		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+		// Manually delete routerCtx on error paths;
+		// HandleResponseBody() and HandleResponseHeaders() will handle it on the happy path.
+		if st.routerCtx != nil {
+			st.routerCtx.Delete()
+		}
 
 		if errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "EOF") {
 			klog.Warning("Stream already closed by client", "requestID", st.requestID)

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -1338,3 +1338,79 @@ func TestProcess_RecvEOF_DuringShutdown(t *testing.T) {
 	srv.AssertExpectations(t)
 	mc.AssertExpectations(t)
 }
+
+// TestProcess_CompletedExitsLoop verifies that if a request completes successfully
+// (which sets st.completed = true), the loop exits gracefully returning nil,
+// even if the client context is cancelled concurrently.
+func TestProcess_CompletedExitsLoop(t *testing.T) {
+	mc := &MockCache{}
+	// mock all funcs we need
+	mc.On("DoneRequestCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mc.On("AddRequestCount", mock.Anything, mock.Anything, mock.Anything).Return(int64(0))
+	mc.On("DoneRequestTrace", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mc.On("HasModel", mock.Anything).Return(true)
+	pods := &utils.PodArray{Pods: []*v1.Pod{
+		{
+			Status: v1.PodStatus{
+				PodIP:      "1.2.3.4",
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			},
+		},
+	}}
+	mc.On("ListPodsByModel", mock.Anything).Return(pods, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := &mockProcessServer{ctx: ctx}
+
+	req := &extProcPb.ProcessingRequest{}
+	recvCount := 0
+	// we need to fully test s.Process, so we mock a full stream request with header body and resp
+	srv.On("Recv").Return(req, nil).Run(func(args mock.Arguments) {
+		switch recvCount {
+		case 0:
+			// mock on RequestHeaders
+			req.Request = &extProcPb.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extProcPb.HttpHeaders{
+					Headers: &configPb.HeaderMap{
+						Headers: []*configPb.HeaderValue{
+							{Key: ":routing-strategy", Value: "random", RawValue: []byte("random")},
+							{Key: ":path", Value: "/v1/chat/completions", RawValue: []byte("/v1/chat/completions")},
+						},
+					},
+				},
+			}
+		case 1:
+			// mock on RequestBody，contains stream=true
+			req.Request = &extProcPb.ProcessingRequest_RequestBody{
+				RequestBody: &extProcPb.HttpBody{
+					Body: []byte(`{"model": "test", "messages": [{"role": "user", "content": "hello"}], "stream": true}`),
+				},
+			}
+		case 2:
+			// mock on ResponseBody，with [DONE]
+			req.Request = &extProcPb.ProcessingRequest_ResponseBody{
+				ResponseBody: &extProcPb.HttpBody{
+					Body:        []byte("data: [DONE]\n\n"),
+					EndOfStream: true, // if we get [Done], completed == True
+				},
+			}
+			cancel()
+		}
+		recvCount++
+	})
+
+	srv.On("Send", mock.Anything).Return(nil).Run(nil)
+
+	s := newProcessTestServer(openShutdownCh(), mc)
+
+	err := s.Process(srv)
+
+	// Core assertion: Since st.completed has already been set to true,
+	// even if ctx has been canceled, Process should exit gracefully (return nil) instead of throwing a context.Canceled error.
+	assert.NoError(t, err)
+
+	srv.AssertExpectations(t)
+	mc.AssertExpectations(t)
+}


### PR DESCRIPTION
## Pull Request Description

Proactively break the loop if the response is fully processed, allows Envoy to gracefully close the stream and send 0\r\n\r\n.

Scope Update: Note that this fix naturally extends to non-streaming requests as well. Because st.completed is correctly set for both streaming and non-streaming response bodies, this logic ensures that context cancellation races are prevented across all request types gracefully.

## Related Issues

#2224
