### PR TITLE
fix(batch): accept aibrix.model on the request entry schema

### DIFF
--- a/apps/console/api/proto/console/v1/console.proto
+++ b/apps/console/api/proto/console/v1/console.proto
@@ -445,6 +445,7 @@ message CreateModelRequest {
 //       completion_window="24h",
 //       extra_body={
 //           "aibrix": {
+//               "model": "Qwen/Qwen3.5-32B",       # serving_name; see rules below
 //               "runtime": {
 //                   "target": "Kubernetes",        # registered MDS runtime target
 //                   "options": {"namespace": "default"}  # optional, runtime-owned
@@ -472,6 +473,11 @@ message CreateModelRequest {
 //
 //
 // rules:
+//   - model is the serving identifier (the catalog model's serving_name) that
+//     the batch's body.model carries. MDS echoes it as Batch.model and pins the
+//     engine's --served-model-name to it. Optional; when absent the engine
+//     serves under the template's model_source.uri and Batch.model falls back
+//     to model_template.name.
 //   - runtime.target selects the MDS Runtime. runtime.options is free-form and
 //     owned by the selected runtime; do not introduce runtime.placement.
 //   - resource_allocation carries generic planner / resource-manager output.

--- a/python/aibrix/aibrix/metadata/api/v1/batch.py
+++ b/python/aibrix/aibrix/metadata/api/v1/batch.py
@@ -334,6 +334,10 @@ class AibrixExtension(BaseModel):
     model_config = {"extra": "forbid"}
 
     job_id: Optional[str] = None
+    model: Optional[str] = Field(
+        default=None,
+        description=("Serving identifier the batch's requests carry in body.model"),
+    )
     resource_allocation: Optional[ResourceAllocationRef] = None
     runtime: Optional[RuntimeRef] = Field(
         default=None,
@@ -402,6 +406,7 @@ class BatchSpec(BaseModel):
         if spec.aibrix is not None:
             aibrix = AibrixMetadata(
                 job_id=spec.aibrix.job_id,
+                model=spec.aibrix.model,
                 resource_allocation=spec.aibrix.resource_allocation,
                 runtime=spec.aibrix.runtime,
                 model_template=spec.aibrix.model_template,

--- a/python/aibrix/tests/metadata/test_batches_api.py
+++ b/python/aibrix/tests/metadata/test_batches_api.py
@@ -350,3 +350,61 @@ class TestListBatches:
         with TestClient(create_test_app()) as client:
             response = client.get("/v1/batches", params={"limit": limit})
             assert response.status_code == 422
+
+
+class TestAibrixModelField:
+    """The serving identifier rides under ``extra_body.aibrix.model``.
+
+    Regression guard for the 422 ``extra_forbidden`` that fired when the
+    request-entry schema (``AibrixExtension``, ``extra='forbid'``) lacked the
+    ``model`` field that the console BFF started sending. The value must also
+    survive the conversion into the internal job spec so the renderer can pin
+    ``--served-model-name`` and ``BatchResponse.model`` can echo it.
+    """
+
+    def test_entry_schema_accepts_model(self):
+        from aibrix.metadata.api.v1.batch import BatchSpec
+
+        spec = BatchSpec.model_validate(
+            {
+                "input_file_id": "file-1",
+                "endpoint": "/v1/chat/completions",
+                "aibrix": {
+                    "model": "Qwen/Qwen3.5-32B",
+                    "model_template": {"name": "A30-2"},
+                },
+            }
+        )
+        assert spec.aibrix is not None
+        assert spec.aibrix.model == "Qwen/Qwen3.5-32B"
+
+    def test_model_survives_internal_spec_conversion(self):
+        from aibrix.metadata.api.v1.batch import BatchSpec
+
+        spec = BatchSpec.model_validate(
+            {
+                "input_file_id": "file-1",
+                "endpoint": "/v1/chat/completions",
+                "aibrix": {
+                    "model": "Qwen/Qwen3.5-32B",
+                    "model_template": {"name": "A30-2"},
+                },
+            }
+        )
+        job_spec = BatchSpec.newBatchJobSpec(spec)
+        assert job_spec.model == "Qwen/Qwen3.5-32B"
+
+    def test_model_is_optional(self):
+        # The wire schema stays permissive: External / standalone requests may
+        # omit model, and deploy-bound requests fall back to the template name.
+        from aibrix.metadata.api.v1.batch import BatchSpec
+
+        spec = BatchSpec.model_validate(
+            {
+                "input_file_id": "file-1",
+                "endpoint": "/v1/chat/completions",
+                "aibrix": {"model_template": {"name": "A30-2"}},
+            }
+        )
+        assert spec.aibrix.model is None
+        assert BatchSpec.newBatchJobSpec(spec).model is None


### PR DESCRIPTION
## Pull Request Description
#2300 added `model` to the internal AibrixMetadata but missed the strict request-entry schema AibrixExtension, so MDS rejected it with 422 extra_forbidden. Add it there, thread it through newBatchJobSpec, sync the proto SDK contract, and add regression tests.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>