### PR TITLE
fix(docs): document AIBRIX_STATESYNC_ENABLED requirement and fix Helm chart env var name

### DIFF
--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -88,7 +88,7 @@ gatewayPlugin:
       AIBRIX_PREFIX_CACHE_POD_RUNNING_REQUEST_IMBALANCE_ABS_COUNT: "16"
       AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR: "2"
       AIBRIX_PREFILL_REQUEST_TIMEOUT: "60"
-      AIBRIX_REDISSYNC_ENABLED: "false"
+      AIBRIX_STATESYNC_ENABLED: "false"
   dependencies:
     redis:
       host: "" # aibrix-redis-master

--- a/docs/source/production/gateway.rst
+++ b/docs/source/production/gateway.rst
@@ -57,11 +57,19 @@ Enabling Redis for Multi-Replica Deployments
 
 When running more than one gateway plugin replica, shared state is required so that all
 instances agree on routing decisions (e.g. prefix-cache block assignments, rate-limit counters).
-The gateway plugin reads the ``REDIS_HOST`` environment variable at startup to connect to a
-Redis instance. If the variable is unset or Redis is unreachable, each replica operates with
-in-process state only, which causes inconsistent routing across pods.
+Two settings must both be configured:
 
-Enable Redis by pointing the gateway plugin at the bundled Redis instance:
+1. **Connect to Redis** — the gateway plugin reads the ``REDIS_HOST`` environment variable at
+   startup. If the variable is unset or Redis is unreachable, each replica operates with
+   in-process state only, which causes inconsistent routing across pods.
+
+2. **Enable cross-replica state sync** — setting ``AIBRIX_STATESYNC_ENABLED=true`` activates
+   the Redis-backed delta-sync mechanism that propagates prefix-cache state across replicas.
+   Without this flag, the gateway connects to Redis for other purposes (e.g. rate limiting)
+   but **does not** synchronize prefix-cache routing state between pods, so multi-replica
+   ``prefix-cache`` routing will still produce inconsistent decisions.
+
+Enable both by updating your ``values.yaml`` override:
 
 .. code-block:: yaml
 
@@ -70,10 +78,18 @@ Enable Redis by pointing the gateway plugin at the bundled Redis instance:
         redis:
           host: ""   # leave empty to use the chart-managed Redis (aibrix-redis-master)
           port: 6379
+      container:
+        envs:
+          AIBRIX_STATESYNC_ENABLED: "true"
 
 The Helm chart sets ``REDIS_HOST`` automatically from ``gatewayPlugin.dependencies.redis.host``,
 defaulting to ``<release-name>-redis-master`` when the field is empty. For an external Redis
 cluster, set ``host`` to the service hostname or IP of your Redis endpoint.
+
+.. note::
+    ``AIBRIX_STATESYNC_ENABLED`` defaults to ``false``. It must be explicitly set to ``true``
+    for cross-replica state sync to activate. Omitting this flag is the most common cause of
+    inconsistent ``prefix-cache`` routing when scaling the gateway plugin beyond one replica.
 
 Sizing Redis
 ~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Description

- **Fix Helm chart bug**: `dist/chart/values.yaml` had `AIBRIX_REDISSYNC_ENABLED`
  which the Go code never reads — statesync was silently never activated even when
  set to `"true"`. Renamed to `AIBRIX_STATESYNC_ENABLED` to match what
  `cmd/plugins/main.go` actually reads.

- **Update docs**: The "Enabling Redis for Multi-Replica Deployments" section only
  described the Redis connection (`REDIS_HOST`) but omitted that
  `AIBRIX_STATESYNC_ENABLED=true` is also required to activate cross-replica
  prefix-cache state sync. Added a clear two-step explanation, a concrete
  `values.yaml` snippet, and a note calling out the `false` default as the most
  common misconfiguration for multi-replica `prefix-cache` routing.

## Related Issues
Resolves: #2351

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>