### PR TITLE
[Bug] Drop duplicate sanitizeMetricValueLabels call in worker

### DIFF
--- a/pkg/cache/cache_metrics.go
+++ b/pkg/cache/cache_metrics.go
@@ -288,6 +288,7 @@ func (c *Store) worker(jobs <-chan *Pod) {
 		}
 
 		for metricName, metricValue := range result.ModelMetrics {
+			sanitizeMetricValueLabels(pod, metricValue)
 			parts := strings.SplitN(metricName, "/", 2)
 			if len(parts) != 2 {
 				continue
@@ -296,7 +297,6 @@ func (c *Store) worker(jobs <-chan *Pod) {
 			metric := parts[1]
 
 			model = resolveMetricModelName(pod, model)
-			sanitizeMetricValueLabels(pod, metricValue)
 
 			if shouldSkipMetric(pod.Name, metric) {
 				continue
@@ -526,11 +526,14 @@ func (c *Store) updateRealtimeRunningRequestsDrainRate1m(pod *Pod) {
 	}
 }
 
-// updatePodMetricsFromTypedResult processes the typed metrics result and updates pod storage
+// updatePodMetricsFromTypedResult processes the typed metrics result and updates pod storage.
+// Precondition: labels in result must already be sanitized via sanitizeMetricValueLabels.
+// The production caller worker() sanitizes every MetricValue in result before invoking this
+// function, so labels stored in pod.Metrics / pod.ModelMetrics carry resolved model_name /
+// engine_type values rather than the "undefined" sentinel emitted by some engines (e.g. trtllm).
 func (c *Store) updatePodMetricsFromTypedResult(pod *Pod, result *metrics.EngineMetricsResult) {
 	// Process pod-scoped metrics
 	for metricName, metricValue := range result.Metrics {
-		sanitizeMetricValueLabels(pod, metricValue)
 		if metricDef, exists := metrics.Metrics[metricName]; exists {
 			err := c.updatePodRecord(pod, "", metricName, metricDef.MetricScope, metricValue)
 			if err != nil {
@@ -546,7 +549,6 @@ func (c *Store) updatePodMetricsFromTypedResult(pod *Pod, result *metrics.Engine
 		modelName, metricName := parseModelMetricKey(modelMetricKey)
 
 		modelName = resolveMetricModelName(pod, modelName)
-		sanitizeMetricValueLabels(pod, metricValue)
 
 		if metricDef, exists := metrics.Metrics[metricName]; exists {
 			err := c.updatePodRecord(pod, modelName, metricName, metricDef.MetricScope, metricValue)
@@ -614,16 +616,26 @@ func sanitizeMetricLabels(pod *Pod, labelValues map[string]string) map[string]st
 		return labelValues
 	}
 
+	// Key-existence check is required: isUndefinedMetricLabelValue("") is true, so a missing
+	// key would otherwise falsely trigger the alloc path even though we never add it back.
+	modelVal, hasModel := labelValues["model_name"]
+	engineVal, hasEngine := labelValues["engine_type"]
+	modelNeedsFix := hasModel && isUndefinedMetricLabelValue(modelVal)
+	engineNeedsFix := hasEngine && isUndefinedMetricLabelValue(engineVal)
+
+	if !modelNeedsFix && !engineNeedsFix {
+		return labelValues
+	}
+
 	sanitized := make(map[string]string, len(labelValues))
 	for key, value := range labelValues {
 		sanitized[key] = value
 	}
-
-	if modelName, ok := sanitized["model_name"]; ok {
-		sanitized["model_name"] = resolveMetricModelName(pod, modelName)
+	if modelNeedsFix {
+		sanitized["model_name"] = resolveMetricModelName(pod, modelVal)
 	}
-	if engineType, ok := sanitized["engine_type"]; ok {
-		sanitized["engine_type"] = resolveMetricEngineType(pod, engineType)
+	if engineNeedsFix {
+		sanitized["engine_type"] = resolveMetricEngineType(pod, engineVal)
 	}
 
 	return sanitized

--- a/pkg/cache/cache_metrics_test.go
+++ b/pkg/cache/cache_metrics_test.go
@@ -153,6 +153,42 @@ func TestSanitizeMetricLabelsFallback(t *testing.T) {
 	require.Equal(t, "pod:8000", sanitized["instance"])
 }
 
+func TestSanitizeMetricLabels_ReturnsSameMapWhenClean(t *testing.T) {
+	pod := &Pod{Pod: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}}}
+
+	in := map[string]string{
+		"model_name":  "raw-model",
+		"engine_type": "vllm",
+		"instance":    "pod:8000",
+	}
+	out := sanitizeMetricLabels(pod, in)
+
+	// Mutating in must show up in out — proves early-return returned the same underlying map
+	// (i.e. no alloc + copy happened).
+	in["__canary"] = "x"
+	require.Equal(t, "x", out["__canary"], "expected early-return to return same map when labels are clean")
+}
+
+func TestSanitizeMetricLabels_NoFalsePositiveWhenKeyMissing(t *testing.T) {
+	pod := &Pod{Pod: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}}}
+
+	in := map[string]string{"instance": "pod:8000"}
+	out := sanitizeMetricLabels(pod, in)
+
+	in["__canary"] = "x"
+	require.Equal(t, "x", out["__canary"], "missing model_name / engine_type keys must not trigger alloc path")
+}
+
+func TestSanitizeMetricLabels_EmptyMap(t *testing.T) {
+	pod := &Pod{Pod: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}}}
+
+	in := map[string]string{}
+	out := sanitizeMetricLabels(pod, in)
+
+	in["__canary"] = "x"
+	require.Equal(t, "x", out["__canary"], "empty map must short-circuit to same map")
+}
+
 func TestMetricRoleFilters(t *testing.T) {
 	require.True(t, isPrefillOnlyMetric(metrics.TimeToFirstTokenSeconds))
 	require.False(t, isPrefillOnlyMetric(metrics.GenerationTokenTotal))


### PR DESCRIPTION
## What this fixes

Fixes #2179.

`sanitizeMetricValueLabels` was getting called twice on every metric, every worker tick — once in `worker()` before emit, then again in `updatePodMetricsFromTypedResult` before storage. It's idempotent so nothing was broken, but the second call allocated a fresh map for no reason.

I also noticed `sanitizeMetricLabels` always allocates a copy, even when nothing needs fixing. For vllm/sglang every call is wasted, since they don't emit `"undefined"`.

## What changed

- Dropped the two `sanitizeMetricValueLabels` calls inside `updatePodMetricsFromTypedResult`. By the time we get there, `worker()` has already sanitized everything. Added a doc comment so future callers know the precondition.
- Moved the remaining sanitize call in `worker()`'s ModelMetrics loop to the top, before the `len(parts) != 2` guard. That branch is dead today (the fetcher always builds keys with `/`), but if anyone changes the key format later, sanitize won't get silently skipped.
- `sanitizeMetricLabels` now returns the input map unchanged when neither `model_name` nor `engine_type` actually needs fixing. One gotcha: `isUndefinedMetricLabelValue("")` returns true, so the key-existence check matters — without it, a label map missing `model_name` would falsely take the alloc path.

## Test plan

- [x] `go test ./pkg/cache/...` passes
- [x] `TestSanitizeMetricLabelsFallback` still passes (trtllm `"undefined"` → pod-label fallback)
- [x] `TestUpdatePodMetricsFromTypedResultModelFallback` still passes (storage model-name fallback)
- [x] Added 3 tests for the early-return:
  - `TestSanitizeMetricLabels_ReturnsSameMapWhenClean`
  - `TestSanitizeMetricLabels_NoFalsePositiveWhenKeyMissing`
  - `TestSanitizeMetricLabels_EmptyMap`