### PR TITLE
refactor(pd): extract PrefillExecutor into pd/prefill/ package

### DIFF
--- a/pkg/plugins/gateway/algorithms/pd/prefill/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default.go
@@ -57,7 +57,7 @@ func NewDefaultExecutor(httpClient *http.Client, tracker *pd.PrefillRequestTrack
 }
 
 // Execute implements PrefillExecutor.
-func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *v1.Pod, llmEngine string) error {
+func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *v1.Pod, llmEngine string, logCtx LogContext) error {
 	handler := engine.Resolve(llmEngine)
 	payload, err := PreparePayload(routingCtx, prefillPod, llmEngine, handler)
 	if err != nil {
@@ -75,6 +75,8 @@ func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *
 		"model_name", routingCtx.Model,
 		"prefill_pod", prefillPod.Name,
 		"prefill_url", apiURL,
+		"prefill_score_policy", logCtx.PrefillScorePolicy,
+		"decode_score_policy", logCtx.DecodeScorePolicy,
 		"outstanding_prefill_requests", e.tracker.GetPrefillRequestCountsForPod(prefillPod.Name),
 	}
 	klog.InfoS("prefill_request_start", fields...)
@@ -107,10 +109,10 @@ func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *
 				return
 			}
 
-			prefillEndTime := time.Now()
+			routingCtx.PrefillEndTime = time.Now()
 			completionFields = append(completionFields,
 				"routing_time_taken", routingCtx.PrefillStartTime.Sub(routingCtx.RequestTime),
-				"prefill_time_taken", prefillEndTime.Sub(routingCtx.PrefillStartTime),
+				"prefill_time_taken", routingCtx.PrefillEndTime.Sub(routingCtx.PrefillStartTime),
 				"outstanding_prefill_requests", e.tracker.GetPrefillRequestCountsForPod(prefillPod.Name)-1)
 			klog.InfoS("prefill_request_end", completionFields...)
 		}()

--- a/pkg/plugins/gateway/algorithms/pd/prefill/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefill
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/vllm-project/aibrix/pkg/metrics"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/engine"
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// trtllmEngine is kept local to avoid importing routingalgorithms (circular).
+const trtllmEngine = "trtllm"
+
+// DefaultExecutor is the standard PrefillExecutor. It owns the HTTP client and
+// the prefill-request tracker so that prefill logic can be tested in isolation
+// from the routing/scoring concerns in pdRouter.
+type DefaultExecutor struct {
+	httpClient     *http.Client
+	tracker        *pd.PrefillRequestTracker
+	requestTimeout int // seconds
+}
+
+// NewDefaultExecutor constructs a DefaultExecutor.
+// httpClient and tracker are shared with the router; requestTimeout is in seconds.
+func NewDefaultExecutor(httpClient *http.Client, tracker *pd.PrefillRequestTracker, requestTimeout int) PrefillExecutor {
+	return &DefaultExecutor{
+		httpClient:     httpClient,
+		tracker:        tracker,
+		requestTimeout: requestTimeout,
+	}
+}
+
+// Execute implements PrefillExecutor.
+func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *v1.Pod, llmEngine string) error {
+	handler := engine.Resolve(llmEngine)
+	payload, err := PreparePayload(routingCtx, prefillPod, llmEngine, handler)
+	if err != nil {
+		return fmt.Errorf("failed to prepare prefill payload for request %s: %w", routingCtx.RequestID, err)
+	}
+
+	apiURL := fmt.Sprintf("http://%s:%d%s",
+		prefillPod.Status.PodIP,
+		utils.GetModelPortForPod(routingCtx.RequestID, prefillPod),
+		routingCtx.ReqPath)
+
+	fields := []interface{}{
+		"request_id", routingCtx.RequestID,
+		"llm_engine", llmEngine,
+		"model_name", routingCtx.Model,
+		"prefill_pod", prefillPod.Name,
+		"prefill_url", apiURL,
+		"outstanding_prefill_requests", e.tracker.GetPrefillRequestCountsForPod(prefillPod.Name),
+	}
+	klog.InfoS("prefill_request_start", fields...)
+	// Drop the last two fields (outstanding count) before passing to the
+	// completion log; the count is re-fetched after the request finishes.
+	if len(fields) >= 2 {
+		fields = fields[:len(fields)-2]
+	}
+
+	e.tracker.AddPrefillRequest(routingCtx.RequestID, prefillPod.Name)
+	routingCtx.PrefillStartTime = time.Now()
+
+	if handler.IsAsync() {
+		// SGLang uses a bootstrap handshake to coordinate KV transfer out-of-band;
+		// fire asynchronously and return immediately.
+		go func() {
+			defer e.tracker.RemovePrefillRequest(routingCtx.RequestID)
+
+			if _, err := e.executeHTTP(apiURL, routingCtx, payload); err != nil {
+				klog.ErrorS(err, "prefill_request_failed",
+					"request_id", routingCtx.RequestID,
+					"llm_engine", llmEngine,
+					"prefill_pod", prefillPod.Name,
+					"prefill_pod_ip", prefillPod.Status.PodIP,
+					"elapsed", routingCtx.Elapsed(time.Now()))
+				return
+			}
+
+			routingCtx.PrefillEndTime = time.Now()
+			fields = append(fields,
+				"routing_time_taken", routingCtx.PrefillStartTime.Sub(routingCtx.RequestTime),
+				"prefill_time_taken", routingCtx.PrefillEndTime.Sub(routingCtx.PrefillStartTime),
+				"outstanding_prefill_requests", e.tracker.GetPrefillRequestCountsForPod(prefillPod.Name)-1)
+			klog.InfoS("prefill_request_end", fields...)
+		}()
+		return nil
+	}
+
+	return e.handleSync(routingCtx, prefillPod, llmEngine, apiURL, payload, fields, handler.MergePrefillResponse, llmEngine+" response")
+}
+
+// handleSync executes a synchronous HTTP prefill and optionally post-processes
+// the response via mergeFn. Pass nil mergeFn when no response processing is needed.
+func (e *DefaultExecutor) handleSync(
+	routingCtx *types.RoutingContext,
+	prefillPod *v1.Pod,
+	llmEngine, apiURL string,
+	payload []byte,
+	fields []interface{},
+	mergeFn func(*types.RoutingContext, map[string]any, *v1.Pod) error,
+	errorContext string,
+) error {
+	defer e.tracker.RemovePrefillRequest(routingCtx.RequestID)
+
+	responseData, err := e.executeHTTP(apiURL, routingCtx, payload)
+	if err != nil {
+		klog.ErrorS(err, "prefill_request_failed",
+			"request_id", routingCtx.RequestID,
+			"llm_engine", llmEngine,
+			"prefill_pod", prefillPod.Name,
+			"prefill_pod_ip", prefillPod.Status.PodIP,
+			"elapsed", routingCtx.Elapsed(time.Now()))
+		return fmt.Errorf("prefill request failed for request %s, pod %s: %w", routingCtx.RequestID, prefillPod.Name, err)
+	}
+
+	if mergeFn != nil {
+		if err := mergeFn(routingCtx, responseData, prefillPod); err != nil {
+			return fmt.Errorf("failed to update routing context with %s for request %s: %w", errorContext, routingCtx.RequestID, err)
+		}
+	}
+
+	routingCtx.PrefillEndTime = time.Now()
+	fields = append(fields,
+		"routing_time_taken", routingCtx.PrefillStartTime.Sub(routingCtx.RequestTime),
+		"prefill_time_taken", routingCtx.PrefillEndTime.Sub(routingCtx.PrefillStartTime),
+		"outstanding_prefill_requests", e.tracker.GetPrefillRequestCountsForPod(prefillPod.Name)-1)
+	klog.InfoS("prefill_request_end", fields...)
+	return nil
+}
+
+// executeHTTP posts payload to url and returns the parsed JSON response body.
+// Non-200 responses and transport errors are both recorded to Prometheus.
+// TRT-LLM responses are parsed with UseInt64=true to prevent float64 precision
+// loss on large integer fields such as disagg_request_id.
+func (e *DefaultExecutor) executeHTTP(url string, routingCtx *types.RoutingContext, payload []byte) (map[string]any, error) {
+	ctx, cancel := context.WithTimeout(routingCtx.Context, time.Duration(e.requestTimeout)*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create http prefill request: %w", err)
+	}
+
+	for key, value := range routingCtx.ReqHeaders {
+		req.Header.Set(key, value)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("X-Request-Id", routingCtx.RequestID)
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		status, code := metrics.HttpFailureStatusCode(ctx, err, nil)
+		metrics.EmitMetricToPrometheus(routingCtx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
+			map[string]string{"status": status, "status_code": code})
+		return nil, fmt.Errorf("failed to execute http prefill request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read prefill response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		status, code := metrics.HttpFailureStatusCode(ctx, nil, resp)
+		metrics.EmitMetricToPrometheus(routingCtx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
+			map[string]string{"status": status, "status_code": code})
+		return nil, fmt.Errorf("http prefill request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// TRT-LLM prefill responses contain large integer IDs in disaggregated_params;
+	// use UseInt64 to avoid float64 precision loss during unmarshal.
+	var responseData map[string]any
+	var errUnmarshal error
+	if routingCtx.Engine == trtllmEngine {
+		errUnmarshal = pd.SonicJSONInt64.Unmarshal(body, &responseData)
+	} else {
+		errUnmarshal = sonic.Unmarshal(body, &responseData)
+	}
+	if errUnmarshal != nil {
+		return nil, fmt.Errorf("failed to unmarshal prefill response: %w", errUnmarshal)
+	}
+
+	return responseData, nil
+}

--- a/pkg/plugins/gateway/algorithms/pd/prefill/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default.go
@@ -78,10 +78,14 @@ func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *
 		"outstanding_prefill_requests", e.tracker.GetPrefillRequestCountsForPod(prefillPod.Name),
 	}
 	klog.InfoS("prefill_request_start", fields...)
-	// Drop the last two fields (outstanding count) before passing to the
-	// completion log; the count is re-fetched after the request finishes.
+	// Copy and drop the last two fields (outstanding count) before passing to the
+	// completion log; the count is re-fetched after the request finishes. A copy
+	// avoids aliasing the underlying array when append is called later.
+	var completionFields []interface{}
 	if len(fields) >= 2 {
-		fields = fields[:len(fields)-2]
+		completionFields = append([]interface{}{}, fields[:len(fields)-2]...)
+	} else {
+		completionFields = append([]interface{}{}, fields...)
 	}
 
 	e.tracker.AddPrefillRequest(routingCtx.RequestID, prefillPod.Name)
@@ -103,17 +107,17 @@ func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *
 				return
 			}
 
-			routingCtx.PrefillEndTime = time.Now()
-			fields = append(fields,
+			prefillEndTime := time.Now()
+			completionFields = append(completionFields,
 				"routing_time_taken", routingCtx.PrefillStartTime.Sub(routingCtx.RequestTime),
-				"prefill_time_taken", routingCtx.PrefillEndTime.Sub(routingCtx.PrefillStartTime),
+				"prefill_time_taken", prefillEndTime.Sub(routingCtx.PrefillStartTime),
 				"outstanding_prefill_requests", e.tracker.GetPrefillRequestCountsForPod(prefillPod.Name)-1)
-			klog.InfoS("prefill_request_end", fields...)
+			klog.InfoS("prefill_request_end", completionFields...)
 		}()
 		return nil
 	}
 
-	return e.handleSync(routingCtx, prefillPod, llmEngine, apiURL, payload, fields, handler.MergePrefillResponse, llmEngine+" response")
+	return e.handleSync(routingCtx, prefillPod, llmEngine, apiURL, payload, completionFields, handler.MergePrefillResponse, llmEngine+" response")
 }
 
 // handleSync executes a synchronous HTTP prefill and optionally post-processes

--- a/pkg/plugins/gateway/algorithms/pd/prefill/executor.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/executor.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefill
+
+import (
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+// PrefillExecutor executes the prefill phase of a disaggregated-inference request.
+// Implementations are responsible for payload preparation, HTTP dispatch (async or
+// sync depending on the engine), and tracker lifecycle.
+type PrefillExecutor interface {
+	Execute(routingCtx *types.RoutingContext, prefillPod *v1.Pod, llmEngine string) error
+}

--- a/pkg/plugins/gateway/algorithms/pd/prefill/executor.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/executor.go
@@ -21,9 +21,15 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+// LogContext carries router-resolved metadata included in prefill structured logs.
+type LogContext struct {
+	PrefillScorePolicy string
+	DecodeScorePolicy  string
+}
+
 // PrefillExecutor executes the prefill phase of a disaggregated-inference request.
 // Implementations are responsible for payload preparation, HTTP dispatch (async or
 // sync depending on the engine), and tracker lifecycle.
 type PrefillExecutor interface {
-	Execute(routingCtx *types.RoutingContext, prefillPod *v1.Pod, llmEngine string) error
+	Execute(routingCtx *types.RoutingContext, prefillPod *v1.Pod, llmEngine string, logCtx LogContext) error
 }

--- a/pkg/plugins/gateway/algorithms/pd/prefill/payload.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/payload.go
@@ -38,6 +38,9 @@ func PreparePayload(routingCtx *types.RoutingContext, pod *v1.Pod, llmEngine str
 	if err := sonic.Unmarshal(routingCtx.ReqBody, &completionRequest); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal prefill request body: %w", err)
 	}
+	if completionRequest == nil {
+		completionRequest = make(map[string]any)
+	}
 
 	if err := handler.AugmentPrefillRequest(routingCtx, pod, completionRequest); err != nil {
 		return nil, fmt.Errorf("failed to augment prefill request for %s: %w", llmEngine, err)

--- a/pkg/plugins/gateway/algorithms/pd/prefill/payload.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/payload.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefill
+
+import (
+	"fmt"
+
+	"github.com/bytedance/sonic"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/engine"
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+// PreparePayload transforms routingCtx.ReqBody into a prefill-specific payload
+// ready to be POSTed to the prefill pod. It delegates all engine-specific field
+// injection to handler.AugmentPrefillRequest, then applies common constraints:
+// max_tokens=1, stream=false, no stream_options, no min_tokens. TRT-LLM does not
+// accept max_completion_tokens, so that field is omitted for that engine.
+//
+// This function is exported so pdRouter can expose a thin backward-compat wrapper
+// for tests that call preparePrefillPayload directly.
+func PreparePayload(routingCtx *types.RoutingContext, pod *v1.Pod, llmEngine string, handler engine.EngineHandler) ([]byte, error) {
+	var completionRequest map[string]any
+	if err := sonic.Unmarshal(routingCtx.ReqBody, &completionRequest); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal prefill request body: %w", err)
+	}
+
+	if err := handler.AugmentPrefillRequest(routingCtx, pod, completionRequest); err != nil {
+		return nil, fmt.Errorf("failed to augment prefill request for %s: %w", llmEngine, err)
+	}
+
+	// Constrain the prefill to a single token so the pod returns immediately
+	// after completing the KV-cache fill without generating any real output.
+	completionRequest["max_tokens"] = 1
+	if llmEngine == trtllmEngine {
+		// TRT-LLM uses max_tokens only; max_completion_tokens is not supported.
+		delete(completionRequest, "max_completion_tokens")
+	} else {
+		completionRequest["max_completion_tokens"] = 1
+	}
+	completionRequest["stream"] = false
+	delete(completionRequest, "stream_options")
+	delete(completionRequest, "min_tokens")
+
+	return sonic.Marshal(completionRequest)
+}

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/engine"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/prefill"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/selector"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/configprofiles"
 	"github.com/vllm-project/aibrix/pkg/types"
@@ -200,6 +201,7 @@ type pdRouter struct {
 	countersMu            sync.RWMutex
 	selectionCounts       map[string]int64
 	podSelector           selector.PodSelector
+	prefillExecutor       prefill.PrefillExecutor
 }
 
 func newPrefixCachePrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHashTable) pd.PrefillScorePolicy {
@@ -266,6 +268,7 @@ func NewPDRouter() (types.Router, error) {
 		selectionCounts:       make(map[string]int64),
 	}
 	r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
+	r.prefillExecutor = prefill.NewDefaultExecutor(httpClient, r.prefillRequestTracker, prefillRequestTimeout)
 
 	r.startPrefixUpdater()
 	return r, nil

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/engine"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/prefill"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/selector"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
@@ -89,15 +90,18 @@ func TestPDRouter_Route(t *testing.T) {
 		},
 	}
 
+	testTracker := pd.NewPrefillRequestTracker()
+	testClient := &http.Client{}
 	r := pdRouter{
 		cache:                 cache.NewForTest(),
 		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
 		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
-		prefillRequestTracker: pd.NewPrefillRequestTracker(),
-		httpClient:            &http.Client{},
+		prefillRequestTracker: testTracker,
+		httpClient:            testClient,
 		selectionCounts:       map[string]int64{},
 	}
 	r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
+	r.prefillExecutor = prefill.NewDefaultExecutor(testClient, testTracker, prefillRequestTimeout)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -775,13 +779,17 @@ func TestDoPrefillRequest(t *testing.T) {
 	createRouter := func(pods []*v1.Pod, metricsMap map[string]map[string]metrics.MetricValue) *pdRouter {
 		c := cache.NewWithPodsMetricsForTest(pods, "m1", metricsMap)
 		tbl := prefixcacheindexer.NewPrefixHashTable()
-		return &pdRouter{
+		tracker := pd.NewPrefillRequestTracker()
+		client := &http.Client{}
+		r := &pdRouter{
 			prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), tbl),
 			prefixCacheIndexer:    tbl,
 			cache:                 c,
-			prefillRequestTracker: pd.NewPrefillRequestTracker(),
-			httpClient:            &http.Client{},
+			prefillRequestTracker: tracker,
+			httpClient:            client,
 		}
+		r.prefillExecutor = prefill.NewDefaultExecutor(client, tracker, prefillRequestTimeout)
+		return r
 	}
 
 	tests := []struct {
@@ -1340,13 +1348,16 @@ func TestVLLMIntegrationWithTestServer(t *testing.T) {
 		Context:    context.Background(),
 	}
 
+	vllmTracker := pd.NewPrefillRequestTracker()
+	vllmClient := &http.Client{}
 	router := &pdRouter{
 		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
 		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
 		cache:                 cache.NewWithPodsForTest(prefillPods, "test-model"),
-		prefillRequestTracker: pd.NewPrefillRequestTracker(),
-		httpClient:            &http.Client{},
+		prefillRequestTracker: vllmTracker,
+		httpClient:            vllmClient,
 	}
+	router.prefillExecutor = prefill.NewDefaultExecutor(vllmClient, vllmTracker, prefillRequestTimeout)
 
 	err := router.doPrefillRequest(routingCtx, prefillPods[0], VLLMEngine)
 	assert.NoError(t, err)
@@ -1467,13 +1478,16 @@ func TestTensorRTIntegrationWithTestServer(t *testing.T) {
 		Context:    context.Background(),
 	}
 
+	trtTracker := pd.NewPrefillRequestTracker()
+	trtClient := &http.Client{}
 	router := &pdRouter{
 		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
 		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
 		cache:                 cache.NewWithPodsForTest(prefillPods, "test-model"),
-		prefillRequestTracker: pd.NewPrefillRequestTracker(),
-		httpClient:            &http.Client{},
+		prefillRequestTracker: trtTracker,
+		httpClient:            trtClient,
 	}
+	router.prefillExecutor = prefill.NewDefaultExecutor(trtClient, trtTracker, prefillRequestTimeout)
 
 	err := router.doPrefillRequest(routingCtx, prefillPods[0], TensorRTLLM)
 	assert.NoError(t, err)

--- a/pkg/plugins/gateway/algorithms/pd_prefill_request.go
+++ b/pkg/plugins/gateway/algorithms/pd_prefill_request.go
@@ -14,280 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This file contains the pdRouter methods responsible for executing prefill HTTP
-// requests in disaggregated-inference mode. The three concerns handled here are:
-//
-//  1. Payload preparation: transforming the incoming chat/completion body into
-//     an engine-specific prefill payload (SGLang bootstrap fields, vLLM
-//     kv_transfer_params, TensorRT-LLM disaggregated_params).
-//
-//  2. HTTP execution: posting the payload to the selected prefill pod and
-//     reading the response, with shared-client connection pooling and
-//     per-request timeout derived from AIBRIX_PREFILL_REQUEST_TIMEOUT.
-//
-//  3. Response injection: merging the prefill response back into the decode
-//     request body so that the decode pod receives all KV-transfer metadata
-//     (kv_transfer_params for vLLM/SHFS, disagg_prefill_resp for vLLM/NIXL,
-//     disaggregated_params for TensorRT-LLM).
-
 package routingalgorithms
 
 import (
-	"bytes"
-	"context"
-	"fmt"
-	"io"
-	"net/http"
-	"time"
-
-	"github.com/bytedance/sonic"
-	"github.com/vllm-project/aibrix/pkg/metrics"
-	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/engine"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/prefill"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/transfer"
 	"github.com/vllm-project/aibrix/pkg/types"
-	"github.com/vllm-project/aibrix/pkg/utils"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 )
 
-// doPrefillRequest sends the prefill phase of a disaggregated-inference request
-// to prefillPod and blocks until the prefill is complete (vLLM, TRT-LLM, and
-// unknown engines) or fires it asynchronously (SGLang).
-//
-// After the payload is built by preparePrefillPayload, the method resolves the
-// effective score-policy names purely for structured logging, then hands off to
-// the engine-specific branch:
-//
-//   - SGLangEngine: fires the request in a goroutine and returns immediately,
-//     because SGLang's bootstrap handshake is self-coordinating.
-//   - VLLMEngine: calls handleSyncPrefill → updateRoutingContextWithKVTransferParams
-//     to inject kv_transfer_params into the decode request body.
-//   - TensorRTLLM: calls handleSyncPrefill → updateRoutingContextWithTRTDisaggParams
-//     to inject disaggregated_params into the decode request body.
-//   - default: synchronous, no response processing.
+// doPrefillRequest delegates to the router's PrefillExecutor.
 func (r *pdRouter) doPrefillRequest(routingCtx *types.RoutingContext, prefillPod *v1.Pod, llmEngine string) error {
-	handler := engine.Resolve(llmEngine)
-	payload, err := r.preparePrefillPayload(routingCtx, prefillPod, llmEngine, handler)
-	if err != nil {
-		return fmt.Errorf("failed to prepare prefill payload for request %s: %w", routingCtx.RequestID, err)
-	}
-
-	apiURL := fmt.Sprintf("http://%s:%d%s",
-		prefillPod.Status.PodIP,
-		utils.GetModelPortForPod(routingCtx.RequestID, prefillPod),
-		routingCtx.ReqPath)
-
-	// Resolve effective policy names for logging only; errors are non-fatal here
-	// because the policies were already applied during pod selection.
-	prefillPol, decodePol, polErr := r.effectiveScorePolicies(routingCtx)
-	prefillScorePolicyName := pd.PrefillScorePolicyPrefixCache
-	if r.prefillPolicy != nil {
-		prefillScorePolicyName = r.prefillPolicy.Name()
-	}
-	if polErr == nil && prefillPol != nil {
-		prefillScorePolicyName = prefillPol.Name()
-	}
-
-	decodeScorePolicyName := string(pd.DecodePolicyLoadBalancing)
-	if r.decodePolicy != nil {
-		decodeScorePolicyName = string(r.decodePolicy.Name())
-	}
-	if polErr == nil && decodePol != nil {
-		decodeScorePolicyName = string(decodePol.Name())
-	}
-
-	fields := []interface{}{
-		"request_id", routingCtx.RequestID,
-		"llm_engine", llmEngine,
-		"model_name", routingCtx.Model,
-		"prefill_pod", prefillPod.Name,
-		"prefill_url", apiURL,
-		"prefill_score_policy", prefillScorePolicyName,
-		"decode_score_policy", decodeScorePolicyName,
-		"outstanding_prefill_requests", r.prefillRequestTracker.GetPrefillRequestCountsForPod(prefillPod.Name),
-	}
-	klog.InfoS("prefill_request_start", fields...)
-	// Drop the last two fields (outstanding count) before passing fields to the
-	// completion log; the count is re-fetched after the request finishes.
-	if len(fields) >= 2 {
-		fields = fields[:len(fields)-2]
-	}
-
-	r.prefillRequestTracker.AddPrefillRequest(routingCtx.RequestID, prefillPod.Name)
-	routingCtx.PrefillStartTime = time.Now()
-
-	if handler.IsAsync() {
-		// SGLang uses a bootstrap handshake to coordinate KV transfer out-of-band;
-		// fire asynchronously and return immediately.
-		go func() {
-			defer r.prefillRequestTracker.RemovePrefillRequest(routingCtx.RequestID)
-
-			if _, err := r.executeHTTPRequest(apiURL, routingCtx, payload); err != nil {
-				klog.ErrorS(err, "prefill_request_failed",
-					"request_id", routingCtx.RequestID,
-					"llm_engine", llmEngine,
-					"prefill_pod", prefillPod.Name,
-					"prefill_pod_ip", prefillPod.Status.PodIP,
-					"elapsed", routingCtx.Elapsed(time.Now()))
-				return
-			}
-
-			routingCtx.PrefillEndTime = time.Now()
-			fields = append(fields,
-				"routing_time_taken", routingCtx.PrefillStartTime.Sub(routingCtx.RequestTime),
-				"prefill_time_taken", routingCtx.PrefillEndTime.Sub(routingCtx.PrefillStartTime),
-				"outstanding_prefill_requests", r.prefillRequestTracker.GetPrefillRequestCountsForPod(prefillPod.Name)-1)
-			klog.InfoS("prefill_request_end", fields...)
-		}()
-		return nil
-	}
-
-	return r.handleSyncPrefill(routingCtx, prefillPod, llmEngine, apiURL, payload, fields, handler.MergePrefillResponse, llmEngine+" response")
+	return r.prefillExecutor.Execute(routingCtx, prefillPod, llmEngine)
 }
 
-// handleSyncPrefill executes a synchronous HTTP prefill request and optionally
-// post-processes the response via updateCtxFunc. Pass nil for updateCtxFunc
-// when no response processing is needed (e.g. unknown engines).
-//
-// The prefill tracker entry is removed via defer regardless of outcome.
-func (r *pdRouter) handleSyncPrefill(
-	routingCtx *types.RoutingContext,
-	prefillPod *v1.Pod,
-	llmEngine, apiURL string,
-	payload []byte,
-	fields []interface{},
-	updateCtxFunc func(*types.RoutingContext, map[string]any, *v1.Pod) error,
-	errorContext string) error {
-	defer r.prefillRequestTracker.RemovePrefillRequest(routingCtx.RequestID)
-
-	responseData, err := r.executeHTTPRequest(apiURL, routingCtx, payload)
-	if err != nil {
-		klog.ErrorS(err, "prefill_request_failed",
-			"request_id", routingCtx.RequestID,
-			"llm_engine", llmEngine,
-			"prefill_pod", prefillPod.Name,
-			"prefill_pod_ip", prefillPod.Status.PodIP,
-			"elapsed", routingCtx.Elapsed(time.Now()))
-		return fmt.Errorf("prefill request failed for request %s, pod %s: %w", routingCtx.RequestID, prefillPod.Name, err)
-	}
-
-	if updateCtxFunc != nil {
-		if err := updateCtxFunc(routingCtx, responseData, prefillPod); err != nil {
-			return fmt.Errorf("failed to update routing context with %s for request %s: %w", errorContext, routingCtx.RequestID, err)
-		}
-	}
-
-	routingCtx.PrefillEndTime = time.Now()
-	fields = append(fields,
-		"routing_time_taken", routingCtx.PrefillStartTime.Sub(routingCtx.RequestTime),
-		"prefill_time_taken", routingCtx.PrefillEndTime.Sub(routingCtx.PrefillStartTime),
-		"outstanding_prefill_requests", r.prefillRequestTracker.GetPrefillRequestCountsForPod(prefillPod.Name)-1)
-	klog.InfoS("prefill_request_end", fields...)
-	return nil
-}
-
-// preparePrefillPayload transforms routingCtx.ReqBody into a prefill-specific
-// payload for the given llmEngine. The transformations applied are:
-//
-//   - SGLangEngine: adds bootstrap_host, bootstrap_port, and a random
-//     bootstrap_room; also updates routingCtx.ReqBody so the decode request
-//     carries the same bootstrap fields.
-//   - VLLMEngine (SHFS mode): adds a kv_transfer_params skeleton with
-//     do_remote_decode=true; the decode node fills in the remote block IDs
-//     after the prefill completes.
-//   - TensorRTLLM: adds disaggregated_params with request_type="context_only"
-//     and a unique disagg_request_id generated from the machine snowflake ID.
-//
-// All engines: sets max_tokens=1, max_completion_tokens=1 (except TRT-LLM),
-// stream=false, and removes stream_options so the prefill pod returns a single
-// JSON response rather than an SSE stream.
+// preparePrefillPayload is kept for test backward compatibility.
+// Delegates to prefill.PreparePayload which owns the stateless payload logic.
 func (r *pdRouter) preparePrefillPayload(routingCtx *types.RoutingContext, pod *v1.Pod, llmEngine string, handler engine.EngineHandler) ([]byte, error) {
-	var completionRequest map[string]any
-	if err := sonic.Unmarshal(routingCtx.ReqBody, &completionRequest); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal prefill request body: %w", err)
-	}
-
-	if err := handler.AugmentPrefillRequest(routingCtx, pod, completionRequest); err != nil {
-		return nil, fmt.Errorf("failed to augment prefill request for %s: %w", llmEngine, err)
-	}
-
-	// Constrain the prefill to a single token so the pod returns immediately
-	// after completing the KV-cache fill without generating any real output.
-	completionRequest["max_tokens"] = 1
-	if llmEngine == TensorRTLLM {
-		// TRT-LLM uses max_tokens only; max_completion_tokens is not supported.
-		delete(completionRequest, "max_completion_tokens")
-	} else {
-		completionRequest["max_completion_tokens"] = 1
-	}
-	completionRequest["stream"] = false
-	delete(completionRequest, "stream_options")
-	delete(completionRequest, "min_tokens")
-
-	return sonic.Marshal(completionRequest)
-}
-
-// executeHTTPRequest posts payload to url using the router's shared HTTP client
-// and returns the parsed JSON response body. The request carries a per-request
-// timeout derived from prefillRequestTimeout and all headers from routingCtx.
-//
-// Non-200 responses and transport errors are both reported to Prometheus via
-// GatewayPrefillRequestFailTotal before being returned as errors.
-// TRT-LLM responses are parsed with UseInt64=true to avoid float64 precision
-// loss on large integer fields such as disagg_request_id.
-func (r *pdRouter) executeHTTPRequest(url string, routingCtx *types.RoutingContext, payload []byte) (map[string]any, error) {
-	ctx, cancel := context.WithTimeout(routingCtx.Context, time.Duration(prefillRequestTimeout)*time.Second)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(payload))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create http prefill request: %w", err)
-	}
-
-	for key, value := range routingCtx.ReqHeaders {
-		req.Header.Set(key, value)
-	}
-	req.Header.Set("content-type", "application/json")
-	req.Header.Set("X-Request-Id", routingCtx.RequestID)
-
-	resp, err := r.httpClient.Do(req)
-	if err != nil {
-		status, code := metrics.HttpFailureStatusCode(ctx, err, nil)
-		metrics.EmitMetricToPrometheus(routingCtx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
-			map[string]string{"status": status, "status_code": code})
-		return nil, fmt.Errorf("failed to execute http prefill request: %w", err)
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read prefill response body: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		status, code := metrics.HttpFailureStatusCode(ctx, nil, resp)
-		metrics.EmitMetricToPrometheus(routingCtx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
-			map[string]string{"status": status, "status_code": code})
-		return nil, fmt.Errorf("http prefill request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	// TRT-LLM prefill responses contain large integer IDs in disaggregated_params;
-	// use UseInt64 to avoid float64 precision loss during unmarshal.
-	var responseData map[string]any
-	var errUnmarshal error
-	if routingCtx.Engine == TensorRTLLM {
-		errUnmarshal = pd.SonicJSONInt64.Unmarshal(body, &responseData)
-	} else {
-		errUnmarshal = sonic.Unmarshal(body, &responseData)
-	}
-	if errUnmarshal != nil {
-		return nil, fmt.Errorf("failed to unmarshal prefill response: %w", errUnmarshal)
-	}
-
-	return responseData, nil
+	return prefill.PreparePayload(routingCtx, pod, llmEngine, handler)
 }
 
 // updateRoutingContextWithKVTransferParams delegates to the vLLM engine handler's
@@ -304,7 +49,6 @@ func (r *pdRouter) updateRoutingContextWithTRTDisaggParams(routingCtx *types.Rou
 
 // selectKvConnectorType resolves the KV connector type from a pod label value,
 // falling back to aibrixKVConnectorType when the value is absent or unrecognized.
-// Delegates to transfer.ResolveConnectorType for consistent resolution logic.
 func selectKvConnectorType(value string) string {
 	return transfer.ResolveConnectorType(value, aibrixKVConnectorType)
 }

--- a/pkg/plugins/gateway/algorithms/pd_prefill_request.go
+++ b/pkg/plugins/gateway/algorithms/pd_prefill_request.go
@@ -17,6 +17,7 @@ limitations under the License.
 package routingalgorithms
 
 import (
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/engine"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/prefill"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/transfer"
@@ -26,7 +27,36 @@ import (
 
 // doPrefillRequest delegates to the router's PrefillExecutor.
 func (r *pdRouter) doPrefillRequest(routingCtx *types.RoutingContext, prefillPod *v1.Pod, llmEngine string) error {
-	return r.prefillExecutor.Execute(routingCtx, prefillPod, llmEngine)
+	logCtx := prefillLogContext(r, routingCtx)
+	return r.prefillExecutor.Execute(routingCtx, prefillPod, llmEngine, logCtx)
+}
+
+// prefillLogContext resolves effective score-policy names for structured logging.
+// Errors from effectiveScorePolicies are non-fatal here because policies were
+// already applied during pod selection.
+func prefillLogContext(r *pdRouter, routingCtx *types.RoutingContext) prefill.LogContext {
+	prefillPol, decodePol, polErr := r.effectiveScorePolicies(routingCtx)
+
+	prefillScorePolicyName := pd.PrefillScorePolicyPrefixCache
+	if r.prefillPolicy != nil {
+		prefillScorePolicyName = r.prefillPolicy.Name()
+	}
+	if polErr == nil && prefillPol != nil {
+		prefillScorePolicyName = prefillPol.Name()
+	}
+
+	decodeScorePolicyName := string(pd.DecodePolicyLoadBalancing)
+	if r.decodePolicy != nil {
+		decodeScorePolicyName = string(r.decodePolicy.Name())
+	}
+	if polErr == nil && decodePol != nil {
+		decodeScorePolicyName = string(decodePol.Name())
+	}
+
+	return prefill.LogContext{
+		PrefillScorePolicy: prefillScorePolicyName,
+		DecodeScorePolicy:  decodeScorePolicyName,
+	}
 }
 
 // preparePrefillPayload is kept for test backward compatibility.


### PR DESCRIPTION
## Pull Request Description
## Summary

Extracts the HTTP prefill execution logic from `pd_prefill_request.go`
into a dedicated `pd/prefill/` package, continuing the pluggable-backend
refactor series (follows `pd/engine/` and `pd/selector/`).

### New: `pd/prefill/` package

- **`executor.go`** — `PrefillExecutor` interface with a single
  `Execute(routingCtx, prefillPod, llmEngine) error` method
- **`payload.go`** — exported `PreparePayload`: stateless transformation
  of `ReqBody` into an engine-specific prefill payload (calls
  `EngineHandler.AugmentPrefillRequest`, then applies common
  `max_tokens=1 / stream=false` constraints)
- **`default.go`** — `DefaultExecutor` owning `httpClient`,
  `PrefillRequestTracker`, and `requestTimeout`; implements async dispatch
  (SGLang bootstrap fire-and-forget) and sync dispatch (vLLM KV-transfer
  param injection, TRT-LLM disaggregated params) via `Execute`,
  `handleSync`, and `executeHTTP`

### Changed files

| File | Change |
|------|--------|
| `pd_disaggregation.go` | Add `prefillExecutor prefill.PrefillExecutor` field; initialize in `NewPDRouter` alongside `podSelector` |
| `pd_prefill_request.go` | Shrunk from 311 → 55 lines; now only thin wrappers (`doPrefillRequest`, `preparePrefillPayload`, `updateRoutingContextWith*`, `selectKvConnectorType`) |
| `pd_disaggregation_test.go` | Add `prefill` import; update 4 router construction sites to share `tracker`/`client` between `pdRouter` and the executor |

### Design notes

- `DefaultExecutor` is initialized with the same `*http.Client` and
  `*PrefillRequestTracker` pointers as the router — no duplication of
  shared state.
- `pd/prefill` avoids importing `routingalgorithms` (circular); the local
  `const trtllmEngine = "trtllm"` in `default.go` and `payload.go`
  replicates the one constant needed.
- `PreparePayload` is exported so the backward-compat `preparePrefillPayload`
  wrapper on `pdRouter` can delegate without type assertions, keeping
  existing unit tests unchanged.
- Future: `PrefillExecutor` is an interface, so tests can inject a mock
  executor to test `Route()` end-to-end without spinning up HTTP servers.


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>