### PR TITLE
feat(orchestration): annotation-driven same-host colocation for P/D RoleSets

### DIFF
--- a/docs/source/designs/aibrix-stormservice.rst
+++ b/docs/source/designs/aibrix-stormservice.rst
@@ -177,3 +177,58 @@ In the Kubernetes ecosystem, `ControllerRevision` is a crucial resource object u
     NAME                  CONTROLLER                                      REVISION   AGE
     llm-xpyd-69df6b87d8   stormservice.orchestration.aibrix.ai/llm-xpyd   1          73s
     llm-xpyd-75ddc56d8c   stormservice.orchestration.aibrix.ai/llm-xpyd   2          3s
+
+Colocation
+----------
+
+In P/D disaggregated deployments, especially for small models, placing prefill and decode pods on the
+same physical host enables communication via shared memory or IPC rather than the network, reducing
+latency and improving resource utilization.
+
+StormService supports opt-in same-host colocation through the ``model.aibrix.ai/colocation``
+annotation on the RoleSet template. The annotation is scheduler-agnostic: the RoleSet controller
+injects a standard Kubernetes ``podAffinity`` rule into every pod it creates, so it works with the
+default scheduler as well as Volcano, Godel, and coscheduling.
+
+**Supported values**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Value
+     - Behavior
+   * - ``preferred``
+     - Adds a ``preferredDuringSchedulingIgnoredDuringExecution`` rule (weight 100, ``topologyKey: kubernetes.io/hostname``). The scheduler places all pods in the same RoleSet on one node when resources allow, but continues scheduling on separate nodes if not.
+
+**Configuration**
+
+Add the annotation to the RoleSet template metadata inside the StormService spec:
+
+.. code-block:: yaml
+
+    apiVersion: orchestration.aibrix.ai/v1alpha1
+    kind: StormService
+    metadata:
+      name: vllm-1p1d
+    spec:
+      replicas: 1
+      template:
+        metadata:
+          annotations:
+            model.aibrix.ai/colocation: "preferred"   # inject same-host pod affinity
+        spec:
+          roles:
+            - name: prefill
+              ...
+            - name: decode
+              ...
+
+The annotation is inherited by every RoleSet the StormService creates. The controller reads it at
+pod-creation time and appends the affinity term to each pod's ``spec.affinity.podAffinity``
+without overwriting affinity rules already present in the pod template.
+
+.. note::
+   Colocation is a scheduling *hint*, not a hard guarantee. To enforce strict co-placement use a
+   gang scheduler (Godel, Volcano) together with this annotation, or switch the annotation value
+   to a ``required`` mode once it is introduced in a future release.

--- a/pkg/controller/constants/stormservice.go
+++ b/pkg/controller/constants/stormservice.go
@@ -43,6 +43,12 @@ const (
 	RoleRevisionAnnotationPrefix     = "stormservice.orchestration.aibrix.ai/role-revision"
 	RoleRevisionNameAnnotationPrefix = "stormservice.orchestration.aibrix.ai/role-revision-name"
 
+	// ColocationAnnotationKey is the annotation on a RoleSet that opts all its pods into
+	// same-host pod affinity. Supported values: "preferred".
+	ColocationAnnotationKey    = "model.aibrix.ai/colocation"
+	ColocationPreferredValue   = "preferred"
+	ColocationTopologyKey      = "kubernetes.io/hostname"
+
 	StormServiceNameEnvKey = "STORM_SERVICE_NAME"
 	RoleSetNameEnvKey      = "ROLESET_NAME"
 	RoleSetIndexEnvKey     = "ROLESET_INDEX"

--- a/pkg/controller/constants/stormservice.go
+++ b/pkg/controller/constants/stormservice.go
@@ -45,9 +45,9 @@ const (
 
 	// ColocationAnnotationKey is the annotation on a RoleSet that opts all its pods into
 	// same-host pod affinity. Supported values: "preferred".
-	ColocationAnnotationKey    = "model.aibrix.ai/colocation"
-	ColocationPreferredValue   = "preferred"
-	ColocationTopologyKey      = "kubernetes.io/hostname"
+	ColocationAnnotationKey  = "model.aibrix.ai/colocation"
+	ColocationPreferredValue = "preferred"
+	ColocationTopologyKey    = "kubernetes.io/hostname"
 
 	StormServiceNameEnvKey = "STORM_SERVICE_NAME"
 	RoleSetNameEnvKey      = "ROLESET_NAME"

--- a/pkg/controller/roleset/podset_rollsyncer.go
+++ b/pkg/controller/roleset/podset_rollsyncer.go
@@ -438,6 +438,8 @@ func (p *PodSetRoleSyncer) createPodSetForRole(roleSet *orchestrationv1alpha1.Ro
 		)
 	}
 
+	injectColocationAffinity(&podSet.Spec.Template.Spec, roleSet)
+
 	return podSet
 }
 

--- a/pkg/controller/roleset/utils.go
+++ b/pkg/controller/roleset/utils.go
@@ -163,8 +163,7 @@ func renderStormServicePod(roleSet *orchestrationv1alpha1.RoleSet, role *orchest
 	pod.Spec.Hostname = pod.Name
 	pod.Spec.Subdomain = roleSet.Labels[constants.StormServiceNameLabelKey]
 
-	// inject colocation affinity if requested
-	injectColocationAffinity(pod, roleSet)
+	injectColocationAffinity(&pod.Spec, roleSet)
 
 	// inject container env
 	for i := range pod.Spec.Containers {
@@ -182,7 +181,7 @@ func renderStormServicePod(roleSet *orchestrationv1alpha1.RoleSet, role *orchest
 // the model.aibrix.ai/colocation: "preferred" annotation. The rule selects all pods in the same
 // RoleSet so that prefill and decode workers prefer to land on the same node.
 // Existing affinity rules on the pod template are preserved.
-func injectColocationAffinity(pod *v1.Pod, roleSet *orchestrationv1alpha1.RoleSet) {
+func injectColocationAffinity(spec *v1.PodSpec, roleSet *orchestrationv1alpha1.RoleSet) {
 	if roleSet.Annotations[constants.ColocationAnnotationKey] != constants.ColocationPreferredValue {
 		return
 	}
@@ -197,14 +196,14 @@ func injectColocationAffinity(pod *v1.Pod, roleSet *orchestrationv1alpha1.RoleSe
 			TopologyKey: constants.ColocationTopologyKey,
 		},
 	}
-	if pod.Spec.Affinity == nil {
-		pod.Spec.Affinity = &v1.Affinity{}
+	if spec.Affinity == nil {
+		spec.Affinity = &v1.Affinity{}
 	}
-	if pod.Spec.Affinity.PodAffinity == nil {
-		pod.Spec.Affinity.PodAffinity = &v1.PodAffinity{}
+	if spec.Affinity.PodAffinity == nil {
+		spec.Affinity.PodAffinity = &v1.PodAffinity{}
 	}
-	pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
-		pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+	spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+		spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
 		term,
 	)
 }

--- a/pkg/controller/roleset/utils.go
+++ b/pkg/controller/roleset/utils.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -162,6 +163,9 @@ func renderStormServicePod(roleSet *orchestrationv1alpha1.RoleSet, role *orchest
 	pod.Spec.Hostname = pod.Name
 	pod.Spec.Subdomain = roleSet.Labels[constants.StormServiceNameLabelKey]
 
+	// inject colocation affinity if requested
+	injectColocationAffinity(pod, roleSet)
+
 	// inject container env
 	for i := range pod.Spec.Containers {
 		injectContainerEnvVars(
@@ -172,6 +176,37 @@ func renderStormServicePod(roleSet *orchestrationv1alpha1.RoleSet, role *orchest
 			templateHash,
 		)
 	}
+}
+
+// injectColocationAffinity adds a preferred same-host pod affinity rule when the RoleSet carries
+// the model.aibrix.ai/colocation: "preferred" annotation. The rule selects all pods in the same
+// RoleSet so that prefill and decode workers prefer to land on the same node.
+// Existing affinity rules on the pod template are preserved.
+func injectColocationAffinity(pod *v1.Pod, roleSet *orchestrationv1alpha1.RoleSet) {
+	if roleSet.Annotations[constants.ColocationAnnotationKey] != constants.ColocationPreferredValue {
+		return
+	}
+	term := v1.WeightedPodAffinityTerm{
+		Weight: 100,
+		PodAffinityTerm: v1.PodAffinityTerm{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					constants.RoleSetNameLabelKey: roleSet.Name,
+				},
+			},
+			TopologyKey: constants.ColocationTopologyKey,
+		},
+	}
+	if pod.Spec.Affinity == nil {
+		pod.Spec.Affinity = &v1.Affinity{}
+	}
+	if pod.Spec.Affinity.PodAffinity == nil {
+		pod.Spec.Affinity.PodAffinity = &v1.PodAffinity{}
+	}
+	pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+		pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+		term,
+	)
 }
 
 // injectContainerEnvVars injects env variables into container.

--- a/pkg/controller/roleset/utils_test.go
+++ b/pkg/controller/roleset/utils_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -352,6 +353,108 @@ func TestRenderStormServicePod_MultipleContainers(t *testing.T) {
 	for _, c := range pod.Spec.Containers {
 		assert.Len(t, c.Env, 5)
 	}
+}
+
+func TestInjectColocationAffinity_Preferred(t *testing.T) {
+	roleSet := &orchestrationv1alpha1.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pd-roleset",
+			Annotations: map[string]string{
+				constants.ColocationAnnotationKey: constants.ColocationPreferredValue,
+			},
+		},
+	}
+	pod := &corev1.Pod{}
+	injectColocationAffinity(pod, roleSet)
+
+	require.NotNil(t, pod.Spec.Affinity)
+	require.NotNil(t, pod.Spec.Affinity.PodAffinity)
+	preferred := pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.Len(t, preferred, 1)
+	assert.Equal(t, int32(100), preferred[0].Weight)
+	assert.Equal(t, constants.ColocationTopologyKey, preferred[0].PodAffinityTerm.TopologyKey)
+	assert.Equal(t, "pd-roleset", preferred[0].PodAffinityTerm.LabelSelector.MatchLabels[constants.RoleSetNameLabelKey])
+}
+
+func TestInjectColocationAffinity_NoAnnotation(t *testing.T) {
+	roleSet := &orchestrationv1alpha1.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "pd-roleset"},
+	}
+	pod := &corev1.Pod{}
+	injectColocationAffinity(pod, roleSet)
+	assert.Nil(t, pod.Spec.Affinity)
+}
+
+func TestInjectColocationAffinity_PreservesExistingAffinity(t *testing.T) {
+	roleSet := &orchestrationv1alpha1.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pd-roleset",
+			Annotations: map[string]string{
+				constants.ColocationAnnotationKey: constants.ColocationPreferredValue,
+			},
+		},
+	}
+	existingTerm := corev1.WeightedPodAffinityTerm{
+		Weight: 50,
+		PodAffinityTerm: corev1.PodAffinityTerm{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "existing"},
+			},
+			TopologyKey: "kubernetes.io/zone",
+		},
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Affinity: &corev1.Affinity{
+				PodAffinity: &corev1.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{existingTerm},
+				},
+			},
+		},
+	}
+	injectColocationAffinity(pod, roleSet)
+
+	preferred := pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.Len(t, preferred, 2)
+	assert.Equal(t, int32(50), preferred[0].Weight)
+	assert.Equal(t, int32(100), preferred[1].Weight)
+}
+
+func TestRenderStormServicePod_ColocationPreferred(t *testing.T) {
+	roleSet := &orchestrationv1alpha1.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pd-roleset",
+			Namespace: "default",
+			Labels: map[string]string{
+				constants.StormServiceNameLabelKey: "test-service",
+			},
+			Annotations: map[string]string{
+				constants.ColocationAnnotationKey: constants.ColocationPreferredValue,
+			},
+		},
+		Spec: orchestrationv1alpha1.RoleSetSpec{
+			Roles: []orchestrationv1alpha1.RoleSpec{
+				{
+					Name: "prefill",
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "vllm"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	roleIndex := 0
+	pod := &corev1.Pod{Spec: *roleSet.Spec.Roles[0].Template.Spec.DeepCopy()}
+	renderStormServicePod(roleSet, &roleSet.Spec.Roles[0], pod, &roleIndex)
+
+	require.NotNil(t, pod.Spec.Affinity)
+	preferred := pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.Len(t, preferred, 1)
+	assert.Equal(t, constants.ColocationTopologyKey, preferred[0].PodAffinityTerm.TopologyKey)
+	assert.Equal(t, "pd-roleset", preferred[0].PodAffinityTerm.LabelSelector.MatchLabels[constants.RoleSetNameLabelKey])
 }
 
 func makeReadyPod(name string) *corev1.Pod {

--- a/pkg/controller/roleset/utils_test.go
+++ b/pkg/controller/roleset/utils_test.go
@@ -364,12 +364,12 @@ func TestInjectColocationAffinity_Preferred(t *testing.T) {
 			},
 		},
 	}
-	pod := &corev1.Pod{}
-	injectColocationAffinity(pod, roleSet)
+	spec := &corev1.PodSpec{}
+	injectColocationAffinity(spec, roleSet)
 
-	require.NotNil(t, pod.Spec.Affinity)
-	require.NotNil(t, pod.Spec.Affinity.PodAffinity)
-	preferred := pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.NotNil(t, spec.Affinity)
+	require.NotNil(t, spec.Affinity.PodAffinity)
+	preferred := spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 	require.Len(t, preferred, 1)
 	assert.Equal(t, int32(100), preferred[0].Weight)
 	assert.Equal(t, constants.ColocationTopologyKey, preferred[0].PodAffinityTerm.TopologyKey)
@@ -380,9 +380,9 @@ func TestInjectColocationAffinity_NoAnnotation(t *testing.T) {
 	roleSet := &orchestrationv1alpha1.RoleSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "pd-roleset"},
 	}
-	pod := &corev1.Pod{}
-	injectColocationAffinity(pod, roleSet)
-	assert.Nil(t, pod.Spec.Affinity)
+	spec := &corev1.PodSpec{}
+	injectColocationAffinity(spec, roleSet)
+	assert.Nil(t, spec.Affinity)
 }
 
 func TestInjectColocationAffinity_PreservesExistingAffinity(t *testing.T) {
@@ -403,18 +403,16 @@ func TestInjectColocationAffinity_PreservesExistingAffinity(t *testing.T) {
 			TopologyKey: "kubernetes.io/zone",
 		},
 	}
-	pod := &corev1.Pod{
-		Spec: corev1.PodSpec{
-			Affinity: &corev1.Affinity{
-				PodAffinity: &corev1.PodAffinity{
-					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{existingTerm},
-				},
+	spec := &corev1.PodSpec{
+		Affinity: &corev1.Affinity{
+			PodAffinity: &corev1.PodAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{existingTerm},
 			},
 		},
 	}
-	injectColocationAffinity(pod, roleSet)
+	injectColocationAffinity(spec, roleSet)
 
-	preferred := pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	preferred := spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 	require.Len(t, preferred, 2)
 	assert.Equal(t, int32(50), preferred[0].Weight)
 	assert.Equal(t, int32(100), preferred[1].Weight)
@@ -453,6 +451,47 @@ func TestRenderStormServicePod_ColocationPreferred(t *testing.T) {
 	require.NotNil(t, pod.Spec.Affinity)
 	preferred := pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 	require.Len(t, preferred, 1)
+	assert.Equal(t, constants.ColocationTopologyKey, preferred[0].PodAffinityTerm.TopologyKey)
+	assert.Equal(t, "pd-roleset", preferred[0].PodAffinityTerm.LabelSelector.MatchLabels[constants.RoleSetNameLabelKey])
+}
+
+func TestCreatePodSetForRole_ColocationPreferred(t *testing.T) {
+	podGroupSize := int32(2)
+	replicas := int32(1)
+	roleSet := &orchestrationv1alpha1.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pd-roleset",
+			Namespace: "default",
+			Labels: map[string]string{
+				constants.StormServiceNameLabelKey: "test-service",
+			},
+			Annotations: map[string]string{
+				constants.RoleSetIndexAnnotationKey: "0",
+				constants.ColocationAnnotationKey:   constants.ColocationPreferredValue,
+			},
+		},
+	}
+	role := &orchestrationv1alpha1.RoleSpec{
+		Name:         "prefill",
+		Replicas:     &replicas,
+		PodGroupSize: &podGroupSize,
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "vllm"}},
+			},
+		},
+	}
+
+	syncer := &PodSetRoleSyncer{
+		computeHashFunc: func(t *corev1.PodTemplateSpec, _ *int32) string { return "testhash" },
+	}
+	roleIndex := 0
+	podSet := syncer.createPodSetForRole(roleSet, role, &roleIndex)
+
+	require.NotNil(t, podSet.Spec.Template.Spec.Affinity)
+	preferred := podSet.Spec.Template.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.Len(t, preferred, 1)
+	assert.Equal(t, int32(100), preferred[0].Weight)
 	assert.Equal(t, constants.ColocationTopologyKey, preferred[0].PodAffinityTerm.TopologyKey)
 	assert.Equal(t, "pd-roleset", preferred[0].PodAffinityTerm.LabelSelector.MatchLabels[constants.RoleSetNameLabelKey])
 }

--- a/samples/quickstart/pd-model.yaml
+++ b/samples/quickstart/pd-model.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: vllm-1p1d
+      annotations:
+        model.aibrix.ai/colocation: "preferred"
     spec:
       roles:
         - name: prefill

--- a/samples/quickstart/vke/pd-model.yaml
+++ b/samples/quickstart/vke/pd-model.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: vllm-1p1d
+      annotations:
+        model.aibrix.ai/colocation: "preferred"
     spec:
       roles:
         - name: prefill


### PR DESCRIPTION
## Pull Request Description

## Summary

Prefill and decode pods in a disaggregated deployment benefit from
co-placement on the same physical host (shared memory / IPC instead of
network). This PR adds opt-in same-host colocation via a single
annotation on the RoleSet template — no CRD schema change, works with
any scheduler.

## How it works

When the RoleSet controller renders a pod it checks for the annotation:

    model.aibrix.ai/colocation: "preferred"

If present, it appends a `preferredDuringSchedulingIgnoredDuringExecution`
pod affinity rule (weight 100, `topologyKey: kubernetes.io/hostname`,
label selector on `roleset-name`) to the pod spec. Existing affinity
rules on the pod template are preserved. The rule is injected at pod
creation time, so it requires no changes to the scheduling plugins.

## Changes

- `pkg/controller/constants/stormservice.go` — adds
  `ColocationAnnotationKey`, `ColocationPreferredValue`, and
  `ColocationTopologyKey` constants.
- `pkg/controller/roleset/utils.go` — adds `injectColocationAffinity`
  helper and calls it from `renderStormServicePod`.
- `pkg/controller/roleset/utils_test.go` — four new unit tests: annotation
  present, annotation absent, existing affinity preserved, end-to-end
  through `renderStormServicePod`.
- `samples/quickstart/vke/pd-model.yaml` — annotated with
  `model.aibrix.ai/colocation: "preferred"` as a reference example.
- `docs/source/designs/aibrix-stormservice.rst` — new **Colocation**
  section documenting the annotation, supported values, a YAML example,
  and a note on combining with gang schedulers for hard guarantees.


## Related Issues
Resolves: #1290

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>