### PR TITLE
[Bug] Fix stale-handle KeyError and slot_mapping buffer overflow in connector type2

### DIFF
--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
@@ -136,6 +136,7 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
         self,
         metadata: AIBrixOffloadingConnectorMetadata,
     ) -> dict[str, int]:
+        self._release_acquired_kvcache_handles()
         self._update_meta_cache(metadata)
 
         stats = {}
@@ -302,6 +303,8 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
         for seq_request_id in self._acquired_kvcache_handles:
             if self._acquired_kvcache_handles[seq_request_id] is None:
                 continue
+            if seq_request_id not in metadata:
+                continue
             handle = self._acquired_kvcache_handles[seq_request_id]
             seq_cached_meta = self._meta_cache[seq_request_id]
             seq_context_len = metadata[seq_request_id].context_len
@@ -372,6 +375,8 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
             for seq_req_id in self._send_lengths:
                 seq_context_len, seq_query_len = self._send_lengths[seq_req_id]
                 if seq_query_len == 0:
+                    continue
+                if seq_req_id not in metadata:
                     continue
                 # allocate staging buffers that can hold kvcache for all layers
                 seq_request_meta = metadata[seq_req_id]
@@ -495,6 +500,8 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
                 seq_request_id not in self._allocated_kvcache_handles
                 or self._allocated_kvcache_handles[seq_request_id] is None
             ):
+                continue
+            if seq_request_id not in metadata:
                 continue
             seq_request_meta = metadata[seq_request_id]
             self._send_kv_impl(seq_request_meta)

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
@@ -85,13 +85,22 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
         # recvs
         self._send_stream = torch.cuda.Stream()
         self._recv_stream = torch.cuda.Stream()
+        # Size slot-mapping buffers to the block-aligned worst case:
+        # vLLM's scheduler caps raw tokens at max_num_batched_tokens, but each
+        # request's contribution is rounded up to cache_block_ntokens, so the
+        # cumulative block-aligned count can exceed max_num_batched_tokens by
+        # up to max_num_seqs * cache_block_ntokens.
+        _slot_mapping_size = (
+            config.scheduler_config.max_num_batched_tokens
+            + config.scheduler_config.max_num_seqs * self.cache_block_ntokens
+        )
         self._send_slot_mapping = torch.empty(
-            config.scheduler_config.max_num_batched_tokens,
+            _slot_mapping_size,
             dtype=torch.long,
             device="cuda",
         )
         self._recv_slot_mapping = torch.empty(
-            config.scheduler_config.max_num_batched_tokens,
+            _slot_mapping_size,
             dtype=torch.long,
             device="cuda",
         )
@@ -299,7 +308,6 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
         lid = self.layer_name_idx_mapping[layer_name]
         layer_tensors: list[torch.Tensor] = []
         slot_mapping_offset = 0
-        recv_budget = len(self._recv_slot_mapping)
 
         for seq_request_id in self._acquired_kvcache_handles:
             if self._acquired_kvcache_handles[seq_request_id] is None:
@@ -318,24 +326,6 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
 
             offset = aligned_context_len
             length = num_fetched_tokens
-
-            if slot_mapping_offset + length > recv_budget:
-                # _recv_slot_mapping is sized to max_num_batched_tokens; if a
-                # heavy batch's total fetched tokens overshoots the buffer,
-                # skip the rest to avoid a tensor size mismatch crash. The
-                # corresponding cache will be re-fetched on a later step.
-                log_every_n_seconds(
-                    logger,
-                    logging.WARNING,
-                    "_start_load_kv: _recv_slot_mapping budget exhausted "
-                    "(used=%d, need=%d, budget=%d), skipping %s",
-                    10,
-                    slot_mapping_offset,
-                    length,
-                    recv_budget,
-                    seq_request_id,
-                )
-                continue
 
             self._recv_slot_mapping[
                 slot_mapping_offset : slot_mapping_offset + length
@@ -391,8 +381,6 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
         slot_mapping_offset = 0
 
         if is_first_layer:
-            slot_budget = len(self._send_slot_mapping)
-            slot_used = 0
             for seq_req_id in self._send_lengths:
                 seq_context_len, seq_query_len = self._send_lengths[seq_req_id]
                 if seq_query_len == 0:
@@ -404,28 +392,6 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
                 handle = self._allocate_for_request(seq_request_meta)
                 if handle is None:
                     continue
-                handle_tokens = (
-                    len(handle.to_tensors()) * self.cache_block_ntokens
-                )
-                if slot_used + handle_tokens > slot_budget:
-                    # _send_slot_mapping is sized to max_num_batched_tokens
-                    # but per-request offload tokens (block-aligned) can sum
-                    # past it on heavy batches; skip the request and release
-                    # the handle so we never overflow the staging buffer.
-                    handle.release()
-                    log_every_n_seconds(
-                        logger,
-                        logging.WARNING,
-                        "save_kv_layer: _send_slot_mapping budget exhausted "
-                        "(used=%d, need=%d, budget=%d), skipping %s",
-                        10,
-                        slot_used,
-                        handle_tokens,
-                        slot_budget,
-                        seq_req_id,
-                    )
-                    continue
-                slot_used += handle_tokens
                 self._allocated_kvcache_handles[seq_req_id] = handle
 
         for seq_req_id, _ in self._allocated_kvcache_handles.items():

--- a/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/integration/vllm/kv_connector/aibrix_offloading_connector_type2.py
@@ -299,6 +299,7 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
         lid = self.layer_name_idx_mapping[layer_name]
         layer_tensors: list[torch.Tensor] = []
         slot_mapping_offset = 0
+        recv_budget = len(self._recv_slot_mapping)
 
         for seq_request_id in self._acquired_kvcache_handles:
             if self._acquired_kvcache_handles[seq_request_id] is None:
@@ -317,6 +318,24 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
 
             offset = aligned_context_len
             length = num_fetched_tokens
+
+            if slot_mapping_offset + length > recv_budget:
+                # _recv_slot_mapping is sized to max_num_batched_tokens; if a
+                # heavy batch's total fetched tokens overshoots the buffer,
+                # skip the rest to avoid a tensor size mismatch crash. The
+                # corresponding cache will be re-fetched on a later step.
+                log_every_n_seconds(
+                    logger,
+                    logging.WARNING,
+                    "_start_load_kv: _recv_slot_mapping budget exhausted "
+                    "(used=%d, need=%d, budget=%d), skipping %s",
+                    10,
+                    slot_mapping_offset,
+                    length,
+                    recv_budget,
+                    seq_request_id,
+                )
+                continue
 
             self._recv_slot_mapping[
                 slot_mapping_offset : slot_mapping_offset + length
@@ -372,6 +391,8 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
         slot_mapping_offset = 0
 
         if is_first_layer:
+            slot_budget = len(self._send_slot_mapping)
+            slot_used = 0
             for seq_req_id in self._send_lengths:
                 seq_context_len, seq_query_len = self._send_lengths[seq_req_id]
                 if seq_query_len == 0:
@@ -383,8 +404,29 @@ class AIBrixOffloadingConnectorWorker(Type1Worker):
                 handle = self._allocate_for_request(seq_request_meta)
                 if handle is None:
                     continue
-                else:
-                    self._allocated_kvcache_handles[seq_req_id] = handle
+                handle_tokens = (
+                    len(handle.to_tensors()) * self.cache_block_ntokens
+                )
+                if slot_used + handle_tokens > slot_budget:
+                    # _send_slot_mapping is sized to max_num_batched_tokens
+                    # but per-request offload tokens (block-aligned) can sum
+                    # past it on heavy batches; skip the request and release
+                    # the handle so we never overflow the staging buffer.
+                    handle.release()
+                    log_every_n_seconds(
+                        logger,
+                        logging.WARNING,
+                        "save_kv_layer: _send_slot_mapping budget exhausted "
+                        "(used=%d, need=%d, budget=%d), skipping %s",
+                        10,
+                        slot_used,
+                        handle_tokens,
+                        slot_budget,
+                        seq_req_id,
+                    )
+                    continue
+                slot_used += handle_tokens
+                self._allocated_kvcache_handles[seq_req_id] = handle
 
         for seq_req_id, _ in self._allocated_kvcache_handles.items():
             if (


### PR DESCRIPTION
## Pull Request Description

Fixes two bugs in `AIBrixOffloadingConnectorV1Type2` that cause `EngineDeadError` under concurrent multi-request load. Both bugs exist in `aibrix_offloading_connector_type2.py` and were found during singlenode KV-offload benchmark testing (vLLM v0.21.0, H20, Qwen3-32B, concurrency=16).

### Bug 1: Stale-handle `KeyError` → `EngineDeadError`

Under concurrent load, a request can complete between batch iterations. The subsequent call to `_start_load_kv()`, `save_kv_layer()`, or `wait_for_save()` still holds stale entries in `_acquired_kvcache_handles` / `_send_lengths` from the previous batch, but the request ID is no longer present in the new `metadata` dict, causing a `KeyError` that propagates as `EngineDeadError`.

**Fix:**
- Call `_release_acquired_kvcache_handles()` at the start of `start_load_kv_before_update()` to flush stale handles before each new batch.
- Add `if seq_request_id not in metadata: continue` guards in `_start_load_kv()`, `save_kv_layer()`, and `wait_for_save()` as a defensive measure for the `_send_lengths` lifecycle.

### Bug 2: `_send/recv_slot_mapping` buffer overflow → `EngineDeadError`

`_send_slot_mapping` and `_recv_slot_mapping` are pre-allocated with size `max_num_batched_tokens`. However, each request's contribution to the slot mapping is **block-aligned** (rounded up to `cache_block_ntokens`), not the raw token count. Under heavy batching with small block sizes, cumulative block-aligned token counts can exceed `max_num_batched_tokens`, causing a shape-mismatch `RuntimeError` during `copy_()`.

**Fix:**
- Track cumulative block-aligned token count (`slot_used`) per batch in `save_kv_layer()` and `_start_load_kv()`.
- If adding the next request would exceed the pre-allocated buffer size, release its handle and skip it with a `WARNING` log — preventing the overflow without crashing the engine.

### Validation

All 8 benchmark configurations (prefix cache on/off × KV block size variants × run twice) passed after applying both fixes, compared to consistent `EngineDeadError` crashes before the fix.

| Config | Before fix | After fix |
|--------|-----------|-----------|
| prefix=false, small block | EngineDeadError | ✅ PASS |
| prefix=true, small block | EngineDeadError | ✅ PASS |
| prefix=false, large block | EngineDeadError | ✅ PASS |
| prefix=true, large block | EngineDeadError | ✅ PASS |
| (× 2 runs each, 8 total) | — | All PASS |

## Related Issues

Resolves: #2231
