### PR TITLE
docs: Examples should come with health and readiness checks

### DIFF
--- a/samples/adapter/base-without-runtime.yaml
+++ b/samples/adapter/base-without-runtime.yaml
@@ -48,3 +48,30 @@ spec:
               nvidia.com/gpu: "1"
             requests:
               nvidia.com/gpu: "1"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1

--- a/samples/kvcache/infinistore/vllm.yaml
+++ b/samples/kvcache/infinistore/vllm.yaml
@@ -131,6 +131,33 @@ spec:
               vke.volcengine.com/rdma: "1"
               cpu: "10"
               memory: "120G"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
           securityContext:
             capabilities:
               add:

--- a/samples/kvcache/l1cache/vllm.yaml
+++ b/samples/kvcache/l1cache/vllm.yaml
@@ -110,6 +110,33 @@ spec:
               nvidia.com/gpu: "1"
               cpu: "10"
               memory: "120G"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
       volumes:
         - name: model-hostpath
           hostPath:

--- a/samples/kvcache/vineyard/deployment-tp.yaml
+++ b/samples/kvcache/vineyard/deployment-tp.yaml
@@ -71,6 +71,33 @@ spec:
               nvidia.com/gpu: "1"
             requests:
               nvidia.com/gpu: "1"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 240
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
       volumes:
         - name: kvcache-socket
           hostPath:

--- a/samples/kvcache/vineyard/deployment.yaml
+++ b/samples/kvcache/vineyard/deployment.yaml
@@ -66,6 +66,33 @@ spec:
               nvidia.com/gpu: "1"
             requests:
               nvidia.com/gpu: "1"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 120
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
       volumes:
         - name: kvcache-socket
           hostPath:

--- a/samples/multimodality/vllm/dse-qwen2-2b.yaml
+++ b/samples/multimodality/vllm/dse-qwen2-2b.yaml
@@ -92,6 +92,33 @@ spec:
             requests:
               nvidia.com/gpu: "1"
               cpu: "10"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
       volumes:
         - name: model-hostpath
           hostPath:

--- a/samples/multimodality/vllm/llava-7b.yaml
+++ b/samples/multimodality/vllm/llava-7b.yaml
@@ -95,6 +95,33 @@ spec:
             requests:
               nvidia.com/gpu: "1"
               cpu: "10"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
       volumes:
         - name: model-hostpath
           hostPath:

--- a/samples/multimodality/vllm/qwen-audio.yaml
+++ b/samples/multimodality/vllm/qwen-audio.yaml
@@ -91,6 +91,33 @@ spec:
             requests:
               nvidia.com/gpu: "1"
               cpu: "10"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 120
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
       volumes:
         - name: model-hostpath
           hostPath:

--- a/samples/multimodality/vllm/qwen-vl.yaml
+++ b/samples/multimodality/vllm/qwen-vl.yaml
@@ -99,6 +99,33 @@ spec:
             requests:
               nvidia.com/gpu: "1"
               cpu: "10"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
       volumes:
         - name: model-hostpath
           hostPath:

--- a/samples/quickstart/vke/model.yaml
+++ b/samples/quickstart/vke/model.yaml
@@ -86,6 +86,33 @@ spec:
               nvidia.com/gpu: "1"
               cpu: "12"
               memory: "48G"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
       volumes:
         - name: model-hostpath
           hostPath:


### PR DESCRIPTION
## Summary

Several example Deployment YAML files in `samples/` lacked `livenessProbe`, `readinessProbe`, and `startupProbe` definitions. Without these, Kubernetes marks pods as ready immediately after the container starts, even though vllm takes significant time to load the model.


## Root cause

Several example Deployment YAML files in `samples/` lacked `livenessProbe`, `readinessProbe`, and `startupProbe` definitions. Without these, Kubernetes marks pods as ready immediately after the container starts, even though vllm takes significant time to load the model. Requests sent during this window fail because the model server is not yet ready to serve.

The `samples/quickstart/model.yaml` already had the correct probe configuration and served as the reference.


## What changed

Added `livenessProbe`, `readinessProbe`, and `startupProbe` to the `vllm-openai` container in 10 Deployment YAML files that were missing them:

- `samples/adapter/base-without-runtime.yaml`
- `samples/kvcache/infinistore/vllm.yaml`
- `samples/kvcache/l1cache/vllm.yaml`
- `samples/kvcache/vineyard/deployment.yaml`
- `samples/kvcache/vineyard/deployment-tp.yaml`
- `samples/multimodality/vllm/dse-qwen2-2b.yaml`
- `samples/multimodality/vllm/llava-7b.yaml`
- `samples/multimodality/vllm/qwen-audio.yaml`
- `samples/multimodality/vllm/qwen-vl.yaml`
- `samples/quickstart/vke/model.yaml`

The probe configuration added to each file:

```yaml
livenessProbe:
  httpGet:
    path: /health
    port: 8000
    scheme: HTTP
  failureThreshold: 3
  periodSeconds: 5
  successThreshold: 1
  timeoutSeconds: 1
readinessProbe:
  httpGet:
    path: /health
    port: 8000
    scheme: HTTP
  failureThreshold: 5
  periodSeconds: 5
  successThreshold: 1
  timeoutSeconds: 1
startupProbe:
  httpGet:
    path: /health
    port: 8000
    scheme: HTTP
  failureThreshold: 30
  periodSeconds: 5
  successThreshold: 1
  timeoutSeconds: 1
```

The `startupProbe` with `failureThreshold: 30` gives the model server up to 150 seconds (30 * 5s) to finish loading before Kubernetes considers it failed, which handles the long model loading time. The `readinessProbe` then controls when traffic is routed to the pod.

Following review feedback, three deployments that need longer startup time use a higher `startupProbe` `failureThreshold` while keeping the liveness and readiness probes unchanged:

- `samples/multimodality/vllm/qwen-audio.yaml`: 120 (about 10 minutes), because the container runs `pip install "vllm[audio]"` at startup before serving.
- `samples/kvcache/vineyard/deployment.yaml`: 120 (about 10 minutes), because deepseek-coder-6.7b-instruct (around 13GB) is pulled from Hugging Face at startup with no cache volume.
- `samples/kvcache/vineyard/deployment-tp.yaml`: 240 (about 20 minutes), because deepseek-coder-33b-instruct (around 65GB) is pulled from Hugging Face at startup with no cache volume.

Files not modified (intentionally):
- Mock server deployments (`ai-gateway-integration/llama-7b.yaml`, `mistral-7b.yaml`) use `aibrix/vllm-mock:nightly`, not real vllm
- Custom CRDs (`StormService`, `RayClusterFleet` resources) for the disaggregation and deepseek-r1 samples; some already had `startupProbe`
- Files that already had probes (`quickstart/model.yaml`, `adapter/base.yaml`, `autoscaling/deploy.yaml`, etc.)


## Issue

Fixes #685

Issue: https://github.com/vllm-project/aibrix/issues/685


## Diffstat

```
 samples/adapter/base-without-runtime.yaml    | 27 +++++++++++++++++++++++++++
 samples/kvcache/infinistore/vllm.yaml        | 27 +++++++++++++++++++++++++++
 samples/kvcache/l1cache/vllm.yaml            | 27 +++++++++++++++++++++++++++
 samples/kvcache/vineyard/deployment-tp.yaml  | 27 +++++++++++++++++++++++++++
 samples/kvcache/vineyard/deployment.yaml     | 27 +++++++++++++++++++++++++++
 samples/multimodality/vllm/dse-qwen2-2b.yaml | 27 +++++++++++++++++++++++++++
 samples/multimodality/vllm/llava-7b.yaml     | 27 +++++++++++++++++++++++++++
 samples/multimodality/vllm/qwen-audio.yaml   | 27 +++++++++++++++++++++++++++
 samples/multimodality/vllm/qwen-vl.yaml      | 27 +++++++++++++++++++++++++++
 samples/quickstart/vke/model.yaml            | 27 +++++++++++++++++++++++++++
 10 files changed, 270 insertions(+)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.
