### PR TITLE
fix(gateway): make gRPC max message size configurable via env var

### DIFF
--- a/cmd/plugins/main.go
+++ b/cmd/plugins/main.go
@@ -48,6 +48,11 @@ import (
 	"sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
 
+const (
+	defaultGRPCMaxMessageSizeBytes = 4 * 1024 * 1024
+	envGRPCMaxMessageSizeBytes     = "AIBRIX_GRPC_MAX_MESSAGE_SIZE_BYTES"
+)
+
 var (
 	grpcAddr        string
 	httpAddr        string
@@ -196,6 +201,13 @@ func main() {
 		}
 		opts = append(opts, grpc.StatsHandler(otelgrpc.NewServerHandler()))
 	}
+
+	grpcMaxMessageSize := utils.LoadEnvInt(envGRPCMaxMessageSizeBytes, defaultGRPCMaxMessageSizeBytes)
+	opts = append(opts,
+		grpc.MaxRecvMsgSize(grpcMaxMessageSize),
+		grpc.MaxSendMsgSize(grpcMaxMessageSize),
+	)
+	klog.Infof("gRPC max message size: %d bytes", grpcMaxMessageSize)
 
 	s := grpc.NewServer(opts...)
 

--- a/cmd/plugins/main.go
+++ b/cmd/plugins/main.go
@@ -203,11 +203,7 @@ func main() {
 	}
 
 	grpcMaxMessageSize := utils.LoadEnvInt(envGRPCMaxMessageSizeBytes, defaultGRPCMaxMessageSizeBytes)
-	opts = append(opts,
-		grpc.MaxRecvMsgSize(grpcMaxMessageSize),
-		grpc.MaxSendMsgSize(grpcMaxMessageSize),
-	)
-	klog.Infof("gRPC max message size: %d bytes", grpcMaxMessageSize)
+	opts = append(opts, grpc.MaxRecvMsgSize(grpcMaxMessageSize))
 
 	s := grpc.NewServer(opts...)
 

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -89,6 +89,7 @@ gatewayPlugin:
       AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR: "2"
       AIBRIX_PREFILL_REQUEST_TIMEOUT: "60"
       AIBRIX_STATESYNC_ENABLED: "false"
+      AIBRIX_GRPC_MAX_MESSAGE_SIZE_BYTES: "4194304" # 4MB
   dependencies:
     redis:
       host: "" # aibrix-redis-master

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -200,7 +200,7 @@ gateway:
             memory: 32Mi
   clientTrafficPolicy:
     connection:
-      bufferLimit: 4194304  # 4MiB
+      bufferLimit: 4194304  # 4MiB — keep in sync with AIBRIX_GRPC_MAX_MESSAGE_SIZE_BYTES
       connectionLimit:
         value: 1024
     http2:

--- a/docs/source/features/gateway-plugins.rst
+++ b/docs/source/features/gateway-plugins.rst
@@ -642,3 +642,51 @@ Example (Kubernetes Secret)
    export PROMETHEUS_ENDPOINT="http://prometheus-operated.prometheus.svc:9090"
    export PROMETHEUS_BASIC_AUTH_SECRET_NAME="prometheus-basic-auth"
    export PROMETHEUS_BASIC_AUTH_SECRET_NAMESPACE="aibrix-system"
+
+Message Size Configuration
+---------------------------
+
+Two independent size limits apply to requests flowing through the gateway. Both default to **4 MiB** and must be kept in sync when you raise or lower the limit.
+
+Gateway Plugin gRPC Buffer (``AIBRIX_GRPC_MAX_MESSAGE_SIZE_BYTES``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Envoy communicates with the AIBrix gateway plugin over an external-processing (ext_proc) gRPC connection. This env var controls the maximum size of a single gRPC message on that connection. Requests or responses larger than this value are rejected before they reach routing logic.
+
+Configure it under ``gatewayPlugin.envs`` in ``values.yaml``:
+
+.. code-block:: yaml
+
+   gatewayPlugin:
+     envs:
+       AIBRIX_GRPC_MAX_MESSAGE_SIZE_BYTES: "4194304"  # 4 MiB
+
+Envoy Connection Buffer (``clientTrafficPolicy.connection.bufferLimit``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Envoy itself buffers each incoming HTTP connection up to ``bufferLimit`` bytes before it begins processing. If a request body exceeds this limit Envoy returns a ``413`` before the ext_proc filter is even invoked.
+
+Configure it under ``envoyGateway.clientTrafficPolicy`` in ``values.yaml``:
+
+.. code-block:: yaml
+
+   envoyGateway:
+     clientTrafficPolicy:
+       connection:
+         bufferLimit: 4194304  # 4 MiB
+
+Keeping the two values in sync
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Because Envoy drops the connection before the gateway plugin sees it when ``bufferLimit`` is the binding limit, both values should always be set to the same size. When you need to support larger payloads (e.g. large KV-cache state-sync messages), update **both** fields together:
+
+.. code-block:: yaml
+
+   gatewayPlugin:
+     envs:
+       AIBRIX_GRPC_MAX_MESSAGE_SIZE_BYTES: "16777216"  # 16 MiB
+
+   envoyGateway:
+     clientTrafficPolicy:
+       connection:
+         bufferLimit: 16777216  # 16 MiB


### PR DESCRIPTION
## Pull Request Description

The gateway plugin's gRPC server previously used the default message size
limit, which could cause failures for large request/response payloads. This
change makes the limit configurable without requiring a rebuild.

- Add `AIBRIX_GRPC_MAX_MESSAGE_SIZE_BYTES` env var (default: 4MB) to control
  both `MaxRecvMsgSize` and `MaxSendMsgSize` on the gRPC server
- Expose the env var in the Helm chart `values.yaml` with the 4MB default

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>