### PR TITLE
[Bug] Prevent double-release on submitted job cancellation

### DIFF
--- a/apps/console/api/planner/impl/planner.go
+++ b/apps/console/api/planner/impl/planner.go
@@ -632,7 +632,6 @@ func (q *Planner) Cancel(ctx context.Context, jobID string) (*plannerapi.Job, er
 	}
 	status := job.status
 	batchID := job.batchID
-	provisionID := job.provisionID
 	req := job.req
 	queuedAt := job.queuedAt
 	now := time.Now()
@@ -659,8 +658,20 @@ func (q *Planner) Cancel(ctx context.Context, jobID string) (*plannerapi.Job, er
 		if err != nil {
 			return nil, err
 		}
+		var toRelease string
+		q.mu.Lock()
+		if job, ok := q.jobs[jobID]; ok {
+			toRelease = job.provisionID
+			job.status = plannerapi.JobStatusCancelled
+			job.canceledAt = now
+			job.provisionID = ""
+		}
+		q.mu.Unlock()
+
+		if toRelease != "" {
+			q.releaseAfter(jobID, toRelease, "cancel submitted")
+		}
 		q.syncFromBatch(jobID, batch)
-		q.releaseAfter(jobID, provisionID, "cancel submitted")
 		return &plannerapi.Job{JobID: jobID, Batch: batch}, nil
 	}
 	// Already terminal — return current view, no double-cancel side effects.


### PR DESCRIPTION
## Pull Request Description
This PR resolves a race condition/double-release issue in the job `Planner`'s `Cancel` flow that caused `TestCancelSubmittedJobForwardsToMDSAndReleasesProvision` to flakily fail.

### Root Cause
During the cancellation of a submitted job (meaning an active job with an associated MDS batch), the planner synchronously called `releaseAfter(..., "cancel submitted")` and subsequently called `syncFromBatch`. Since the returned batch status was `cancelled` (terminal), `syncFromBatch` detected the status change and asynchronously spawned a second `releaseAfter` call in a goroutine. This resulted in two concurrent release calls on the provisioner, causing test assertion failures and potential leaks or double-frees.

### Fix
1. Synchronously release the provisioned resource manager resource in the `Cancel` flow, which ensures immediate, deterministic resource cleanup and consistent test assertions.
2. Under the planner's mutex, update the local job status to `JobStatusCancelled`, set `canceledAt`, and clear the `provisionID` field to record that the resource has been freed.
3. Call `syncFromBatch` after updating local status. Since the local job status matches the batch status (`cancelled`), no status change is detected, preventing the redundant asynchronous `releaseAfter` call from being spawned.

All planner tests (including concurrent stress tests under `go test -v -race -count=5`) now pass successfully without race detections.

## Related Issues
Resolves: #2223

---

### Submission Checklist
- [x] PR title includes appropriate prefix(es)
- [x] Changes are clearly explained in the PR description
- [x] New and existing tests pass successfully
- [x] Code adheres to project style and best practices
- [x] Thorough testing completed, no regressions introduced
