### PR TITLE
fix(gateway): interrupt idle ext_proc Recv on shutdown to fix slow pod termination

### DIFF
--- a/apps/console/api/handler/job.go
+++ b/apps/console/api/handler/job.go
@@ -68,6 +68,7 @@ const (
 	metadataConsoleTemplateName    = "aibrix.console.template_name"
 	metadataConsoleTemplateVersion = "aibrix.console.template_version"
 	defaultListLimit               = 20
+	jsonNullLiteral                = "null"
 )
 
 // JobHandler implements console.v1.JobService.
@@ -556,11 +557,11 @@ func parseBatchExtraBody(b *openai.Batch) map[string]json.RawMessage {
 		return nil
 	}
 	out := make(map[string]json.RawMessage)
-	if raw, ok := root["extra_body"]; ok && len(raw) > 0 && string(raw) != "null" {
+	if raw, ok := root["extra_body"]; ok && len(raw) > 0 && string(raw) != jsonNullLiteral {
 		var extra map[string]json.RawMessage
 		if err := json.Unmarshal(raw, &extra); err == nil {
 			for k, v := range extra {
-				if len(v) > 0 && string(v) != "null" {
+				if len(v) > 0 && string(v) != jsonNullLiteral {
 					out[k] = v
 				}
 			}
@@ -573,7 +574,7 @@ func parseBatchExtraBody(b *openai.Batch) map[string]json.RawMessage {
 		if _, standard := standardBatchResponseFields[k]; standard {
 			continue
 		}
-		if len(v) > 0 && string(v) != "null" {
+		if len(v) > 0 && string(v) != jsonNullLiteral {
 			out[k] = v
 		}
 	}
@@ -604,14 +605,14 @@ func applyKnownBatchExtensions(job *pb.Job, extraBody map[string]json.RawMessage
 }
 
 func applyAibrixBatchExtension(job *pb.Job, raw json.RawMessage) {
-	if len(raw) == 0 || string(raw) == "null" {
+	if len(raw) == 0 || string(raw) == jsonNullLiteral {
 		return
 	}
 	var payload rawBatchExtensionPayload
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		return
 	}
-	if len(payload.Runtime) > 0 && string(payload.Runtime) != "null" {
+	if len(payload.Runtime) > 0 && string(payload.Runtime) != jsonNullLiteral {
 		var runtime rawRuntimePayload
 		if err := json.Unmarshal(payload.Runtime, &runtime); err == nil {
 			job.Runtime = &pb.JobRuntime{
@@ -621,7 +622,7 @@ func applyAibrixBatchExtension(job *pb.Job, raw json.RawMessage) {
 			}
 		}
 	}
-	if len(payload.ResourceAllocation) > 0 && string(payload.ResourceAllocation) != "null" {
+	if len(payload.ResourceAllocation) > 0 && string(payload.ResourceAllocation) != jsonNullLiteral {
 		var allocation rawResourceAllocationPayload
 		if err := json.Unmarshal(payload.ResourceAllocation, &allocation); err == nil {
 			job.ResourceAllocation = &pb.JobResourceAllocation{
@@ -640,7 +641,7 @@ func applyAibrixBatchExtension(job *pb.Job, raw json.RawMessage) {
 			}
 		}
 	}
-	if len(payload.ModelTemplate) > 0 && string(payload.ModelTemplate) != "null" {
+	if len(payload.ModelTemplate) > 0 && string(payload.ModelTemplate) != jsonNullLiteral {
 		var modelTemplate rawNamedRefPayload
 		if err := json.Unmarshal(payload.ModelTemplate, &modelTemplate); err == nil {
 			job.ModelTemplateRef = &pb.JobModelTemplateRef{
@@ -656,7 +657,7 @@ func applyAibrixBatchExtension(job *pb.Job, raw json.RawMessage) {
 			}
 		}
 	}
-	if len(payload.Profile) > 0 && string(payload.Profile) != "null" {
+	if len(payload.Profile) > 0 && string(payload.Profile) != jsonNullLiteral {
 		var profile rawNamedRefPayload
 		if err := json.Unmarshal(payload.Profile, &profile); err == nil {
 			job.Profile = &pb.JobProfileRef{

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -197,10 +197,11 @@ func (s *Server) processOnce(srv extProcPb.ExternalProcessor_ProcessServer, st *
 		}
 		req = r.req
 	case <-s.shutdownCh:
-		modelTag := GetModelTag(st.model)
-		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, modelTag, "aibrix_gateway_server_shutdown", "503")
+		if st.model != "" {
+			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503")
+			s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+		}
 		klog.ErrorS(nil, "server shutdown requested; aborting blocked Recv", "request_id", st.requestID, "model", st.model)
-		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
 		return status.Error(codes.Unavailable, "server shutdown in progress")
 	}
 
@@ -213,20 +214,21 @@ func (s *Server) processOnce(srv extProcPb.ExternalProcessor_ProcessServer, st *
 
 func (s *Server) preRecvCheck(st *processState) error {
 	select {
-	// Always emit a server-shutdown metric
 	case <-s.shutdownCh:
-		modelTag := GetModelTag(st.model)
-		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, modelTag, "aibrix_gateway_server_shutdown", "503")
+		if st.model != "" {
+			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503")
+			s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+		}
 		klog.ErrorS(nil, "server shutdown requested; draining request", "request_id", st.requestID, "model", st.model)
-		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
 		return status.Error(codes.Unavailable, "server shutdown in progress")
 
 	// Client cancelled or deadline exceeded
 	case <-st.ctx.Done():
-		modelTag := GetModelTag(st.model)
-		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, modelTag, "context_cancelled", "499")
+		if st.model != "" {
+			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "context_cancelled", "499")
+			s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+		}
 		klog.ErrorS(st.ctx.Err(), "context cancelled", "request_id", st.requestID, "model", st.model)
-		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
 		return st.ctx.Err()
 
 	default:
@@ -239,10 +241,11 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 		select {
 		// check for shutdown
 		case <-s.shutdownCh:
-			modelTag := GetModelTag(st.model)
-			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, modelTag, "aibrix_gateway_server_shutdown", "503")
+			if st.model != "" {
+				s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503")
+				s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+			}
 			klog.ErrorS(nil, "server shutdown requested; stream closed (EOF) during shutdown drain", "requestID", st.requestID, "model", st.model)
-			s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
 			return status.Error(codes.Unavailable, "server shutdown in progress")
 
 		default:

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -71,7 +72,9 @@ type Server struct {
 	cache               cache.Cache
 	httpServer          *http.Server
 	// Broadcast channel for server-initiated shutdown
-	shutdownCh <-chan struct{}
+	shutdownCh   <-chan struct{}
+	shutdown     chan struct{}
+	shutdownOnce sync.Once
 }
 
 type processState struct {
@@ -114,6 +117,7 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 	// Initialize the routers
 	routing.Init()
 
+	shutdown := make(chan struct{})
 	return &Server{
 		redisClient:         redisClient,
 		ratelimiter:         r,
@@ -122,6 +126,8 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 		gatewayClient:       gatewayClient,
 		requestCountTracker: map[string]int{},
 		cache:               c,
+		shutdownCh:          shutdown,
+		shutdown:            shutdown,
 	}
 }
 
@@ -166,16 +172,42 @@ func (s *Server) processOnce(srv extProcPb.ExternalProcessor_ProcessServer, st *
 		return err
 	}
 
-	req, err := srv.Recv()
-	if err != nil {
-		return s.handleRecvError(st, err)
+	// Run Recv in a goroutine so we can interrupt it if shutdown or context
+	// cancellation arrives while the stream is idle. Envoy keeps ext_proc
+	// streams open indefinitely between requests, so a bare srv.Recv() would
+	// block GracefulStop() forever on rollout.
+	type recvResult struct {
+		req *extProcPb.ProcessingRequest
+		err error
+	}
+	ch := make(chan recvResult, 1)
+	go func() {
+		req, err := srv.Recv()
+		ch <- recvResult{req, err}
+	}()
+
+	// ctx.Done() is intentionally omitted here: gRPC unblocks Recv when the
+	// stream context is cancelled, so handleRecvError handles that path.
+	// preRecvCheck covers the case where ctx is already done before we spawn.
+	var req *extProcPb.ProcessingRequest
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			return s.handleRecvError(st, r.err)
+		}
+		req = r.req
+	case <-s.shutdownCh:
+		modelTag := GetModelTag(st.model)
+		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, modelTag, "aibrix_gateway_server_shutdown", "503")
+		klog.ErrorS(nil, "server shutdown requested; aborting blocked Recv", "request_id", st.requestID, "model", st.model)
+		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+		return status.Error(codes.Unavailable, "server shutdown in progress")
 	}
 
 	resp, err := s.handleProcessingRequest(st, req)
 	if err != nil {
 		return err
 	}
-
 	return s.sendProcessingResponse(srv, st, resp)
 }
 
@@ -501,6 +533,9 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) Shutdown() {
+	if s.shutdown != nil {
+		s.shutdownOnce.Do(func() { close(s.shutdown) })
+	}
 	if s.httpServer != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -1191,7 +1191,7 @@ func openShutdownCh() <-chan struct{} {
 // shutdown channel is closed before any message is received.
 func TestProcess_ServerShutdown(t *testing.T) {
 	mc := &MockCache{}
-	mc.On("DoneRequestCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	// st.model is empty (idle stream); DoneRequestCount must not be called.
 
 	srv := &mockProcessServer{ctx: context.Background()}
 	s := newProcessTestServer(closedShutdownCh(), mc)
@@ -1212,7 +1212,7 @@ func TestProcess_ServerShutdown(t *testing.T) {
 // context is cancelled before any message is received.
 func TestProcess_ContextCancelled(t *testing.T) {
 	mc := &MockCache{}
-	mc.On("DoneRequestCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	// st.model is empty (idle stream); DoneRequestCount must not be called.
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -1318,7 +1318,7 @@ func TestProcess_RecvNonGRPCError(t *testing.T) {
 // server shutdown is in progress results in a codes.Unavailable error.
 func TestProcess_RecvEOF_DuringShutdown(t *testing.T) {
 	mc := &MockCache{}
-	mc.On("DoneRequestCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	// st.model is empty (idle stream); DoneRequestCount must not be called.
 
 	shutdownCh := make(chan struct{})
 
@@ -1423,7 +1423,7 @@ func TestProcess_CompletedExitsLoop(t *testing.T) {
 // previously caused GracefulStop to hang until SIGKILL).
 func TestProcess_ShutdownWhileRecvBlocked(t *testing.T) {
 	mc := &MockCache{}
-	mc.On("DoneRequestCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	// st.model is empty (idle stream); DoneRequestCount must not be called.
 
 	shutdownCh := make(chan struct{})
 

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -1417,3 +1417,43 @@ func TestProcess_CompletedExitsLoop(t *testing.T) {
 	srv.AssertExpectations(t)
 	mc.AssertExpectations(t)
 }
+
+// TestProcess_ShutdownWhileRecvBlocked verifies that Process exits promptly when
+// shutdownCh is closed while srv.Recv() is blocking (the idle-stream case that
+// previously caused GracefulStop to hang until SIGKILL).
+func TestProcess_ShutdownWhileRecvBlocked(t *testing.T) {
+	mc := &MockCache{}
+	mc.On("DoneRequestCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+	shutdownCh := make(chan struct{})
+
+	srv := &mockProcessServer{ctx: context.Background()}
+	// Recv blocks until shutdownCh is closed, then returns an error.
+	srv.On("Recv").Return((*extProcPb.ProcessingRequest)(nil), status.Error(codes.Unavailable, "stream closed")).
+		Run(func(args mock.Arguments) {
+			// Simulate Envoy holding an idle stream open; close shutdown concurrently.
+			close(shutdownCh)
+			// Recv itself returns after shutdown (as it would when the gRPC server
+			// eventually tears down the connection), but the select should have
+			// already fired the shutdownCh case and returned before this matters.
+			time.Sleep(10 * time.Millisecond)
+		})
+
+	s := newProcessTestServer(shutdownCh, mc)
+
+	done := make(chan error, 1)
+	go func() { done <- s.Process(srv) }()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Unavailable, st.Code())
+		assert.Contains(t, st.Message(), "server shutdown in progress")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Process did not exit within 2s after shutdownCh was closed (would have hung GracefulStop)")
+	}
+
+	mc.AssertExpectations(t)
+}


### PR DESCRIPTION
## Pull Request Description
### Problem

On rollout, the `gateway-plugins` pod hangs in `Terminating` for the full `terminationGracePeriodSeconds` before being `SIGKILL`ed, even when there are no active, in-flight requests.

This hang was caused by a combination of two bugs:

1. **`shutdownCh` was never wired in production:** `NewServer` left the field as `nil`. Because a `nil` channel blocks forever in a Go `select` statement, all of the shutdown-detection logic in `preRecvCheck` and `handleRecvError` was silently dead code.
2. **`srv.Recv()` was not interruptible:** Even if the channel had been wired, `preRecvCheck` uses a non-blocking `select` (via a `default` branch) that only runs *before* each `Recv()` call. Once execution reached `srv.Recv()`, it blocked indefinitely. Because Envoy keeps `ext_proc` streams open between requests, an idle stream's `Recv()` would never return on its own. Consequently, gRPC's `GracefulStop()` waited indefinitely for the stream to close, hanging the pod until it received a `SIGKILL`.

### Fix

* **Wire `shutdownCh` in production:** `NewServer` now creates an internal `shutdown chan struct{}` and assigns it to `shutdownCh`. `Shutdown()` closes this channel safely using `sync.Once`.
* **Make `Recv()` interruptible:** Refactored `processOnce` to run `srv.Recv()` in a buffered goroutine, using a `select` block to race the result channel against `s.shutdownCh`. When a shutdown is triggered on an idle stream, the `select` immediately aborts and returns a `codes.Unavailable` error. The underlying goroutine is naturally cleaned up when gRPC tears down the connection after `Process()` returns.
* *Note on Contexts:* `ctx.Done()` was intentionally omitted from the blocking `select` block because gRPC automatically unblocks `Recv()` when the stream context is cancelled, and `preRecvCheck` already handles the pre-`Recv` fast-path check.

## Related Issues
Resolves: #2275

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>