### PR TITLE
[Bug] Fix /v1/models returning 404 without a trailing slash

### DIFF
--- a/python/aibrix/aibrix/metadata/api/v1/models.py
+++ b/python/aibrix/aibrix/metadata/api/v1/models.py
@@ -174,7 +174,8 @@ class K8sModelDiscovery:
 k8s_discovery = K8sModelDiscovery()
 
 
-@router.get("/")
+@router.get("", include_in_schema=True)
+@router.get("/", include_in_schema=False)
 async def list_models(request: Request) -> ModelListResponse:
     """List all models from Kubernetes.
 

--- a/python/aibrix/tests/metadata/test_models_api.py
+++ b/python/aibrix/tests/metadata/test_models_api.py
@@ -206,6 +206,24 @@ class TestK8sModelDiscovery:
 class TestModelsAPI:
     """Integration tests for /v1/models API."""
 
+    @pytest.fixture(autouse=True)
+    def _reset_k8s_discovery_singleton(self):
+        """Reset the module-level k8s_discovery singleton around each test.
+
+        models.k8s_discovery caches its CoreV1Api/CustomObjectsApi the first
+        time it is used (init_k8s_clients only initializes when core_api is
+        None). Without this reset, the first API test's mocked clients leak
+        into later tests, making this module order-dependent (e.g. under
+        pytest-randomly).
+        """
+        from aibrix.metadata.api.v1 import models as models_module
+
+        models_module.k8s_discovery.core_api = None
+        models_module.k8s_discovery.custom_api = None
+        yield
+        models_module.k8s_discovery.core_api = None
+        models_module.k8s_discovery.custom_api = None
+
     @patch("kubernetes.config.load_kube_config")
     @patch("kubernetes.config.load_incluster_config")
     @patch("kubernetes.client.CustomObjectsApi")
@@ -285,3 +303,59 @@ class TestModelsAPI:
             assert "created" in model
             assert "owned_by" in model
             assert model["owned_by"] == "aibrix"
+
+    @patch("kubernetes.config.load_kube_config")
+    @patch("kubernetes.config.load_incluster_config")
+    @patch("kubernetes.client.CustomObjectsApi")
+    @patch("kubernetes.client.CoreV1Api")
+    def test_list_models_trailing_slash_optional(
+        self,
+        mock_core_v1,
+        mock_custom_objects,
+        mock_incluster_config,
+        mock_kube_config,
+    ):
+        """Both /v1/models and /v1/models/ must return 200 (regression for #1740).
+
+        build_app sets redirect_slashes=False, so the router has to register the
+        no-trailing-slash path explicitly (mirroring files.py / batch.py); a bare
+        /v1/models otherwise 404s instead of getting a 307 redirect.
+        """
+        from argparse import Namespace
+
+        from kubernetes import config as k8s_config
+
+        mock_incluster_config.side_effect = k8s_config.ConfigException("Not in cluster")
+
+        mock_pod = V1Pod(
+            metadata=V1ObjectMeta(
+                name="llama-3-8b-pod",
+                labels={"model.aibrix.ai/name": "llama-3-8b"},
+            ),
+            status=V1PodStatus(phase="Running"),
+        )
+        mock_core_v1.return_value.list_pod_for_all_namespaces.return_value.items = [
+            mock_pod,
+        ]
+        mock_custom_objects.return_value.list_cluster_custom_object.return_value = {
+            "items": []
+        }
+
+        args = Namespace(
+            enable_fastapi_docs=False,
+            disable_batch_api=True,
+            disable_file_api=True,
+            enable_k8s_job=False,
+            disable_inference_endpoint=True,
+        )
+        app = build_app(args)
+        client = TestClient(app)
+
+        # No trailing slash: the path that used to 404 (#1740).
+        resp_no_slash = client.get("/v1/models")
+        assert resp_no_slash.status_code == 200
+
+        # Trailing slash keeps working, and both forms hit the same handler.
+        resp_slash = client.get("/v1/models/")
+        assert resp_slash.status_code == 200
+        assert resp_no_slash.json() == resp_slash.json()


### PR DESCRIPTION
## What this fixes

Fixes #1740.

`curl http://$ENDPOINT/v1/models` returns 404 — you only get a response if you add the trailing slash (`/v1/models/`). The metadata service mounts the models router at prefix `/v1/models` but only registers `@router.get("/")`, so the one real path is `/v1/models/`. FastAPI would normally 307-redirect the bare path to the slash version, but `build_app` sets `redirect_slashes=False`, so it just 404s.

## What changed

- Registered the no-slash route explicitly (`@router.get("")` alongside `@router.get("/")`), the same way `files.py` already does it. Both `/v1/models` and `/v1/models/` now reach the handler.
- Added a regression test asserting both paths return 200 with the same body.
- While writing that test I tripped over a pre-existing trap: `k8s_discovery` is a module-level singleton that caches its k8s client on first use, so the first API test's mocks leaked into the second one and the module turned order-dependent (it failed `assert 1 == 3` when the new test ran first). Added an autouse fixture that resets the singleton around each test.

## Test plan

- [x] `poetry run pytest tests/metadata/test_models_api.py` — 5 passed
- [x] Verified the new test fails without the route fix (bare `/v1/models` → 404)
- [x] Verified the order-dependency is gone (running the two API tests in reverse order now passes)
- [x] `ruff check .` / `ruff format --check .` / `mypy .` clean

One thing I left out of scope: in standalone mode the Go gateway handler (`pkg/plugins/gateway/gateway.go`) registers `/v1/models` with the exact opposite behavior — it serves the bare path and 404s on the trailing slash. Not part of this bug, but worth a follow-up if we want both modes to match.