### PR TITLE
feat(pd): introduce pluggable KVTransferAgent abstraction with Mooncake stub

### DIFF
--- a/pkg/plugins/gateway/algorithms/pd/transfer/agent.go
+++ b/pkg/plugins/gateway/algorithms/pd/transfer/agent.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transfer
+
+import (
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+// KVTransferAgent owns connector-specific request and response mutation for one
+// KV transfer backend. Each implementation handles one backend (SHFS, NIXL, Mooncake, …).
+type KVTransferAgent interface {
+	// Type returns the connector identifier (e.g. "shfs", "nixl", "mooncake").
+	Type() string
+
+	// AugmentPrefillRequest mutates completionRequest with any fields the prefill
+	// pod requires before the HTTP request is sent (e.g. kv_transfer_params for SHFS).
+	AugmentPrefillRequest(
+		routingCtx *types.RoutingContext,
+		prefillPod *v1.Pod,
+		completionRequest map[string]any,
+	) error
+
+	// MergePrefillResponse injects connector-specific metadata from the prefill
+	// response into routingCtx.ReqBody before the request is forwarded to the decode pod.
+	MergePrefillResponse(
+		routingCtx *types.RoutingContext,
+		prefillResponse map[string]any,
+		prefillPod *v1.Pod,
+	) error
+}

--- a/pkg/plugins/gateway/algorithms/pd/transfer/mooncake.go
+++ b/pkg/plugins/gateway/algorithms/pd/transfer/mooncake.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transfer
+
+import (
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+func init() {
+	Register(ConnectorTypeMooncake, func() KVTransferAgent { return &MooncakeAgent{} })
+}
+
+// MooncakeAgent implements KVTransferAgent for the Mooncake KV transfer backend.
+// TODO: implement based on confirmed vLLM MooncakeConnector contract.
+type MooncakeAgent struct{}
+
+func (a *MooncakeAgent) Type() string { return ConnectorTypeMooncake }
+
+// AugmentPrefillRequest adds any Mooncake-specific fields to the prefill request.
+// TODO: implement once vLLM MooncakeConnector prefill request contract is confirmed.
+func (a *MooncakeAgent) AugmentPrefillRequest(
+	_ *types.RoutingContext,
+	_ *v1.Pod,
+	_ map[string]any,
+) error {
+	return nil
+}
+
+// MergePrefillResponse injects Mooncake-specific metadata from the prefill response
+// into routingCtx.ReqBody before the request is forwarded to the decode pod.
+// TODO: implement once vLLM MooncakeConnector response contract is confirmed.
+func (a *MooncakeAgent) MergePrefillResponse(
+	_ *types.RoutingContext,
+	_ map[string]any,
+	_ *v1.Pod,
+) error {
+	return nil
+}

--- a/pkg/plugins/gateway/algorithms/pd/transfer/nixl.go
+++ b/pkg/plugins/gateway/algorithms/pd/transfer/nixl.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transfer
+
+import (
+	"fmt"
+
+	"github.com/bytedance/sonic"
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	Register(ConnectorTypeNIXL, func() KVTransferAgent { return &NIXLAgent{} })
+}
+
+// NIXLAgent implements KVTransferAgent for the NIXL backend (Neuron).
+type NIXLAgent struct{}
+
+func (a *NIXLAgent) Type() string { return ConnectorTypeNIXL }
+
+// AugmentPrefillRequest is a no-op for NIXL: the backend manages KV transfer
+// through its own mechanism and does not require a prefill request skeleton.
+func (a *NIXLAgent) AugmentPrefillRequest(
+	_ *types.RoutingContext,
+	_ *v1.Pod,
+	_ map[string]any,
+) error {
+	return nil
+}
+
+// MergePrefillResponse wraps the entire prefill response under disagg_prefill_resp
+// so the NixlConnector on the decode side can locate and pull the KV blocks.
+func (a *NIXLAgent) MergePrefillResponse(
+	routingCtx *types.RoutingContext,
+	prefillResponse map[string]any,
+	prefillPod *v1.Pod,
+) error {
+	var originalRequest map[string]any
+	if err := sonic.Unmarshal(routingCtx.ReqBody, &originalRequest); err != nil {
+		return fmt.Errorf("failed to unmarshal original request body: %w", err)
+	}
+
+	originalRequest["disagg_prefill_resp"] = prefillResponse
+	updatedReqBody, err := sonic.Marshal(originalRequest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated request body: %w", err)
+	}
+	routingCtx.ReqBody = updatedReqBody
+
+	klog.InfoS("updated routing context with disagg_prefill_resp (NIXL)",
+		"request_id", routingCtx.RequestID,
+		"prefill_pod", prefillPod.Name,
+		"prefill_host", prefillPod.Status.PodIP,
+		"kv_connector_type", ConnectorTypeNIXL)
+	return nil
+}

--- a/pkg/plugins/gateway/algorithms/pd/transfer/nixl.go
+++ b/pkg/plugins/gateway/algorithms/pd/transfer/nixl.go
@@ -55,6 +55,9 @@ func (a *NIXLAgent) MergePrefillResponse(
 	if err := sonic.Unmarshal(routingCtx.ReqBody, &originalRequest); err != nil {
 		return fmt.Errorf("failed to unmarshal original request body: %w", err)
 	}
+	if originalRequest == nil {
+		return fmt.Errorf("original request body is empty or null")
+	}
 
 	originalRequest["disagg_prefill_resp"] = prefillResponse
 	updatedReqBody, err := sonic.Marshal(originalRequest)

--- a/pkg/plugins/gateway/algorithms/pd/transfer/registry.go
+++ b/pkg/plugins/gateway/algorithms/pd/transfer/registry.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transfer
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+var (
+	mu       sync.RWMutex
+	registry = map[string]func() KVTransferAgent{}
+)
+
+// Register makes a KVTransferAgent factory available under name.
+// Called from init() in each agent file.
+func Register(name string, factory func() KVTransferAgent) {
+	mu.Lock()
+	defer mu.Unlock()
+	registry[name] = factory
+}
+
+// Resolve returns a new KVTransferAgent for the given connector type.
+// Returns an error for unknown types.
+func Resolve(connectorType string) (KVTransferAgent, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+	factory, ok := registry[connectorType]
+	if !ok {
+		return nil, fmt.Errorf("unknown KV transfer connector type %q (valid: %v)", connectorType, validNames())
+	}
+	return factory(), nil
+}
+
+// ValidAgentNames returns a sorted list of registered connector type names.
+func ValidAgentNames() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	return validNames()
+}
+
+func validNames() []string {
+	names := make([]string, 0, len(registry))
+	for k := range registry {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/plugins/gateway/algorithms/pd/transfer/resolver.go
+++ b/pkg/plugins/gateway/algorithms/pd/transfer/resolver.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transfer
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// ConnectorTypeIdentifier is the pod label that specifies the KV transfer backend.
+	ConnectorTypeIdentifier = "model.aibrix.ai/kv-connector-type"
+
+	ConnectorTypeSHFS     = "shfs"
+	ConnectorTypeNIXL     = "nixl"
+	ConnectorTypeMooncake = "mooncake"
+)
+
+// ResolveConnectorType resolves the effective connector type from a pod label value,
+// falling back to globalDefault when the label is absent or unrecognized.
+func ResolveConnectorType(podLabelValue, globalDefault string) string {
+	v := strings.ToLower(podLabelValue)
+	switch v {
+	case ConnectorTypeSHFS, ConnectorTypeNIXL, ConnectorTypeMooncake:
+		return v
+	default:
+		if podLabelValue != "" {
+			klog.Warningf("unrecognized kv-connector-type label %q, falling back to global config (%s)", podLabelValue, globalDefault)
+		}
+		return globalDefault
+	}
+}
+
+// ResolveAgentForPod resolves the KVTransferAgent for a pod. It checks the
+// ConnectorTypeIdentifier pod label first, then falls back to globalDefault.
+func ResolveAgentForPod(pod *v1.Pod, globalDefault string) (KVTransferAgent, error) {
+	connectorType := ResolveConnectorType(pod.Labels[ConnectorTypeIdentifier], globalDefault)
+	return Resolve(connectorType)
+}

--- a/pkg/plugins/gateway/algorithms/pd/transfer/resolver.go
+++ b/pkg/plugins/gateway/algorithms/pd/transfer/resolver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package transfer
 
 import (
+	"errors"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -50,6 +51,9 @@ func ResolveConnectorType(podLabelValue, globalDefault string) string {
 // ResolveAgentForPod resolves the KVTransferAgent for a pod. It checks the
 // ConnectorTypeIdentifier pod label first, then falls back to globalDefault.
 func ResolveAgentForPod(pod *v1.Pod, globalDefault string) (KVTransferAgent, error) {
+	if pod == nil {
+		return nil, errors.New("cannot resolve KV transfer agent: pod is nil")
+	}
 	connectorType := ResolveConnectorType(pod.Labels[ConnectorTypeIdentifier], globalDefault)
 	return Resolve(connectorType)
 }

--- a/pkg/plugins/gateway/algorithms/pd/transfer/shfs.go
+++ b/pkg/plugins/gateway/algorithms/pd/transfer/shfs.go
@@ -64,6 +64,9 @@ func (a *SHFSAgent) MergePrefillResponse(
 	if err := sonic.Unmarshal(routingCtx.ReqBody, &originalRequest); err != nil {
 		return fmt.Errorf("failed to unmarshal original request body: %w", err)
 	}
+	if originalRequest == nil {
+		return fmt.Errorf("original request body is empty or null")
+	}
 
 	kvTransferParams, exists := prefillResponse["kv_transfer_params"]
 	if !exists {

--- a/pkg/plugins/gateway/algorithms/pd/transfer/shfs.go
+++ b/pkg/plugins/gateway/algorithms/pd/transfer/shfs.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transfer
+
+import (
+	"fmt"
+
+	"github.com/bytedance/sonic"
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	Register(ConnectorTypeSHFS, func() KVTransferAgent { return &SHFSAgent{} })
+}
+
+// SHFSAgent implements KVTransferAgent for the AIBrix SHFS/KVCacheManager backend (GPU).
+type SHFSAgent struct{}
+
+func (a *SHFSAgent) Type() string { return ConnectorTypeSHFS }
+
+// AugmentPrefillRequest adds a kv_transfer_params skeleton so the prefill pod
+// knows to populate remote block IDs for the decode side.
+func (a *SHFSAgent) AugmentPrefillRequest(
+	_ *types.RoutingContext,
+	_ *v1.Pod,
+	completionRequest map[string]any,
+) error {
+	completionRequest["kv_transfer_params"] = map[string]any{
+		"do_remote_decode":  true,
+		"do_remote_prefill": false,
+		"remote_engine_id":  nil,
+		"remote_block_ids":  nil,
+		"remote_host":       nil,
+		"remote_port":       nil,
+	}
+	return nil
+}
+
+// MergePrefillResponse extracts kv_transfer_params from the prefill response,
+// sets remote_host to the prefill pod IP, and writes the merged params into
+// routingCtx.ReqBody so the decode pod can pull the KV cache blocks.
+func (a *SHFSAgent) MergePrefillResponse(
+	routingCtx *types.RoutingContext,
+	prefillResponse map[string]any,
+	prefillPod *v1.Pod,
+) error {
+	var originalRequest map[string]any
+	if err := sonic.Unmarshal(routingCtx.ReqBody, &originalRequest); err != nil {
+		return fmt.Errorf("failed to unmarshal original request body: %w", err)
+	}
+
+	kvTransferParams, exists := prefillResponse["kv_transfer_params"]
+	if !exists {
+		klog.InfoS("no kv_transfer_params in prefill response (SHFS)", "request_id", routingCtx.RequestID)
+		return nil
+	}
+
+	kvTransferParamsMap, ok := kvTransferParams.(map[string]any)
+	if !ok {
+		return fmt.Errorf("kv_transfer_params has unexpected type %T, expected map[string]any", kvTransferParams)
+	}
+	kvTransferParamsMap["remote_host"] = prefillPod.Status.PodIP
+
+	originalRequest["kv_transfer_params"] = kvTransferParams
+	updatedReqBody, err := sonic.Marshal(originalRequest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated request body: %w", err)
+	}
+	routingCtx.ReqBody = updatedReqBody
+
+	klog.InfoS("updated routing context with kv_transfer_params (SHFS)",
+		"request_id", routingCtx.RequestID,
+		"prefill_pod", prefillPod.Name,
+		"prefill_host", prefillPod.Status.PodIP,
+		"kv_connector_type", ConnectorTypeSHFS)
+	return nil
+}

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -77,11 +77,12 @@ const (
 )
 
 const (
-	// KVConnectorTypeIdentifier specifies the KV transfer backend for a PD pod. Supported values include "shfs" and "nixl".
+	// KVConnectorTypeIdentifier specifies the KV transfer backend for a PD pod. Supported values include "shfs", "nixl", and "mooncake".
 	KVConnectorTypeIdentifier = "model.aibrix.ai/kv-connector-type"
 	// KV connector types for different backends
-	KVConnectorTypeSHFS = "shfs" // Default - AIBrix SHFS/KVCacheManager (GPU)
-	KVConnectorTypeNIXL = "nixl" // NIXL for Neuron (uses disagg_prefill_resp wrapper)
+	KVConnectorTypeSHFS     = "shfs"     // Default - AIBrix SHFS/KVCacheManager (GPU)
+	KVConnectorTypeNIXL     = "nixl"     // NIXL for Neuron (uses disagg_prefill_resp wrapper)
+	KVConnectorTypeMooncake = "mooncake" // Mooncake KV transfer backend
 
 	HeaderPrefillTargetPodIP = "prefill-target-pod-ip"
 	HeaderPrefillTargetPod   = "prefill-target-pod"

--- a/pkg/plugins/gateway/algorithms/pd_prefill_request.go
+++ b/pkg/plugins/gateway/algorithms/pd_prefill_request.go
@@ -39,12 +39,12 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/transfer"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 	v1 "k8s.io/api/core/v1"
@@ -238,19 +238,16 @@ func (r *pdRouter) preparePrefillPayload(routingCtx *types.RoutingContext, pod *
 		routingCtx.ReqBody = bodyCopy
 	}
 
-	// vLLM SHFS mode: send a kv_transfer_params skeleton; the remote_host and
-	// remote_block_ids are populated by updateRoutingContextWithKVTransferParams
-	// after the prefill response arrives. NIXL mode omits this field entirely
-	// because the backend manages KV transfer through its own mechanism.
-	kvConnectorType := selectKvConnectorType(pod.Labels[KVConnectorTypeIdentifier])
-	if llmEngine == VLLMEngine && kvConnectorType == KVConnectorTypeSHFS {
-		completionRequest["kv_transfer_params"] = map[string]any{
-			"do_remote_decode":  true,
-			"do_remote_prefill": false,
-			"remote_engine_id":  nil,
-			"remote_block_ids":  nil,
-			"remote_host":       nil,
-			"remote_port":       nil,
+	// For vLLM, delegate connector-specific request augmentation to the transfer agent.
+	// Each agent decides what fields (if any) to add to the prefill request body
+	// (e.g. SHFSAgent adds a kv_transfer_params skeleton; NIXLAgent is a no-op).
+	if llmEngine == VLLMEngine {
+		agent, err := transfer.ResolveAgentForPod(pod, aibrixKVConnectorType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve KV transfer agent for prefill payload: %w", err)
+		}
+		if err := agent.AugmentPrefillRequest(routingCtx, pod, completionRequest); err != nil {
+			return nil, fmt.Errorf("failed to augment prefill request: %w", err)
 		}
 	}
 
@@ -356,57 +353,11 @@ func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingConte
 // pod did not fill the field), the function returns nil without modifying
 // the request body, which is a valid no-op for backends that self-coordinate.
 func (r *pdRouter) updateRoutingContextWithKVTransferParams(routingCtx *types.RoutingContext, responseData map[string]any, prefillPod *v1.Pod) error {
-	var originalRequest map[string]any
-	if err := sonic.Unmarshal(routingCtx.ReqBody, &originalRequest); err != nil {
-		return fmt.Errorf("failed to unmarshal original request body: %w", err)
+	agent, err := transfer.ResolveAgentForPod(prefillPod, aibrixKVConnectorType)
+	if err != nil {
+		return fmt.Errorf("failed to resolve KV transfer agent for response merge: %w", err)
 	}
-
-	kvConnectorType := selectKvConnectorType(prefillPod.Labels[KVConnectorTypeIdentifier])
-	if kvConnectorType == KVConnectorTypeNIXL {
-		originalRequest["disagg_prefill_resp"] = responseData
-
-		updatedReqBody, err := sonic.Marshal(originalRequest)
-		if err != nil {
-			return fmt.Errorf("failed to marshal updated request body: %w", err)
-		}
-
-		routingCtx.ReqBody = updatedReqBody
-
-		klog.InfoS("updated routing context with disagg_prefill_resp (NIXL mode)",
-			"request_id", routingCtx.RequestID,
-			"prefill_pod", prefillPod.Name,
-			"prefill_host", prefillPod.Status.PodIP,
-			"kv_connector_type", kvConnectorType)
-	} else {
-		kvTransferParams, exists := responseData["kv_transfer_params"]
-		if !exists {
-			klog.InfoS("no kv_transfer_params in prefill response", "request_id", routingCtx.RequestID)
-			return nil
-		}
-
-		originalRequest["kv_transfer_params"] = kvTransferParams
-
-		kvTransferParamsMap, ok := kvTransferParams.(map[string]any)
-		if !ok {
-			return fmt.Errorf("kv_transfer_params has unexpected type %T, expected map[string]any", kvTransferParams)
-		}
-		kvTransferParamsMap["remote_host"] = prefillPod.Status.PodIP
-
-		updatedReqBody, err := sonic.Marshal(originalRequest)
-		if err != nil {
-			return fmt.Errorf("failed to marshal updated request body: %w", err)
-		}
-
-		routingCtx.ReqBody = updatedReqBody
-
-		klog.InfoS("updated routing context with kv_transfer_params (SHFS mode)",
-			"request_id", routingCtx.RequestID,
-			"prefill_pod", prefillPod.Name,
-			"prefill_host", prefillPod.Status.PodIP,
-			"kv_connector_type", kvConnectorType)
-	}
-
-	return nil
+	return agent.MergePrefillResponse(routingCtx, responseData, prefillPod)
 }
 
 // updateRoutingContextWithTRTDisaggParams merges TensorRT-LLM disaggregated
@@ -480,17 +431,9 @@ func (r *pdRouter) updateRoutingContextWithTRTDisaggParams(routingCtx *types.Rou
 	return nil
 }
 
-// selectKvConnectorType resolves the KV connector type from the pod label,
-// allowing per-pod overrides for mixed PD deployments and falling back to
-// the global configuration when the label is empty or invalid.
+// selectKvConnectorType resolves the KV connector type from a pod label value,
+// falling back to aibrixKVConnectorType when the value is absent or unrecognized.
+// Delegates to transfer.ResolveConnectorType for consistent resolution logic.
 func selectKvConnectorType(value string) string {
-	switch strings.ToLower(value) {
-	case KVConnectorTypeNIXL, KVConnectorTypeSHFS:
-		return strings.ToLower(value)
-	default:
-		if value != "" {
-			klog.Warningf("unrecognized kv-connector-type label %q, falling back to global config", value)
-		}
-		return aibrixKVConnectorType
-	}
+	return transfer.ResolveConnectorType(value, aibrixKVConnectorType)
 }


### PR DESCRIPTION
## Pull Request Description

The PD disaggregation router previously had SHFS and NIXL KV transfer logic tightly coupled inside `pd_prefill_request.go`. This PR extracts that logic into a new `pd/transfer/` sub-package behind a clean `KVTransferAgent` interface and adds a Mooncake stub as the first pluggable backend.

### What changed

* **New `pkg/plugins/gateway/algorithms/pd/transfer/` package:**
* `agent.go`: Defines the `KVTransferAgent` interface (`Type`, `AugmentPrefillRequest`, `MergePrefillResponse`).
* `registry.go`: Thread-safe factory registry allowing agents to self-register via `init()`.
* `resolver.go`: Houses connector type constants (`shfs`, `nixl`, `mooncake`) and `ResolveAgentForPod`. This checks the `model.aibrix.ai/kv-connector-type` pod label, falling back to the global config default.
* `shfs.go`: `SHFSAgent` (encapsulates existing SHFS behavior).
* `nixl.go`: `NIXLAgent` (encapsulates existing NIXL behavior).
* `mooncake.go`: `MooncakeAgent` stub (currently no-ops pending vLLM MooncakeConnector contract confirmation).


* **`pd_prefill_request.go`:** Refactored the vLLM prefill path to call `agent.AugmentPrefillRequest`, and updated `updateRoutingContextWithKVTransferParams` to utilize `agent.MergePrefillResponse`.
* **`pd_disaggregation.go`:** Added the `KVConnectorTypeMooncake` constant.

> **Note:** This architectural change introduces zero behavior changes for existing SHFS/NIXL paths. Adding a new backend going forward now only requires implementing `KVTransferAgent` and registering it—completely isolating the router and prefill request logic from future backend updates.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>