### PR TITLE
Decoupling redis client and redis libs.

### DIFF
--- a/python/aibrix/aibrix/client/redis.py
+++ b/python/aibrix/aibrix/client/redis.py
@@ -1,0 +1,229 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timedelta
+from typing import AbstractSet, Any, Callable, Mapping, Optional, Protocol, cast
+
+from aibrix import envs
+from aibrix.logger import init_logger
+
+from .utils import _require_setting
+
+logger = init_logger(__name__)
+
+
+class RedisPipeline(Protocol):
+    def get(self, name: bytes | str | memoryview) -> Any: ...
+
+    def smembers(self, name: bytes | str | memoryview) -> Any: ...
+
+    def set(
+        self,
+        name: bytes | str | memoryview,
+        value: bytes | bytearray | memoryview | str | int | float,
+        ex: int | timedelta | None = None,
+        px: int | timedelta | None = None,
+        nx: bool = False,
+        xx: bool = False,
+        keepttl: bool = False,
+        get: bool = False,
+        exat: int | datetime | None = None,
+        pxat: int | datetime | None = None,
+        ifeq: str | bytes | None = None,
+        ifne: str | bytes | None = None,
+        ifdeq: Optional[str] = None,
+        ifdne: Optional[str] = None,
+    ) -> Any: ...
+
+    def zadd(
+        self,
+        name: bytes | str | memoryview,
+        mapping: Mapping[Any, bytes | bytearray | memoryview | str | int | float],
+        nx: bool = False,
+        xx: bool = False,
+        ch: bool = False,
+        incr: bool = False,
+        gt: bool = False,
+        lt: bool = False,
+    ) -> Any: ...
+
+    def sadd(
+        self,
+        name: bytes | str | memoryview,
+        *values: bytes | bytearray | memoryview | str | int | float,
+    ) -> Any: ...
+
+    def delete(self, *names: bytes | str | memoryview) -> Any: ...
+
+    def zrem(
+        self,
+        name: bytes | str | memoryview,
+        *values: bytes | bytearray | memoryview | str | int | float,
+    ) -> Any: ...
+
+    def srem(
+        self,
+        name: bytes | str | memoryview,
+        *values: bytes | bytearray | memoryview | str | int | float,
+    ) -> Any: ...
+
+    async def execute(self, raise_on_error: bool = True) -> list[Any]: ...
+
+
+class AsyncRedis(Protocol):
+    async def get(self, name: bytes | str | memoryview) -> Optional[bytes | str]: ...
+
+    async def set(
+        self,
+        name: bytes | str | memoryview,
+        value: bytes | bytearray | memoryview | str | int | float,
+        ex: int | timedelta | None = None,
+        px: int | timedelta | None = None,
+        nx: bool = False,
+        xx: bool = False,
+        keepttl: bool = False,
+        get: bool = False,
+        exat: int | datetime | None = None,
+        pxat: int | datetime | None = None,
+        ifeq: str | bytes | None = None,
+        ifne: str | bytes | None = None,
+        ifdeq: Optional[str] = None,
+        ifdne: Optional[str] = None,
+    ) -> Any: ...
+
+    async def exists(self, *names: bytes | str | memoryview) -> Any: ...
+
+    async def delete(self, *names: bytes | str | memoryview) -> Any: ...
+
+    async def ping(self) -> Any: ...
+
+    async def zadd(
+        self,
+        name: bytes | str | memoryview,
+        mapping: Mapping[Any, bytes | bytearray | memoryview | str | int | float],
+        nx: bool = False,
+        xx: bool = False,
+        ch: bool = False,
+        incr: bool = False,
+        gt: bool = False,
+        lt: bool = False,
+    ) -> Any: ...
+
+    async def zrange(
+        self,
+        name: bytes | str | memoryview,
+        start: bytes | bytearray | memoryview | str | int | float,
+        end: bytes | bytearray | memoryview | str | int | float,
+        desc: bool = False,
+        withscores: bool = False,
+        score_cast_func: type | Any = float,
+        byscore: bool = False,
+        bylex: bool = False,
+        offset: Optional[int] = None,
+        num: Optional[int] = None,
+    ) -> list[Any]: ...
+
+    async def zrevrange(
+        self,
+        name: bytes | str | memoryview,
+        start: int,
+        end: int,
+        withscores: bool = False,
+        score_cast_func: type | Any = float,
+    ) -> list[Any]: ...
+
+    async def zrevrank(
+        self,
+        name: bytes | str | memoryview,
+        value: bytes | bytearray | memoryview | str | int | float,
+    ) -> Optional[int]: ...
+
+    async def zrem(
+        self,
+        name: bytes | str | memoryview,
+        *values: bytes | bytearray | memoryview | str | int | float,
+    ) -> Any: ...
+
+    async def sadd(
+        self,
+        name: bytes | str | memoryview,
+        *values: bytes | bytearray | memoryview | str | int | float,
+    ) -> Any: ...
+
+    async def srem(
+        self,
+        name: bytes | str | memoryview,
+        *values: bytes | bytearray | memoryview | str | int | float,
+    ) -> Any: ...
+
+    async def smembers(self, name: bytes | str | memoryview) -> AbstractSet[Any]: ...
+
+    async def strlen(self, key: bytes | str | memoryview) -> int: ...
+
+    async def aclose(self) -> None: ...
+
+    def pipeline(
+        self, transaction: bool = True, shard_hint: Optional[str] = None
+    ) -> RedisPipeline: ...
+
+
+async def run_pipeline(
+    client: AsyncRedis, callback: Callable[[RedisPipeline], Any]
+) -> list[Any]:
+    pipeline = client.pipeline()
+    callback(pipeline)
+    return await pipeline.execute()
+
+
+def get_redis_client(require_check: bool = False, **kwargs) -> AsyncRedis:
+    import redis.asyncio as redis
+
+    resolved_host = _require_setting(
+        "REDIS_HOST",
+        kwargs.get("host")
+        or envs.STORAGE_REDIS_HOST
+        or (None if require_check else "localhost"),
+    )
+    resolved_port = kwargs.get("port") or envs.STORAGE_REDIS_PORT
+    resolved_db = (
+        cast(int, kwargs.get("db"))
+        if kwargs.get("db") is not None
+        else envs.STORAGE_REDIS_DB
+    )
+    resolved_password = kwargs.get("password") or envs.STORAGE_REDIS_PASSWORD
+    logger.info(  # type: ignore[call-arg]
+        "Creating Redis client",
+        host=resolved_host,
+        port=resolved_port,
+        db=resolved_db,
+        password_configured=resolved_password is not None,
+        require_check=require_check,
+        extra_kwargs=sorted(
+            key for key in kwargs if key not in {"host", "port", "db", "password"}
+        ),
+    )
+    return cast(
+        AsyncRedis,
+        redis.Redis(
+            host=resolved_host,
+            port=resolved_port,
+            db=resolved_db,
+            password=resolved_password,
+            **{
+                key: value
+                for key, value in kwargs.items()
+                if key not in {"host", "port", "db", "password"}
+            },
+        ),
+    )

--- a/python/aibrix/aibrix/client/utils.py
+++ b/python/aibrix/aibrix/client/utils.py
@@ -1,0 +1,21 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+
+def _require_setting(name: str, value: Any) -> Any:
+    if value is None or value == "":
+        raise RuntimeError(f"{name} environment variable is required")
+    return value

--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -24,7 +24,6 @@ from fastapi.responses import JSONResponse
 from kubernetes import client as k8s_client
 from kubernetes import config
 
-from aibrix import envs
 from aibrix.batch import BatchDriver
 from aibrix.batch.client import (
     EndpointSource,
@@ -36,6 +35,7 @@ from aibrix.logger import init_logger, logging_basic_config
 from aibrix.metadata.api.v1 import batch, files, models, users
 from aibrix.metadata.core import HTTPXClientWrapper
 from aibrix.metadata.setting import settings
+from aibrix.metadata.store import RedisMetadataStore
 from aibrix.storage import create_storage
 
 logger = init_logger(__name__)
@@ -170,22 +170,12 @@ async def lifespan(app: FastAPI):
     # Initialize metadata store (abstraction over Redis) only if not already set
     # (e.g., tests may pre-configure a mock store before lifespan runs)
     if not hasattr(app.state, "metadata_store") or app.state.metadata_store is None:
-        from aibrix.metadata.store import RedisMetadataStore
-
-        redis_host = envs.STORAGE_REDIS_HOST or "localhost"
-        metadata_store = RedisMetadataStore(
-            host=redis_host,
-            port=envs.STORAGE_REDIS_PORT,
-            db=envs.STORAGE_REDIS_DB,
-            password=envs.STORAGE_REDIS_PASSWORD,
-        )
+        metadata_store = RedisMetadataStore()
         app.state.metadata_store = metadata_store
         # Backward compatibility: expose underlying Redis client for components
         # that haven't migrated to the MetadataStore interface yet
         app.state.redis_client = metadata_store.client
-        logger.info(
-            f"Metadata store initialized: {redis_host}:{envs.STORAGE_REDIS_PORT}"
-        )
+        logger.info("Metadata store initialized")
 
     if hasattr(app.state, "httpx_client_wrapper"):
         app.state.httpx_client_wrapper.start()

--- a/python/aibrix/aibrix/metadata/store.py
+++ b/python/aibrix/aibrix/metadata/store.py
@@ -23,8 +23,7 @@ This allows for easier testing, backend swapping, and separation of concerns.
 from abc import ABC, abstractmethod
 from typing import Optional
 
-import redis.asyncio as redis
-
+import aibrix.client.redis as redis
 from aibrix.logger import init_logger
 
 logger = init_logger(__name__)
@@ -106,24 +105,12 @@ class MetadataStore(ABC):
 class RedisMetadataStore(MetadataStore):
     """Redis-backed implementation of the metadata store."""
 
-    def __init__(
-        self,
-        host: str = "localhost",
-        port: int = 6379,
-        db: int = 0,
-        password: Optional[str] = None,
-    ):
-        self._client = redis.Redis(
-            host=host,
-            port=port,
-            db=db,
-            password=password,
-            decode_responses=False,
-        )
-        logger.info(f"Redis metadata store initialized: {host}:{port}")
+    def __init__(self):
+        self._client = redis.get_redis_client()
+        logger.info("Redis metadata store initialized")
 
     @property
-    def client(self) -> redis.Redis:
+    def client(self) -> redis.AsyncRedis:
         """Expose underlying Redis client for backward compatibility.
 
         This property allows existing code that directly accesses the

--- a/python/aibrix/aibrix/storage/redis.py
+++ b/python/aibrix/aibrix/storage/redis.py
@@ -67,10 +67,8 @@ class RedisStorage(BaseStorage):
         loop_id = id(asyncio.get_running_loop())
         redis_client = self._redis_clients.get(loop_id)
         if redis_client is None:
-            redis_client = redis.get_redis_client(
-                decode_responses=False,  # Keep as bytes
-                **self._kwargs,
-            )
+            client_kwargs = {**self._kwargs, "decode_responses": False}  # Keep as bytes
+            redis_client = redis.get_redis_client(**client_kwargs)
             self._redis_clients[loop_id] = redis_client
         return redis_client
 

--- a/python/aibrix/aibrix/storage/redis.py
+++ b/python/aibrix/aibrix/storage/redis.py
@@ -16,8 +16,7 @@ import asyncio
 import time
 from typing import BinaryIO, Optional, TextIO, Union
 
-import redis.asyncio as redis
-
+import aibrix.client.redis as redis
 from aibrix.storage.base import (
     BaseStorage,
     PutObjectOptions,
@@ -48,18 +47,12 @@ class RedisStorage(BaseStorage):
 
     def __init__(
         self,
-        host: str = "localhost",
-        port: int = 6379,
-        db: int = 0,
-        password: Optional[str] = None,
         config: Optional[StorageConfig] = None,
+        **kwargs,
     ):
         super().__init__(config)
-        self.host = host
-        self.port = port
-        self.db = db
-        self.password = password
-        self._redis_clients: dict[int, redis.Redis] = {}
+        self._redis_clients: dict[int, redis.AsyncRedis] = {}
+        self._kwargs = kwargs
 
     def get_type(self) -> StorageType:
         """Get the type of storage.
@@ -69,17 +62,14 @@ class RedisStorage(BaseStorage):
         """
         return StorageType.REDIS
 
-    async def _get_redis(self) -> redis.Redis:
+    async def _get_redis(self) -> redis.AsyncRedis:
         """Get Redis connection, creating it if necessary."""
         loop_id = id(asyncio.get_running_loop())
         redis_client = self._redis_clients.get(loop_id)
         if redis_client is None:
-            redis_client = redis.Redis(
-                host=self.host,
-                port=self.port,
-                db=self.db,
-                password=self.password,
+            redis_client = redis.get_redis_client(
                 decode_responses=False,  # Keep as bytes
+                **self._kwargs,
             )
             self._redis_clients[loop_id] = redis_client
         return redis_client
@@ -209,6 +199,8 @@ class RedisStorage(BaseStorage):
         data = await redis_client.get(key)
         if data is None:
             raise FileNotFoundError(f"Object not found: {key}")
+        if isinstance(data, str):
+            data = data.encode()
 
         # Handle range requests
         if range_start is not None:

--- a/python/aibrix/tests/metadata/test_app_integration.py
+++ b/python/aibrix/tests/metadata/test_app_integration.py
@@ -31,9 +31,10 @@ from aibrix.storage import StorageType
 def _args(**overrides):
     defaults = {
         "enable_fastapi_docs": False,
-        "enable_k8s_support": False,
+        "enable_k8s_support": True,
         "disable_batch_api": True,
         "disable_file_api": True,
+        "job_store_provider": None,
         "dry_run": False,
     }
     defaults.update(overrides)
@@ -145,8 +146,8 @@ def test_build_app_skips_k8s_clients_when_disabled(
     assert hasattr(app.state, "batch_driver")
 
 
-def test_status_endpoint(_mock_k8s_config_loading):
-    """The /status endpoint reports the HTTP client and batch driver (no kopf)."""
+def test_status_endpoint_without_k8s(_mock_k8s_config_loading):
+    """Test /status endpoint without K8s support."""
     args = _args(
         enable_k8s_support=False,
         disable_batch_api=True,

--- a/python/aibrix/tests/storage/test_redis_storage.py
+++ b/python/aibrix/tests/storage/test_redis_storage.py
@@ -13,33 +13,30 @@
 # limitations under the License.
 
 import asyncio
-import os
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeoutError
 
 import pytest
 
+import aibrix.client.redis as redis_client
 from aibrix.storage import RedisStorage, StorageType, create_storage
 
 
 def _test_redis_connectivity():
     """Test if Redis is accessible on localhost:6379."""
     try:
-        import redis
 
         def test_connection():
-            # Try to connect to Redis with a short timeout
-            client = redis.Redis(
-                host=os.environ.get("REDIS_HOST", "localhost"),
-                port=int(os.environ.get("REDIS_PORT", "6379")),
-                db=int(os.environ.get("REDIS_DB", "0")),
-                password=os.environ.get("REDIS_PASSWORD"),
-                socket_connect_timeout=2,
-                socket_timeout=2,
-                decode_responses=True,
-            )
-            # Test with a simple ping
-            return client.ping()
+            async def ping():
+                # Try to connect to Redis with a short timeout.
+                client = redis_client.get_redis_client()
+                try:
+                    # Test with a simple ping against the async client.
+                    return await client.ping()
+                finally:
+                    await client.aclose()
+
+            return asyncio.run(ping())
 
         # Use ThreadPoolExecutor to enforce timeout
         with ThreadPoolExecutor(max_workers=1) as executor:
@@ -75,32 +72,7 @@ def get_redis_storage(**kwargs):
 async def test_redis_storage_creation():
     """Test Redis storage can be created."""
     storage = RedisStorage()
-    assert storage.host == "localhost"
-    assert storage.port == 6379
-    assert storage.db == 0
-    assert storage.password is None
-    await storage.close()
-
-
-@pytest.mark.asyncio
-async def test_redis_storage_creation_with_params():
-    """Test Redis storage can be created with custom parameters."""
-    storage = RedisStorage(host="redis-server", port=6380, db=1, password="secret")
-    assert storage.host == "redis-server"
-    assert storage.port == 6380
-    assert storage.db == 1
-    assert storage.password == "secret"
-    await storage.close()
-
-
-@pytest.mark.asyncio
-async def test_redis_storage_factory():
-    """Test Redis storage can be created via factory."""
-    storage = create_storage(StorageType.REDIS, host="localhost", port=6379, db=0)
-    assert isinstance(storage, RedisStorage)
-    assert storage.host == "localhost"
-    assert storage.port == 6379
-    assert storage.db == 0
+    assert storage._kwargs == {}
     await storage.close()
 
 


### PR DESCRIPTION
## Pull Request Description
- This change makes storage/redis.py and metadata/store.py less coupled to the concrete Redis client construction details.
- Instead of passing library-specific arguments inline at the call site, it first assembles a normalized client_kwargs dict and then delegates client creation to redis.get_redis_client(**client_kwargs) .
- That keeps RedisStorage focused on storage behavior, while the actual Redis client instantiation stays behind the client factory/helper boundary.
- In short, this is a small but meaningful step toward separating storage logic from Redis backend / client initialization details

## Related Issues
Resolves: #2333 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>