### PR TITLE
[Misc] Add exponential backoff to provisioning failure.

### DIFF
--- a/python/aibrix/aibrix/batch/job_driver/runtime/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/base.py
@@ -36,6 +36,7 @@ built here.
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import (
@@ -50,7 +51,7 @@ from typing import (
 )
 
 from aibrix.batch.client import EndpointSource
-from aibrix.batch.job_entity import BatchJob
+from aibrix.batch.job_entity import BatchJob, BatchJobError, BatchJobErrorCode
 
 
 @dataclass(slots=True)
@@ -132,6 +133,8 @@ class RuntimeBase:
     """
 
     provisions: bool = False
+    session_retry_attempts: int = 3
+    session_retry_base_delay_s: float = 2.0
 
     def cancelled(self) -> bool:
         return False
@@ -169,11 +172,77 @@ class RuntimeBase:
             "(Endpoint(source=None) + provisions=True)"
         )
 
+    @staticmethod
+    def _is_not_found_error(exc: Exception) -> bool:
+        # Runtime backends surface "resource disappeared" through a few shapes:
+        # batch-domain errors, HTTP/K8s-style 404s, filesystem not-found, and
+        # provider-specific exception names.
+        if isinstance(exc, BatchJobError):
+            return exc.code == BatchJobErrorCode.RESOURCE_NOTFOUND_ERROR.value
+        status = getattr(exc, "status", None)
+        if status == 404:
+            return True
+        status_code = getattr(exc, "status_code", None)
+        if status_code == 404:
+            return True
+        if isinstance(exc, FileNotFoundError):
+            return True
+        name = type(exc).__name__.lower()
+        return "notfound" in name or "not_found" in name
+
+    def _should_retry_wait_ready(self, exc: Exception) -> bool:
+        return self._is_not_found_error(exc)
+
+    def _should_teardown_failed_wait_ready(self, exc: Exception) -> bool:
+        # If readiness proves the resource no longer exists, there is nothing
+        # meaningful left to tear down; retry by provisioning a fresh resource.
+        return not self._is_not_found_error(exc)
+
+    async def _sleep_before_session_retry(self, attempt: int) -> None:
+        await asyncio.sleep(self.session_retry_base_delay_s * (2**attempt))
+
     @asynccontextmanager
     async def session(self, job: BatchJob, job_id: str) -> AsyncIterator[Endpoint]:
-        handle = await self._provision(job, job_id)
+        handle = None
+        ready = False
+        max_attempts = self.session_retry_attempts + 1
+        for attempt in range(max_attempts):
+            phase = "provision"
+            try:
+                handle = await self._provision(job, job_id)
+                phase = "wait_ready"
+                await self._wait_ready(handle)
+                # Only yield a connected endpoint after both startup phases
+                # succeed within the same attempt.
+                ready = True
+                break
+            except Exception as exc:
+                should_retry = False
+                should_teardown = handle is not None
+
+                if phase == "provision":
+                    # Provision failures are treated as transient until the
+                    # retry budget is exhausted.
+                    should_retry = attempt + 1 < max_attempts
+                elif phase == "wait_ready":
+                    # A not-found during readiness means provisioning looked
+                    # successful but the backend resource vanished before it
+                    # became reachable, so reprovision instead of failing fast.
+                    should_retry = (
+                        self._should_retry_wait_ready(exc)
+                        and attempt + 1 < max_attempts
+                    )
+                    should_teardown = self._should_teardown_failed_wait_ready(exc)
+
+                if should_teardown and handle is not None:
+                    await self._teardown(handle)
+                if not should_retry:
+                    raise
+                handle = None
+                await self._sleep_before_session_retry(attempt)
+        if not ready:
+            raise RuntimeError("runtime session exhausted retries without becoming ready")
         try:
-            await self._wait_ready(handle)
             yield await self._connect(handle)
         finally:
             await self._teardown(handle)

--- a/python/aibrix/aibrix/batch/job_driver/runtime/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/base.py
@@ -241,7 +241,9 @@ class RuntimeBase:
                 handle = None
                 await self._sleep_before_session_retry(attempt)
         if not ready:
-            raise RuntimeError("runtime session exhausted retries without becoming ready")
+            raise RuntimeError(
+                "runtime session exhausted retries without becoming ready"
+            )
         try:
             yield await self._connect(handle)
         finally:

--- a/python/aibrix/aibrix/batch/job_driver/runtime/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/base.py
@@ -52,6 +52,9 @@ from typing import (
 
 from aibrix.batch.client import EndpointSource
 from aibrix.batch.job_entity import BatchJob, BatchJobError, BatchJobErrorCode
+from aibrix.logger import init_logger
+
+logger = init_logger(__name__)
 
 
 @dataclass(slots=True)
@@ -180,10 +183,10 @@ class RuntimeBase:
         if isinstance(exc, BatchJobError):
             return exc.code == BatchJobErrorCode.RESOURCE_NOTFOUND_ERROR.value
         status = getattr(exc, "status", None)
-        if status == 404:
+        if status in (404, "404"):
             return True
         status_code = getattr(exc, "status_code", None)
-        if status_code == 404:
+        if status_code in (404, "404"):
             return True
         if isinstance(exc, FileNotFoundError):
             return True
@@ -204,7 +207,6 @@ class RuntimeBase:
     @asynccontextmanager
     async def session(self, job: BatchJob, job_id: str) -> AsyncIterator[Endpoint]:
         handle = None
-        ready = False
         max_attempts = self.session_retry_attempts + 1
         for attempt in range(max_attempts):
             phase = "provision"
@@ -214,7 +216,6 @@ class RuntimeBase:
                 await self._wait_ready(handle)
                 # Only yield a connected endpoint after both startup phases
                 # succeed within the same attempt.
-                ready = True
                 break
             except Exception as exc:
                 should_retry = False
@@ -235,15 +236,20 @@ class RuntimeBase:
                     should_teardown = self._should_teardown_failed_wait_ready(exc)
 
                 if should_teardown and handle is not None:
-                    await self._teardown(handle)
+                    try:
+                        await self._teardown(handle)
+                    except Exception as teardown_exc:
+                        logger.warning(
+                            "Runtime teardown failed during retry recovery; continuing with retry",
+                            job_id=job_id,
+                            phase=phase,
+                            handle=repr(handle),
+                            error=str(teardown_exc),
+                        )  # type: ignore[call-arg]
                 if not should_retry:
                     raise
                 handle = None
                 await self._sleep_before_session_retry(attempt)
-        if not ready:
-            raise RuntimeError(
-                "runtime session exhausted retries without becoming ready"
-            )
         try:
             yield await self._connect(handle)
         finally:

--- a/python/aibrix/aibrix/batch/job_entity/batch_job.py
+++ b/python/aibrix/aibrix/batch/job_entity/batch_job.py
@@ -73,6 +73,7 @@ class BatchJobErrorCode(str, Enum):
     DRIVER_CONFIGURATION_ERROR = "driver_configuration_error"
     CONNECTION_ERROR = "connection_error"
     RESOURCE_CREATION_ERROR = "resource_creation_failed"
+    RESOURCE_NOTFOUND_ERROR = "resource_not_found"
     RESOURCE_DELETION_ERROR = "resource_deletion_failed"
     INVALID_DRIVER = "invalid_driver"
     UNKNOWN_ERROR = "unknown_error"

--- a/python/aibrix/tests/batch/test_runtime.py
+++ b/python/aibrix/tests/batch/test_runtime.py
@@ -190,6 +190,83 @@ async def test_runtime_base_session_retries_wait_ready_batch_job_not_found(
 
 
 @pytest.mark.asyncio
+async def test_runtime_base_session_ignores_teardown_failure_during_retry(
+    monkeypatch,
+):
+    calls: list[tuple[str, str]] = []
+    sleeps: list[float] = []
+    warnings: list[dict[str, object]] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    def _fake_warning(message: str, **kwargs) -> None:
+        warnings.append({"message": message, **kwargs})
+
+    monkeypatch.setattr(runtime_base_mod.asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(runtime_base_mod.logger, "warning", _fake_warning)
+
+    class _RetryableReadyError(RuntimeError):
+        pass
+
+    class _R(RuntimeBase):
+        provisions = True
+
+        def __init__(self) -> None:
+            self._attempt = 0
+
+        def _should_retry_wait_ready(self, exc: Exception) -> bool:
+            return isinstance(exc, _RetryableReadyError)
+
+        def _should_teardown_failed_wait_ready(self, exc: Exception) -> bool:
+            return True
+
+        async def _provision(self, job, job_id):
+            self._attempt += 1
+            handle = f"handle-{self._attempt}"
+            calls.append(("provision", handle))
+            return handle
+
+        async def _wait_ready(self, handle):
+            calls.append(("wait_ready", handle))
+            if handle == "handle-1":
+                raise _RetryableReadyError("try again")
+
+        async def _connect(self, handle):
+            calls.append(("connect", handle))
+            return Endpoint(source=None, model_name="m")
+
+        async def _teardown(self, handle):
+            calls.append(("teardown", handle))
+            if handle == "handle-1":
+                raise RuntimeError("teardown failed")
+
+    runtime = _R()
+    async with runtime.session(job=None, job_id="job-1") as endpoint:
+        assert endpoint.model_name == "m"
+
+    assert sleeps == [2.0]
+    assert calls == [
+        ("provision", "handle-1"),
+        ("wait_ready", "handle-1"),
+        ("teardown", "handle-1"),
+        ("provision", "handle-2"),
+        ("wait_ready", "handle-2"),
+        ("connect", "handle-2"),
+        ("teardown", "handle-2"),
+    ]
+    assert warnings == [
+        {
+            "message": "Runtime teardown failed during retry recovery; continuing with retry",
+            "job_id": "job-1",
+            "phase": "wait_ready",
+            "handle": "'handle-1'",
+            "error": "teardown failed",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_local_runtime_yields_injected_source():
     sentinel_source = object()
     runtime = ExternalRuntime(sentinel_source)  # type: ignore[arg-type]

--- a/python/aibrix/tests/batch/test_runtime.py
+++ b/python/aibrix/tests/batch/test_runtime.py
@@ -15,8 +15,6 @@
 
 import pytest
 
-from aibrix.batch.job_entity import BatchJobError, BatchJobErrorCode
-from aibrix.batch.job_driver.runtime import base as runtime_base_mod
 from aibrix.batch.job_driver.runtime import (
     Endpoint,
     ExternalRuntime,
@@ -27,6 +25,8 @@ from aibrix.batch.job_driver.runtime import (
     register_runtime,
     registered_runtimes,
 )
+from aibrix.batch.job_driver.runtime import base as runtime_base_mod
+from aibrix.batch.job_entity import BatchJobError, BatchJobErrorCode
 
 
 @pytest.mark.asyncio
@@ -133,6 +133,7 @@ async def test_runtime_base_session_retries_provision_with_exponential_backoff(
         "body",
         ("teardown", "handle-4"),
     ]
+
 
 @pytest.mark.asyncio
 async def test_runtime_base_session_retries_wait_ready_batch_job_not_found(

--- a/python/aibrix/tests/batch/test_runtime.py
+++ b/python/aibrix/tests/batch/test_runtime.py
@@ -15,6 +15,8 @@
 
 import pytest
 
+from aibrix.batch.job_entity import BatchJobError, BatchJobErrorCode
+from aibrix.batch.job_driver.runtime import base as runtime_base_mod
 from aibrix.batch.job_driver.runtime import (
     Endpoint,
     ExternalRuntime,
@@ -75,6 +77,115 @@ async def test_runtime_base_teardown_runs_even_when_body_raises():
             raise ValueError("boom")
 
     assert torn_down == ["h"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_base_session_retries_provision_with_exponential_backoff(
+    monkeypatch,
+):
+    calls: list[object] = []
+    sleeps: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(runtime_base_mod.asyncio, "sleep", _fake_sleep)
+
+    class _TemporaryProvisionError(RuntimeError):
+        pass
+
+    class _R(RuntimeBase):
+        provisions = True
+
+        def __init__(self) -> None:
+            self._attempt = 0
+
+        async def _provision(self, job, job_id):
+            self._attempt += 1
+            calls.append(("provision", self._attempt))
+            if self._attempt < 4:
+                raise _TemporaryProvisionError("temporary failure")
+            return f"handle-{self._attempt}"
+
+        async def _wait_ready(self, handle):
+            calls.append(("wait_ready", handle))
+
+        async def _connect(self, handle):
+            calls.append(("connect", handle))
+            return Endpoint(source=None, model_name="m")
+
+        async def _teardown(self, handle):
+            calls.append(("teardown", handle))
+
+    runtime = _R()
+    async with runtime.session(job=None, job_id="j") as endpoint:
+        calls.append("body")
+        assert endpoint.model_name == "m"
+
+    assert sleeps == [2.0, 4.0, 8.0]
+    assert calls == [
+        ("provision", 1),
+        ("provision", 2),
+        ("provision", 3),
+        ("provision", 4),
+        ("wait_ready", "handle-4"),
+        ("connect", "handle-4"),
+        "body",
+        ("teardown", "handle-4"),
+    ]
+
+@pytest.mark.asyncio
+async def test_runtime_base_session_retries_wait_ready_batch_job_not_found(
+    monkeypatch,
+):
+    calls: list[tuple[str, str]] = []
+    sleeps: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(runtime_base_mod.asyncio, "sleep", _fake_sleep)
+
+    class _R(RuntimeBase):
+        provisions = True
+
+        def __init__(self) -> None:
+            self._attempt = 0
+
+        async def _provision(self, job, job_id):
+            self._attempt += 1
+            handle = f"handle-{self._attempt}"
+            calls.append(("provision", handle))
+            return handle
+
+        async def _wait_ready(self, handle):
+            calls.append(("wait_ready", handle))
+            if handle == "handle-1":
+                raise BatchJobError(
+                    code=BatchJobErrorCode.RESOURCE_NOTFOUND_ERROR,
+                    message="runtime not found",
+                )
+
+        async def _connect(self, handle):
+            calls.append(("connect", handle))
+            return Endpoint(source=None, model_name="m")
+
+        async def _teardown(self, handle):
+            calls.append(("teardown", handle))
+
+    runtime = _R()
+    async with runtime.session(job=None, job_id="j") as endpoint:
+        assert endpoint.model_name == "m"
+
+    assert sleeps == [2.0]
+    assert calls == [
+        ("provision", "handle-1"),
+        ("wait_ready", "handle-1"),
+        ("provision", "handle-2"),
+        ("wait_ready", "handle-2"),
+        ("connect", "handle-2"),
+        ("teardown", "handle-2"),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Pull Request Description
Improve runtime provisioning resilience by adding exponential backoff. The BaseRuntime.session call will retry up to 3 times in cases:
1. provisioning failure
2. provisioning success, but later wait_ready call find resource not found.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>