### PR TITLE
fix(gateway): fix SLO router fallback initialization race against global RouterManager

### DIFF
--- a/pkg/plugins/gateway/algorithms/router.go
+++ b/pkg/plugins/gateway/algorithms/router.go
@@ -515,7 +515,7 @@ func (rm *RouterManager) RegisterProvider(algorithm types.RoutingAlgorithm, prov
 	defer rm.routerMu.Unlock()
 	rm.routerFactory[algorithm] = provider
 	rm.multiRouterCache = make(map[string]*multiStrategyRouter)
-	klog.Infof("Registered router for %s", algorithm)
+	klog.V(4).Infof("Registered router for %s", algorithm)
 }
 func RegisterProvider(algorithm types.RoutingAlgorithm, provider types.RouterProviderFunc) {
 	defaultRM.RegisterProvider(algorithm, provider)
@@ -552,7 +552,7 @@ func (rm *RouterManager) Init() {
 	defer rm.routerMu.Unlock()
 	for algorithm, constructor := range rm.routerConstructor {
 		rm.routerFactory[algorithm] = constructor()
-		klog.Infof("Registered router for %s", algorithm)
+		klog.V(4).Infof("Registered router for %s", algorithm)
 	}
 	rm.multiRouterCache = make(map[string]*multiStrategyRouter)
 	rm.routerDoneInit()

--- a/pkg/plugins/gateway/algorithms/slo.go
+++ b/pkg/plugins/gateway/algorithms/slo.go
@@ -73,6 +73,21 @@ func NewSLORouter(modelName string) (types.QueueRouter, error) {
 		return nil, err
 	}
 
+	// Each SLORouter instance owns a private RouterManager for its internal sub-routing.
+	// We intentionally use this local rm — not defaultRM — for SetFallback below.
+	//
+	// Why: NewSLORouter is called per-model from the Kubernetes informer
+	// (cache.addPodAndModelMappingLocked), which can fire before routing.Init() has
+	// been called on defaultRM. The global SetFallback blocks on defaultRM.routerInited
+	// (5 s timeout) and fails with "router did not initialized" if Init() hasn't run yet.
+	// Using the local rm avoids that race; rm.Init() is called synchronously below, so
+	// the fallback lookup succeeds immediately.
+	//
+	// TODO: A cleaner design would either (a) guarantee routing.Init() runs before any
+	// model router is created, or (b) allow fallback routers to reference defaultRM's
+	// already-registered providers without waiting on Init(). Either change would let
+	// this fallback delegate back to defaultRM's shared least-request policy instead of
+	// each SLO router instance carrying its own copy.
 	rm := NewRouterManager()
 	defaultRouter, _ := NewLeastLoadPullingRouter(loadProvider)
 	defaultProvider := func(_ *types.RoutingContext) (types.Router, error) { return defaultRouter, nil }
@@ -80,6 +95,8 @@ func NewSLORouter(modelName string) (types.QueueRouter, error) {
 	rm.RegisterProvider(RouterSLOLeastLoadPulling, defaultProvider)
 	rm.Register(RouterSLOPackLoad, func() (types.Router, error) { return NewPackLoadRouter(loadProvider) })
 	rm.Register(RouterSLOLeastLoad, func() (types.Router, error) { return NewLeastLoadRouter(loadProvider) })
+	// RouterLeastRequest must be registered on the local rm because rm.SetFallback
+	// resolves the provider from rm.routerFactory, populated by rm.Init() below.
 	rm.Register(RouterLeastRequest, NewLeastRequestRouter)
 	rm.Init()
 

--- a/pkg/plugins/gateway/algorithms/slo.go
+++ b/pkg/plugins/gateway/algorithms/slo.go
@@ -80,6 +80,7 @@ func NewSLORouter(modelName string) (types.QueueRouter, error) {
 	rm.RegisterProvider(RouterSLOLeastLoadPulling, defaultProvider)
 	rm.Register(RouterSLOPackLoad, func() (types.Router, error) { return NewPackLoadRouter(loadProvider) })
 	rm.Register(RouterSLOLeastLoad, func() (types.Router, error) { return NewLeastLoadRouter(loadProvider) })
+	rm.Register(RouterLeastRequest, NewLeastRequestRouter)
 	rm.Init()
 
 	sloQueue, err := queue.NewSLOQueue(rm.Select, modelName)
@@ -87,7 +88,7 @@ func NewSLORouter(modelName string) (types.QueueRouter, error) {
 		return nil, err
 	}
 	router := &SLORouter{SLOQueue: sloQueue}
-	if err := SetFallback(router, RouterLeastRequest); err != nil {
+	if err := rm.SetFallback(router, RouterLeastRequest); err != nil {
 		return nil, err
 	}
 	return NewQueueRouter(router, sloQueue)


### PR DESCRIPTION
## Pull Request Description
## Problem

`NewSLORouter` was calling the package-level `SetFallback(router, RouterLeastRequest)`,
which delegates to `defaultRM.SetFallback`. That function blocks until `defaultRM` is
initialized (via `routing.Init()`), with a 5-second timeout.

The race: `cache.InitWithOptions` starts informers which trigger `NewSLORouter` for each
observed model, but `routing.Init()` is only called later inside `gateway.NewServer()`.
The global `defaultRM` is never initialized in time, so every SLO router creation fails
with:

**_failed to initialize model-based queue router: router did not initialized: context deadline exceeded_**



## Fix

Register `RouterLeastRequest` in the local `RouterManager` that `NewSLORouter` already
creates and initializes, then call `rm.SetFallback` on that local manager instead of the
global one. The local `rm.Init()` is called synchronously in `NewSLORouter`, so
`rm.SetFallback` returns immediately with no timing dependency on the gateway startup
sequence.


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>