### PR TITLE
[bug] fix console and planner job fetching interaction logics for terminal jobs

### DIFF
--- a/apps/console/api/handler/job.go
+++ b/apps/console/api/handler/job.go
@@ -124,11 +124,25 @@ func (h *JobHandler) ListJobs(ctx context.Context, req *pb.ListJobsRequest) (*pb
 	}, nil
 }
 
-// GetJob proxies to GET /v1/batches/{id}. Console-owned fields ride on
-// batch.metadata; the store overlay path is parked (see CreateJob).
+// GetJob proxies to GET /v1/batches/{id}. Terminal jobs are served from
+// the store to avoid the planner placeholder path dropping MDS-owned
+// fields.
 func (h *JobHandler) GetJob(ctx context.Context, req *pb.GetJobRequest) (*pb.Job, error) {
 	if req.Id == "" {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	if h.store != nil {
+		rec, err := h.store.GetJob(ctx, req.Id)
+		if err != nil {
+			klog.Warningf("GetJob store lookup id=%s: %v", req.Id, err)
+		} else if rec != nil && plannerapi.JobStatus(rec.Status).IsTerminal() {
+			pbJob, perr := rec.ToPB()
+			if perr != nil {
+				klog.Warningf("GetJob terminal store->pb id=%s: %v", req.Id, perr)
+			} else {
+				return pbJob, nil
+			}
+		}
 	}
 	job, err := h.planner.GetJob(ctx, req.Id)
 	if err != nil {


### PR DESCRIPTION
## Pull Request Description

Bug: After a job completes, its status is shown incorrectly as shown below. The planner's GetJob logic resets the job info back to its just-enqueued state instead of returning the post-completion status (no completed time, and output dataset).

<img width="1280" height="634" alt="image" src="https://github.com/user-attachments/assets/be2b55ac-533c-40e6-802d-177416be2185" />


To preserve the lazy-sync logic on the planner side and keep the diff minimal, this PR changes GetJob to first check the store: if the job is already in a terminal state, the stored record is returned directly. This preserves the full terminal job data while keeping the existing planner path intact for non-terminal jobs.