### PR TITLE
refactor[planner] split provider-agnostic core from planner

### DIFF
--- a/apps/console/api/planner/client/submission.go
+++ b/apps/console/api/planner/client/submission.go
@@ -21,13 +21,25 @@ import (
 )
 
 // PlannerDecision is the backend-agnostic planner allocation decision
-// carried on AIBrixExtraBody.PlannerDecision. ResourceDetails is an
-// untyped payload so each backend can attach its own shape.
-type PlannerDecision struct {
-	ProvisionID               string `json:"provision_id,omitempty"`
-	ProvisionResourceDeadline int64  `json:"provision_resource_deadline,omitempty"`
-	ResourceDetails           any    `json:"resource_details,omitempty"`
+// carried on AIBrixExtraBody.PlannerDecision. Each backend defines its
+// own concrete type implementing this interface.
+//
+// isPlannerDecision is an unexported, no-op marker method (empty body,
+// never called at runtime) that exists purely to seal the interface:
+// because it is unexported, only types declared in this package can
+// satisfy PlannerDecision, preventing arbitrary structs from accidentally
+// satisfying it.
+type PlannerDecision interface {
+	isPlannerDecision()
 }
+
+// DefaultDecision is the shape used by backends that only need to carry
+// the provision ID (kubernetes / aws / lambdaCloud today).
+type DefaultDecision struct {
+	ProvisionID string `json:"provision_id,omitempty"`
+}
+
+func (*DefaultDecision) isPlannerDecision() {}
 
 // AIBrixExtraBody is the AIBrix-specific extension the BatchClient
 // serializes onto POST /v1/batches via the openai-go SDK's extra_body
@@ -35,6 +47,6 @@ type PlannerDecision struct {
 // directly.
 type AIBrixExtraBody struct {
 	JobID           string                       `json:"job_id,omitempty"`
-	PlannerDecision *PlannerDecision             `json:"planner_decision,omitempty"`
+	PlannerDecision PlannerDecision              `json:"planner_decision,omitempty"`
 	ModelTemplate   *plannerapi.ModelTemplateRef `json:"model_template,omitempty"`
 }

--- a/apps/console/api/planner/client/submission.go
+++ b/apps/console/api/planner/client/submission.go
@@ -20,34 +20,19 @@ import (
 	plannerapi "github.com/vllm-project/aibrix/apps/console/api/planner/api"
 )
 
-// PlannerDecision is the planner's allocation decision projected into
-// AIBrixExtraBody. ResourceDetails stays as a nested anonymous struct
-// because its shape will evolve as the RM populates per-group allocation
-// details (currently always nil — RM doesn't return them yet).
+// PlannerDecision is the backend-agnostic planner allocation decision
+// carried on AIBrixExtraBody.PlannerDecision. ResourceDetails is an
+// untyped payload so each backend can attach its own shape.
 type PlannerDecision struct {
-	// ProvisionID mirrors rmtypes.ProvisionResult.ProvisionID returned
-	// by Provisioner.Provision.
-	ProvisionID string `json:"provision_id,omitempty"`
-	// ProvisionResourceDeadline is the unix-seconds deadline.
-	ProvisionResourceDeadline int64 `json:"provision_resource_deadline,omitempty"`
-	ResourceDetails           []struct {
-		// ResourceType maps to rmtypes.ResourceProvisionType
-		// (kubernetes / aws / lambdaCloud); may grow finer-grained.
-		ResourceType string `json:"resource_type"`
-		// EndpointCluster identifies the cluster serving this group;
-		EndpointCluster string `json:"endpoint_cluster,omitempty"`
-		// GPUType identifies the GPU model of the provisioned nodes.
-		// The GPU count is not defined here; it comes from the ModelTemplate.
-		GPUType string `json:"gpu_type,omitempty"`
-		// WorkerNum identifies the number of replicas to provision
-		WorkerNum int `json:"worker_num,omitempty"`
-	} `json:"resource_details,omitempty"`
+	ProvisionID               string `json:"provision_id,omitempty"`
+	ProvisionResourceDeadline int64  `json:"provision_resource_deadline,omitempty"`
+	ResourceDetails           any    `json:"resource_details,omitempty"`
 }
 
 // AIBrixExtraBody is the AIBrix-specific extension the BatchClient
 // serializes onto POST /v1/batches via the openai-go SDK's extra_body
 // channel. Everything else on the submission rides on openai.BatchNewParams
-// directly — this struct is the only piece of the contract we own.
+// directly.
 type AIBrixExtraBody struct {
 	JobID           string                       `json:"job_id,omitempty"`
 	PlannerDecision *PlannerDecision             `json:"planner_decision,omitempty"`

--- a/apps/console/api/planner/impl/backend.go
+++ b/apps/console/api/planner/impl/backend.go
@@ -51,12 +51,6 @@ type provisionResponseLogger interface {
 	LogProvisionResponse(jobID string, prov *rmtypes.ProvisionResult, spec rmtypes.ResourceProvisionSpec)
 }
 
-// provisionOverride is an optional capability to bypass the real RM call
-// and supply a ProvisionResult directly.
-type provisionOverride interface {
-	TryProvisionOverride(req *plannerapi.EnqueueRequest) (*rmtypes.ProvisionResult, bool)
-}
-
 // backendFactory constructs a plannerBackend for a provisioner type.
 type backendFactory func(prov provisioner.Provisioner) plannerBackend
 
@@ -126,19 +120,17 @@ func (b *defaultPlannerBackend) ValidateRequest(*plannerapi.EnqueueRequest) erro
 	return nil
 }
 
-func (b *defaultPlannerBackend) Schedule(_ context.Context, req *plannerapi.EnqueueRequest) (rmtypes.ResourceProvisionSpec, string, int, error) {
-	spec := rmtypes.ResourceProvisionSpec{
-		Credential: rmtypes.ResourceCredential{Provider: b.provider},
-	}
+func (b *defaultPlannerBackend) Schedule(_ context.Context, req *plannerapi.EnqueueRequest) (spec rmtypes.ResourceProvisionSpec, gpuType string, gpusPerReplica int, err error) {
+	spec.Credential = rmtypes.ResourceCredential{Provider: b.provider}
 	if req == nil || req.ModelTemplate == nil {
-		return spec, "", 0, nil
+		return
 	}
-	gpuType, gpusPerReplica, err := decodeAcceleratorFromTemplate(req.ModelTemplate)
+	gpuType, gpusPerReplica, err = decodeAcceleratorFromTemplate(req.ModelTemplate)
 	if err != nil {
-		return rmtypes.ResourceProvisionSpec{}, "", 0, err
+		return
 	}
 	spec.Groups = &[]rmtypes.ResourceGroupSpec{buildProvisionGroupPlan(gpuType, gpusPerReplica)}
-	return spec, gpuType, gpusPerReplica, nil
+	return
 }
 
 func (b *defaultPlannerBackend) BuildDecision(_ rmtypes.ResourceProvisionSpec, prov *rmtypes.ProvisionResult, _ string, _ int) plannerclient.PlannerDecision {

--- a/apps/console/api/planner/impl/backend.go
+++ b/apps/console/api/planner/impl/backend.go
@@ -42,7 +42,7 @@ import (
 type plannerBackend interface {
 	ValidateRequest(req *plannerapi.EnqueueRequest) error
 	Schedule(ctx context.Context, req *plannerapi.EnqueueRequest) (spec rmtypes.ResourceProvisionSpec, gpuType string, gpusPerReplica int, err error)
-	BuildDecision(spec rmtypes.ResourceProvisionSpec, prov *rmtypes.ProvisionResult, gpuType string, gpusPerReplica int) *plannerclient.PlannerDecision
+	BuildDecision(spec rmtypes.ResourceProvisionSpec, prov *rmtypes.ProvisionResult, gpuType string, gpusPerReplica int) plannerclient.PlannerDecision
 }
 
 // provisionResponseLogger is an optional capability to log provider-specific
@@ -141,7 +141,7 @@ func (b *defaultPlannerBackend) Schedule(_ context.Context, req *plannerapi.Enqu
 	return spec, gpuType, gpusPerReplica, nil
 }
 
-func (b *defaultPlannerBackend) BuildDecision(_ rmtypes.ResourceProvisionSpec, prov *rmtypes.ProvisionResult, _ string, _ int) *plannerclient.PlannerDecision {
+func (b *defaultPlannerBackend) BuildDecision(_ rmtypes.ResourceProvisionSpec, prov *rmtypes.ProvisionResult, _ string, _ int) plannerclient.PlannerDecision {
 	// Default decision shape; accelerator scalars are ignored here.
-	return &plannerclient.PlannerDecision{ProvisionID: prov.ProvisionID}
+	return &plannerclient.DefaultDecision{ProvisionID: prov.ProvisionID}
 }

--- a/apps/console/api/planner/impl/backend.go
+++ b/apps/console/api/planner/impl/backend.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package impl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	plannerapi "github.com/vllm-project/aibrix/apps/console/api/planner/api"
+	plannerclient "github.com/vllm-project/aibrix/apps/console/api/planner/client"
+	"github.com/vllm-project/aibrix/apps/console/api/resource_manager/provisioner"
+	rmtypes "github.com/vllm-project/aibrix/apps/console/api/resource_manager/types"
+	"k8s.io/utils/ptr"
+)
+
+// plannerBackend is the per-provisioner extension surface invoked per job
+// as: ValidateRequest → Schedule → BuildDecision.
+//   - Schedule produces the ResourceProvisionSpec; it is the hook for
+//     future capacity-aware scheduling (replica sizing, gpu type selection, etc.).
+//   - BuildDecision projects the ProvisionResult onto the batch submission
+//     and folds in ready-state logging.
+//
+// Accepted-provision logging is opt-in via provisionResponseLogger.
+//
+// TODO: add Plan(ctx, req) before Schedule to fetch RM-catalog capacity
+// (per-accelerator, quotas, etc.) so Schedule can be capacity-aware.
+type plannerBackend interface {
+	ValidateRequest(req *plannerapi.EnqueueRequest) error
+	Schedule(ctx context.Context, req *plannerapi.EnqueueRequest) (spec rmtypes.ResourceProvisionSpec, gpuType string, gpusPerReplica int, err error)
+	BuildDecision(spec rmtypes.ResourceProvisionSpec, prov *rmtypes.ProvisionResult, gpuType string, gpusPerReplica int) *plannerclient.PlannerDecision
+}
+
+// provisionResponseLogger is an optional capability to log provider-specific
+// detail of an accepted provision.
+type provisionResponseLogger interface {
+	LogProvisionResponse(jobID string, prov *rmtypes.ProvisionResult, spec rmtypes.ResourceProvisionSpec)
+}
+
+// provisionOverride is an optional capability to bypass the real RM call
+// and supply a ProvisionResult directly.
+type provisionOverride interface {
+	TryProvisionOverride(req *plannerapi.EnqueueRequest) (*rmtypes.ProvisionResult, bool)
+}
+
+// backendFactory constructs a plannerBackend for a provisioner type.
+type backendFactory func(prov provisioner.Provisioner) plannerBackend
+
+// backendRegistry holds plannerBackend factories registered from init()
+// by provider-specific files.
+var backendRegistry = map[rmtypes.ResourceProvisionType]backendFactory{}
+
+// RegisterBackend registers a factory for a provisioner type; last writer wins.
+func RegisterBackend(t rmtypes.ResourceProvisionType, f backendFactory) {
+	backendRegistry[t] = f
+}
+
+// newPlannerBackend returns the registered backend for prov, or
+// defaultPlannerBackend when none is registered (or prov is nil).
+func newPlannerBackend(prov provisioner.Provisioner) plannerBackend {
+	if prov == nil {
+		return &defaultPlannerBackend{}
+	}
+	t := prov.Type()
+	if f, ok := backendRegistry[t]; ok {
+		return f(prov)
+	}
+	return &defaultPlannerBackend{provider: t}
+}
+
+// decodeAcceleratorFromTemplate parses ModelTemplateRef.Spec (a protojson-
+// encoded ModelDeploymentTemplateSpec) and returns the accelerator type
+// and per-replica count. Returns ("", 0, nil) when ref or Spec is empty.
+func decodeAcceleratorFromTemplate(ref *plannerapi.ModelTemplateRef) (gpuType string, gpusPerReplica int, err error) {
+	if ref == nil || len(ref.Spec) == 0 {
+		return "", 0, nil
+	}
+	var spec struct {
+		Accelerator struct {
+			Type  string `json:"type"`
+			Count int    `json:"count"`
+		} `json:"accelerator"`
+	}
+	if err := json.Unmarshal(ref.Spec, &spec); err != nil {
+		return "", 0, fmt.Errorf("decode model_template.spec: %w", err)
+	}
+	return spec.Accelerator.Type, spec.Accelerator.Count, nil
+}
+
+// buildProvisionGroupPlan composes the single-replica ResourceGroupSpec
+// shared by all backends today.
+func buildProvisionGroupPlan(gpuType string, gpusPerReplica int) rmtypes.ResourceGroupSpec {
+	group := rmtypes.ResourceGroupSpec{
+		Replicas:       ptr.To(1),
+		GpusPerReplica: gpusPerReplica,
+	}
+	if gpuType != "" {
+		group.AcceleratorPreference = &rmtypes.AcceleratorPreference{
+			PreferredTypes: ptr.To([]string{gpuType}),
+		}
+	}
+	return group
+}
+
+// defaultPlannerBackend serves kubernetes / aws / lambdaCloud.
+type defaultPlannerBackend struct {
+	provider rmtypes.ResourceProvisionType
+}
+
+func (b *defaultPlannerBackend) ValidateRequest(*plannerapi.EnqueueRequest) error {
+	// Lenient by default; ModelTemplate is optional.
+	return nil
+}
+
+func (b *defaultPlannerBackend) Schedule(_ context.Context, req *plannerapi.EnqueueRequest) (rmtypes.ResourceProvisionSpec, string, int, error) {
+	spec := rmtypes.ResourceProvisionSpec{
+		Credential: rmtypes.ResourceCredential{Provider: b.provider},
+	}
+	if req == nil || req.ModelTemplate == nil {
+		return spec, "", 0, nil
+	}
+	gpuType, gpusPerReplica, err := decodeAcceleratorFromTemplate(req.ModelTemplate)
+	if err != nil {
+		return rmtypes.ResourceProvisionSpec{}, "", 0, err
+	}
+	spec.Groups = &[]rmtypes.ResourceGroupSpec{buildProvisionGroupPlan(gpuType, gpusPerReplica)}
+	return spec, gpuType, gpusPerReplica, nil
+}
+
+func (b *defaultPlannerBackend) BuildDecision(_ rmtypes.ResourceProvisionSpec, prov *rmtypes.ProvisionResult, _ string, _ int) *plannerclient.PlannerDecision {
+	// Default decision shape; accelerator scalars are ignored here.
+	return &plannerclient.PlannerDecision{ProvisionID: prov.ProvisionID}
+}

--- a/apps/console/api/planner/impl/planner.go
+++ b/apps/console/api/planner/impl/planner.go
@@ -47,6 +47,8 @@ type Planner struct {
 	prov  provisioner.Provisioner
 	store store.Store
 
+	backend plannerBackend // per-provisioner decision-making
+
 	queue pendingQueue
 
 	baseCtx    context.Context
@@ -116,6 +118,7 @@ func NewPlanner(bc plannerclient.BatchClient, prov provisioner.Provisioner, st s
 		bc:               bc,
 		prov:             prov,
 		store:            st,
+		backend:          newPlannerBackend(prov),
 		queue:            newFIFOPendingQueue(queueCapacity),
 		baseCtx:          ctx,
 		baseCancel:       cancel,
@@ -174,28 +177,58 @@ func (q *Planner) process(jobID string) {
 	q.mu.Unlock()
 	q.persist(jobID)
 
-	provReq := &rmtypes.ResourceProvision{
-		Spec: rmtypes.ResourceProvisionSpec{
-			Credential: rmtypes.ResourceCredential{Provider: q.prov.Type()},
-		},
-		IdempotencyKey: req.JobID,
-	}
-	provResult, err := q.prov.Provision(q.baseCtx, provReq)
+	// Backend.Schedule decides what to provision (RM-spec shaping today;
+	// future scheduling decisions live here too).
+	spec, gpuType, gpusPerReplica, err := q.backend.Schedule(q.baseCtx, req)
 	if err != nil {
-		q.markFailed(jobID, plannerapi.JobStatusResourceFailed, errors.Join(plannerapi.ErrInsufficientResources, err))
+		q.markFailed(jobID, plannerapi.JobStatusResourceFailed, errors.Join(plannerapi.ErrInvalidJob, err))
 		return
 	}
-	q.mu.Lock()
-	q.jobs[jobID].provisionID = provResult.ProvisionID
-	q.mu.Unlock()
+
+	// Optional backend override can bypass real RM provisioning.
+	var provResult *rmtypes.ProvisionResult
+	overrode := false
+	if override, ok := q.backend.(provisionOverride); ok {
+		if prov, used := override.TryProvisionOverride(req); used && prov != nil {
+			provResult = prov
+			overrode = true
+			klog.Infof("[planner] backend override: skipping RM provisioning job_id=%q provision_id=%q",
+				jobID, provResult.ProvisionID)
+			q.mu.Lock()
+			q.jobs[jobID].provisionID = provResult.ProvisionID
+			q.mu.Unlock()
+		}
+	}
+	if provResult == nil {
+		provReq := &rmtypes.ResourceProvision{
+			Spec:           spec,
+			IdempotencyKey: req.JobID,
+		}
+		provResult, err = q.prov.Provision(q.baseCtx, provReq)
+		if err != nil {
+			q.markFailed(jobID, plannerapi.JobStatusResourceFailed, errors.Join(plannerapi.ErrInsufficientResources, err))
+			return
+		}
+		q.mu.Lock()
+		q.jobs[jobID].provisionID = provResult.ProvisionID
+		q.mu.Unlock()
+		if logger, ok := q.backend.(provisionResponseLogger); ok {
+			logger.LogProvisionResponse(req.JobID, provResult, spec)
+		}
+	}
 
 	// Provision returns when the request is accepted, not when the resource
 	// is ready. Wait for Running before submitting to MDS, which rejects
-	// batches that point to not-yet-ready provisions.
-	if err := q.waitForProvisionReady(provResult.ProvisionID); err != nil {
-		q.releaseAfter(jobID, provResult.ProvisionID, "wait failure")
-		q.markFailed(jobID, plannerapi.JobStatusResourceFailed, errors.Join(plannerapi.ErrInsufficientResources, err))
-		return
+	// batches that point to not-yet-ready provisions. A backend override
+	// supplies an already-ready result, so the wait is skipped for it.
+	readyResult := provResult
+	if !overrode {
+		readyResult, err = q.waitForProvisionReady(provResult.ProvisionID)
+		if err != nil {
+			q.releaseAfter(jobID, provResult.ProvisionID, "wait failure")
+			q.markFailed(jobID, plannerapi.JobStatusResourceFailed, errors.Join(plannerapi.ErrInsufficientResources, err))
+			return
+		}
 	}
 	klog.Infof("[planner] provision ready job_id=%q provision_id=%q provider=%q",
 		jobID, provResult.ProvisionID, q.prov.Type())
@@ -209,15 +242,18 @@ func (q *Planner) process(jobID string) {
 	q.persist(jobID)
 
 	aibrix := plannerclient.AIBrixExtraBody{
-		JobID: req.JobID,
-		PlannerDecision: &plannerclient.PlannerDecision{
-			ProvisionID: provResult.ProvisionID,
-		},
-		ModelTemplate: req.ModelTemplate,
+		JobID:           req.JobID,
+		PlannerDecision: q.backend.BuildDecision(spec, readyResult, gpuType, gpusPerReplica),
+		ModelTemplate:   req.ModelTemplate,
 	}
 
-	klog.Infof("[planner] submit job_id=%q provision_id=%q model_template=%v",
-		req.JobID, provResult.ProvisionID, req.ModelTemplate)
+	if mt := req.ModelTemplate; mt != nil {
+		klog.Infof("[planner] submit job_id=%q provision_id=%q model_template=%s@%s spec=%s",
+			req.JobID, provResult.ProvisionID, mt.Name, mt.Version, mt.Spec)
+	} else {
+		klog.Infof("[planner] submit job_id=%q provision_id=%q model_template=<none>",
+			req.JobID, provResult.ProvisionID)
+	}
 
 	batch, err := q.bc.CreateBatch(q.baseCtx, req.BatchParams, aibrix)
 	if err != nil {
@@ -258,7 +294,7 @@ func (q *Planner) process(jobID string) {
 // or Failed, the timeout elapses, or the scheduler is shutting down.
 // Provisioner.Provision returns when the request is accepted, not when the
 // resource is ready; Planner must wait for Running before invoking CreateBatch.
-func (q *Planner) waitForProvisionReady(provisionID string) error {
+func (q *Planner) waitForProvisionReady(provisionID string) (*rmtypes.ProvisionResult, error) {
 	filter := &rmtypes.ListOptions{ProvisionIDs: &[]string{provisionID}}
 	deadline := time.Now().Add(provReadyTimeout)
 	for {
@@ -267,21 +303,21 @@ func (q *Planner) waitForProvisionReady(provisionID string) error {
 		case err != nil:
 			klog.Warningf("[planner] poll provision_id=%q: %v", provisionID, err)
 		case len(results) == 0:
-			return fmt.Errorf("provision %q not found", provisionID)
+			return nil, fmt.Errorf("provision %q not found", provisionID)
 		default:
 			switch results[0].Status {
 			case rmtypes.ProvisionStatusRunning:
-				return nil
+				return results[0], nil
 			case rmtypes.ProvisionStatusFailed:
-				return fmt.Errorf("provision failed: %s", results[0].ErrorMessage)
+				return nil, fmt.Errorf("provision failed: %s", results[0].ErrorMessage)
 			}
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("provision %q did not reach Running within %v", provisionID, provReadyTimeout)
+			return nil, fmt.Errorf("provision %q did not reach Running within %v", provisionID, provReadyTimeout)
 		}
 		select {
 		case <-q.baseCtx.Done():
-			return q.baseCtx.Err()
+			return nil, q.baseCtx.Err()
 		case <-time.After(q.provPollInterval):
 		}
 	}
@@ -545,6 +581,10 @@ func (q *Planner) Enqueue(ctx context.Context, req *plannerapi.EnqueueRequest) (
 	}
 	if q.prov == nil {
 		return nil, fmt.Errorf("%w: missing provisioner", plannerapi.ErrInsufficientResources)
+	}
+	// Backend may impose additional pre-flight checks. Default is a no-op.
+	if err := q.backend.ValidateRequest(req); err != nil {
+		return nil, err
 	}
 	if err := q.baseCtx.Err(); err != nil {
 		return nil, fmt.Errorf("planner closed: %w", err)

--- a/apps/console/api/planner/impl/planner.go
+++ b/apps/console/api/planner/impl/planner.go
@@ -185,50 +185,30 @@ func (q *Planner) process(jobID string) {
 		return
 	}
 
-	// Optional backend override can bypass real RM provisioning.
-	var provResult *rmtypes.ProvisionResult
-	overrode := false
-	if override, ok := q.backend.(provisionOverride); ok {
-		if prov, used := override.TryProvisionOverride(req); used && prov != nil {
-			provResult = prov
-			overrode = true
-			klog.Infof("[planner] backend override: skipping RM provisioning job_id=%q provision_id=%q",
-				jobID, provResult.ProvisionID)
-			q.mu.Lock()
-			q.jobs[jobID].provisionID = provResult.ProvisionID
-			q.mu.Unlock()
-		}
+	provReq := &rmtypes.ResourceProvision{
+		Spec:           spec,
+		IdempotencyKey: req.JobID,
 	}
-	if provResult == nil {
-		provReq := &rmtypes.ResourceProvision{
-			Spec:           spec,
-			IdempotencyKey: req.JobID,
-		}
-		provResult, err = q.prov.Provision(q.baseCtx, provReq)
-		if err != nil {
-			q.markFailed(jobID, plannerapi.JobStatusResourceFailed, errors.Join(plannerapi.ErrInsufficientResources, err))
-			return
-		}
-		q.mu.Lock()
-		q.jobs[jobID].provisionID = provResult.ProvisionID
-		q.mu.Unlock()
-		if logger, ok := q.backend.(provisionResponseLogger); ok {
-			logger.LogProvisionResponse(req.JobID, provResult, spec)
-		}
+	provResult, err := q.prov.Provision(q.baseCtx, provReq)
+	if err != nil {
+		q.markFailed(jobID, plannerapi.JobStatusResourceFailed, errors.Join(plannerapi.ErrInsufficientResources, err))
+		return
+	}
+	q.mu.Lock()
+	q.jobs[jobID].provisionID = provResult.ProvisionID
+	q.mu.Unlock()
+	if logger, ok := q.backend.(provisionResponseLogger); ok {
+		logger.LogProvisionResponse(req.JobID, provResult, spec)
 	}
 
 	// Provision returns when the request is accepted, not when the resource
 	// is ready. Wait for Running before submitting to MDS, which rejects
-	// batches that point to not-yet-ready provisions. A backend override
-	// supplies an already-ready result, so the wait is skipped for it.
-	readyResult := provResult
-	if !overrode {
-		readyResult, err = q.waitForProvisionReady(provResult.ProvisionID)
-		if err != nil {
-			q.releaseAfter(jobID, provResult.ProvisionID, "wait failure")
-			q.markFailed(jobID, plannerapi.JobStatusResourceFailed, errors.Join(plannerapi.ErrInsufficientResources, err))
-			return
-		}
+	// batches that point to not-yet-ready provisions.
+	readyResult, err := q.waitForProvisionReady(provResult.ProvisionID)
+	if err != nil {
+		q.releaseAfter(jobID, provResult.ProvisionID, "wait failure")
+		q.markFailed(jobID, plannerapi.JobStatusResourceFailed, errors.Join(plannerapi.ErrInsufficientResources, err))
+		return
 	}
 	klog.Infof("[planner] provision ready job_id=%q provision_id=%q provider=%q",
 		jobID, provResult.ProvisionID, q.prov.Type())


### PR DESCRIPTION
## Pull Request Description

The PRs aim to refactor planner core logics to support different providers to develop their implementation without any conflict.
