### PR TITLE
[Bug] Propagate Redis password to KubernetesJob batch worker

### DIFF
--- a/python/aibrix/aibrix/batch/manifest/storage_env.py
+++ b/python/aibrix/aibrix/batch/manifest/storage_env.py
@@ -144,6 +144,13 @@ def _redis_env() -> List[Dict[str, Any]]:
     metadata share the same Service DNS name. Dev (metadata on host): set
     ``REDIS_HOST=localhost`` for the metadata process and
     ``WORKER_REDIS_HOST=<service-dns>`` for the workers.
+
+    On an authenticated metastore, set ``WORKER_REDIS_PASSWORD_SECRET_NAME`` and
+    ``WORKER_REDIS_PASSWORD_SECRET_KEY`` to inject ``REDIS_PASSWORD`` from a
+    Secret via ``valueFrom.secretKeyRef``. The worker reads it through
+    ``envs.STORAGE_REDIS_PASSWORD`` (which falls back to ``REDIS_PASSWORD``).
+    Nothing is injected when either var is unset, so the Deployment path and
+    no-auth dev setups are unchanged.
     """
     worker_host = (
         os.getenv("WORKER_REDIS_HOST")
@@ -151,9 +158,20 @@ def _redis_env() -> List[Dict[str, Any]]:
         or "aibrix-redis-master.aibrix-system.svc.cluster.local"
     )
     worker_port = os.getenv("WORKER_REDIS_PORT") or str(envs.STORAGE_REDIS_PORT)
-    return [
+    env: List[Dict[str, Any]] = [
         {"name": "REDIS_HOST", "value": worker_host},
         {"name": "REDIS_PORT", "value": worker_port},
         {"name": "REDIS_DB", "value": str(envs.STORAGE_REDIS_DB)},
-        # Password cannot be passed in env; set it via a secret ref.
     ]
+    secret_name = os.getenv("WORKER_REDIS_PASSWORD_SECRET_NAME")
+    secret_key = os.getenv("WORKER_REDIS_PASSWORD_SECRET_KEY")
+    if secret_name and secret_key:
+        env.append(
+            {
+                "name": "REDIS_PASSWORD",
+                "valueFrom": {
+                    "secretKeyRef": {"name": secret_name, "key": secret_key},
+                },
+            }
+        )
+    return env

--- a/python/aibrix/aibrix/batch/manifest/storage_env.py
+++ b/python/aibrix/aibrix/batch/manifest/storage_env.py
@@ -37,7 +37,10 @@ import os
 from typing import Any, Dict, List
 
 from aibrix import envs
+from aibrix.logger import init_logger
 from aibrix.storage import StorageType
+
+logger = init_logger(__name__)
 
 
 def build_storage_env() -> List[Dict[str, Any]]:
@@ -150,7 +153,8 @@ def _redis_env() -> List[Dict[str, Any]]:
     Secret via ``valueFrom.secretKeyRef``. The worker reads it through
     ``envs.STORAGE_REDIS_PASSWORD`` (which falls back to ``REDIS_PASSWORD``).
     Nothing is injected when either var is unset, so the Deployment path and
-    no-auth dev setups are unchanged.
+    no-auth dev setups are unchanged. A partial config, or a metastore password
+    with no secret ref, is logged as a warning.
     """
     worker_host = (
         os.getenv("WORKER_REDIS_HOST")
@@ -173,5 +177,17 @@ def _redis_env() -> List[Dict[str, Any]]:
                     "secretKeyRef": {"name": secret_name, "key": secret_key},
                 },
             }
+        )
+    elif secret_name or secret_key:
+        logger.warning(
+            "Ignoring partial worker Redis password config; set both "
+            "WORKER_REDIS_PASSWORD_SECRET_NAME and "
+            "WORKER_REDIS_PASSWORD_SECRET_KEY to inject REDIS_PASSWORD."
+        )
+    elif envs.STORAGE_REDIS_PASSWORD:
+        logger.warning(
+            "Metastore Redis password is set but no worker secret ref is "
+            "configured; set WORKER_REDIS_PASSWORD_SECRET_NAME and "
+            "WORKER_REDIS_PASSWORD_SECRET_KEY so workers can authenticate."
         )
     return env

--- a/python/aibrix/tests/batch/test_manifest_renderer.py
+++ b/python/aibrix/tests/batch/test_manifest_renderer.py
@@ -640,6 +640,66 @@ class TestMetastoreEnv:
         env_names = {e["name"] for e in _worker_container(m)["env"]}
         assert "REDIS_PASSWORD" not in env_names
 
+    def test_worker_redis_password_partial_config_warns(
+        self, renderer_factory, monkeypatch
+    ):
+        """A half-configured secret (only the name or only the key) injects no
+        REDIS_PASSWORD and logs a warning so the misconfiguration is visible."""
+        from unittest import mock
+
+        from aibrix.batch.manifest import storage_env
+        from aibrix.batch.storage import batch_metastore
+        from aibrix.storage import StorageType
+
+        monkeypatch.setattr(
+            batch_metastore, "get_metastore_type", lambda: StorageType.REDIS
+        )
+        monkeypatch.setenv("WORKER_REDIS_PASSWORD_SECRET_NAME", "aibrix-redis")
+        monkeypatch.delenv("WORKER_REDIS_PASSWORD_SECRET_KEY", raising=False)
+        log = mock.Mock()
+        monkeypatch.setattr(storage_env, "logger", log)
+
+        r = renderer_factory(
+            templates=[_vllm_template(count=1)],
+            profiles=[_profile()],
+        )
+        m = r.render(session_id="s1", spec=_spec())
+        env_names = {e["name"] for e in _worker_container(m)["env"]}
+        assert "REDIS_PASSWORD" not in env_names
+        log.warning.assert_called_once()
+        assert "partial" in log.warning.call_args.args[0].lower()
+
+    def test_worker_redis_password_warns_when_metastore_password_unwired(
+        self, renderer_factory, monkeypatch
+    ):
+        """A metastore password with no worker secret ref leaves the worker
+        unable to authenticate, so the renderer logs a warning."""
+        from unittest import mock
+
+        from aibrix import envs
+        from aibrix.batch.manifest import storage_env
+        from aibrix.batch.storage import batch_metastore
+        from aibrix.storage import StorageType
+
+        monkeypatch.setattr(
+            batch_metastore, "get_metastore_type", lambda: StorageType.REDIS
+        )
+        monkeypatch.delenv("WORKER_REDIS_PASSWORD_SECRET_NAME", raising=False)
+        monkeypatch.delenv("WORKER_REDIS_PASSWORD_SECRET_KEY", raising=False)
+        monkeypatch.setattr(envs, "STORAGE_REDIS_PASSWORD", "s3cr3t")
+        log = mock.Mock()
+        monkeypatch.setattr(storage_env, "logger", log)
+
+        r = renderer_factory(
+            templates=[_vllm_template(count=1)],
+            profiles=[_profile()],
+        )
+        m = r.render(session_id="s1", spec=_spec())
+        env_names = {e["name"] for e in _worker_container(m)["env"]}
+        assert "REDIS_PASSWORD" not in env_names
+        log.warning.assert_called_once()
+        assert "no worker secret ref" in log.warning.call_args.args[0]
+
 
 class TestMockEngineOverrideNoop:
     def test_mock_template_ignores_engine_args_override(self, renderer_factory, caplog):

--- a/python/aibrix/tests/batch/test_manifest_renderer.py
+++ b/python/aibrix/tests/batch/test_manifest_renderer.py
@@ -593,6 +593,53 @@ class TestMetastoreEnv:
         assert env["REDIS_HOST"] == "redis-shared.aibrix.svc"
         assert env["REDIS_PORT"] == "16379"
 
+    def test_worker_redis_password_injected_as_secret_ref(
+        self, renderer_factory, monkeypatch
+    ):
+        """An authenticated metastore needs the worker to receive the Redis
+        password. It is delivered via a Secret reference so the password is
+        never written into the rendered pod spec as a literal value."""
+        from aibrix.batch.storage import batch_metastore
+        from aibrix.storage import StorageType
+
+        monkeypatch.setattr(
+            batch_metastore, "get_metastore_type", lambda: StorageType.REDIS
+        )
+        monkeypatch.setenv("WORKER_REDIS_PASSWORD_SECRET_NAME", "aibrix-redis")
+        monkeypatch.setenv("WORKER_REDIS_PASSWORD_SECRET_KEY", "redis-password")
+
+        r = renderer_factory(
+            templates=[_vllm_template(count=1)],
+            profiles=[_profile()],
+        )
+        m = r.render(session_id="s1", spec=_spec())
+        env = {e["name"]: e for e in _worker_container(m)["env"]}
+        assert "value" not in env["REDIS_PASSWORD"]
+        secret_ref = env["REDIS_PASSWORD"]["valueFrom"]["secretKeyRef"]
+        assert secret_ref == {"name": "aibrix-redis", "key": "redis-password"}
+
+    def test_redis_password_secret_ref_omitted_when_unset(
+        self, renderer_factory, monkeypatch
+    ):
+        """Without the Secret env vars the worker emits no REDIS_PASSWORD entry,
+        so the Deployment path and no-auth dev setups stay unchanged."""
+        from aibrix.batch.storage import batch_metastore
+        from aibrix.storage import StorageType
+
+        monkeypatch.setattr(
+            batch_metastore, "get_metastore_type", lambda: StorageType.REDIS
+        )
+        monkeypatch.delenv("WORKER_REDIS_PASSWORD_SECRET_NAME", raising=False)
+        monkeypatch.delenv("WORKER_REDIS_PASSWORD_SECRET_KEY", raising=False)
+
+        r = renderer_factory(
+            templates=[_vllm_template(count=1)],
+            profiles=[_profile()],
+        )
+        m = r.render(session_id="s1", spec=_spec())
+        env_names = {e["name"] for e in _worker_container(m)["env"]}
+        assert "REDIS_PASSWORD" not in env_names
+
 
 class TestMockEngineOverrideNoop:
     def test_mock_template_ignores_engine_args_override(self, renderer_factory, caplog):


### PR DESCRIPTION
## Pull Request Description
In `KubernetesJob` (self-hosting) mode the batch worker runs its own metastore I/O and inherits the metadata service's Redis configuration from `build_metastore_env()` in `aibrix/batch/manifest/storage_env.py`. `_redis_env()` emitted `REDIS_HOST`, `REDIS_PORT`, and `REDIS_DB` only, omitting the password. On a Redis that requires authentication the worker connected unauthenticated and metastore I/O failed, so the batch produced no results. The `Kubernetes` (Deployment) path is unaffected, since it does its I/O in the metadata process.

`_redis_env()` now appends a `REDIS_PASSWORD` env sourced from `valueFrom.secretKeyRef` when both `WORKER_REDIS_PASSWORD_SECRET_NAME` and `WORKER_REDIS_PASSWORD_SECRET_KEY` are set, mirroring the existing `WORKER_REDIS_HOST` override. The password is delivered through a Secret, never a literal pod-spec value. The worker reads it via `envs.STORAGE_REDIS_PASSWORD`, which already falls back to `REDIS_PASSWORD` (`aibrix/envs.py`). `create_storage(StorageType.REDIS)` then resolves it in `storage/factory.py`. When either variable is unset no entry is injected, so the Deployment path and no-auth dev setups are unchanged.
Two renderer tests cover the injection and the unset path; the injection test asserts `REDIS_PASSWORD` carries no literal `value`, only a `secretKeyRef`:

```
pytest tests/batch/test_manifest_renderer.py -k redis_password -v
tests/batch/test_manifest_renderer.py::TestMetastoreEnv::test_worker_redis_password_injected_as_secret_ref PASSED
tests/batch/test_manifest_renderer.py::TestMetastoreEnv::test_redis_password_secret_ref_omitted_when_unset PASSED
2 passed, 35 deselected
```

The full file passes with no regressions (`37 passed`).

## Related Issues
Resolves: #2262

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>