### PR TITLE
perf(gateway): cache HTTPRoute status to eliminate per-request Kubernetes API calls

### DIFF
--- a/pkg/plugins/gateway/algorithms/slo_test.go
+++ b/pkg/plugins/gateway/algorithms/slo_test.go
@@ -253,6 +253,13 @@ var _ = Describe("SLO", func() {
 	It("Queue router should be blocked and released successfully", func() {
 		pods, _ := store.ListPodsByModel(model)
 
+		const (
+			pendingLoadCap      = 1.0
+			pendingLoadEpsilon  = 1e-6
+			fillRequestTimeout  = 100 * time.Millisecond
+			blockRequestTimeout = time.Second
+		)
+
 		makeOneRequest := func(id int, timeout time.Duration) (*types.RoutingContext, float64) {
 			defer GinkgoRecover()
 
@@ -268,12 +275,12 @@ var _ = Describe("SLO", func() {
 
 		// Fill pods just enough.
 		filledPods := make([]*v1.Pod, 0, pods.Len())
-		firstReq, unitPendingLoad := makeOneRequest(1, 10*time.Millisecond)
+		firstReq, unitPendingLoad := makeOneRequest(1, fillRequestTimeout)
 		filledPods = append(filledPods, firstReq.TargetPod())
 		lastPendingLoad := unitPendingLoad
 		id := 2
-		for len(filledPods) < pods.Len() || lastPendingLoad+unitPendingLoad < 1.0 {
-			req, pendingLoad := makeOneRequest(id, 10*time.Millisecond)
+		for len(filledPods) < pods.Len() || lastPendingLoad+unitPendingLoad < pendingLoadCap-pendingLoadEpsilon {
+			req, pendingLoad := makeOneRequest(id, fillRequestTimeout)
 			if req.TargetPod() != filledPods[len(filledPods)-1] {
 				filledPods = append(filledPods, req.TargetPod())
 			}
@@ -284,11 +291,11 @@ var _ = Describe("SLO", func() {
 		// Make the request that should be blocked.
 		var lastReq *types.RoutingContext
 		blockage := shouldBlock(func() {
-			lastReq, _ = makeOneRequest(id, 100*time.Millisecond)
+			lastReq, _ = makeOneRequest(id, blockRequestTimeout)
 		}, 10*time.Millisecond)
 
 		// Release the request.
-		store.DoneRequestCount(firstReq, "request_id_1", firstReq.Model, 1)
+		store.DoneRequestCount(firstReq, firstReq.RequestID, firstReq.Model, firstReq.TraceTerm)
 
 		// Check the blockage is released.
 		Eventually(blockage, 1*time.Second).Should(BeClosed())

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -55,12 +55,19 @@ import (
 )
 
 const (
-	defaultAIBrixNamespace = "aibrix-system"
-	metricHeaderErr        = "metric-header-err"
-	gatewayRespBody        = "gateway_rsp_body"
-	gatewayRespHeaders     = "gateway_rsp_headers"
-	gatewayReqBody         = "gateway_req_body"
+	defaultAIBrixNamespace        = "aibrix-system"
+	metricHeaderErr               = "metric-header-err"
+	gatewayRespBody               = "gateway_rsp_body"
+	gatewayRespHeaders            = "gateway_rsp_headers"
+	gatewayReqBody                = "gateway_req_body"
+	defaultHTTPRouteCacheTTL      = 30 * time.Second
+	envHTTPRouteCacheTTL          = "AIBRIX_HTTPROUTE_CACHE_TTL"
 )
+
+type httpRouteCacheEntry struct {
+	err       error
+	expiresAt time.Time
+}
 
 type Server struct {
 	redisClient         *redis.Client
@@ -71,6 +78,8 @@ type Server struct {
 	requestCountTracker map[string]int
 	cache               cache.Cache
 	httpServer          *http.Server
+	httprouteCache      sync.Map
+	httprouteCacheTTL   time.Duration
 	// Broadcast channel for server-initiated shutdown
 	shutdownCh   <-chan struct{}
 	shutdown     chan struct{}
@@ -99,6 +108,15 @@ type processState struct {
 var podName = os.Getenv("POD_NAME")
 var tracer = otel.Tracer("envoy-ext-proc-server")
 
+func httpRouteCacheTTL() time.Duration {
+	if v := os.Getenv(envHTTPRouteCacheTTL); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultHTTPRouteCacheTTL
+}
+
 func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayClient gatewayapi.Interface) *Server {
 	c, err := cache.Get()
 	if err != nil {
@@ -126,6 +144,7 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 		gatewayClient:       gatewayClient,
 		requestCountTracker: map[string]int{},
 		cache:               c,
+		httprouteCacheTTL:   httpRouteCacheTTL(),
 		shutdownCh:          shutdown,
 		shutdown:            shutdown,
 	}
@@ -433,17 +452,27 @@ func (s *Server) selectTargetPod(ctx context.Context, routeCtx *types.RoutingCon
 	return router.Route(routeCtx, &utils.PodArray{Pods: readyPods})
 }
 
-// validateHTTPRouteStatus checks if httproute object exists and validates its conditions are true
+// validateHTTPRouteStatus checks if httproute object exists and validates its conditions are true.
+// Results are cached with a TTL (default 30s, configurable via AIBRIX_HTTPROUTE_CACHE_TTL) to
+// avoid hammering the Kubernetes API on every request.
 func (s *Server) validateHTTPRouteStatus(ctx context.Context, model string) error {
 	// Skip validation in standalone mode (no gateway client)
 	if s.gatewayClient == nil {
 		return nil
 	}
 
+	if cached, ok := s.httprouteCache.Load(model); ok {
+		entry := cached.(httpRouteCacheEntry)
+		if time.Now().Before(entry.expiresAt) {
+			return entry.err
+		}
+	}
+
 	errMsg := []string{}
 	name := fmt.Sprintf("%s-router", model)
 	httproute, err := s.gatewayClient.GatewayV1().HTTPRoutes(defaultAIBrixNamespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
+		s.httprouteCache.Store(model, httpRouteCacheEntry{err: err, expiresAt: time.Now().Add(s.httprouteCacheTTL)})
 		return err
 	}
 
@@ -463,11 +492,12 @@ func (s *Server) validateHTTPRouteStatus(ctx context.Context, model string) erro
 		}
 	}
 
-	if len(errMsg) == 0 {
-		return nil
+	var result error
+	if len(errMsg) > 0 {
+		result = errors.New(strings.Join(errMsg, ", "))
 	}
-
-	return errors.New(strings.Join(errMsg, ", "))
+	s.httprouteCache.Store(model, httpRouteCacheEntry{err: result, expiresAt: time.Now().Add(s.httprouteCacheTTL)})
+	return result
 }
 
 // StartHTTPServer starts the gateway's HTTP server with metrics and API handlers.

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -36,6 +36,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/client-go/kubernetes"
@@ -55,13 +56,13 @@ import (
 )
 
 const (
-	defaultAIBrixNamespace        = "aibrix-system"
-	metricHeaderErr               = "metric-header-err"
-	gatewayRespBody               = "gateway_rsp_body"
-	gatewayRespHeaders            = "gateway_rsp_headers"
-	gatewayReqBody                = "gateway_req_body"
-	defaultHTTPRouteCacheTTL      = 30 * time.Second
-	envHTTPRouteCacheTTL          = "AIBRIX_HTTPROUTE_CACHE_TTL"
+	defaultAIBrixNamespace   = "aibrix-system"
+	metricHeaderErr          = "metric-header-err"
+	gatewayRespBody          = "gateway_rsp_body"
+	gatewayRespHeaders       = "gateway_rsp_headers"
+	gatewayReqBody           = "gateway_req_body"
+	defaultHTTPRouteCacheTTL = 30 * time.Second
+	envHTTPRouteCacheTTL     = "AIBRIX_HTTPROUTE_CACHE_TTL"
 )
 
 type httpRouteCacheEntry struct {
@@ -80,6 +81,7 @@ type Server struct {
 	httpServer          *http.Server
 	httprouteCache      sync.Map
 	httprouteCacheTTL   time.Duration
+	httprouteSFGroup    singleflight.Group
 	// Broadcast channel for server-initiated shutdown
 	shutdownCh   <-chan struct{}
 	shutdown     chan struct{}
@@ -468,36 +470,60 @@ func (s *Server) validateHTTPRouteStatus(ctx context.Context, model string) erro
 		}
 	}
 
-	errMsg := []string{}
-	name := fmt.Sprintf("%s-router", model)
-	httproute, err := s.gatewayClient.GatewayV1().HTTPRoutes(defaultAIBrixNamespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		s.httprouteCache.Store(model, httpRouteCacheEntry{err: err, expiresAt: time.Now().Add(s.httprouteCacheTTL)})
-		return err
-	}
-
-	for _, status := range httproute.Status.Parents {
-		if len(status.Conditions) == 0 {
-			errMsg = append(errMsg, fmt.Sprintf("httproute: %s/%s, does not have valid status", defaultAIBrixNamespace, name))
-			break
-		}
-		for _, condition := range status.Conditions {
-			if condition.Type == string(gatewayv1.RouteConditionAccepted) &&
-				condition.Reason != string(gatewayv1.RouteReasonAccepted) {
-				errMsg = append(errMsg, fmt.Sprintf("httproute: %s/%s, route is not accepted: %s.", defaultAIBrixNamespace, name, condition.Reason))
-			} else if condition.Type == string(gatewayv1.RouteConditionResolvedRefs) &&
-				condition.Reason != string(gatewayv1.RouteReasonResolvedRefs) {
-				errMsg = append(errMsg, fmt.Sprintf("httproute: %s/%s, route's object references are not resolved: %s.", defaultAIBrixNamespace, name, condition.Reason))
+	// Use singleflight to collapse concurrent cache-miss requests for the same
+	// model into a single Kubernetes API call, preventing thundering herd on
+	// cache expiry under high load.
+	v, err, _ := s.httprouteSFGroup.Do(model, func() (interface{}, error) {
+		// Re-check cache inside the group: a previous waiter may have already
+		// populated it while we were queued.
+		if cached, ok := s.httprouteCache.Load(model); ok {
+			entry := cached.(httpRouteCacheEntry)
+			if time.Now().Before(entry.expiresAt) {
+				return entry.err, nil
 			}
 		}
-	}
 
-	var result error
-	if len(errMsg) > 0 {
-		result = errors.New(strings.Join(errMsg, ", "))
+		name := fmt.Sprintf("%s-router", model)
+		httproute, err := s.gatewayClient.GatewayV1().HTTPRoutes(defaultAIBrixNamespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+				s.httprouteCache.Store(model, httpRouteCacheEntry{err: err, expiresAt: time.Now().Add(s.httprouteCacheTTL)})
+			}
+			return nil, err
+		}
+
+		errMsg := []string{}
+		for _, status := range httproute.Status.Parents {
+			if len(status.Conditions) == 0 {
+				errMsg = append(errMsg, fmt.Sprintf("httproute: %s/%s, does not have valid status", defaultAIBrixNamespace, name))
+				break
+			}
+			for _, condition := range status.Conditions {
+				if condition.Type == string(gatewayv1.RouteConditionAccepted) &&
+					condition.Reason != string(gatewayv1.RouteReasonAccepted) {
+					errMsg = append(errMsg, fmt.Sprintf("httproute: %s/%s, route is not accepted: %s.", defaultAIBrixNamespace, name, condition.Reason))
+				} else if condition.Type == string(gatewayv1.RouteConditionResolvedRefs) &&
+					condition.Reason != string(gatewayv1.RouteReasonResolvedRefs) {
+					errMsg = append(errMsg, fmt.Sprintf("httproute: %s/%s, route's object references are not resolved: %s.", defaultAIBrixNamespace, name, condition.Reason))
+				}
+			}
+		}
+
+		var result error
+		if len(errMsg) > 0 {
+			result = errors.New(strings.Join(errMsg, ", "))
+		}
+		s.httprouteCache.Store(model, httpRouteCacheEntry{err: result, expiresAt: time.Now().Add(s.httprouteCacheTTL)})
+		return result, nil
+	})
+
+	if err != nil {
+		return err
 	}
-	s.httprouteCache.Store(model, httpRouteCacheEntry{err: result, expiresAt: time.Now().Add(s.httprouteCacheTTL)})
-	return result
+	if v != nil {
+		return v.(error)
+	}
+	return nil
 }
 
 // StartHTTPServer starts the gateway's HTTP server with metrics and API handlers.

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -741,6 +741,83 @@ func TestValidateHTTPRouteStatus_StandaloneModeSkipsValidation(t *testing.T) {
 	assert.NoError(t, s.validateHTTPRouteStatus(context.Background(), "any-model"))
 }
 
+func TestValidateHTTPRouteStatus_CachesResult(t *testing.T) {
+	mockGW := &MockGatewayClient{}
+	mockGWV1 := &MockGatewayV1Client{}
+	mockHTTP := &MockHTTPRouteClient{}
+
+	route := &gatewayv1.HTTPRoute{
+		Status: gatewayv1.HTTPRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{{
+					Conditions: []metav1.Condition{{
+						Type:   string(gatewayv1.RouteConditionAccepted),
+						Reason: string(gatewayv1.RouteReasonAccepted),
+					}, {
+						Type:   string(gatewayv1.RouteConditionResolvedRefs),
+						Reason: string(gatewayv1.RouteReasonResolvedRefs),
+					}},
+				}},
+			},
+		},
+	}
+	// Expect only one API call despite two invocations
+	mockGW.On("GatewayV1").Return(mockGWV1).Once()
+	mockGWV1.On("HTTPRoutes", "aibrix-system").Return(mockHTTP).Once()
+	mockHTTP.On("Get", mock.Anything, "cached-model-router", mock.Anything).Return(route, nil).Once()
+
+	s := &Server{
+		gatewayClient:     mockGW,
+		httprouteCacheTTL: 30 * time.Second,
+	}
+
+	assert.NoError(t, s.validateHTTPRouteStatus(context.Background(), "cached-model"))
+	assert.NoError(t, s.validateHTTPRouteStatus(context.Background(), "cached-model"))
+
+	mockGW.AssertExpectations(t)
+	mockGWV1.AssertExpectations(t)
+	mockHTTP.AssertExpectations(t)
+}
+
+func TestValidateHTTPRouteStatus_CacheExpiry(t *testing.T) {
+	mockGW := &MockGatewayClient{}
+	mockGWV1 := &MockGatewayV1Client{}
+	mockHTTP := &MockHTTPRouteClient{}
+
+	route := &gatewayv1.HTTPRoute{
+		Status: gatewayv1.HTTPRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{{
+					Conditions: []metav1.Condition{{
+						Type:   string(gatewayv1.RouteConditionAccepted),
+						Reason: string(gatewayv1.RouteReasonAccepted),
+					}, {
+						Type:   string(gatewayv1.RouteConditionResolvedRefs),
+						Reason: string(gatewayv1.RouteReasonResolvedRefs),
+					}},
+				}},
+			},
+		},
+	}
+	// Expect two API calls because the TTL is already expired
+	mockGW.On("GatewayV1").Return(mockGWV1).Twice()
+	mockGWV1.On("HTTPRoutes", "aibrix-system").Return(mockHTTP).Twice()
+	mockHTTP.On("Get", mock.Anything, "expire-model-router", mock.Anything).Return(route, nil).Twice()
+
+	s := &Server{
+		gatewayClient:     mockGW,
+		httprouteCacheTTL: 1 * time.Millisecond,
+	}
+
+	assert.NoError(t, s.validateHTTPRouteStatus(context.Background(), "expire-model"))
+	time.Sleep(5 * time.Millisecond)
+	assert.NoError(t, s.validateHTTPRouteStatus(context.Background(), "expire-model"))
+
+	mockGW.AssertExpectations(t)
+	mockGWV1.AssertExpectations(t)
+	mockHTTP.AssertExpectations(t)
+}
+
 func Test_responseErrorProcessing_ErrorCodeAndMessage(t *testing.T) {
 	baseResp := &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_ResponseHeaders{

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -818,6 +818,53 @@ func TestValidateHTTPRouteStatus_CacheExpiry(t *testing.T) {
 	mockHTTP.AssertExpectations(t)
 }
 
+func TestValidateHTTPRouteStatus_ContextErrorNotCached(t *testing.T) {
+	for _, ctxErr := range []error{context.Canceled, context.DeadlineExceeded} {
+		t.Run(ctxErr.Error(), func(t *testing.T) {
+			mockGW := &MockGatewayClient{}
+			mockGWV1 := &MockGatewayV1Client{}
+			mockHTTP := &MockHTTPRouteClient{}
+
+			// First call returns a context error; second call succeeds.
+			// Both must hit the API — the context error must not be cached.
+			mockGW.On("GatewayV1").Return(mockGWV1).Twice()
+			mockGWV1.On("HTTPRoutes", "aibrix-system").Return(mockHTTP).Twice()
+			mockHTTP.On("Get", mock.Anything, "ctx-err-model-router", mock.Anything).
+				Return((*gatewayv1.HTTPRoute)(nil), ctxErr).Once()
+
+			route := &gatewayv1.HTTPRoute{
+				Status: gatewayv1.HTTPRouteStatus{
+					RouteStatus: gatewayv1.RouteStatus{
+						Parents: []gatewayv1.RouteParentStatus{{
+							Conditions: []metav1.Condition{{
+								Type:   string(gatewayv1.RouteConditionAccepted),
+								Reason: string(gatewayv1.RouteReasonAccepted),
+							}, {
+								Type:   string(gatewayv1.RouteConditionResolvedRefs),
+								Reason: string(gatewayv1.RouteReasonResolvedRefs),
+							}},
+						}},
+					},
+				},
+			}
+			mockHTTP.On("Get", mock.Anything, "ctx-err-model-router", mock.Anything).
+				Return(route, nil).Once()
+
+			s := &Server{
+				gatewayClient:     mockGW,
+				httprouteCacheTTL: 30 * time.Second,
+			}
+
+			assert.ErrorIs(t, s.validateHTTPRouteStatus(context.Background(), "ctx-err-model"), ctxErr)
+			assert.NoError(t, s.validateHTTPRouteStatus(context.Background(), "ctx-err-model"))
+
+			mockGW.AssertExpectations(t)
+			mockGWV1.AssertExpectations(t)
+			mockHTTP.AssertExpectations(t)
+		})
+	}
+}
+
 func Test_responseErrorProcessing_ErrorCodeAndMessage(t *testing.T) {
 	baseResp := &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_ResponseHeaders{


### PR DESCRIPTION
## Pull Request Description

## Problem

`validateHTTPRouteStatus` was querying the Kubernetes API on every incoming
request. Under load, this caused severe K8s API rate limiting, dropping
gateway throughput by ~75% (16.49 → 4.05 req/s) and inflating mean TTFT
from ~1,238ms to ~29,611ms.

Fixes #2281

## Solution

Add an in-process TTL cache (`sync.Map` + expiry timestamp) on the `Server`
struct so that HTTPRoute status is fetched at most once per TTL window per
model. Both successful and error results are cached — stale status within the
window is acceptable since HTTPRoute condition changes are rare operational
events, not high-frequency state.

The TTL defaults to 30 seconds and is tunable via the
`AIBRIX_HTTPROUTE_CACHE_TTL` environment variable (accepts Go duration strings,
e.g. `"60s"`, `"2m"`).

## Changes

- `pkg/plugins/gateway/gateway.go`: add `httpRouteCacheEntry` type,
  `httprouteCache`/`httprouteCacheTTL` fields on `Server`, and cache
  read/write logic in `validateHTTPRouteStatus`
- `pkg/plugins/gateway/gateway_test.go`: add tests verifying cache hit
  (single API call for repeated requests) and cache expiry (re-fetches after
  TTL)

## No new dependencies

Uses only stdlib `sync.Map` and `time` — no external caching library required.


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>