### PR TITLE
fix(console): mark required fields in deployment template form

### DIFF
--- a/apps/console/web/src/components/CreateModelDeploymentTemplate.tsx
+++ b/apps/console/web/src/components/CreateModelDeploymentTemplate.tsx
@@ -222,12 +222,39 @@ export function CreateModelDeploymentTemplate({
 
   const handleSave = async () => {
     setError(null);
+    // Validation runs top-to-bottom in the form's visual order so the first
+    // error surfaced maps to the topmost incomplete field.
     if (!name.trim()) {
       setError('Template name is required');
       return;
     }
+    if (!version.trim()) {
+      setError('Version is required');
+      return;
+    }
+    if (!spec.modelSource?.uri?.trim()) {
+      setError('Model source URI is required');
+      return;
+    }
+    const uriErr = validateSourceUri(spec.modelSource?.type, spec.modelSource?.uri ?? '');
+    if (uriErr) {
+      setError(uriErr);
+      return;
+    }
     if (!spec.accelerator?.type) {
       setError('Accelerator type is required');
+      return;
+    }
+    if (!spec.accelerator?.count || spec.accelerator.count < 1) {
+      setError('Accelerator count must be at least 1');
+      return;
+    }
+    if (!spec.engine?.version?.trim()) {
+      setError('Engine version is required');
+      return;
+    }
+    if (!spec.engine?.image?.trim()) {
+      setError('Engine image is required');
       return;
     }
     // Treat 0 (proto int default for unset fields) as 1, since each dim is 1-based.
@@ -242,11 +269,6 @@ export function CreateModelDeploymentTemplate({
     }
     if (!spec.supportedEndpoints || spec.supportedEndpoints.length === 0) {
       setError('Pick at least one supported endpoint');
-      return;
-    }
-    const uriErr = validateSourceUri(spec.modelSource?.type, spec.modelSource?.uri ?? '');
-    if (uriErr) {
-      setError(uriErr);
       return;
     }
     if (engineArgsError) {
@@ -338,7 +360,7 @@ export function CreateModelDeploymentTemplate({
               }
             />
           </Field>
-          <Field label="Version">
+          <Field label="Version" required>
             <input
               type="text"
               value={version}
@@ -346,7 +368,7 @@ export function CreateModelDeploymentTemplate({
               className={inputCls}
             />
           </Field>
-          <Field label="Status">
+          <Field label="Status" required>
             <select value={statusValue} onChange={(e) => setStatusValue(e.target.value)} className={inputCls}>
               {STATUS_OPTIONS.map((s) => (
                 <option key={s} value={s}>{s}</option>
@@ -362,7 +384,7 @@ export function CreateModelDeploymentTemplate({
           const isHF = sourceType === 'huggingface';
           return (
             <Section title="Model Source">
-              <Field label="Type">
+              <Field label="Type" required>
                 <select
                   value={sourceType}
                   onChange={(e) => updateSpec('modelSource', { type: e.target.value })}
@@ -373,7 +395,7 @@ export function CreateModelDeploymentTemplate({
                   ))}
                 </select>
               </Field>
-              <Field label="URI" wide>
+              <Field label="URI" wide required>
                 {(() => {
                   const uri = spec.modelSource?.uri ?? '';
                   const uriErr = validateSourceUri(sourceType, uri);
@@ -476,7 +498,7 @@ export function CreateModelDeploymentTemplate({
               ))}
             </select>
           </Field>
-          <Field label="Count">
+          <Field label="Count" required>
             <input
               type="number"
               min={1}
@@ -499,7 +521,7 @@ export function CreateModelDeploymentTemplate({
         {/* Engine (mega-group: engine selection + tuning) */}
         <Group title="Engine">
           <SubSection title="Engine">
-            <Field label="Type">
+            <Field label="Type" required>
               <select
                 value={spec.engine?.type ?? 'vllm'}
                 onChange={(e) => updateSpec('engine', { type: e.target.value })}
@@ -510,7 +532,7 @@ export function CreateModelDeploymentTemplate({
                 ))}
               </select>
             </Field>
-            <Field label="Version">
+            <Field label="Version" required>
               <input
                 type="text"
                 value={spec.engine?.version ?? ''}
@@ -527,7 +549,7 @@ export function CreateModelDeploymentTemplate({
                 className={inputCls}
               />
             </Field>
-            <Field label="Image" wide>
+            <Field label="Image" wide required>
               <input
                 type="text"
                 value={spec.engine?.image ?? ''}
@@ -618,7 +640,7 @@ export function CreateModelDeploymentTemplate({
         </Section>
       </fieldset>
 
-      <div className="flex items-center gap-3 mt-6">
+      <div className="flex flex-wrap items-center gap-3 mt-6">
         {!isView && (
           <button
             onClick={handleSave}
@@ -641,6 +663,7 @@ export function CreateModelDeploymentTemplate({
         >
           {isView ? 'Back' : 'Cancel'}
         </button>
+        {error && <span className="text-sm text-red-600">{error}</span>}
       </div>
     </div>
   );
@@ -665,7 +688,10 @@ function Section({
       <h3 className="text-sm mb-4">
         {title}
         {required && (
-          <span className="text-red-500 ml-0.5" aria-hidden="true">*</span>
+          <>
+            <span className="text-red-500 ml-0.5" aria-hidden="true">*</span>
+            <span className="sr-only"> (required)</span>
+          </>
         )}
       </h3>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">{children}</div>
@@ -709,7 +735,10 @@ function Field({
       <label className="block text-xs text-gray-600 mb-1">
         {label}
         {required && (
-          <span className="text-red-500 ml-0.5" aria-hidden="true">*</span>
+          <>
+            <span className="text-red-500 ml-0.5" aria-hidden="true">*</span>
+            <span className="sr-only"> (required)</span>
+          </>
         )}
       </label>
       {children}

--- a/apps/console/web/src/components/CreateModelDeploymentTemplate.tsx
+++ b/apps/console/web/src/components/CreateModelDeploymentTemplate.tsx
@@ -321,7 +321,7 @@ export function CreateModelDeploymentTemplate({
       <fieldset disabled={isView} className="space-y-6 disabled:opacity-90">
         {/* Identity */}
         <Section title="Identity">
-          <Field label="Name">
+          <Field label="Name" required>
             <input
               type="text"
               value={name}
@@ -453,7 +453,7 @@ export function CreateModelDeploymentTemplate({
 
         {/* Accelerator */}
         <Section title="Accelerator">
-          <Field label="GPU">
+          <Field label="GPU" required>
             <select
               value={spec.accelerator?.type ?? ''}
               onChange={(e) => {
@@ -595,7 +595,7 @@ export function CreateModelDeploymentTemplate({
         </Group>
 
         {/* Endpoints */}
-        <Section title="Supported endpoints">
+        <Section title="Supported endpoints" required>
           <div className="col-span-full flex flex-wrap gap-2">
             {COMMON_ENDPOINTS.map((ep) => {
               const active = (spec.supportedEndpoints ?? []).includes(ep);
@@ -651,10 +651,23 @@ const inputClsBase =
 const inputCls = `${inputClsBase} border-gray-200`;
 const inputErrCls = `${inputClsBase} border-red-300`;
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  required,
+  children,
+}: {
+  title: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
   return (
     <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
-      <h3 className="text-sm mb-4">{title}</h3>
+      <h3 className="text-sm mb-4">
+        {title}
+        {required && (
+          <span className="text-red-500 ml-0.5" aria-hidden="true">*</span>
+        )}
+      </h3>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">{children}</div>
     </div>
   );
@@ -683,15 +696,22 @@ function SubSection({ title, children }: { title: string; children: React.ReactN
 function Field({
   label,
   wide,
+  required,
   children,
 }: {
   label: string;
   wide?: boolean;
+  required?: boolean;
   children: React.ReactNode;
 }) {
   return (
     <div className={wide ? 'sm:col-span-2 lg:col-span-3' : ''}>
-      <label className="block text-xs text-gray-600 mb-1">{label}</label>
+      <label className="block text-xs text-gray-600 mb-1">
+        {label}
+        {required && (
+          <span className="text-red-500 ml-0.5" aria-hidden="true">*</span>
+        )}
+      </label>
       {children}
     </div>
   );


### PR DESCRIPTION
## Pull Request Description
Add red asterisk markers to required inputs (Name, GPU, Supported endpoints) so required fields are visible inline instead of only surfacing via the top error banner on save.

<img width="1926" height="1436" alt="image" src="https://github.com/user-attachments/assets/8784ad17-4a4f-43d7-b4ff-fe5af4aad7c0" />


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>