### PR TITLE
fix(console): improve batch job creation UX

### DIFF
--- a/apps/console/web/src/components/CreateJob.tsx
+++ b/apps/console/web/src/components/CreateJob.tsx
@@ -30,6 +30,7 @@ import {
   MutationDiff,
   ParseResult,
   parseJsonl,
+  validateBatchFileName,
   applyBatchOverrides,
   serializeJsonl,
   hasAnyOverride,
@@ -38,6 +39,7 @@ import {
 import {
   formatBytes,
   formatFileCreatedAt,
+  formatModelSelectionLabel,
   getBatchExampleJsonlLine,
   getCreateJobEndpoint,
   getCreateJobReadiness,
@@ -91,6 +93,7 @@ export function CreateJob({ onBack }: CreateJobProps) {
   const [uploading, setUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [datasetDragActive, setDatasetDragActive] = useState(false);
 
   // Validation state
   const [validating, setValidating] = useState(false);
@@ -211,16 +214,26 @@ export function CreateJob({ onBack }: CreateJobProps) {
     }
   };
 
-  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
+  const handleDatasetFile = async (file: File) => {
     setSelectedFile(file);
     setUploadedFileId(null);
     setSelectedExistingFile(null);
     setValidation(null);
     setSelectedFileParse(null);
     setSubmitError(null);
+
+    const fileNameError = validateBatchFileName(file.name);
+    if (fileNameError) {
+      setValidation({
+        valid: false,
+        totalLines: 0,
+        errors: [fileNameError],
+        warnings: [],
+        detectedModel: null,
+        endpoints: [],
+      });
+      return;
+    }
 
     // Validate immediately
     setValidating(true);
@@ -244,6 +257,41 @@ export function CreateJob({ onBack }: CreateJobProps) {
     } finally {
       setValidating(false);
     }
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    void handleDatasetFile(file);
+  };
+
+  const handleDatasetDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'copy';
+    setDatasetDragActive(true);
+  };
+
+  const handleDatasetDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const nextTarget = e.relatedTarget;
+    if (!nextTarget || !e.currentTarget.contains(nextTarget as Node)) {
+      setDatasetDragActive(false);
+    }
+  };
+
+  const handleDatasetDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDatasetDragActive(false);
+
+    const file = e.dataTransfer.files?.[0];
+    if (!file) return;
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+    void handleDatasetFile(file);
   };
 
   const handleRemoveFile = () => {
@@ -350,6 +398,7 @@ export function CreateJob({ onBack }: CreateJobProps) {
   });
   const canSubmit = readiness.canSubmit;
   const canContinueDataset = selectedExistingFile != null || (selectedFile != null && (validation?.valid ?? false));
+  const selectedModelLabel = formatModelSelectionLabel(selectedModel, selectedServingName);
 
   const handleCreateJob = async () => {
     if (!canSubmit) return;
@@ -452,7 +501,7 @@ export function CreateJob({ onBack }: CreateJobProps) {
                   onClick={() => setShowModelDropdown(!showModelDropdown)}
                   className="w-full px-4 py-2 border border-gray-200 rounded-lg text-left flex items-center justify-between hover:bg-gray-50"
                 >
-                  <span className="text-sm">{selectedModel || 'Select Model'}</span>
+                  <span className="text-sm truncate pr-2">{selectedModelLabel || 'Select Model'}</span>
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                   </svg>
@@ -484,10 +533,12 @@ export function CreateJob({ onBack }: CreateJobProps) {
                             onClick={() => handleSelectModel(model)}
                             className="w-full px-3 py-2 text-left text-sm hover:bg-gray-50 rounded flex items-center gap-2"
                           >
-                            <div className="w-5 h-5 rounded-full bg-teal-50 flex items-center justify-center">
+                            <div className="w-5 h-5 rounded-full bg-teal-50 flex items-center justify-center shrink-0">
                               <div className="w-2 h-2 rounded-full bg-teal-500"></div>
                             </div>
-                            {model.name}
+                            <span className="min-w-0 flex-1 truncate">
+                              {formatModelSelectionLabel(model.name, model.servingName)}
+                            </span>
                           </button>
                         ))
                       )}
@@ -590,15 +641,22 @@ export function CreateJob({ onBack }: CreateJobProps) {
                     type="file"
                     ref={fileInputRef}
                     onChange={handleFileSelect}
-                    accept=".json,.jsonl"
+                    accept=".jsonl"
                     className="hidden"
                   />
                   {selectedFile ? (
-                    <div className={`border-2 rounded-xl p-4 flex items-center justify-between ${
-                      validation?.valid === false
-                        ? 'border-red-200 bg-red-50'
-                        : 'border-teal-200 bg-teal-50'
-                    }`}>
+                    <div
+                      onDragOver={handleDatasetDragOver}
+                      onDragLeave={handleDatasetDragLeave}
+                      onDrop={handleDatasetDrop}
+                      className={`border-2 rounded-xl p-4 flex items-center justify-between ${
+                        validation?.valid === false
+                          ? 'border-red-200 bg-red-50'
+                          : datasetDragActive
+                            ? 'border-teal-500 bg-teal-50'
+                            : 'border-teal-200 bg-teal-50'
+                      }`}
+                    >
                       <div className="flex items-center gap-3">
                         <Upload className={`w-5 h-5 ${validation?.valid === false ? 'text-red-600' : 'text-teal-600'}`} />
                         <span className="text-sm text-gray-900">{selectedFile.name}</span>
@@ -613,7 +671,14 @@ export function CreateJob({ onBack }: CreateJobProps) {
                   ) : (
                     <div
                       onClick={() => fileInputRef.current?.click()}
-                      className="border-2 border-dashed border-gray-200 rounded-xl p-8 text-center hover:border-teal-400 transition-colors cursor-pointer"
+                      onDragOver={handleDatasetDragOver}
+                      onDragLeave={handleDatasetDragLeave}
+                      onDrop={handleDatasetDrop}
+                      className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
+                        datasetDragActive
+                          ? 'border-teal-500 bg-teal-50'
+                          : 'border-gray-200 hover:border-teal-400'
+                      }`}
                     >
                       <Upload className="w-8 h-8 text-gray-300 mx-auto mb-2" />
                       <p className="text-sm text-gray-500 mb-1">Click to upload or drag and drop</p>

--- a/apps/console/web/src/utils/batchProduct.test.ts
+++ b/apps/console/web/src/utils/batchProduct.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { formatModelSelectionLabel } from './batchProduct';
+
+describe('batch product helpers', () => {
+  it('shows the serving model name beside the display name when they differ', () => {
+    expect(formatModelSelectionLabel('Qwen3.6 32B', 'Qwen/Qwen3.5-32B')).toBe(
+      'Qwen3.6 32B (Qwen/Qwen3.5-32B)',
+    );
+  });
+
+  it('does not duplicate the model label when the serving name is empty or identical', () => {
+    expect(formatModelSelectionLabel('Qwen/Qwen3.5-32B', 'Qwen/Qwen3.5-32B')).toBe(
+      'Qwen/Qwen3.5-32B',
+    );
+    expect(formatModelSelectionLabel('Qwen3.6 32B', '')).toBe('Qwen3.6 32B');
+  });
+});

--- a/apps/console/web/src/utils/batchProduct.ts
+++ b/apps/console/web/src/utils/batchProduct.ts
@@ -55,6 +55,15 @@ export interface BatchJobSummary {
   totalRequests: number;
 }
 
+export function formatModelSelectionLabel(name: string, servingName?: string): string {
+  const displayName = name.trim();
+  const inferenceName = (servingName || '').trim();
+
+  if (!displayName) return inferenceName;
+  if (!inferenceName || inferenceName === displayName) return displayName;
+  return `${displayName} (${inferenceName})`;
+}
+
 export function getCreateJobReadiness(input: CreateJobReadinessInput): CreateJobReadiness {
   if (input.submitting) return { canSubmit: false, reason: 'Creating job' };
   if (!input.selectedModel) return { canSubmit: false, reason: 'Select a model' };

--- a/apps/console/web/src/utils/batchValidation.test.ts
+++ b/apps/console/web/src/utils/batchValidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseJsonl, validateBatchLines } from './batchValidation';
+import { parseJsonl, validateBatchFile, validateBatchLines } from './batchValidation';
 
 function jsonlLine(url: string, model = 'qwen-serving'): string {
   return JSON.stringify({
@@ -25,5 +25,19 @@ describe('batch validation', () => {
     expect(result.valid).toBe(true);
     expect(result.errors).toEqual([]);
     expect(result.endpoints).toEqual(['/v1/embeddings']);
+  });
+
+  it('rejects a json file even when the content is valid jsonl', async () => {
+    const file = new File([jsonlLine('/v1/chat/completions')], 'requests.json', {
+      type: 'application/json',
+    });
+
+    const result = await validateBatchFile(file, {
+      expectedModel: 'qwen-serving',
+      supportedEndpoints: ['/v1/chat/completions'],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('File must use the .jsonl extension.');
   });
 });

--- a/apps/console/web/src/utils/batchValidation.ts
+++ b/apps/console/web/src/utils/batchValidation.ts
@@ -54,6 +54,7 @@ const MAX_ERRORS = 20;
 const MAX_DIFF_SAMPLES = 5;
 // OpenAI Batch API hard limit; MDS enforces the same cap (python/aibrix/.../batch.py).
 const MAX_REQUESTS_PER_BATCH = 50000;
+export const JSONL_EXTENSION_ERROR = 'File must use the .jsonl extension.';
 
 const OVERRIDE_FIELD_MAP: Record<keyof BatchOverrides, string> = {
   maxTokens: 'max_tokens',
@@ -64,6 +65,10 @@ const OVERRIDE_FIELD_MAP: Record<keyof BatchOverrides, string> = {
 
 // Endpoints where completion-style sampling params apply.
 const COMPLETION_ENDPOINTS = new Set(['/v1/chat/completions', '/v1/completions']);
+
+export function validateBatchFileName(fileName: string): string | null {
+  return fileName.trim().toLowerCase().endsWith('.jsonl') ? null : JSONL_EXTENSION_ERROR;
+}
 
 export function parseJsonl(text: string): ParseResult {
   const rawLines = text.trimEnd().split('\n');
@@ -208,6 +213,18 @@ export function validateBatchLines(parsed: ParseResult, ctx: ValidationContext):
 
 // Convenience wrapper: read file, parse, validate.
 export async function validateBatchFile(file: File, ctx: ValidationContext): Promise<ValidationResult> {
+  const fileNameError = validateBatchFileName(file.name);
+  if (fileNameError) {
+    return {
+      valid: false,
+      totalLines: 0,
+      errors: [fileNameError],
+      warnings: [],
+      detectedModel: null,
+      endpoints: [],
+    };
+  }
+
   const text = await file.text();
   const parsed = parseJsonl(text);
   return validateBatchLines(parsed, ctx);


### PR DESCRIPTION
## Pull Request Description
- Reject non-.jsonl batch datasets before content validation so .json files cannot pass as single-line JSONL.
- Wire dataset drag-and-drop to the same validation path as file picker uploads.
- Show model serving_name beside display name so users know the JSONL body.model value.
- 

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>