### PR TITLE
fix(batch): correct resource-failed job finalization and runtime display

### DIFF
--- a/apps/console/web/src/components/BatchJobsList.tsx
+++ b/apps/console/web/src/components/BatchJobsList.tsx
@@ -86,7 +86,7 @@ function statusClass(s: JobStatus): string {
 }
 
 function runtimeLabel(job: Job): string {
-  return job.runtime?.target || job.provision?.provider || '—';
+  return job.runtime?.target || '—';
 }
 
 function provisionLabel(job: Job): string {

--- a/python/aibrix/aibrix/batch/batch_manager.py
+++ b/python/aibrix/aibrix/batch/batch_manager.py
@@ -110,6 +110,7 @@ class BatchManager(RunningJobs, SchedulableJobs):
         ],
         BatchJobState.IN_PROGRESS: [
             BatchJobState.FINALIZING,
+            BatchJobState.FINALIZED,  # failure with no output to aggregate
             BatchJobState.CANCELLING,  # For cancellation
         ],
         BatchJobState.FINALIZING: [BatchJobState.FINALIZED],
@@ -834,7 +835,11 @@ class BatchManager(RunningJobs, SchedulableJobs):
             )
         )
         job.status.errors = [ex]
-        if meta_data.status.state == BatchJobState.IN_PROGRESS:
+        has_partial_output = (
+            meta_data.status.temp_output_file_id is not None
+            or meta_data.status.temp_error_file_id is not None
+        )
+        if meta_data.status.state == BatchJobState.IN_PROGRESS and has_partial_output:
             job.status.finalizing_at = datetime.now(timezone.utc)
             job.status.state = BatchJobState.FINALIZING
         else:


### PR DESCRIPTION
## Pull Request Description
  1. feat(batch): surface CREATED as 'scheduling' status
  2. fix(batch): finalize resource-failed jobs directly...
  3. fix(console): don't fall back to provider in batch list runtime column


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>