### PR TITLE
fix(console/web): page through all jobs via cursor instead of capping the list

### DIFF
--- a/apps/console/web/src/components/BatchJobsList.tsx
+++ b/apps/console/web/src/components/BatchJobsList.tsx
@@ -9,7 +9,7 @@ import {
   Plus,
   Search,
 } from 'lucide-react';
-import { listJobs, getUserInfo } from '../utils/api';
+import { listAllJobs, getUserInfo } from '../utils/api';
 import { Job, JobStatus } from '../data/mockData';
 import {
   getBatchJobSummary,
@@ -132,13 +132,17 @@ export function BatchJobsList({ onSelectJob, onCreateJob }: BatchJobsListProps) 
         setLoading(true);
         setLoadError(null);
       }
-      listJobs()
-        .then(res => {
+      // Pull the full job set via cursor paging so the client-side
+      // pagination/search/filter/summary (which all assume every job is in
+      // memory) sees everything. The BFF defaults to a 20-job page without an
+      // explicit limit, which silently hid jobs past the 2nd page.
+      listAllJobs()
+        .then(allJobs => {
           if (cancelled) return;
           // Order strictly by creation time, newest first. The store list is
           // already ordered this way, but in-memory/placeholder entries from
           // older BFF builds were prepended out of order — sort defensively.
-          const next = [...(res.jobs ?? [])].sort((a, b) => jobCreatedTs(b) - jobCreatedTs(a));
+          const next = [...allJobs].sort((a, b) => jobCreatedTs(b) - jobCreatedTs(a));
           setJobs(next);
           // Poll while any job is in a non-terminal state.
           const hasActive = next.some(j => !TERMINAL_STATUSES.has(j.status));

--- a/apps/console/web/src/utils/api.ts
+++ b/apps/console/web/src/utils/api.ts
@@ -409,6 +409,23 @@ export async function listJobs(params?: { after?: string; limit?: number }): Pro
   return normalizeJobsResponse(await apiFetch<ListJobsResponse>(`/api/v1/jobs${query}`));
 }
 
+// Fetch every job by following the cursor until the server reports no more pages.
+export async function listAllJobs(): Promise<Job[]> {
+  const PAGE_LIMIT = 200;
+  const MAX_PAGES = 50;
+  const all: Job[] = [];
+  let after: string | undefined;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const res = await listJobs({ after, limit: PAGE_LIMIT });
+    const batch = res.jobs ?? [];
+    all.push(...batch);
+    const last = batch[batch.length - 1];
+    if (!res.hasMore || !last?.id) break;
+    after = last.id;
+  }
+  return all;
+}
+
 export async function getJob(id: string): Promise<Job> {
   return normalizeJob(await apiFetch<Job>(`/api/v1/jobs/${encodeURIComponent(id)}`));
 }


### PR DESCRIPTION
## Pull Request Description

<img width="2490" height="262" alt="image" src="https://github.com/user-attachments/assets/5ebb9283-0350-483a-9cfb-23353df23b47" />
<img width="586" height="92" alt="image" src="https://github.com/user-attachments/assets/f7d987eb-90b6-4544-b691-569e852588b8" />


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>