### PR TITLE
feat(pd): extract EngineHandler and PodSelector abstractions for PD routing

### DIFF
--- a/pkg/plugins/gateway/algorithms/pd/engine/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/engine/default.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+// DefaultHandler is a no-op handler used for unknown or future engines.
+// It performs a synchronous prefill with no request augmentation or response
+// processing, which matches the original "default" branch behaviour.
+type DefaultHandler struct{}
+
+func (h *DefaultHandler) Name() string    { return "default" }
+func (h *DefaultHandler) IsAsync() bool   { return false }
+func (h *DefaultHandler) AugmentPrefillRequest(_ *types.RoutingContext, _ *v1.Pod, _ map[string]any) error {
+	return nil
+}
+func (h *DefaultHandler) MergePrefillResponse(_ *types.RoutingContext, _ map[string]any, _ *v1.Pod) error {
+	return nil
+}

--- a/pkg/plugins/gateway/algorithms/pd/engine/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/engine/default.go
@@ -26,8 +26,8 @@ import (
 // processing, which matches the original "default" branch behaviour.
 type DefaultHandler struct{}
 
-func (h *DefaultHandler) Name() string    { return "default" }
-func (h *DefaultHandler) IsAsync() bool   { return false }
+func (h *DefaultHandler) Name() string  { return "default" }
+func (h *DefaultHandler) IsAsync() bool { return false }
 func (h *DefaultHandler) AugmentPrefillRequest(_ *types.RoutingContext, _ *v1.Pod, _ map[string]any) error {
 	return nil
 }

--- a/pkg/plugins/gateway/algorithms/pd/engine/handler.go
+++ b/pkg/plugins/gateway/algorithms/pd/engine/handler.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+// EngineHandler encapsulates engine-specific behaviour for PD-disaggregated
+// prefill: how to augment the outbound prefill request body and how to merge
+// the prefill response back into the decode request body.
+type EngineHandler interface {
+	// Name returns the engine identifier (e.g. "vllm", "sglang", "trtllm").
+	Name() string
+	// IsAsync returns true when the engine's prefill handshake is
+	// self-coordinating and should be fired in a goroutine (e.g. SGLang).
+	IsAsync() bool
+	// AugmentPrefillRequest adds engine-specific fields to completionRequest
+	// before it is POSTed to the prefill pod.
+	AugmentPrefillRequest(routingCtx *types.RoutingContext, pod *v1.Pod, completionRequest map[string]any) error
+	// MergePrefillResponse injects engine-specific data from the prefill
+	// response into routingCtx.ReqBody before the decode pod receives it.
+	MergePrefillResponse(routingCtx *types.RoutingContext, responseData map[string]any, pod *v1.Pod) error
+}

--- a/pkg/plugins/gateway/algorithms/pd/engine/registry.go
+++ b/pkg/plugins/gateway/algorithms/pd/engine/registry.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"sort"
+	"sync"
+)
+
+var (
+	mu       sync.RWMutex
+	registry = map[string]EngineHandler{}
+)
+
+// Register adds h to the global engine registry.
+// Called from init() in each engine file.
+func Register(h EngineHandler) {
+	mu.Lock()
+	defer mu.Unlock()
+	registry[h.Name()] = h
+}
+
+// Resolve returns the registered EngineHandler for name.
+// Returns DefaultHandler for unknown engines so the caller always gets a
+// valid handler without needing to check for nil.
+func Resolve(name string) EngineHandler {
+	mu.RLock()
+	defer mu.RUnlock()
+	if h, ok := registry[name]; ok {
+		return h
+	}
+	return &DefaultHandler{}
+}
+
+// ValidEngineNames returns the sorted list of registered engine names.
+func ValidEngineNames() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	names := make([]string, 0, len(registry))
+	for k := range registry {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/plugins/gateway/algorithms/pd/engine/registry.go
+++ b/pkg/plugins/gateway/algorithms/pd/engine/registry.go
@@ -22,8 +22,9 @@ import (
 )
 
 var (
-	mu       sync.RWMutex
-	registry = map[string]EngineHandler{}
+	mu             sync.RWMutex
+	registry       = map[string]EngineHandler{}
+	defaultHandler = &DefaultHandler{}
 )
 
 // Register adds h to the global engine registry.
@@ -43,7 +44,7 @@ func Resolve(name string) EngineHandler {
 	if h, ok := registry[name]; ok {
 		return h
 	}
-	return &DefaultHandler{}
+	return defaultHandler
 }
 
 // ValidEngineNames returns the sorted list of registered engine names.

--- a/pkg/plugins/gateway/algorithms/pd/engine/sglang.go
+++ b/pkg/plugins/gateway/algorithms/pd/engine/sglang.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+
+	"github.com/bytedance/sonic"
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	sglangBootstrapPort           int64  = 8998
+	sglangBootstrapPortIdentifier string = "model.aibrix.ai/sglang-bootstrap-port"
+)
+
+func init() {
+	Register(&SGLangHandler{})
+}
+
+// SGLangHandler implements EngineHandler for SGLang.
+// SGLang uses a bootstrap handshake (bootstrap_host/port/room) to coordinate
+// KV transfer between prefill and decode pods out-of-band, so the prefill
+// fires asynchronously (IsAsync returns true).
+type SGLangHandler struct{}
+
+func (h *SGLangHandler) Name() string  { return "sglang" }
+func (h *SGLangHandler) IsAsync() bool { return true }
+
+// AugmentPrefillRequest injects bootstrap_host, bootstrap_port, and a random
+// bootstrap_room. It also propagates these fields into routingCtx.ReqBody so
+// the decode pod receives the bootstrap address.
+func (h *SGLangHandler) AugmentPrefillRequest(
+	routingCtx *types.RoutingContext,
+	pod *v1.Pod,
+	completionRequest map[string]any,
+) error {
+	completionRequest["bootstrap_host"] = pod.Status.PodIP
+	completionRequest["bootstrap_port"] = sglangBootstrapPortFor(pod)
+	completionRequest["bootstrap_room"] = rand.Int63n(1<<63 - 1)
+
+	// Propagate bootstrap fields to the decode request body so the decode pod
+	// can locate the prefill pod's bootstrap server.
+	reqBody, err := sonic.Marshal(completionRequest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal SGLang prefill request body: %w", err)
+	}
+	bodyCopy := make([]byte, len(reqBody))
+	copy(bodyCopy, reqBody)
+	routingCtx.ReqBody = bodyCopy
+	return nil
+}
+
+// MergePrefillResponse is a no-op for SGLang: the bootstrap handshake is
+// self-coordinating, so no data from the prefill response needs to be injected
+// into the decode request.
+func (h *SGLangHandler) MergePrefillResponse(
+	_ *types.RoutingContext,
+	_ map[string]any,
+	_ *v1.Pod,
+) error {
+	return nil
+}
+
+func sglangBootstrapPortFor(pod *v1.Pod) int64 {
+	if portStr, exists := pod.Annotations[sglangBootstrapPortIdentifier]; exists {
+		if port, err := strconv.ParseInt(portStr, 10, 32); err == nil {
+			return port
+		}
+	}
+	return sglangBootstrapPort
+}

--- a/pkg/plugins/gateway/algorithms/pd/engine/sglang.go
+++ b/pkg/plugins/gateway/algorithms/pd/engine/sglang.go
@@ -62,9 +62,7 @@ func (h *SGLangHandler) AugmentPrefillRequest(
 	if err != nil {
 		return fmt.Errorf("failed to marshal SGLang prefill request body: %w", err)
 	}
-	bodyCopy := make([]byte, len(reqBody))
-	copy(bodyCopy, reqBody)
-	routingCtx.ReqBody = bodyCopy
+	routingCtx.ReqBody = reqBody
 	return nil
 }
 

--- a/pkg/plugins/gateway/algorithms/pd/engine/trtllm.go
+++ b/pkg/plugins/gateway/algorithms/pd/engine/trtllm.go
@@ -178,9 +178,7 @@ func (h *TRTLLMHandler) MergePrefillResponse(
 // anySliceForJSON converts a JSON-decoded array into []any suitable for map[string]any marshaling.
 func anySliceForJSON(v any) ([]any, bool) {
 	if s, ok := v.([]any); ok {
-		out := make([]any, len(s))
-		copy(out, s)
-		return out, true
+		return s, true
 	}
 	val := reflect.ValueOf(v)
 	if val.Kind() != reflect.Slice {

--- a/pkg/plugins/gateway/algorithms/pd/engine/trtllm.go
+++ b/pkg/plugins/gateway/algorithms/pd/engine/trtllm.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"fmt"
+	"reflect"
+	"sync/atomic"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// Snowflake-style disagg request ID constants for TensorRT-LLM PD routing.
+// Layout: [timestamp(41b)][machineID(10b)][counter(12b)]
+// The modulo rotation guarantees result >= trtMinGlobalID so TRT-LLM's executor
+// treats it as a global (cross-worker) disagg ID rather than a local one.
+const (
+	trtCounterBits      = 12
+	trtMachineIDBits    = 10
+	trtTimestampBits    = 41
+	trtSnowflakeEpochMs = int64(1672531200000) // 2023-01-01T00:00:00Z in milliseconds
+	trtCounterMask      = (1 << trtCounterBits) - 1
+	trtTimestampMax     = (1 << trtTimestampBits) - 1
+	trtMinGlobalID      = int64(1) << 42
+	trtMaxInt64         = int64(1<<63 - 1)
+)
+
+var (
+	// trtMachineID is the 10-bit machine ID embedded in every snowflake disagg request ID.
+	trtMachineID int64 = int64(utils.LoadEnvInt("AIBRIX_TRT_MACHINE_ID", 0))
+
+	// globalDisaggCounter is a per-process monotonic counter for snowflake ID generation.
+	globalDisaggCounter atomic.Int64
+
+	// sonicJSONInt64 unmarshals JSON numbers as int64 to avoid float64 precision loss
+	// on large fields such as disagg_request_id.
+	sonicJSONInt64 = sonic.Config{UseInt64: true}.Froze()
+)
+
+func init() {
+	if err := ValidateTRTMachineID(trtMachineID); err != nil {
+		panic("routingalgorithms/engine: " + err.Error())
+	}
+	Register(&TRTLLMHandler{})
+}
+
+// ValidateTRTMachineID returns an error if machineID does not fit in trtMachineIDBits bits.
+func ValidateTRTMachineID(machineID int64) error {
+	maxExclusive := int64(1 << trtMachineIDBits)
+	if machineID < 0 || machineID >= maxExclusive {
+		return fmt.Errorf("invalid AIBRIX_TRT_MACHINE_ID=%d: must satisfy 0 <= id < %d (10-bit field)", machineID, maxExclusive)
+	}
+	return nil
+}
+
+// GetDisaggRequestID generates a snowflake-style ID shared between a prefill
+// and its decode request so TRT-LLM can correlate the KV-cache entry.
+func GetDisaggRequestID(machineID int64) int64 {
+	timestampMs := time.Now().UnixMilli() - trtSnowflakeEpochMs
+	if timestampMs < 0 {
+		timestampMs = 0
+	}
+	if timestampMs > trtTimestampMax {
+		timestampMs = trtTimestampMax
+	}
+	counter := (globalDisaggCounter.Add(1) - 1) & trtCounterMask
+	globalID := (timestampMs << (trtMachineIDBits + trtCounterBits)) |
+		(machineID << trtCounterBits) |
+		counter
+	return globalID%(trtMaxInt64-trtMinGlobalID) + trtMinGlobalID
+}
+
+// TRTLLMHandler implements EngineHandler for TensorRT-LLM.
+type TRTLLMHandler struct{}
+
+func (h *TRTLLMHandler) Name() string  { return "trtllm" }
+func (h *TRTLLMHandler) IsAsync() bool { return false }
+
+// AugmentPrefillRequest adds disaggregated_params with request_type="context_only"
+// and a unique disagg_request_id generated from the machine snowflake ID.
+func (h *TRTLLMHandler) AugmentPrefillRequest(
+	_ *types.RoutingContext,
+	_ *v1.Pod,
+	completionRequest map[string]any,
+) error {
+	completionRequest["disaggregated_params"] = map[string]any{
+		"request_type":      "context_only",
+		"disagg_request_id": GetDisaggRequestID(trtMachineID),
+	}
+	return nil
+}
+
+// MergePrefillResponse injects TensorRT-LLM disaggregated_params from the
+// prefill response into routingCtx.ReqBody so the decode worker can resume
+// generation from the pre-filled KV cache.
+func (h *TRTLLMHandler) MergePrefillResponse(
+	routingCtx *types.RoutingContext,
+	responseData map[string]any,
+	prefillPod *v1.Pod,
+) error {
+	var originalRequest map[string]any
+	if err := sonicJSONInt64.Unmarshal(routingCtx.ReqBody, &originalRequest); err != nil {
+		return fmt.Errorf("failed to unmarshal original request body: %w", err)
+	}
+	if originalRequest == nil {
+		return fmt.Errorf("original request body is empty or null")
+	}
+
+	// Locate disaggregated_params: top-level first, then choices[0] fallback.
+	var disaggParams any
+	var exists bool
+
+	disaggParams, exists = responseData["disaggregated_params"]
+	if !exists {
+		if choices, ok := responseData["choices"].([]any); ok && len(choices) > 0 {
+			if choice, ok := choices[0].(map[string]any); ok {
+				disaggParams, exists = choice["disaggregated_params"]
+			}
+		}
+	}
+
+	if !exists {
+		klog.InfoS("no disaggregated_params in TRT prefill response", "request_id", routingCtx.RequestID)
+		return nil
+	}
+
+	disaggParamsMap, ok := disaggParams.(map[string]any)
+	if !ok {
+		return fmt.Errorf("disaggregated_params has unexpected type %T, expected map[string]any", disaggParams)
+	}
+
+	disaggParamsMap["request_type"] = "generation_only"
+	originalRequest["disaggregated_params"] = disaggParamsMap
+
+	if pti, ok := responseData["prompt_token_ids"]; ok && pti != nil {
+		if ids, ok := anySliceForJSON(pti); ok {
+			switch routingCtx.ReqPath {
+			case "/v1/completions":
+				originalRequest["prompt"] = ids
+			case "/v1/chat/completions":
+				originalRequest["prompt_token_ids"] = ids
+			}
+		}
+	}
+
+	updatedReqBody, err := sonic.Marshal(originalRequest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated request body: %w", err)
+	}
+	routingCtx.ReqBody = updatedReqBody
+
+	klog.InfoS("updated routing context with disaggregated_params (TensorRT-LLM)",
+		"request_id", routingCtx.RequestID,
+		"prefill_pod", prefillPod.Name,
+		"prefill_host", prefillPod.Status.PodIP)
+	return nil
+}
+
+// anySliceForJSON converts a JSON-decoded array into []any suitable for map[string]any marshaling.
+func anySliceForJSON(v any) ([]any, bool) {
+	if s, ok := v.([]any); ok {
+		out := make([]any, len(s))
+		copy(out, s)
+		return out, true
+	}
+	val := reflect.ValueOf(v)
+	if val.Kind() != reflect.Slice {
+		return nil, false
+	}
+	out := make([]any, val.Len())
+	for i := 0; i < val.Len(); i++ {
+		out[i] = val.Index(i).Interface()
+	}
+	return out, true
+}

--- a/pkg/plugins/gateway/algorithms/pd/engine/trtllm.go
+++ b/pkg/plugins/gateway/algorithms/pd/engine/trtllm.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 	v1 "k8s.io/api/core/v1"
@@ -31,16 +32,19 @@ import (
 
 // Snowflake-style disagg request ID constants for TensorRT-LLM PD routing.
 // Layout: [timestamp(41b)][machineID(10b)][counter(12b)]
-// The modulo rotation guarantees result >= trtMinGlobalID so TRT-LLM's executor
+// The modulo rotation guarantees result >= TRTMinGlobalID so TRT-LLM's executor
 // treats it as a global (cross-worker) disagg ID rather than a local one.
 const (
+	// TRTMachineIDBits is the width of the machine-ID field in snowflake disagg request IDs.
+	TRTMachineIDBits = 10
+	// TRTMinGlobalID is the minimum global disagg ID; values below this are treated as local by TRT-LLM.
+	TRTMinGlobalID = int64(1) << 42
+
 	trtCounterBits      = 12
-	trtMachineIDBits    = 10
 	trtTimestampBits    = 41
 	trtSnowflakeEpochMs = int64(1672531200000) // 2023-01-01T00:00:00Z in milliseconds
 	trtCounterMask      = (1 << trtCounterBits) - 1
 	trtTimestampMax     = (1 << trtTimestampBits) - 1
-	trtMinGlobalID      = int64(1) << 42
 	trtMaxInt64         = int64(1<<63 - 1)
 )
 
@@ -50,10 +54,6 @@ var (
 
 	// globalDisaggCounter is a per-process monotonic counter for snowflake ID generation.
 	globalDisaggCounter atomic.Int64
-
-	// sonicJSONInt64 unmarshals JSON numbers as int64 to avoid float64 precision loss
-	// on large fields such as disagg_request_id.
-	sonicJSONInt64 = sonic.Config{UseInt64: true}.Froze()
 )
 
 func init() {
@@ -63,9 +63,9 @@ func init() {
 	Register(&TRTLLMHandler{})
 }
 
-// ValidateTRTMachineID returns an error if machineID does not fit in trtMachineIDBits bits.
+// ValidateTRTMachineID returns an error if machineID does not fit in TRTMachineIDBits bits.
 func ValidateTRTMachineID(machineID int64) error {
-	maxExclusive := int64(1 << trtMachineIDBits)
+	maxExclusive := int64(1 << TRTMachineIDBits)
 	if machineID < 0 || machineID >= maxExclusive {
 		return fmt.Errorf("invalid AIBRIX_TRT_MACHINE_ID=%d: must satisfy 0 <= id < %d (10-bit field)", machineID, maxExclusive)
 	}
@@ -83,10 +83,10 @@ func GetDisaggRequestID(machineID int64) int64 {
 		timestampMs = trtTimestampMax
 	}
 	counter := (globalDisaggCounter.Add(1) - 1) & trtCounterMask
-	globalID := (timestampMs << (trtMachineIDBits + trtCounterBits)) |
+	globalID := (timestampMs << (TRTMachineIDBits + trtCounterBits)) |
 		(machineID << trtCounterBits) |
 		counter
-	return globalID%(trtMaxInt64-trtMinGlobalID) + trtMinGlobalID
+	return globalID%(trtMaxInt64-TRTMinGlobalID) + TRTMinGlobalID
 }
 
 // TRTLLMHandler implements EngineHandler for TensorRT-LLM.
@@ -118,7 +118,7 @@ func (h *TRTLLMHandler) MergePrefillResponse(
 	prefillPod *v1.Pod,
 ) error {
 	var originalRequest map[string]any
-	if err := sonicJSONInt64.Unmarshal(routingCtx.ReqBody, &originalRequest); err != nil {
+	if err := pd.SonicJSONInt64.Unmarshal(routingCtx.ReqBody, &originalRequest); err != nil {
 		return fmt.Errorf("failed to unmarshal original request body: %w", err)
 	}
 	if originalRequest == nil {

--- a/pkg/plugins/gateway/algorithms/pd/engine/vllm.go
+++ b/pkg/plugins/gateway/algorithms/pd/engine/vllm.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/transfer"
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
+	v1 "k8s.io/api/core/v1"
+)
+
+// connectorTypeFunc returns the live global KV connector type fallback.
+// Defaults to loading AIBRIX_KV_CONNECTOR_TYPE. The routingalgorithms package
+// overrides this via SetConnectorTypeFunc so tests that modify the package-level
+// var in routingalgorithms are reflected here without a second env-var copy.
+var connectorTypeFunc = func() string {
+	return utils.LoadEnv("AIBRIX_KV_CONNECTOR_TYPE", transfer.ConnectorTypeSHFS)
+}
+
+// SetConnectorTypeFunc installs a function that returns the current global
+// KV connector type. Call this once at startup with a closure over the
+// routingalgorithms package-level var.
+func SetConnectorTypeFunc(fn func() string) {
+	connectorTypeFunc = fn
+}
+
+func init() {
+	Register(&VLLMHandler{})
+}
+
+// VLLMHandler implements EngineHandler for vLLM.
+// KV-transfer augmentation is fully delegated to the KVTransferAgent resolved
+// for the prefill pod, so adding a new connector type (e.g. Mooncake) requires
+// no changes here.
+type VLLMHandler struct{}
+
+func (h *VLLMHandler) Name() string  { return "vllm" }
+func (h *VLLMHandler) IsAsync() bool { return false }
+
+func (h *VLLMHandler) AugmentPrefillRequest(
+	routingCtx *types.RoutingContext,
+	pod *v1.Pod,
+	completionRequest map[string]any,
+) error {
+	agent, err := transfer.ResolveAgentForPod(pod, connectorTypeFunc())
+	if err != nil {
+		return err
+	}
+	return agent.AugmentPrefillRequest(routingCtx, pod, completionRequest)
+}
+
+func (h *VLLMHandler) MergePrefillResponse(
+	routingCtx *types.RoutingContext,
+	responseData map[string]any,
+	pod *v1.Pod,
+) error {
+	agent, err := transfer.ResolveAgentForPod(pod, connectorTypeFunc())
+	if err != nil {
+		return err
+	}
+	return agent.MergePrefillResponse(routingCtx, responseData, pod)
+}

--- a/pkg/plugins/gateway/algorithms/pd/json.go
+++ b/pkg/plugins/gateway/algorithms/pd/json.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pd
+
+import "github.com/bytedance/sonic"
+
+// SonicJSONInt64 unmarshals JSON numbers into map[string]any as int64 (not float64), so large
+// integer fields (e.g. ctx_request_id, disagg_request_id in disaggregated_params) survive
+// marshal/unmarshal without float64 precision loss.
+var SonicJSONInt64 = sonic.Config{UseInt64: true}.Froze()

--- a/pkg/plugins/gateway/algorithms/pd/selector/selector.go
+++ b/pkg/plugins/gateway/algorithms/pd/selector/selector.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package selector defines the PodSelector contract for PD-disaggregated routing.
+// A PodSelector takes the full list of ready pods and returns the chosen prefill
+// pod (may be nil for combined-role routing) and decode pod for a given request.
+//
+// The DefaultSelector returned by NewDefaultSelector wraps a scoring function
+// supplied by the router; future phases will move the scoring logic here so it
+// can be composed and tested independently of the router.
+package selector
+
+import (
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+// PodSelector picks a prefill/decode pod pair from the full ready-pod list.
+// A nil prefill pod signals combined-role routing (decode pod handles both phases).
+type PodSelector interface {
+	Select(routingCtx *types.RoutingContext, readyPods []*v1.Pod) (prefill *v1.Pod, decode *v1.Pod, err error)
+}
+
+// SelectFunc is a function signature matching PodSelector.Select.
+type SelectFunc func(routingCtx *types.RoutingContext, readyPods []*v1.Pod) (*v1.Pod, *v1.Pod, error)
+
+// DefaultSelector wraps a SelectFunc as a PodSelector.
+// This lets the router register its existing filterPrefillDecodePods method
+// behind the interface without moving the implementation prematurely.
+type DefaultSelector struct {
+	fn SelectFunc
+}
+
+// NewDefaultSelector returns a PodSelector backed by fn.
+func NewDefaultSelector(fn SelectFunc) PodSelector {
+	return &DefaultSelector{fn: fn}
+}
+
+func (s *DefaultSelector) Select(routingCtx *types.RoutingContext, readyPods []*v1.Pod) (*v1.Pod, *v1.Pod, error) {
+	return s.fn(routingCtx, readyPods)
+}

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -32,6 +32,8 @@ import (
 	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/engine"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/selector"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/configprofiles"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
@@ -114,6 +116,9 @@ var loadBalancingDecodePolicy = pd.LoadBalancingDecodePolicy{}
 
 func init() {
 	Register(RouterPD, NewPDRouter)
+	// Point the vLLM engine handler at the live connector-type var so that tests
+	// (and runtime config changes via env) are reflected without a second copy.
+	engine.SetConnectorTypeFunc(func() string { return aibrixKVConnectorType })
 }
 
 // pdAlgorithmConfig holds PD-specific algorithm configuration parsed from RoutingConfig.
@@ -202,6 +207,7 @@ type pdRouter struct {
 	prefixUpdateCh        chan prefixUpdateJob
 	countersMu            sync.RWMutex
 	selectionCounts       map[string]int64
+	podSelector           selector.PodSelector
 }
 
 func newPrefixCachePrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHashTable) pd.PrefillScorePolicy {
@@ -256,7 +262,7 @@ func NewPDRouter() (types.Router, error) {
 		},
 	}
 
-	pdRouter := pdRouter{
+	r := &pdRouter{
 		cache:                 c,
 		prefillPolicy:         policy,
 		decodePolicy:          decodePol,
@@ -267,9 +273,10 @@ func NewPDRouter() (types.Router, error) {
 		prefixUpdateCh:        make(chan prefixUpdateJob, 1024),
 		selectionCounts:       make(map[string]int64),
 	}
+	r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
 
-	pdRouter.startPrefixUpdater()
-	return &pdRouter, nil
+	r.startPrefixUpdater()
+	return r, nil
 }
 
 func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) (string, error) {
@@ -282,7 +289,10 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		return "", fmt.Errorf("engine validation failed for request %s: %w", ctx.RequestID, err)
 	}
 
-	prefillPod, decodePod, err := r.filterPrefillDecodePods(ctx, readyPods)
+	if r.podSelector == nil {
+		r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
+	}
+	prefillPod, decodePod, err := r.podSelector.Select(ctx, readyPods)
 	if err != nil {
 		metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
 			map[string]string{"status": pdRouteFilterPrefillDecodePodsFail, "status_code": "400"})

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -43,18 +43,18 @@ import (
 )
 
 const (
-	RouterPD            types.RoutingAlgorithm = "pd"
-	VLLMEngine          string                 = "vllm"
-	SGLangEngine        string                 = "sglang"
-	TensorRTLLM         string                 = "trtllm"
-	LLMEngineIdentifier string                 = constants.ModelLabelEngine
-	PDRoleSetIdentifier           string                 = "roleset-name"
-	PDRoleIdentifier              string                 = "role-name"
-	RoleReplicaIndex              string                 = "stormservice.orchestration.aibrix.ai/role-replica-index"
-	PodGroupIndex                 string                 = "stormservice.orchestration.aibrix.ai/pod-group-index"
-	PromptLenBucketMinLength      string                 = "prompt-len-bucket-min-length"
-	PromptLenBucketMaxLength      string                 = "prompt-len-bucket-max-length"
-	defaultPrefillRequestTimeout  int                    = 30
+	RouterPD                     types.RoutingAlgorithm = "pd"
+	VLLMEngine                   string                 = "vllm"
+	SGLangEngine                 string                 = "sglang"
+	TensorRTLLM                  string                 = "trtllm"
+	LLMEngineIdentifier          string                 = constants.ModelLabelEngine
+	PDRoleSetIdentifier          string                 = "roleset-name"
+	PDRoleIdentifier             string                 = "role-name"
+	RoleReplicaIndex             string                 = "stormservice.orchestration.aibrix.ai/role-replica-index"
+	PodGroupIndex                string                 = "stormservice.orchestration.aibrix.ai/pod-group-index"
+	PromptLenBucketMinLength     string                 = "prompt-len-bucket-min-length"
+	PromptLenBucketMaxLength     string                 = "prompt-len-bucket-max-length"
+	defaultPrefillRequestTimeout int                    = 30
 
 	defaultPrefillLoadImbalanceMinSpread      int32   = 16
 	defaultDecodeLoadImbalanceMinSpread       float64 = 16

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -289,9 +289,6 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		return "", fmt.Errorf("engine validation failed for request %s: %w", ctx.RequestID, err)
 	}
 
-	if r.podSelector == nil {
-		r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
-	}
 	prefillPod, decodePod, err := r.podSelector.Select(ctx, readyPods)
 	if err != nil {
 		metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -43,19 +42,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// sonicJSONInt64 unmarshals JSON numbers into map[string]any as int64 (not float64), so large
-// integer fields (e.g. ctx_request_id, disagg_request_id in disaggregated_params) survive
-// marshal/unmarshal without float64 precision loss.
-var sonicJSONInt64 = sonic.Config{UseInt64: true}.Froze()
-
 const (
-	RouterPD                      types.RoutingAlgorithm = "pd"
-	VLLMEngine                    string                 = "vllm"
-	SGLangEngine                  string                 = "sglang"
-	TensorRTLLM                   string                 = "trtllm"
-	SGLangBootstrapPort           int64                  = 8998
-	SGLangBootstrapPortIdentifier string                 = "model.aibrix.ai/sglang-bootstrap-port"
-	LLMEngineIdentifier           string                 = constants.ModelLabelEngine
+	RouterPD            types.RoutingAlgorithm = "pd"
+	VLLMEngine          string                 = "vllm"
+	SGLangEngine        string                 = "sglang"
+	TensorRTLLM         string                 = "trtllm"
+	LLMEngineIdentifier string                 = constants.ModelLabelEngine
 	PDRoleSetIdentifier           string                 = "roleset-name"
 	PDRoleIdentifier              string                 = "role-name"
 	RoleReplicaIndex              string                 = "stormservice.orchestration.aibrix.ai/role-replica-index"
@@ -972,15 +964,6 @@ func getLLMEngine(pod *v1.Pod, labelName string, defaultValue string) string {
 		return defaultValue
 	}
 	return labelTarget
-}
-
-func getSGLangBootstrapPort(pod *v1.Pod) int64 {
-	if portStr, exists := pod.Annotations[SGLangBootstrapPortIdentifier]; exists {
-		if port, err := strconv.ParseInt(portStr, 10, 32); err == nil {
-			return port
-		}
-	}
-	return SGLangBootstrapPort // Default port
 }
 
 // validateAndGetLLMEngine validates that all prefill pods use the same engine and returns it.

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/engine"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/selector"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
@@ -95,6 +97,7 @@ func TestPDRouter_Route(t *testing.T) {
 		httpClient:            &http.Client{},
 		selectionCounts:       map[string]int64{},
 	}
+	r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -985,7 +988,7 @@ func TestPreparePrefillPayload(t *testing.T) {
 				Context: context.Background(),
 			}
 
-			payload, err := router.preparePrefillPayload(routingCtx, pod, tt.llmEngine)
+			payload, err := router.preparePrefillPayload(routingCtx, pod, tt.llmEngine, engine.Resolve(tt.llmEngine))
 			assert.NoError(t, err, tt.description)
 
 			var result map[string]any
@@ -1054,7 +1057,7 @@ func TestPreparePrefillPayloadBackwardCompatibility(t *testing.T) {
 				Context: context.Background(),
 			}
 
-			payload, err := router.preparePrefillPayload(routingCtx, pod, tc.engine)
+			payload, err := router.preparePrefillPayload(routingCtx, pod, tc.engine, engine.Resolve(tc.engine))
 			assert.NoError(t, err)
 
 			var result map[string]any
@@ -2619,17 +2622,17 @@ func TestFilterPrefillDecodePods_CombinedPickImbalance(t *testing.T) {
 }
 
 func TestGetDisaggRequestID_CustomEpoch(t *testing.T) {
-	id1 := getDisaggRequestID(0)
-	id2 := getDisaggRequestID(0)
-	assert.GreaterOrEqual(t, id1, trtMinGlobalID)
-	assert.GreaterOrEqual(t, id2, trtMinGlobalID)
+	id1 := engine.GetDisaggRequestID(0)
+	id2 := engine.GetDisaggRequestID(0)
+	assert.GreaterOrEqual(t, id1, engine.TRTMinGlobalID)
+	assert.GreaterOrEqual(t, id2, engine.TRTMinGlobalID)
 	assert.NotEqual(t, id1, id2, "counter should advance")
-	id3 := getDisaggRequestID(42)
-	assert.GreaterOrEqual(t, id3, trtMinGlobalID)
+	id3 := engine.GetDisaggRequestID(42)
+	assert.GreaterOrEqual(t, id3, engine.TRTMinGlobalID)
 }
 
 func TestValidateTRTMachineIDValue(t *testing.T) {
-	maxExclusive := int64(1 << trtMachineIDBits)
+	maxExclusive := int64(1 << engine.TRTMachineIDBits)
 	tests := []struct {
 		name    string
 		id      int64
@@ -2644,7 +2647,7 @@ func TestValidateTRTMachineIDValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateTRTMachineIDValue(tt.id)
+			err := engine.ValidateTRTMachineID(tt.id)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/plugins/gateway/algorithms/pd_prefill_request.go
+++ b/pkg/plugins/gateway/algorithms/pd_prefill_request.go
@@ -37,13 +37,13 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/engine"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/transfer"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
@@ -116,11 +116,11 @@ func (r *pdRouter) doPrefillRequest(routingCtx *types.RoutingContext, prefillPod
 	r.prefillRequestTracker.AddPrefillRequest(routingCtx.RequestID, prefillPod.Name)
 	routingCtx.PrefillStartTime = time.Now()
 
-	switch llmEngine {
-	case SGLangEngine:
-		// SGLang uses a bootstrap handshake (bootstrap_host/port/room) to
-		// coordinate KV transfer between prefill and decode pods out-of-band,
-		// so we fire the prefill asynchronously and return immediately.
+	handler := engine.Resolve(llmEngine)
+
+	if handler.IsAsync() {
+		// SGLang uses a bootstrap handshake to coordinate KV transfer out-of-band;
+		// fire asynchronously and return immediately.
 		go func() {
 			defer r.prefillRequestTracker.RemovePrefillRequest(routingCtx.RequestID)
 
@@ -141,23 +141,10 @@ func (r *pdRouter) doPrefillRequest(routingCtx *types.RoutingContext, prefillPod
 				"outstanding_prefill_requests", r.prefillRequestTracker.GetPrefillRequestCountsForPod(prefillPod.Name)-1)
 			klog.InfoS("prefill_request_end", fields...)
 		}()
-
-	case VLLMEngine:
-		// vLLM returns kv_transfer_params in the prefill response; inject them
-		// into the decode request body before forwarding to the decode pod.
-		return r.handleSyncPrefill(routingCtx, prefillPod, llmEngine, apiURL, payload, fields, r.updateRoutingContextWithKVTransferParams, "KV transfer params")
-
-	case TensorRTLLM:
-		// TensorRT-LLM returns disaggregated_params (including first_gen_tokens
-		// and opaque_state) needed by the decode worker; inject them synchronously.
-		return r.handleSyncPrefill(routingCtx, prefillPod, llmEngine, apiURL, payload, fields, r.updateRoutingContextWithTRTDisaggParams, "TRT disagg params")
-
-	default:
-		// Unknown engine: synchronous prefill with no response processing.
-		return r.handleSyncPrefill(routingCtx, prefillPod, llmEngine, apiURL, payload, fields, nil, "")
+		return nil
 	}
 
-	return nil
+	return r.handleSyncPrefill(routingCtx, prefillPod, llmEngine, apiURL, payload, fields, handler.MergePrefillResponse, llmEngine+" response")
 }
 
 // handleSyncPrefill executes a synchronous HTTP prefill request and optionally
@@ -222,40 +209,10 @@ func (r *pdRouter) preparePrefillPayload(routingCtx *types.RoutingContext, pod *
 		return nil, fmt.Errorf("failed to unmarshal prefill request body: %w", err)
 	}
 
-	if llmEngine == SGLangEngine {
-		completionRequest["bootstrap_host"] = pod.Status.PodIP
-		completionRequest["bootstrap_port"] = getSGLangBootstrapPort(pod)
-		completionRequest["bootstrap_room"] = rand.Int63n(1<<63 - 1)
-
-		// Propagate the bootstrap fields to the decode request body so that
-		// the decode pod can locate the prefill pod's bootstrap server.
-		reqBody, err := sonic.Marshal(completionRequest)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal post prefill request body: %w", err)
-		}
-		bodyCopy := make([]byte, len(reqBody))
-		copy(bodyCopy, reqBody)
-		routingCtx.ReqBody = bodyCopy
-	}
-
-	// For vLLM, delegate connector-specific request augmentation to the transfer agent.
-	// Each agent decides what fields (if any) to add to the prefill request body
-	// (e.g. SHFSAgent adds a kv_transfer_params skeleton; NIXLAgent is a no-op).
-	if llmEngine == VLLMEngine {
-		agent, err := transfer.ResolveAgentForPod(pod, aibrixKVConnectorType)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve KV transfer agent for prefill payload: %w", err)
-		}
-		if err := agent.AugmentPrefillRequest(routingCtx, pod, completionRequest); err != nil {
-			return nil, fmt.Errorf("failed to augment prefill request: %w", err)
-		}
-	}
-
-	if llmEngine == TensorRTLLM {
-		completionRequest["disaggregated_params"] = map[string]any{
-			"request_type":      "context_only",
-			"disagg_request_id": getDisaggRequestID(trtMachineID),
-		}
+	// Delegate all engine-specific request augmentation to the engine handler.
+	handler := engine.Resolve(llmEngine)
+	if err := handler.AugmentPrefillRequest(routingCtx, pod, completionRequest); err != nil {
+		return nil, fmt.Errorf("failed to augment prefill request for %s: %w", llmEngine, err)
 	}
 
 	// Constrain the prefill to a single token so the pod returns immediately
@@ -336,99 +293,16 @@ func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingConte
 	return responseData, nil
 }
 
-// updateRoutingContextWithKVTransferParams merges vLLM KV-transfer metadata
-// from the prefill response back into routingCtx.ReqBody so the decode pod
-// receives everything it needs to pull KV cache blocks from the prefill pod.
-//
-// The behaviour depends on AIBRIX_KV_CONNECTOR_TYPE:
-//
-//   - NIXL (Neuron): wraps the entire prefill response under
-//     disagg_prefill_resp. NixlConnector on the decode side consumes this
-//     wrapper to locate and pull the KV blocks.
-//   - SHFS (default, GPU): extracts kv_transfer_params from the prefill
-//     response, sets remote_host to the prefill pod's IP, and writes the
-//     merged params into the decode request body.
-//
-// If kv_transfer_params is absent from the SHFS response (e.g. the prefill
-// pod did not fill the field), the function returns nil without modifying
-// the request body, which is a valid no-op for backends that self-coordinate.
+// updateRoutingContextWithKVTransferParams delegates to the vLLM engine handler's
+// MergePrefillResponse so existing tests can call this method directly.
 func (r *pdRouter) updateRoutingContextWithKVTransferParams(routingCtx *types.RoutingContext, responseData map[string]any, prefillPod *v1.Pod) error {
-	agent, err := transfer.ResolveAgentForPod(prefillPod, aibrixKVConnectorType)
-	if err != nil {
-		return fmt.Errorf("failed to resolve KV transfer agent for response merge: %w", err)
-	}
-	return agent.MergePrefillResponse(routingCtx, responseData, prefillPod)
+	return engine.Resolve(VLLMEngine).MergePrefillResponse(routingCtx, responseData, prefillPod)
 }
 
-// updateRoutingContextWithTRTDisaggParams merges TensorRT-LLM disaggregated
-// inference parameters from the prefill response into routingCtx.ReqBody so
-// that the decode pod can resume generation from the pre-filled KV cache.
-//
-// The function looks for disaggregated_params at the top level of the prefill
-// response, then falls back to choices[0] (TRT-LLM serialises handler output
-// as a chat-completion choice). It sets request_type to "generation_only" so
-// the decode pod knows it is continuing a pre-filled context.
-//
-// If the prefill response includes prompt_token_ids, the function routes them
-// into the decode body according to the request path:
-//   - /v1/completions        → "prompt" field (token ID array)
-//   - /v1/chat/completions   → "prompt_token_ids" field
+// updateRoutingContextWithTRTDisaggParams delegates to the TRT-LLM engine handler's
+// MergePrefillResponse so existing tests can call this method directly.
 func (r *pdRouter) updateRoutingContextWithTRTDisaggParams(routingCtx *types.RoutingContext, responseData map[string]any, prefillPod *v1.Pod) error {
-	var originalRequest map[string]any
-	if err := sonicJSONInt64.Unmarshal(routingCtx.ReqBody, &originalRequest); err != nil {
-		return fmt.Errorf("failed to unmarshal original request body: %w", err)
-	}
-
-	// Locate disaggregated_params: top-level first, then choices[0] fallback.
-	var disaggParams any
-	var exists bool
-
-	disaggParams, exists = responseData["disaggregated_params"]
-	if !exists {
-		if choices, ok := responseData["choices"].([]any); ok && len(choices) > 0 {
-			if choice, ok := choices[0].(map[string]any); ok {
-				disaggParams, exists = choice["disaggregated_params"]
-			}
-		}
-	}
-
-	if !exists {
-		klog.InfoS("no disaggregated_params in TRT prefill response", "request_id", routingCtx.RequestID)
-		return nil
-	}
-
-	disaggParamsMap, ok := disaggParams.(map[string]any)
-	if !ok {
-		return fmt.Errorf("disaggregated_params has unexpected type %T, expected map[string]any", disaggParams)
-	}
-
-	disaggParamsMap["request_type"] = "generation_only"
-	originalRequest["disaggregated_params"] = disaggParamsMap
-
-	if pti, ok := responseData["prompt_token_ids"]; ok && pti != nil {
-		if ids, ok := anySliceForJSON(pti); ok {
-			switch routingCtx.ReqPath {
-			case "/v1/completions":
-				originalRequest["prompt"] = ids
-			case "/v1/chat/completions":
-				originalRequest["prompt_token_ids"] = ids
-			}
-		}
-	}
-
-	updatedReqBody, err := sonic.Marshal(originalRequest)
-	if err != nil {
-		return fmt.Errorf("failed to marshal updated request body: %w", err)
-	}
-
-	routingCtx.ReqBody = updatedReqBody
-
-	klog.InfoS("updated routing context with disaggregated_params (TensorRT-LLM)",
-		"request_id", routingCtx.RequestID,
-		"prefill_pod", prefillPod.Name,
-		"prefill_host", prefillPod.Status.PodIP)
-
-	return nil
+	return engine.Resolve(TensorRTLLM).MergePrefillResponse(routingCtx, responseData, prefillPod)
 }
 
 // selectKvConnectorType resolves the KV connector type from a pod label value,

--- a/pkg/plugins/gateway/algorithms/pd_prefill_request.go
+++ b/pkg/plugins/gateway/algorithms/pd_prefill_request.go
@@ -67,7 +67,8 @@ import (
 //     to inject disaggregated_params into the decode request body.
 //   - default: synchronous, no response processing.
 func (r *pdRouter) doPrefillRequest(routingCtx *types.RoutingContext, prefillPod *v1.Pod, llmEngine string) error {
-	payload, err := r.preparePrefillPayload(routingCtx, prefillPod, llmEngine)
+	handler := engine.Resolve(llmEngine)
+	payload, err := r.preparePrefillPayload(routingCtx, prefillPod, llmEngine, handler)
 	if err != nil {
 		return fmt.Errorf("failed to prepare prefill payload for request %s: %w", routingCtx.RequestID, err)
 	}
@@ -115,8 +116,6 @@ func (r *pdRouter) doPrefillRequest(routingCtx *types.RoutingContext, prefillPod
 
 	r.prefillRequestTracker.AddPrefillRequest(routingCtx.RequestID, prefillPod.Name)
 	routingCtx.PrefillStartTime = time.Now()
-
-	handler := engine.Resolve(llmEngine)
 
 	if handler.IsAsync() {
 		// SGLang uses a bootstrap handshake to coordinate KV transfer out-of-band;
@@ -203,14 +202,12 @@ func (r *pdRouter) handleSyncPrefill(
 // All engines: sets max_tokens=1, max_completion_tokens=1 (except TRT-LLM),
 // stream=false, and removes stream_options so the prefill pod returns a single
 // JSON response rather than an SSE stream.
-func (r *pdRouter) preparePrefillPayload(routingCtx *types.RoutingContext, pod *v1.Pod, llmEngine string) ([]byte, error) {
+func (r *pdRouter) preparePrefillPayload(routingCtx *types.RoutingContext, pod *v1.Pod, llmEngine string, handler engine.EngineHandler) ([]byte, error) {
 	var completionRequest map[string]any
 	if err := sonic.Unmarshal(routingCtx.ReqBody, &completionRequest); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal prefill request body: %w", err)
 	}
 
-	// Delegate all engine-specific request augmentation to the engine handler.
-	handler := engine.Resolve(llmEngine)
 	if err := handler.AugmentPrefillRequest(routingCtx, pod, completionRequest); err != nil {
 		return nil, fmt.Errorf("failed to augment prefill request for %s: %w", llmEngine, err)
 	}
@@ -282,7 +279,7 @@ func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingConte
 	var responseData map[string]any
 	var errUnmarshal error
 	if routingCtx.Engine == TensorRTLLM {
-		errUnmarshal = sonicJSONInt64.Unmarshal(body, &responseData)
+		errUnmarshal = pd.SonicJSONInt64.Unmarshal(body, &responseData)
 	} else {
 		errUnmarshal = sonic.Unmarshal(body, &responseData)
 	}

--- a/pkg/plugins/gateway/algorithms/util.go
+++ b/pkg/plugins/gateway/algorithms/util.go
@@ -19,10 +19,8 @@ package routingalgorithms
 import (
 	"fmt"
 	"math"
-	"reflect"
-	"sync/atomic"
-	"time"
 
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/engine"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 
@@ -30,66 +28,22 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// Snowflake-style disagg request ID constants for TensorRT-LLM PD routing.
-// Layout: [timestamp(41b)][machineID(10b)][counter(12b)]
-// The modulo rotation guarantees result >= minGlobalID so TRT-LLM's executor treats
-// it as a global (cross-worker) disagg ID rather than a local one.
-//
-// Timestamp uses milliseconds since trtSnowflakeEpochMs (not Unix epoch) so the 41-bit
-// field does not overflow around year ~2039 when using raw Unix millis from 1970.
+// trtMachineIDBits and trtMinGlobalID are kept here so tests in this package
+// can reference them without importing pd/engine. The authoritative definitions
+// live in pd/engine.
 const (
-	trtCounterBits      = 12
-	trtMachineIDBits    = 10
-	trtTimestampBits    = 41
-	trtSnowflakeEpochMs = int64(1672531200000) // 2023-01-01T00:00:00Z in milliseconds
-	trtCounterMask      = (1 << trtCounterBits) - 1
-	trtTimestampMax     = (1 << trtTimestampBits) - 1 // max ms offset representable in 41 bits (~69.7y span)
-	trtMinGlobalID      = int64(1) << 42
-	trtMaxInt64         = int64(1<<63 - 1)
+	trtMachineIDBits = 10
+	trtMinGlobalID   = int64(1) << 42
 )
 
-var (
-	// Machine ID for TRT-LLM snowflake disagg request IDs (trtMachineIDBits-wide field).
-	// Valid range: 0 <= id < 2^trtMachineIDBits (i.e. [0, 1024) for 10 bits). Out-of-range
-	// values would corrupt the snowflake layout in getDisaggRequestID.
-	trtMachineID int64 = int64(utils.LoadEnvInt("AIBRIX_TRT_MACHINE_ID", 0))
-
-	// Per-process monotonic counter for snowflake ID generation.
-	globalDisaggCounter atomic.Int64
-)
-
-func init() {
-	if err := validateTRTMachineIDValue(trtMachineID); err != nil {
-		panic("routingalgorithms: " + err.Error())
-	}
-}
-
-// validateTRTMachineIDValue ensures machineID fits in trtMachineIDBits bits (used in getDisaggRequestID).
-func validateTRTMachineIDValue(machineID int64) error {
-	maxExclusive := int64(1 << trtMachineIDBits)
-	if machineID < 0 || machineID >= maxExclusive {
-		return fmt.Errorf("invalid AIBRIX_TRT_MACHINE_ID=%d: must satisfy 0 <= id < %d (10-bit field)", machineID, maxExclusive)
-	}
-	return nil
-}
-
-// getDisaggRequestID generates a snowflake-style ID that is shared between a prefill
-// and its corresponding decode request so TRT-LLM can correlate the KV-cache entry.
-// The modulo rotation ensures the result is always >= trtMinGlobalID (1<<42), which
-// is the threshold TRT-LLM uses to distinguish global disagg IDs from local ones.
+// getDisaggRequestID forwards to engine.GetDisaggRequestID.
 func getDisaggRequestID(machineID int64) int64 {
-	timestampMs := time.Now().UnixMilli() - trtSnowflakeEpochMs
-	if timestampMs < 0 {
-		timestampMs = 0 // clock skew before custom epoch
-	}
-	if timestampMs > trtTimestampMax {
-		timestampMs = trtTimestampMax // stay within 41-bit timestamp field (~2092+ from epoch ms)
-	}
-	counter := (globalDisaggCounter.Add(1) - 1) & trtCounterMask
-	globalID := (timestampMs << (trtMachineIDBits + trtCounterBits)) |
-		(machineID << trtCounterBits) |
-		counter
-	return globalID%(trtMaxInt64-trtMinGlobalID) + trtMinGlobalID
+	return engine.GetDisaggRequestID(machineID)
+}
+
+// validateTRTMachineIDValue forwards to engine.ValidateTRTMachineID.
+func validateTRTMachineIDValue(machineID int64) error {
+	return engine.ValidateTRTMachineID(machineID)
 }
 
 // mean calculates the mean of a slice of float64 numbers.
@@ -120,8 +74,6 @@ func standardDeviation(numbers []float64) float64 {
 
 // SelectRandomPodAsFallback selects a pod randomly as a fallback.
 // This method should only be used when all other selection mechanisms have failed.
-// For example, if no pods meet the required criteria (e.g., valid metrics or specific conditions),
-// this method can be called to randomly select a pod from the provided list.
 func SelectRandomPodAsFallback(ctx *types.RoutingContext, pods []*v1.Pod, randomFunc func(int) int) (*v1.Pod, error) {
 	klog.Warningf("No suitable pods found; selecting a pod randomly as fallback, requestID: %s", ctx.RequestID)
 	targetPod, err := utils.SelectRandomPod(pods, randomFunc)
@@ -130,24 +82,4 @@ func SelectRandomPodAsFallback(ctx *types.RoutingContext, pods []*v1.Pod, random
 		return nil, fmt.Errorf("random fallback selection failed: %w", err)
 	}
 	return targetPod, nil
-}
-
-// anySliceForJSON converts a JSON-decoded array (e.g. []any from sonic) into []any suitable for map[string]any marshaling.
-func anySliceForJSON(v any) ([]any, bool) {
-	if s, ok := v.([]any); ok {
-		out := make([]any, len(s))
-		copy(out, s)
-		return out, true
-	}
-
-	val := reflect.ValueOf(v)
-	if val.Kind() != reflect.Slice {
-		return nil, false
-	}
-
-	out := make([]any, val.Len())
-	for i := 0; i < val.Len(); i++ {
-		out[i] = val.Index(i).Interface()
-	}
-	return out, true
 }

--- a/pkg/plugins/gateway/algorithms/util.go
+++ b/pkg/plugins/gateway/algorithms/util.go
@@ -20,31 +20,12 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/engine"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
-
-// trtMachineIDBits and trtMinGlobalID are kept here so tests in this package
-// can reference them without importing pd/engine. The authoritative definitions
-// live in pd/engine.
-const (
-	trtMachineIDBits = 10
-	trtMinGlobalID   = int64(1) << 42
-)
-
-// getDisaggRequestID forwards to engine.GetDisaggRequestID.
-func getDisaggRequestID(machineID int64) int64 {
-	return engine.GetDisaggRequestID(machineID)
-}
-
-// validateTRTMachineIDValue forwards to engine.ValidateTRTMachineID.
-func validateTRTMachineIDValue(machineID int64) error {
-	return engine.ValidateTRTMachineID(machineID)
-}
 
 // mean calculates the mean of a slice of float64 numbers.
 func mean(numbers []float64) float64 {


### PR DESCRIPTION
## Pull Request Description

Follow-up to the `KVTransferAgent` refactor. This PR introduces two new
abstractions that further decompose the PD disaggregation router:

- **`pd/engine/` — `EngineHandler` interface**: moves all engine-specific
  prefill request construction and response merging out of
  `pd_prefill_request.go` into self-contained handlers.
- **`pd/selector/` — `PodSelector` interface**: establishes the pod-selection
  boundary so the scoring logic can be independently composed and tested in
  future phases.

### pd/engine/ 

| File | Role |
|---|---|
| `handler.go` | `EngineHandler` interface (`Name`, `IsAsync`, `AugmentPrefillRequest`, `MergePrefillResponse`) |
| `registry.go` | `Register` / `Resolve` — returns `DefaultHandler` for unknown engines |
| `vllm.go` | `VLLMHandler` — delegates to the `KVTransferAgent` resolved for the pod |
| `sglang.go` | `SGLangHandler` — `IsAsync() = true`; injects bootstrap fields and propagates them to the decode request |
| `trtllm.go` | `TRTLLMHandler` — moves snowflake ID generation here; handles `disaggregated_params` merge |
| `default.go` | No-op synchronous handler for unknown engines |

The `doPrefillRequest` switch is replaced by `engine.Resolve(llmEngine)`:
async engines fire in a goroutine, sync engines call `handler.MergePrefillResponse`
via `handleSyncPrefill`. `preparePrefillPayload` delegates all engine-specific
augmentation to `handler.AugmentPrefillRequest`.

`updateRoutingContextWithKVTransferParams` and
`updateRoutingContextWithTRTDisaggParams` are kept as thin wrappers on
`pdRouter` for test backward compatibility; they now delegate to the engine
handlers.

### pd/selector

`PodSelector` interface (`Select(routingCtx, readyPods) → (prefill, decode, error)`)
backed by `DefaultSelector`, which wraps `pdRouter.filterPrefillDecodePods`.
`pdRouter` gains a `podSelector` field; `Route` calls
`r.podSelector.Select(...)`. The scoring logic stays on the router for now —
this PR establishes the interface boundary for the extraction planned in a
future phase.

### Other

- Snowflake ID constants and `GetDisaggRequestID` / `ValidateTRTMachineID`
  moved from `util.go` into `pd/engine/trtllm.go`; `util.go` retains shims
  (`trtMachineIDBits`, `trtMinGlobalID`, forwarding funcs) for tests that
  reference them directly.
- `engine.SetConnectorTypeFunc` wires the vLLM handler's connector-type lookup
  to the live `aibrixKVConnectorType` package var so tests that mutate it
  continue to work.

### No behavior change

All existing tests pass unchanged.


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>