### PR TITLE
fix(chart): remove redundant openTelemetry provider and prioritize backendRefs

### DIFF
--- a/dist/chart/templates/gateway-instance/gateway.yaml
+++ b/dist/chart/templates/gateway-instance/gateway.yaml
@@ -42,7 +42,9 @@ spec:
         {{- if .Values.openTelemetry.serviceName }}
         backendRefs:
           - name: {{ .Values.openTelemetry.serviceName }}
+            {{- if .Values.openTelemetry.namespace }}
             namespace: {{ .Values.openTelemetry.namespace }}
+            {{- end }}
             port: {{ .Values.openTelemetry.port | default 4317 }}
         {{- else }}
         host: {{ .Values.openTelemetry.host | quote }}

--- a/dist/chart/templates/gateway-instance/gateway.yaml
+++ b/dist/chart/templates/gateway-instance/gateway.yaml
@@ -39,9 +39,15 @@ spec:
       samplingRate: {{ .Values.openTelemetry.samplingRate | default 100 }}
       provider:
         type: OpenTelemetry
-        openTelemetry:
-          host: {{ .Values.openTelemetry.host | quote }}
-          port: {{ .Values.openTelemetry.port | default 4317 }}
+        {{- if .Values.openTelemetry.serviceName }}
+        backendRefs:
+          - name: {{ .Values.openTelemetry.serviceName }}
+            namespace: {{ .Values.openTelemetry.namespace }}
+            port: {{ .Values.openTelemetry.port | default 4317 }}
+        {{- else }}
+        host: {{ .Values.openTelemetry.host | quote }}
+        port: {{ .Values.openTelemetry.port | default 4317 }}
+        {{- end }}
 {{- end }}
   provider:
     type: Kubernetes

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -309,6 +309,12 @@ certmanager:
 
 openTelemetry:
   enable: false
+  # serviceName/namespace takes precedence over host.
+  # If serviceName is provided, it will be used directly in backendRefs.
+  # The 'host' field below will be ignored.
+  serviceName: ""
+  namespace: ""
+  # Only takes effect if serviceName is empty.
   host: ""
   port: 4317
   # -- (Envoy-side only) The sampling rate for distributed tracing.


### PR DESCRIPTION


## Pull Request Description

This PR fixes a schema validation error in the `EnvoyProxy` resource introduced in a previous PR. 

**Changes included:**
- **Removed:** The deprecated/invalid `openTelemetry` nested field under `spec.tracing.provider` in `gateway.yaml`.
- **Updated:** Transitioned the OTel provider routing to use standard Kubernetes `backendRefs`. This aligns with the Gateway API specifications and ensures compatibility with current Envoy Gateway releases (e.g., v1.5.4+).

## Related Issues
Resolves: #2255