### PR TITLE
[Bug] Validate lora_name in ArtifactDelegationService

### DIFF
--- a/python/aibrix/aibrix/runtime/artifact_service.py
+++ b/python/aibrix/aibrix/runtime/artifact_service.py
@@ -16,6 +16,7 @@
 
 import asyncio
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import Dict, Optional
@@ -33,6 +34,9 @@ from aibrix.openapi.protocol import (
 from aibrix.runtime.downloaders import get_downloader
 
 logger = init_logger(__name__)
+
+
+_SAFE_LORA_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
 class ArtifactDelegationService:
@@ -118,9 +122,25 @@ class ArtifactDelegationService:
         logger.info(f"Loaded {len(credentials)} credential keys from {secret_path}")
         return credentials
 
+    def _validate_lora_name(self, lora_name: str) -> None:
+        """Reject lora_name values that could escape self.local_dir."""
+        if not isinstance(lora_name, str) or not _SAFE_LORA_NAME.match(lora_name):
+            raise ValueError(
+                "Invalid lora_name: must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+            )
+
     def _get_local_path_for_adapter(self, lora_name: str) -> str:
-        """Get local path for storing adapter artifacts."""
-        return os.path.join(self.local_dir, lora_name)
+        """Get local path for storing adapter artifacts.
+
+        Validates lora_name and enforces that the resolved path stays inside
+        self.local_dir. Raises ValueError on attempted traversal.
+        """
+        self._validate_lora_name(lora_name)
+        base = Path(self.local_dir).resolve()
+        candidate = (base / lora_name).resolve()
+        if base not in candidate.parents:
+            raise ValueError("lora_name resolves outside local_dir")
+        return str(candidate)
 
     async def download_artifact(
         self,

--- a/python/aibrix/tests/runtime/test_artifact_service_lora_name.py
+++ b/python/aibrix/tests/runtime/test_artifact_service_lora_name.py
@@ -1,0 +1,87 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from aibrix.runtime.artifact_service import ArtifactDelegationService
+
+
+@pytest.fixture
+def service(tmp_path):
+    return ArtifactDelegationService(local_dir=str(tmp_path))
+
+
+class TestLoraNameValidation:
+    """Reject lora_name shapes that escape local_dir."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "../etc",
+            "../../etc/passwd",
+            "..",
+            "a/../b",
+            "valid_but_then/../escape",
+            "/abs/path",
+            "name/with/slash",
+            "name\\with\\backslash",
+            "name\x00null",
+            ".hidden",
+            "-leading-dash",
+            "",
+            "a" * 129,
+        ],
+    )
+    def test_rejects_malicious_names(self, service, name):
+        with pytest.raises(ValueError):
+            service._get_local_path_for_adapter(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "valid_adapter",
+            "adapter-v2",
+            "Adapter.1",
+            "abc123",
+            "a",
+            "A" * 128,
+        ],
+    )
+    def test_accepts_valid_names(self, service, name):
+        path = service._get_local_path_for_adapter(name)
+        assert path.endswith(os.sep + name)
+
+    def test_symlink_traversal_blocked(self, service, tmp_path):
+        outside = tmp_path.parent / "outside_target"
+        outside.mkdir(exist_ok=True)
+        link = tmp_path / "linked"
+        try:
+            os.symlink(outside, link)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+        with pytest.raises(ValueError):
+            service._get_local_path_for_adapter("linked")
+
+    def test_symlink_resolving_to_base_blocked(self, service, tmp_path):
+        """Regression: a name whose resolved path equals local_dir itself
+        must be rejected so cleanup never targets the artifacts root."""
+        link = tmp_path / "selfloop"
+        try:
+            os.symlink(tmp_path, link)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+        with pytest.raises(ValueError):
+            service._get_local_path_for_adapter("selfloop")


### PR DESCRIPTION
# [Bug] Validate lora_name in ArtifactDelegationService

## Pull Request Description

Adds input validation to `lora_name` in `ArtifactDelegationService._get_local_path_for_adapter` so that values which would resolve outside `self.local_dir` are rejected.

Without validation, an arbitrary `lora_name` reaches `os.path.join(self.local_dir, lora_name)` and the resulting path is later passed to filesystem operations including `shutil.rmtree`. Reported privately to `maintainers@aibrix.ai` on 2026-04-21; coordinated with maintainers via email follow-up on 2026-06-09 who requested a direct PR.

The fix lives in the single chokepoint method used by all call sites:
- `download_artifact` (line 145)
- `unload_adapter` cleanup branch (line 322)
- `unload_artifact` (line 346)

It applies two layers:

1. A character-class regex on the name shape (`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
2. A `Path.resolve()` containment check against `Path(self.local_dir).resolve()`

The second layer is defense-in-depth: if the regex ever loosens, the realpath check still blocks any escape, including symlinks that point outside `local_dir`.

## Related Issues

Resolves the issue raised privately with maintainers (`maintainers@aibrix.ai`, 2026-04-21).

## Testing

Added `python/aibrix/tests/runtime/test_artifact_service_lora_name.py` covering:
- Traversal patterns (`..`, `a/../b`, absolute paths, leading-dash, hidden, null byte, oversize)
- Accepted shapes (alphanumeric, dot, underscore, dash, max-length boundary)
- Symlink escape (skipped on platforms without symlink support)

All new and existing tests pass locally:

```
pytest python/aibrix/tests/runtime/test_artifact_service_lora_name.py
pytest python/aibrix/tests/runtime/test_artifact_service_threading.py
```

## Checklist

- [x] PR title includes `[Bug]` prefix
- [x] Changes described above
- [x] New and existing tests pass
- [x] Style matches surrounding code; no new dependencies
- [x] No documentation surface affected (internal validation)
- [x] No regressions: existing valid `lora_name` shapes (alphanumeric + `._-`) continue to work
