### PR TITLE
feat(batch): surface CREATED as 'scheduling' status

### DIFF
--- a/apps/console/api/handler/job.go
+++ b/apps/console/api/handler/job.go
@@ -857,7 +857,7 @@ func buildJobEvents(job *pb.Job) []*pb.JobEvent {
 	add("resource_preparing", "Provisioning", "resource_preparing", "planner", job.ResourcePreparingAt, "Resource provisioning started.")
 	add("submitting", "Submitting", "submitting", "planner", job.SubmittingAt, "Provisioning reached ready and the batch was submitted to MDS.")
 	if job.BatchId != "" {
-		add("batch_created", "MDS batch created", "validating", "mds", job.CreatedAt, "Metadata Service created the OpenAI batch.")
+		add("batch_created", "MDS batch created", "scheduling", "mds", job.CreatedAt, "Metadata Service created the OpenAI batch.")
 	}
 	add("in_progress", "In progress", "in_progress", "mds", job.InProgressAt, "MDS started processing requests.")
 	add("finalizing", "Finalizing", "finalizing", "mds", job.FinalizingAt, "MDS started finalizing output files.")

--- a/apps/console/api/planner/api/status.go
+++ b/apps/console/api/planner/api/status.go
@@ -24,6 +24,7 @@ const (
 	JobStatusResourcePreparing JobStatus = "resource_preparing"
 	JobStatusSubmitting        JobStatus = "submitting"
 
+	JobStatusScheduling JobStatus = "scheduling"
 	JobStatusValidating JobStatus = "validating"
 	JobStatusInProgress JobStatus = "in_progress"
 	JobStatusFinalizing JobStatus = "finalizing"

--- a/apps/console/web/src/components/BatchJobsList.tsx
+++ b/apps/console/web/src/components/BatchJobsList.tsx
@@ -29,6 +29,7 @@ const STATUS_OPTIONS: { label: string; value: BatchStatusFilter }[] = [
   { label: 'queued', value: 'queued' },
   { label: 'resource_preparing', value: 'resource_preparing' },
   { label: 'submitting', value: 'submitting' },
+  { label: 'scheduling', value: 'scheduling' },
   { label: 'validating', value: 'validating' },
   { label: 'in_progress', value: 'in_progress' },
   { label: 'finalizing', value: 'finalizing' },
@@ -70,6 +71,7 @@ function statusClass(s: JobStatus): string {
     case 'queued':
     case 'resource_preparing':
     case 'submitting':
+    case 'scheduling':
     case 'validating':
     case 'in_progress':
     case 'finalizing':

--- a/apps/console/web/src/components/BatchJobsList.tsx
+++ b/apps/console/web/src/components/BatchJobsList.tsx
@@ -88,7 +88,7 @@ function statusClass(s: JobStatus): string {
 }
 
 function runtimeLabel(job: Job): string {
-  return job.runtime?.target || job.provision?.provider || '—';
+  return job.runtime?.target || '—';
 }
 
 function provisionLabel(job: Job): string {

--- a/apps/console/web/src/components/JobDetail.tsx
+++ b/apps/console/web/src/components/JobDetail.tsx
@@ -105,6 +105,7 @@ function statusClass(s: JobStatus): string {
     case 'queued':
     case 'resource_preparing':
     case 'submitting':
+    case 'scheduling':
     case 'validating':
     case 'in_progress':
     case 'finalizing':

--- a/apps/console/web/src/data/mockData.ts
+++ b/apps/console/web/src/data/mockData.ts
@@ -5,6 +5,7 @@ export type JobStatus =
   | 'queued'
   | 'resource_preparing'
   | 'submitting'
+  | 'scheduling'
   | 'validating'
   | 'in_progress'
   | 'finalizing'

--- a/python/aibrix/aibrix/batch/batch_manager.py
+++ b/python/aibrix/aibrix/batch/batch_manager.py
@@ -110,6 +110,7 @@ class BatchManager(RunningJobs, SchedulableJobs):
         ],
         BatchJobState.IN_PROGRESS: [
             BatchJobState.FINALIZING,
+            BatchJobState.FINALIZED,  # failure with no output to aggregate
             BatchJobState.CANCELLING,  # For cancellation
         ],
         BatchJobState.FINALIZING: [BatchJobState.FINALIZED],
@@ -834,7 +835,11 @@ class BatchManager(RunningJobs, SchedulableJobs):
             )
         )
         job.status.errors = [ex]
-        if meta_data.status.state == BatchJobState.IN_PROGRESS:
+        has_partial_output = (
+            meta_data.status.temp_output_file_id is not None
+            and meta_data.status.temp_error_file_id is not None
+        )
+        if meta_data.status.state == BatchJobState.IN_PROGRESS and has_partial_output:
             job.status.finalizing_at = datetime.now(timezone.utc)
             job.status.state = BatchJobState.FINALIZING
         else:

--- a/python/aibrix/aibrix/batch/job_entity/batch_job.py
+++ b/python/aibrix/aibrix/batch/job_entity/batch_job.py
@@ -48,6 +48,7 @@ class BatchJobState(str, Enum):
     """Current state of the batch job."""
 
     CREATED = "created"
+    SCHEDULING = "scheduling"
     VALIDATING = "validating"
     IN_PROGRESS = "in_progress"
     CANCELLING = "cancelling"

--- a/python/aibrix/aibrix/metadata/api/v1/batch.py
+++ b/python/aibrix/aibrix/metadata/api/v1/batch.py
@@ -628,13 +628,13 @@ def _batch_job_to_openai_response(batch_job: BatchJob) -> BatchResponse:
     total_hours = delta.total_seconds() / 3600
     completion_window = f"{int(total_hours)}h"
 
-    # Map the internal state machine to OpenAI's 8-state enum:
-    #   {validating, failed, in_progress, finalizing, completed, expired,
-    #    cancelling, cancelled}
-    # Two internal states have no direct OpenAI counterpart:
-    #   - CREATED: batch just created, validation not yet started — surfaced
-    #     to clients as 'validating' since they cannot distinguish it from
-    #     in-flight validation.
+    # Map the internal state machine to the client-facing status:
+    #   - CREATED: accepted and waiting in the scheduler's pending pool for
+    #     admission (resource bring-up) — surfaced as 'scheduling'. NOTE: this
+    #     deviates from the OpenAI batch enum (no 'scheduling' state); we accept
+    #     the break because our platform spends real time here and 'scheduling'
+    #     is more accurate than OpenAI's 'validating' (which on our side is
+    #     near-instant: VALIDATING flips to IN_PROGRESS inside admit()).
     #   - FINALIZED: terminal umbrella state; the actual outcome lives in
     #     `status.condition` (completed / failed / expired / cancelled).
     if status.finished:
@@ -649,7 +649,7 @@ def _batch_job_to_openai_response(batch_job: BatchJob) -> BatchResponse:
             raise ValueError("job finalized without condition")
         state = condition.value
     elif status.state == BatchJobState.CREATED:
-        state = BatchJobState.VALIDATING.value
+        state = BatchJobState.SCHEDULING.value
     else:
         state = status.state.value
 

--- a/python/aibrix/tests/batch/test_batch_usage.py
+++ b/python/aibrix/tests/batch/test_batch_usage.py
@@ -262,12 +262,12 @@ _OPENAI_8_STATES = {
 
 
 class TestApiResponseStateFlatten:
-    """Internal CREATED / FINALIZED states must not leak to the API."""
+    """FINALIZED is flattened to its condition; CREATED is surfaced as the
+    non-OpenAI 'scheduling' status (it spends real time awaiting admission)."""
 
     @pytest.mark.parametrize(
         "state,expected",
         [
-            (BatchJobState.CREATED, "validating"),
             (BatchJobState.VALIDATING, "validating"),
             (BatchJobState.IN_PROGRESS, "in_progress"),
             (BatchJobState.FINALIZING, "finalizing"),

--- a/python/aibrix/tests/e2e/test_batch_api.py
+++ b/python/aibrix/tests/e2e/test_batch_api.py
@@ -290,7 +290,7 @@ async def test_batch_api_e2e_real_service(service_health):
                 pytest.fail(f"Batch job failed: {error_info}")
             elif current_status in ["cancelled", "expired"]:
                 pytest.fail(f"Batch job was {current_status}")
-            elif current_status in ["validating", "in_progress", "finalizing"]:
+            elif current_status in ["scheduling", "validating", "in_progress", "finalizing"]:
                 # These are expected intermediate states
                 pass
             else:
@@ -435,7 +435,7 @@ async def test_openai_batch_api(service_health):
                 pytest.fail(f"Batch job failed: {error_info}")
             elif current_status in ["cancelled", "expired"]:
                 pytest.fail(f"Batch job was {current_status}")
-            elif current_status in ["validating", "in_progress", "finalizing"]:
+            elif current_status in ["scheduling", "validating", "in_progress", "finalizing"]:
                 # These are expected intermediate states
                 pass
             else:

--- a/python/aibrix/tests/metadata/test_batches_api.py
+++ b/python/aibrix/tests/metadata/test_batches_api.py
@@ -94,8 +94,9 @@ class TestCreateBatch:
             assert body["object"] == "batch"
             assert body["endpoint"] == "/v1/chat/completions"
             assert body["completion_window"] == "24h"
-            # CREATED state is mapped to "validating" for OpenAI compatibility.
-            assert body["status"] in {"validating", "in_progress"}
+            # CREATED is surfaced as "scheduling" (awaiting admission); may have
+            # already advanced to validating/in_progress by the time we read it.
+            assert body["status"] in {"scheduling", "validating", "in_progress"}
             assert body["input_file_id"]
             assert body["created_at"] > 0
             assert body["expires_at"] > body["created_at"]


### PR DESCRIPTION
## Pull Request Description
- Report the resource-admission wait as 'scheduling' instead of OpenAI's near-instant 'validating', end-to-end across MDS, console API and web.
- don't fall back to provider in batch list runtime column
- finalize resource-failed jobs directly instead of stranding in finalizing

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>