### PR TITLE
feat(helm): support disabling in-chart redis with external host valid…

### DIFF
--- a/dist/chart/templates/_helpers.tpl
+++ b/dist/chart/templates/_helpers.tpl
@@ -127,18 +127,20 @@ Create the name of the metadata service service account
 {{- end -}}
 
 {{- define "aibrix.validateValues" -}}
+{{- $values := fromYaml (toYaml .Values) -}}
 {{- if and .Values.gateway.enable .Values.gateway.envoyAsSideCar -}}
 {{- fail "gateway.enable and gateway.envoyAsSideCar are mutually exclusive and cannot both be true." -}}
 {{- end -}}
-{{- if not .Values.metadata.redis.enabled -}}
+{{- $redisEnabled := dig "metadata" "redis" "enabled" true $values -}}
+{{- if not $redisEnabled -}}
 {{- $missingHosts := list -}}
-{{- if empty (trim .Values.metadata.service.redis.host) -}}
+{{- if empty (trim (dig "metadata" "service" "redis" "host" "" $values)) -}}
 {{- $missingHosts = append $missingHosts "metadata.service.redis.host" -}}
 {{- end -}}
-{{- if empty (trim .Values.gatewayPlugin.dependencies.redis.host) -}}
+{{- if empty (trim (dig "gatewayPlugin" "dependencies" "redis" "host" "" $values)) -}}
 {{- $missingHosts = append $missingHosts "gatewayPlugin.dependencies.redis.host" -}}
 {{- end -}}
-{{- if empty (trim .Values.gpuOptimizer.dependencies.redis.host) -}}
+{{- if empty (trim (dig "gpuOptimizer" "dependencies" "redis" "host" "" $values)) -}}
 {{- $missingHosts = append $missingHosts "gpuOptimizer.dependencies.redis.host" -}}
 {{- end -}}
 {{- if gt (len $missingHosts) 0 -}}

--- a/dist/chart/templates/_helpers.tpl
+++ b/dist/chart/templates/_helpers.tpl
@@ -130,4 +130,19 @@ Create the name of the metadata service service account
 {{- if and .Values.gateway.enable .Values.gateway.envoyAsSideCar -}}
 {{- fail "gateway.enable and gateway.envoyAsSideCar are mutually exclusive and cannot both be true." -}}
 {{- end -}}
+{{- if not .Values.metadata.redis.enabled -}}
+{{- $missingHosts := list -}}
+{{- if empty (trim .Values.metadata.service.redis.host) -}}
+{{- $missingHosts = append $missingHosts "metadata.service.redis.host" -}}
+{{- end -}}
+{{- if empty (trim .Values.gatewayPlugin.dependencies.redis.host) -}}
+{{- $missingHosts = append $missingHosts "gatewayPlugin.dependencies.redis.host" -}}
+{{- end -}}
+{{- if empty (trim .Values.gpuOptimizer.dependencies.redis.host) -}}
+{{- $missingHosts = append $missingHosts "gpuOptimizer.dependencies.redis.host" -}}
+{{- end -}}
+{{- if gt (len $missingHosts) 0 -}}
+{{- fail (printf "metadata.redis.enabled=false requires non-empty values for %s." (join ", " $missingHosts)) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/dist/chart/templates/gateway-plugin/deployment.yaml
+++ b/dist/chart/templates/gateway-plugin/deployment.yaml
@@ -1,5 +1,8 @@
 {{- if or .Values.gateway.enable .Values.gateway.envoyAsSideCar }}
-{{- $redisHost := default (printf "%s-redis-master" (include "aibrix.fullname" .)) .Values.gatewayPlugin.dependencies.redis.host }}
+{{- $values := fromYaml (toYaml .Values) -}}
+{{- $redisHost := default (printf "%s-redis-master" (include "aibrix.fullname" .)) (dig "gatewayPlugin" "dependencies" "redis" "host" "" $values) }}
+{{- $redisPort := dig "gatewayPlugin" "dependencies" "redis" "port" 6379 $values }}
+{{- $redisEnablePassword := dig "metadata" "redis" "enablePassword" false $values }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -58,16 +61,16 @@ spec:
       initContainers:
         - name: init-c
           image: {{ .Values.gatewayPlugin.initContainer.image.repository }}:{{ .Values.gatewayPlugin.initContainer.image.tag }}
-          {{- if .Values.metadata.redis.enablePassword }}
+          {{- if $redisEnablePassword }}
           env:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "aibrix.fullname" . }}-redis
                   key: redis-password
-          command: ['sh', '-c', 'until printf ''AUTH %s\nping\n'' "$REDIS_PASSWORD" | nc {{ $redisHost }} {{ .Values.gatewayPlugin.dependencies.redis.port }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
+          command: ['sh', '-c', 'until printf ''AUTH %s\nping\n'' "$REDIS_PASSWORD" | nc {{ $redisHost }} {{ $redisPort }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
           {{- else }}
-          command: ['sh', '-c', 'until echo "ping" | nc {{ $redisHost }} {{ .Values.gatewayPlugin.dependencies.redis.port }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
+          command: ['sh', '-c', 'until echo "ping" | nc {{ $redisHost }} {{ $redisPort }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
           {{- end }}
       containers:
         - name: gateway-plugin
@@ -84,8 +87,8 @@ spec:
             - name: REDIS_HOST
               value: {{ $redisHost }}
             - name: REDIS_PORT
-              value: "{{ .Values.gatewayPlugin.dependencies.redis.port }}"
-            {{- if .Values.metadata.redis.enablePassword }}
+              value: "{{ $redisPort }}"
+            {{- if $redisEnablePassword }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/dist/chart/templates/gpu-optimizer/deployment.yaml
+++ b/dist/chart/templates/gpu-optimizer/deployment.yaml
@@ -1,5 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
+{{- $values := fromYaml (toYaml .Values) -}}
+{{- $redisHost := default (printf "%s-redis-master" (include "aibrix.fullname" .)) (dig "gpuOptimizer" "dependencies" "redis" "host" "" $values) }}
+{{- $redisPort := dig "gpuOptimizer" "dependencies" "redis" "port" 6379 $values }}
+{{- $redisEnablePassword := dig "metadata" "redis" "enablePassword" false $values }}
 metadata:
   name: {{ include "aibrix.fullname" . }}-gpu-optimizer
   labels:
@@ -30,10 +34,10 @@ spec:
           # TODO: add liveness and readiness probes
           env:
             - name: REDIS_HOST
-              value: {{ default (printf "%s-redis-master" (include "aibrix.fullname" .)) .Values.gpuOptimizer.dependencies.redis.host }}
+              value: {{ $redisHost }}
             - name: REDIS_PORT
-              value: "{{ .Values.gpuOptimizer.dependencies.redis.port }}"
-           {{- if .Values.metadata.redis.enablePassword }}
+              value: "{{ $redisPort }}"
+           {{- if $redisEnablePassword }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/dist/chart/templates/metadata-service/deployment.yaml
+++ b/dist/chart/templates/metadata-service/deployment.yaml
@@ -1,4 +1,7 @@
-{{- $redisHost := default (printf "%s-redis-master" (include "aibrix.fullname" .)) .Values.metadata.service.redis.host }}
+{{- $values := fromYaml (toYaml .Values) -}}
+{{- $redisHost := default (printf "%s-redis-master" (include "aibrix.fullname" .)) (dig "metadata" "service" "redis" "host" "" $values) }}
+{{- $redisPort := dig "metadata" "service" "redis" "port" 6379 $values }}
+{{- $redisEnablePassword := dig "metadata" "redis" "enablePassword" false $values }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -24,16 +27,16 @@ spec:
       initContainers:
         - name: init-redis
           image: {{ .Values.metadata.service.initContainer.image.repository }}:{{ .Values.metadata.service.initContainer.image.tag }}
-          {{- if .Values.metadata.redis.enablePassword }}
+          {{- if $redisEnablePassword }}
           env:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "aibrix.fullname" . }}-redis
                   key: redis-password
-          command: ['sh', '-c', 'until printf ''AUTH %s\nping\n'' "$REDIS_PASSWORD" | nc {{ $redisHost }} {{ .Values.metadata.service.redis.port }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
+          command: ['sh', '-c', 'until printf ''AUTH %s\nping\n'' "$REDIS_PASSWORD" | nc {{ $redisHost }} {{ $redisPort }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
           {{- else }}
-          command: ['sh', '-c', 'until echo "ping" | nc {{ $redisHost }} {{ .Values.metadata.service.redis.port }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
+          command: ['sh', '-c', 'until echo "ping" | nc {{ $redisHost }} {{ $redisPort }} -w 1 | grep -c PONG; do echo waiting for redis; sleep 2; done']
           {{- end }}
       containers:
         - name: metadata-service
@@ -66,8 +69,8 @@ spec:
             - name: REDIS_HOST
               value: {{ $redisHost }}
             - name: REDIS_PORT
-              value: "{{ .Values.metadata.service.redis.port }}"
-            {{- if .Values.metadata.redis.enablePassword }}
+              value: "{{ $redisPort }}"
+            {{- if $redisEnablePassword }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/dist/chart/templates/metadata-service/redis.yaml
+++ b/dist/chart/templates/metadata-service/redis.yaml
@@ -1,4 +1,7 @@
 # https://www.callicoder.com/deploy-multi-container-go-redis-app-kubernetes/
+{{- include "aibrix.validateValues" . -}}
+---
+{{- if .Values.metadata.redis.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -48,10 +51,10 @@ spec:
   selector:
     {{- include "aibrix.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: aibrix-metadata-redis
-
----
+{{- end }}
 
 {{- if .Values.metadata.redis.enablePassword }}
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/dist/chart/templates/metadata-service/redis.yaml
+++ b/dist/chart/templates/metadata-service/redis.yaml
@@ -1,7 +1,16 @@
 # https://www.callicoder.com/deploy-multi-container-go-redis-app-kubernetes/
-{{- include "aibrix.validateValues" . -}}
+{{ include "aibrix.validateValues" . }}
+{{- $values := fromYaml (toYaml .Values) -}}
+{{- $redisEnabled := dig "metadata" "redis" "enabled" true $values -}}
+{{- $redisReplicas := dig "metadata" "redis" "replicas" 1 $values -}}
+{{- $redisImagePullSecrets := dig "metadata" "redis" "imagePullSecrets" (list) $values -}}
+{{- $redisImageRepository := dig "metadata" "redis" "container" "image" "repository" "redis" $values -}}
+{{- $redisImageTag := dig "metadata" "redis" "container" "image" "tag" "7.4" $values -}}
+{{- $redisResources := dig "metadata" "redis" "container" "resources" (dict) $values -}}
+{{- $redisEnablePassword := dig "metadata" "redis" "enablePassword" false $values -}}
+{{- $redisPassword := dig "metadata" "redis" "password" "" $values -}}
 ---
-{{- if .Values.metadata.redis.enabled }}
+{{- if $redisEnabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -10,7 +19,7 @@ metadata:
     {{- include "aibrix.labels" . | nindent 4 }}
     app.kubernetes.io/component: aibrix-metadata-redis
 spec:
-  replicas: {{ .Values.metadata.redis.replicas }}
+  replicas: {{ $redisReplicas }}
   selector:
     matchLabels:
       {{- include "aibrix.selectorLabels" . | nindent 6 }}
@@ -21,14 +30,14 @@ spec:
         {{- include "aibrix.labels" . | nindent 8 }}
         app.kubernetes.io/component: aibrix-metadata-redis
     spec:
-      {{- include "aibrix.imagePullSecrets" (dict "componentSecrets" .Values.metadata.redis.imagePullSecrets "globalSecrets" .Values.global.imagePullSecrets) | nindent 6 }}
+      {{- include "aibrix.imagePullSecrets" (dict "componentSecrets" $redisImagePullSecrets "globalSecrets" .Values.global.imagePullSecrets) | nindent 6 }}
       containers:
         - name: master
-          image: {{ .Values.metadata.redis.container.image.repository }}:{{ .Values.metadata.redis.container.image.tag }}
+          image: {{ $redisImageRepository }}:{{ $redisImageTag }}
           ports:
             - containerPort: 6379
-          resources: {{ toYaml .Values.metadata.redis.container.resources | nindent 12 }}
-          {{- if .Values.metadata.redis.enablePassword }}
+          resources: {{ toYaml $redisResources | nindent 12 }}
+          {{- if $redisEnablePassword }}
           env:
             - name: REDIS_PASSWORD
               valueFrom:
@@ -51,9 +60,7 @@ spec:
   selector:
     {{- include "aibrix.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: aibrix-metadata-redis
-{{- end }}
-
-{{- if .Values.metadata.redis.enablePassword }}
+{{- if $redisEnablePassword }}
 ---
 apiVersion: v1
 kind: Secret
@@ -61,5 +68,6 @@ metadata:
   name: {{ include "aibrix.fullname" . }}-redis
 type: Opaque
 data:
-  redis-password: {{ .Values.metadata.redis.password | b64enc }}
+  redis-password: {{ $redisPassword | b64enc }}
+{{- end }}
 {{- end }}

--- a/dist/chart/values.schema.json
+++ b/dist/chart/values.schema.json
@@ -241,6 +241,10 @@
         "redis": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether to create the in-chart Redis deployment and service. If set to false, metadata.service.redis.host, gatewayPlugin.dependencies.redis.host, and gpuOptimizer.dependencies.redis.host must all be non-empty."
+            },
             "replicas": {
               "type": "integer",
               "minimum": 1
@@ -436,7 +440,7 @@
       "properties": {
         "host": {
           "type": "string",
-          "description": "Redis host"
+          "description": "Redis host. Required when metadata.redis.enabled=false because the in-chart Redis service is not created."
         },
         "port": {
           "type": "integer",

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -85,7 +85,7 @@ gatewayPlugin:
       AIBRIX_REDISSYNC_ENABLED: "false"
   dependencies:
     redis:
-      host: "" # aibrix-redis-master
+      host: "" # aibrix-redis-master; required when metadata.redis.enabled=false
       port: 6379
   service:
     type: ClusterIP
@@ -126,7 +126,7 @@ gpuOptimizer:
         memory: 64Mi
   dependencies:
     redis:
-      host: ""  # aibrix-redis-master
+      host: ""  # aibrix-redis-master; required when metadata.redis.enabled=false
       port: 6379
   tolerations: []
   serviceAccount:
@@ -252,9 +252,14 @@ metadata:
     tolerations: []
     affinity: {}
     redis:
-      host: "" # aibrix-redis-master
+      host: "" # aibrix-redis-master; required when metadata.redis.enabled=false
       port: 6379
   redis:
+    # Set to false to disable the in-chart Redis Deployment/Service.
+    # When disabled, you must set all three external Redis hosts:
+    # metadata.service.redis.host, gatewayPlugin.dependencies.redis.host,
+    # and gpuOptimizer.dependencies.redis.host.
+    enabled: true
     replicas: 1
     imagePullSecrets: []
     container:


### PR DESCRIPTION
## Summary

This PR adds support for disabling the in-chart Redis deployment in the Helm chart and introduces validation for external Redis configuration.

## Changes

- add `metadata.redis.enabled` to control whether the chart renders the built-in Redis `Deployment` and `Service`
- add Helm template validation to fail rendering when `metadata.redis.enabled=false` but required external Redis hosts are missing
- require the following values to be non-empty when built-in Redis is disabled:
  - `metadata.service.redis.host`
  - `gatewayPlugin.dependencies.redis.host`
  - `gpuOptimizer.dependencies.redis.host`
- update `values.yaml` and `values.schema.json` to document the dependency between the Redis toggle and external Redis host settings

## Why

Previously, disabling the in-chart Redis resources could still leave other components pointing to the default in-cluster Redis service name, which would result in an invalid deployment at runtime.

This change makes the behavior explicit and prevents misconfiguration during `helm template`, `helm lint`, and install/upgrade flows.

## Validation

- `helm lint dist/chart`
- `helm template aibrix dist/chart --set metadata.redis.enabled=false`
  - expected to fail if external Redis hosts are not set
- `helm template aibrix dist/chart --set metadata.redis.enabled=false --set metadata.service.redis.host=external-redis --set gatewayPlugin.dependencies.redis.host=external-redis --set gpuOptimizer.dependencies.redis.host=external-redis`
  - expected to render successfully