### PR TITLE
Fix BlockHashes cache key identity

### DIFF
--- a/python/aibrix_kvcache/aibrix_kvcache/cache_hashable.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/cache_hashable.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 from abc import ABC, abstractmethod
 from typing import List, Sequence, TypeAlias
 
@@ -19,7 +20,6 @@ import numpy as np
 from farmhash import FarmHash32
 
 from .common import CachedPyObjectBase
-from .utils import hash_combine_128
 
 
 class KVCacheHashable(ABC):
@@ -230,6 +230,22 @@ class TokenListView(CachedPyObjectBase, KVCacheIds):
 BlockHashList: TypeAlias = List[str]
 
 
+def _digest_block_hashes(data: BlockHashList, block_ntokens: int) -> bytes:
+    hasher = hashlib.blake2b(digest_size=16)
+    hasher.update(block_ntokens.to_bytes(8, "little", signed=False))
+    hasher.update(len(data).to_bytes(8, "little", signed=False))
+    for block_hash in data:
+        encoded = block_hash.encode("utf-8")
+        hasher.update(len(encoded).to_bytes(8, "little", signed=False))
+        hasher.update(encoded)
+    return hasher.digest()
+
+
+def _hash_block_hashes(data: BlockHashList, block_ntokens: int) -> int:
+    digest = _digest_block_hashes(data, block_ntokens)
+    return int.from_bytes(digest[:8], "little", signed=False)
+
+
 def is_block_hash_list_type(data) -> bool:
     if not isinstance(data, List):
         return False
@@ -306,20 +322,19 @@ class BlockHashes(CachedPyObjectBase, KVCacheIds):
     def __eq__(self, other):
         if not isinstance(other, BlockHashes):
             return False
-        # we assume a block hash includes the information of both position and
-        # all tokens belonging to this block, therefore, we only need to check
-        # the last block hash and num of blocks to see if two BlockHashes are
-        # the same
-        return self._data[-1] == other._data[-1] and len(self._data) == len(
-            other._data
+        return (
+            self.block_ntokens == other.block_ntokens
+            and self._data == other._data
         )
 
     def __ne__(self, value):
         return not self.__eq__(value)
 
     def __hash__(self) -> int:
-        # use the last block hash and num of blocks for calculating the hash
-        return hash_combine_128(hash(self._data[-1]), len(self._data))
+        return _hash_block_hashes(self._data, self.block_ntokens)
+
+    def to_bytes(self) -> bytes:
+        return _digest_block_hashes(self._data, self.block_ntokens)
 
 
 class TokenCacheKey(KVCacheHashable, CachedPyObjectBase):
@@ -387,6 +402,11 @@ class BlockCacheKey(KVCacheHashable, CachedPyObjectBase):
         else:
             self._query = BlockHashes(query, block_ntokens)
 
+        if self._prefix is not None:
+            self._all_blocks = self._prefix + self._query
+        else:
+            self._all_blocks = self._query
+
     @property
     def prefix(self):
         return self._prefix
@@ -396,12 +416,12 @@ class BlockCacheKey(KVCacheHashable, CachedPyObjectBase):
         return self._query
 
     def __hash__(self) -> int:
-        return hash(self.query)
+        return hash(self._all_blocks)
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, BlockCacheKey):
             return False
-        return self.query == other.query
+        return self._all_blocks == other._all_blocks
 
     def __len__(self) -> int:
         prefix_len = len(self._prefix) if self._prefix is not None else 0

--- a/python/aibrix_kvcache/aibrix_kvcache/l2/l2_cache.py
+++ b/python/aibrix_kvcache/aibrix_kvcache/l2/l2_cache.py
@@ -886,13 +886,21 @@ class L2Cache(MeasurableBase):
             The cache block keys of the kv tensors.
         """
         if isinstance(query, BlockHashes):
+            assert prefix is None or isinstance(prefix, BlockHashes)
+            if prefix is not None:
+                assert prefix.block_ntokens == query.block_ntokens
+                all = prefix + query
+                prefix_len = len(prefix)
+            else:
+                all = query
+                prefix_len = 0
             for i in range(0, len(query), self.block_ntokens):
+                end = prefix_len + i + self.block_ntokens
+                real_key = all[:end]
                 yield tuple(
                     (
-                        query[i : i + self.block_ntokens],
-                        "".join(query[i : i + self.block_ntokens]).encode(
-                            "utf-8"
-                        ),
+                        real_key,
+                        real_key.to_bytes(),
                     )
                 )
         else:

--- a/python/aibrix_kvcache/tests/test_l1cache.py
+++ b/python/aibrix_kvcache/tests/test_l1cache.py
@@ -14,13 +14,15 @@
 
 import copy
 import random
+import subprocess
+import sys
 from typing import Sequence
 
 import pytest
 import torch
 
 from aibrix_kvcache import TokenListView
-from aibrix_kvcache.cache_hashable import BlockHashes
+from aibrix_kvcache.cache_hashable import BlockHashes, KVCacheKey
 from aibrix_kvcache.l1 import L1Cache
 from aibrix_kvcache.memory import (
     ManagedMemoryRegion, MemoryRegion, TensorPoolAllocator
@@ -61,6 +63,36 @@ def test_cache_initialization(cache_conf_fixture):
 
     assert cache.capacity_nbytes == capacity_nbytes
     assert cache.block_shape == tuple(shape)
+
+
+def test_block_hashes_use_full_sequence_for_identity():
+    first = BlockHashes(["hA", "hB", "hC"], 16)
+    second = BlockHashes(["hX", "hY", "hC"], 16)
+
+    assert first != second
+
+
+def test_block_cache_key_includes_prefix():
+    block_ntokens = 16
+    first = BlockHashes(["hA", "hB", "hC"], block_ntokens)
+    second = BlockHashes(["hX", "hY", "hC"], block_ntokens)
+
+    first_key = KVCacheKey(first[:32], first[32:48])
+    second_key = KVCacheKey(second[:32], second[32:48])
+
+    assert first_key != second_key
+    assert {first_key: "first"}.get(second_key) is None
+
+
+def test_block_hashes_hash_is_stable_across_processes():
+    code = (
+        "from aibrix_kvcache.cache_hashable import BlockHashes; "
+        "print(hash(BlockHashes(['hA', 'hB', 'hC'], 16)))"
+    )
+    first = subprocess.check_output([sys.executable, "-c", code], text=True)
+    second = subprocess.check_output([sys.executable, "-c", code], text=True)
+
+    assert first == second
 
 
 def test_put_and_get_aligned(cache_key_fixture, cache_conf_fixture):

--- a/python/aibrix_kvcache/tests/test_l2cache.py
+++ b/python/aibrix_kvcache/tests/test_l2cache.py
@@ -20,7 +20,11 @@ from typing import List
 import pytest
 import torch
 
-from aibrix_kvcache.cache_hashable import KVCacheKeyTypes, TokenListView
+from aibrix_kvcache.cache_hashable import (
+    BlockHashes,
+    KVCacheKeyTypes,
+    TokenListView,
+)
 from aibrix_kvcache.l2 import KeyBuilder, L2Cache
 from aibrix_kvcache.l2.key_builders import Hasher
 from aibrix_kvcache.memory import (
@@ -318,6 +322,28 @@ async def test_conflicted_puts(compact_layout_enabled, l2cache_fixture, mocker):
         assert get_status.is_not_found()
     release_mrs(put_mrs)
     release_mrs(get_mrs)
+
+
+def test_block_hash_l2_keys_include_prefix(l2cache_fixture):
+    _, spec, l2cache = l2cache_fixture
+    block_ntokens = spec.block_ntokens
+    first = BlockHashes(["hA", "hB", "hC"], block_ntokens)
+    second = BlockHashes(["hX", "hY", "hC"], block_ntokens)
+
+    first_key = tuple(
+        l2cache._cache_block_keys(
+            first[: 2 * block_ntokens], first[2 * block_ntokens :]
+        )
+    )[0]
+    second_key = tuple(
+        l2cache._cache_block_keys(
+            second[: 2 * block_ntokens], second[2 * block_ntokens :]
+        )
+    )[0]
+
+    assert first_key[0] == first
+    assert second_key[0] == second
+    assert first_key[1] != second_key[1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- compare and hash BlockHashes using the full block hash sequence and block size
- include prefix context in BlockCacheKey identity
- build L2 BlockHashes backend keys from the full accumulated block sequence digest
- add regression coverage for the BlockHashes collision case

Fixes #2329

## Testing
- python -m py_compile python/aibrix_kvcache/aibrix_kvcache/cache_hashable.py python/aibrix_kvcache/aibrix_kvcache/l2/l2_cache.py python/aibrix_kvcache/tests/test_l1cache.py python/aibrix_kvcache/tests/test_l2cache.py
- lightweight local reproduction confirming distinct BlockHashes/KVCacheKey values no longer collide

## Not run
- python -m pytest python/aibrix_kvcache/tests/test_l1cache.py::test_block_hashes_use_full_sequence_for_identity python/aibrix_kvcache/tests/test_l1cache.py::test_block_cache_key_includes_prefix python/aibrix_kvcache/tests/test_l1cache.py::test_block_hashes_hash_is_stable_across_processes python/aibrix_kvcache/tests/test_l2cache.py::test_block_hash_l2_keys_include_prefix (local environment is missing test/runtime dependencies such as redis/torch)