### PR TITLE
feat(autoscaler): support Kubernetes external metrics

### DIFF
--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -248,6 +248,10 @@ jobs:
           kind get kubeconfig --name installation-test > /tmp/admin.conf
           export KUBECONFIG=/tmp/admin.conf
           make test-e2e
+          export EXTERNAL_METRICS_E2E_CLUSTER=kind
+          export EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER=true
+          export KIND_CLUSTER_NAME=installation-test
+          make test-e2e-external-metrics
 
       - name: Clean up
         run: kind delete cluster --name installation-test

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,10 @@ test-integration-controller: manifests fmt vet envtest ginkgo
 test-e2e:
 	./test/run-e2e-tests.sh
 
+.PHONY: test-e2e-external-metrics
+test-e2e-external-metrics: ## Run external metrics autoscaler e2e against local minikube.
+	./test/run-external-metrics-e2e.sh
+
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter & yamllint
 	$(GOLANGCI_LINT) run

--- a/config/rbac/controller-manager/role.yaml
+++ b/config/rbac/controller-manager/role.yaml
@@ -74,6 +74,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - external.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+- apiGroups:
   - autoscaling.aibrix.ai
   resources:
   - podautoscalers

--- a/pkg/controller/podautoscaler/metrics/collector.go
+++ b/pkg/controller/podautoscaler/metrics/collector.go
@@ -88,7 +88,7 @@ func collectFromExternal(ctx context.Context, spec types.CollectionSpec, fetcher
 	dummyPod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "external-source",
-			Namespace: "default",
+			Namespace: spec.Namespace,
 		},
 	}
 	value, err := fetcher.FetchPodMetrics(ctx, dummyPod, spec.MetricSource)

--- a/pkg/controller/podautoscaler/metrics/collector_test.go
+++ b/pkg/controller/podautoscaler/metrics/collector_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	autoscalingv1alpha1 "github.com/vllm-project/aibrix/api/autoscaling/v1alpha1"
+	patypes "github.com/vllm-project/aibrix/pkg/controller/podautoscaler/types"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type recordingMetricFetcher struct {
+	namespace string
+}
+
+func (f *recordingMetricFetcher) FetchPodMetrics(ctx context.Context, pod corev1.Pod, source autoscalingv1alpha1.MetricSource) (float64, error) {
+	f.namespace = pod.Namespace
+	return 42, nil
+}
+
+type staticMetricFetcherFactory struct {
+	fetcher MetricFetcher
+}
+
+func (f staticMetricFetcherFactory) For(source autoscalingv1alpha1.MetricSource) MetricFetcher {
+	return f.fetcher
+}
+
+func TestCollectMetricsExternalUsesCollectionNamespace(t *testing.T) {
+	fetcher := &recordingMetricFetcher{}
+	spec := patypes.CollectionSpec{
+		Namespace:  "tenant-a",
+		TargetName: "worker",
+		MetricName: "queue_depth",
+		MetricSource: autoscalingv1alpha1.MetricSource{
+			MetricSourceType: autoscalingv1alpha1.EXTERNAL,
+			TargetMetric:     "queue_depth",
+		},
+		Timestamp: time.Now(),
+	}
+
+	snapshot, err := CollectMetrics(context.TODO(), spec, staticMetricFetcherFactory{fetcher: fetcher})
+
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a", fetcher.namespace)
+	assert.Equal(t, []float64{42}, snapshot.Values)
+}

--- a/pkg/controller/podautoscaler/metrics/fetcher.go
+++ b/pkg/controller/podautoscaler/metrics/fetcher.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/metrics/pkg/client/clientset/versioned"
 	"k8s.io/metrics/pkg/client/custom_metrics"
+	"k8s.io/metrics/pkg/client/external_metrics"
 
 	autoscalingv1alpha1 "github.com/vllm-project/aibrix/api/autoscaling/v1alpha1"
 	"github.com/vllm-project/aibrix/pkg/metrics"
@@ -215,7 +216,8 @@ func (f *CustomMetricsFetcher) fetchCustomMetric(ctx context.Context, pod v1.Pod
 
 // ExternalMetricsFetcher handles external metrics with per-pod adaptation
 type ExternalMetricsFetcher struct {
-	engineFetcher *metrics.EngineMetricsFetcher
+	engineFetcher         *metrics.EngineMetricsFetcher
+	externalMetricsClient external_metrics.ExternalMetricsClient
 }
 
 var _ MetricFetcher = (*ExternalMetricsFetcher)(nil)
@@ -223,6 +225,19 @@ var _ MetricFetcher = (*ExternalMetricsFetcher)(nil)
 func NewExternalMetricsFetcher() *ExternalMetricsFetcher {
 	return &ExternalMetricsFetcher{
 		engineFetcher: metrics.NewEngineMetricsFetcher(),
+	}
+}
+
+func NewExternalMetricsFetcherWithClients(
+	engineFetcher *metrics.EngineMetricsFetcher,
+	externalMetricsClient external_metrics.ExternalMetricsClient,
+) *ExternalMetricsFetcher {
+	if engineFetcher == nil {
+		engineFetcher = metrics.NewEngineMetricsFetcher()
+	}
+	return &ExternalMetricsFetcher{
+		engineFetcher:         engineFetcher,
+		externalMetricsClient: externalMetricsClient,
 	}
 }
 
@@ -279,10 +294,23 @@ func (f *ExternalMetricsFetcher) fetchFromK8sExternalMetrics(ctx context.Context
 		"pod", pod.Name,
 		"metric", source.TargetMetric)
 
-	// TODO: Implement Kubernetes external.metrics API client
-	// For now, return a placeholder that won't break the system
-	klog.Warningf("Kubernetes external.metrics API not implemented yet for metric %s", source.TargetMetric)
-	return 0.0, fmt.Errorf("kubernetes external.metrics API not implemented yet for metric %s", source.TargetMetric)
+	if f.externalMetricsClient == nil {
+		return 0.0, fmt.Errorf("kubernetes external.metrics client not initialized for metric %s", source.TargetMetric)
+	}
+
+	metricList, err := f.externalMetricsClient.NamespacedMetrics(pod.Namespace).List(source.TargetMetric, labels.Everything())
+	if err != nil {
+		return 0.0, fmt.Errorf("failed to fetch external metric %s in namespace %s: %w", source.TargetMetric, pod.Namespace, err)
+	}
+	if len(metricList.Items) == 0 {
+		return 0.0, fmt.Errorf("no external metric values returned for %s in namespace %s", source.TargetMetric, pod.Namespace)
+	}
+
+	total := 0.0
+	for _, item := range metricList.Items {
+		total += item.Value.AsApproximateFloat64()
+	}
+	return total, nil
 }
 
 // MetricFetcherFactory provides a clean way to get the right fetcher for each metric source type
@@ -303,12 +331,13 @@ type DefaultMetricFetcherFactory struct {
 func NewDefaultMetricFetcherFactory(
 	resourceClient *versioned.Clientset,
 	customClient custom_metrics.CustomMetricsClient,
+	externalClient external_metrics.ExternalMetricsClient,
 ) *DefaultMetricFetcherFactory {
 	return &DefaultMetricFetcherFactory{
 		rest:     NewRestMetricsFetcher(),
 		resource: NewResourceMetricsFetcher(resourceClient),
 		custom:   NewCustomMetricsFetcher(customClient),
-		external: NewExternalMetricsFetcher(),
+		external: NewExternalMetricsFetcherWithClients(nil, externalClient),
 	}
 }
 

--- a/pkg/controller/podautoscaler/metrics/fetcher.go
+++ b/pkg/controller/podautoscaler/metrics/fetcher.go
@@ -298,6 +298,8 @@ func (f *ExternalMetricsFetcher) fetchFromK8sExternalMetrics(ctx context.Context
 		return 0.0, fmt.Errorf("kubernetes external.metrics client not initialized for metric %s", source.TargetMetric)
 	}
 
+	// MetricSource has no selector today, so this fetch is intentionally scoped only by namespace and metric name.
+	// This assumes a single PodAutoscaler owns each external metric in a namespace; selector-based restriction is a follow-up API change.
 	metricList, err := f.externalMetricsClient.NamespacedMetrics(pod.Namespace).List(source.TargetMetric, labels.Everything())
 	if err != nil {
 		return 0.0, fmt.Errorf("failed to fetch external metric %s in namespace %s: %w", source.TargetMetric, pod.Namespace, err)
@@ -306,6 +308,7 @@ func (f *ExternalMetricsFetcher) fetchFromK8sExternalMetrics(ctx context.Context
 		return 0.0, fmt.Errorf("no external metric values returned for %s in namespace %s", source.TargetMetric, pod.Namespace)
 	}
 
+	// Kubernetes external metrics are treated as aggregate values; multiple returned items are summed.
 	total := 0.0
 	for _, item := range metricList.Items {
 		total += item.Value.AsApproximateFloat64()

--- a/pkg/controller/podautoscaler/metrics/fetcher_test.go
+++ b/pkg/controller/podautoscaler/metrics/fetcher_test.go
@@ -37,9 +37,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	clientgotesting "k8s.io/client-go/testing"
+	externalmetricsv1beta1 "k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
 	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/clientset/versioned"
+	externalmetricsfake "k8s.io/metrics/pkg/client/external_metrics/fake"
 	"k8s.io/utils/ptr"
 )
 
@@ -144,6 +148,68 @@ func TestResourceMetricsFetcher_FetchPodMetrics(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedMetricValue, actualMetricValue)
+}
+
+func TestExternalMetricsFetcher_FetchPodMetricsFromK8sExternalMetrics(t *testing.T) {
+	externalClient := &externalmetricsfake.FakeExternalMetricsClient{}
+	externalClient.AddReactor("list", "queue_depth", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		listAction := action.(clientgotesting.ListAction)
+		assert.Equal(t, "default", listAction.GetNamespace())
+		return true, &externalmetricsv1beta1.ExternalMetricValueList{
+			Items: []externalmetricsv1beta1.ExternalMetricValue{
+				{
+					MetricName: "queue_depth",
+					Value:      resource.MustParse("40"),
+				},
+				{
+					MetricName: "queue_depth",
+					Value:      resource.MustParse("60"),
+				},
+			},
+		}, nil
+	})
+
+	fetcher := NewExternalMetricsFetcherWithClients(nil, externalClient)
+	source := autoscalingv1alpha1.MetricSource{
+		MetricSourceType: autoscalingv1alpha1.EXTERNAL,
+		TargetMetric:     "queue_depth",
+	}
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "external-source",
+			Namespace: "default",
+		},
+	}
+
+	actualMetricValue, err := fetcher.FetchPodMetrics(context.TODO(), pod, source)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 100.0, actualMetricValue)
+}
+
+func TestExternalMetricsFetcher_FetchPodMetricsReturnsErrorForEmptyExternalMetrics(t *testing.T) {
+	externalClient := &externalmetricsfake.FakeExternalMetricsClient{}
+	externalClient.AddReactor("list", "queue_depth", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, &externalmetricsv1beta1.ExternalMetricValueList{}, nil
+	})
+
+	fetcher := NewExternalMetricsFetcherWithClients(nil, externalClient)
+	source := autoscalingv1alpha1.MetricSource{
+		MetricSourceType: autoscalingv1alpha1.EXTERNAL,
+		TargetMetric:     "queue_depth",
+	}
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "external-source",
+			Namespace: "default",
+		},
+	}
+
+	actualMetricValue, err := fetcher.FetchPodMetrics(context.TODO(), pod, source)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no external metric values")
+	assert.Equal(t, 0.0, actualMetricValue)
 }
 
 func parseURL(rawURL string) (string, string) {

--- a/pkg/controller/podautoscaler/metrics/fetcher_test.go
+++ b/pkg/controller/podautoscaler/metrics/fetcher_test.go
@@ -212,6 +212,26 @@ func TestExternalMetricsFetcher_FetchPodMetricsReturnsErrorForEmptyExternalMetri
 	assert.Equal(t, 0.0, actualMetricValue)
 }
 
+func TestExternalMetricsFetcher_FetchPodMetricsReturnsErrorWithoutK8sExternalMetricsClient(t *testing.T) {
+	fetcher := NewExternalMetricsFetcher()
+	source := autoscalingv1alpha1.MetricSource{
+		MetricSourceType: autoscalingv1alpha1.EXTERNAL,
+		TargetMetric:     "queue_depth",
+	}
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "external-source",
+			Namespace: "default",
+		},
+	}
+
+	actualMetricValue, err := fetcher.FetchPodMetrics(context.TODO(), pod, source)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "kubernetes external.metrics client not initialized")
+	assert.Equal(t, 0.0, actualMetricValue)
+}
+
 func parseURL(rawURL string) (string, string) {
 	u, err := url.Parse(rawURL)
 	if err != nil {

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -60,6 +60,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/metrics/pkg/client/clientset/versioned"
 	custommetrics "k8s.io/metrics/pkg/client/custom_metrics"
+	externalmetrics "k8s.io/metrics/pkg/client/external_metrics"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -132,11 +133,16 @@ func newReconciler(mgr manager.Manager, runtimeConfig config.RuntimeConfig) (rec
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(cached)
 	apis := custommetrics.NewAvailableAPIsGetter(disc)
 	customClient := custommetrics.NewForConfig(restConfig, mapper, apis)
+	externalClient, err := externalmetrics.NewForConfig(restConfig)
+	if err != nil {
+		klog.Warningf("Failed to create external metrics client: %v. Kubernetes external metrics will be unavailable.", err)
+		externalClient = nil
+	}
 
 	workloadScaleClient := NewWorkloadScale(mgr.GetClient(), mgr.GetRESTMapper())
 
 	// Create factory with all metric fetcher types
-	factory := metrics.NewDefaultMetricFetcherFactory(resourceClient, customClient)
+	factory := metrics.NewDefaultMetricFetcherFactory(resourceClient, customClient, externalClient)
 
 	// Create a unified autoscaler that can handle all strategies
 	// It will be configured per-request based on PodAutoscaler spec
@@ -264,6 +270,7 @@ type PodAutoscalerReconciler struct {
 //+kubebuilder:rbac:groups=autoscaling.aibrix.ai,resources=podautoscalers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=autoscaling.aibrix.ai,resources=podautoscalers/finalizers,verbs=update
 //+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=external.metrics.k8s.io,resources=*,verbs=get;list
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
 //+kubebuilder:rbac:groups=orchestration.aibrix.ai,resources=stormservices,verbs=get;list;watch;patch
 
@@ -473,6 +480,10 @@ func (r *PodAutoscalerReconciler) validatePodMetricSource(ms *autoscalingv1alpha
 }
 
 func (r *PodAutoscalerReconciler) validateExternalMetricSource(ms *autoscalingv1alpha1.MetricSource) ValidationResult {
+	if ms.Endpoint == "" &&
+		(ms.MetricSourceType == autoscalingv1alpha1.EXTERNAL || ms.MetricSourceType == autoscalingv1alpha1.DOMAIN) {
+		return validOK()
+	}
 	if ms.ProtocolType == "" {
 		return invalid(ReasonMetricsConfigError, "protocolType is required for metricSourceType=external.")
 	}

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -480,6 +480,7 @@ func (r *PodAutoscalerReconciler) validatePodMetricSource(ms *autoscalingv1alpha
 }
 
 func (r *PodAutoscalerReconciler) validateExternalMetricSource(ms *autoscalingv1alpha1.MetricSource) ValidationResult {
+	// Empty endpoint selects the Kubernetes external.metrics API instead of an HTTP metrics endpoint.
 	if ms.Endpoint == "" &&
 		(ms.MetricSourceType == autoscalingv1alpha1.EXTERNAL || ms.MetricSourceType == autoscalingv1alpha1.DOMAIN) {
 		return validOK()

--- a/pkg/controller/podautoscaler/podautoscaler_controller_test.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller_test.go
@@ -82,6 +82,34 @@ func (f *fakeAutoScaler) ComputeDesiredReplicas(ctx context.Context, req Replica
 	return f.result, f.err
 }
 
+func TestValidateMetricsSourcesAllowsK8sExternalMetrics(t *testing.T) {
+	for _, metricSourceType := range []autoscalingv1alpha1.MetricSourceType{
+		autoscalingv1alpha1.EXTERNAL,
+		autoscalingv1alpha1.DOMAIN,
+	} {
+		t.Run(string(metricSourceType), func(t *testing.T) {
+			r := &PodAutoscalerReconciler{}
+			pa := &autoscalingv1alpha1.PodAutoscaler{
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					MetricsSources: []autoscalingv1alpha1.MetricSource{
+						{
+							MetricSourceType: metricSourceType,
+							TargetMetric:     "aibrix_test_queue_depth",
+							TargetValue:      "40",
+						},
+					},
+				},
+			}
+
+			result := r.validateMetricsSources(pa)
+
+			if !result.Valid {
+				t.Fatalf("expected Kubernetes external metrics source to be valid, got reason=%s message=%s", result.Reason, result.Message)
+			}
+		})
+	}
+}
+
 // ---- helpers ----
 
 func buildPod(ns, name string, lbls map[string]string) *corev1.Pod {

--- a/pkg/controller/podautoscaler/podautoscaler_controller_test.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller_test.go
@@ -110,6 +110,32 @@ func TestValidateMetricsSourcesAllowsK8sExternalMetrics(t *testing.T) {
 	}
 }
 
+func TestValidateMetricsSourcesRequiresTargetMetricForK8sExternalMetrics(t *testing.T) {
+	r := &PodAutoscalerReconciler{}
+	pa := &autoscalingv1alpha1.PodAutoscaler{
+		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+			MetricsSources: []autoscalingv1alpha1.MetricSource{
+				{
+					MetricSourceType: autoscalingv1alpha1.EXTERNAL,
+					TargetValue:      "40",
+				},
+			},
+		},
+	}
+
+	result := r.validateMetricsSources(pa)
+
+	if result.Valid {
+		t.Fatal("expected Kubernetes external metrics source without targetMetric to be invalid")
+	}
+	if result.Reason != ReasonMetricsConfigError {
+		t.Fatalf("expected reason=%s, got %s", ReasonMetricsConfigError, result.Reason)
+	}
+	if result.Message != "metricsSource[0]: targetMetric must be specified" {
+		t.Fatalf("unexpected message: %s", result.Message)
+	}
+}
+
 // ---- helpers ----
 
 func buildPod(ns, name string, lbls map[string]string) *corev1.Pod {

--- a/pkg/webhook/podautoscaler_webhook.go
+++ b/pkg/webhook/podautoscaler_webhook.go
@@ -193,6 +193,9 @@ func (v *PodAutoscalerCustomValidator) validatePodAutoscaler(pa *autoscalingv1al
 			}
 
 		case autoscalingv1alpha1.EXTERNAL, autoscalingv1alpha1.DOMAIN:
+			if ms.Endpoint == "" {
+				break
+			}
 			if ms.ProtocolType == "" {
 				allErrs = append(allErrs, field.Required(msPath.Child("protocolType"), "required for metricSourceType=external/domain"))
 			}

--- a/pkg/webhook/podautoscaler_webhook.go
+++ b/pkg/webhook/podautoscaler_webhook.go
@@ -193,6 +193,7 @@ func (v *PodAutoscalerCustomValidator) validatePodAutoscaler(pa *autoscalingv1al
 			}
 
 		case autoscalingv1alpha1.EXTERNAL, autoscalingv1alpha1.DOMAIN:
+			// Empty endpoint selects the Kubernetes external.metrics API instead of an HTTP metrics endpoint.
 			if ms.Endpoint == "" {
 				break
 			}

--- a/pkg/webhook/podautoscaler_webhook_test.go
+++ b/pkg/webhook/podautoscaler_webhook_test.go
@@ -90,6 +90,25 @@ func TestPodAutoscalerCustomValidator_validatePodAutoscaler(t *testing.T) {
 			},
 			expectError: false,
 		},
+		"Kubernetes External Metrics Source Requires TargetMetric": {
+			pa: &autoscalingv1alpha1.PodAutoscaler{
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					ScaleTargetRef: corev1.ObjectReference{
+						Name: "test-deployment",
+						Kind: "Deployment",
+					},
+					ScalingStrategy: autoscalingv1alpha1.APA,
+					MetricsSources: []autoscalingv1alpha1.MetricSource{
+						{
+							MetricSourceType: autoscalingv1alpha1.EXTERNAL,
+							TargetValue:      "40",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "targetMetric",
+		},
 		"Zero Target Value": {
 			pa: &autoscalingv1alpha1.PodAutoscaler{
 				Spec: autoscalingv1alpha1.PodAutoscalerSpec{

--- a/pkg/webhook/podautoscaler_webhook_test.go
+++ b/pkg/webhook/podautoscaler_webhook_test.go
@@ -52,6 +52,44 @@ func TestPodAutoscalerCustomValidator_validatePodAutoscaler(t *testing.T) {
 			},
 			expectError: false,
 		},
+		"Kubernetes External Metrics Source": {
+			pa: &autoscalingv1alpha1.PodAutoscaler{
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					ScaleTargetRef: corev1.ObjectReference{
+						Name: "test-deployment",
+						Kind: "Deployment",
+					},
+					ScalingStrategy: autoscalingv1alpha1.APA,
+					MetricsSources: []autoscalingv1alpha1.MetricSource{
+						{
+							MetricSourceType: autoscalingv1alpha1.EXTERNAL,
+							TargetMetric:     "aibrix_test_queue_depth",
+							TargetValue:      "40",
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		"Kubernetes Domain Metrics Source": {
+			pa: &autoscalingv1alpha1.PodAutoscaler{
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					ScaleTargetRef: corev1.ObjectReference{
+						Name: "test-deployment",
+						Kind: "Deployment",
+					},
+					ScalingStrategy: autoscalingv1alpha1.APA,
+					MetricsSources: []autoscalingv1alpha1.MetricSource{
+						{
+							MetricSourceType: autoscalingv1alpha1.DOMAIN,
+							TargetMetric:     "aibrix_test_queue_depth",
+							TargetValue:      "40",
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
 		"Zero Target Value": {
 			pa: &autoscalingv1alpha1.PodAutoscaler{
 				Spec: autoscalingv1alpha1.PodAutoscalerSpec{

--- a/samples/autoscaling/external-metrics-apa.yaml
+++ b/samples/autoscaling/external-metrics-apa.yaml
@@ -1,0 +1,26 @@
+apiVersion: autoscaling.aibrix.ai/v1alpha1
+kind: PodAutoscaler
+metadata:
+  name: deepseek-r1-distill-llama-8b-external-metrics
+  namespace: default
+  labels:
+    app.kubernetes.io/name: aibrix
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    autoscaling.aibrix.ai/up-fluctuation-tolerance: '0.1'
+    autoscaling.aibrix.ai/down-fluctuation-tolerance: '0.2'
+    apa.autoscaling.aibrix.ai/window: 30s
+spec:
+  scalingStrategy: APA
+  minReplicas: 1
+  maxReplicas: 8
+  metricsSources:
+    # Uses Kubernetes external.metrics.k8s.io. An external metrics adapter must
+    # expose this metric in the same namespace as the target workload.
+    - metricSourceType: external
+      targetMetric: aibrix_queue_depth
+      targetValue: "40"
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: deepseek-r1-distill-llama-8b

--- a/samples/autoscaling/external-metrics-kpa.yaml
+++ b/samples/autoscaling/external-metrics-kpa.yaml
@@ -1,0 +1,24 @@
+apiVersion: autoscaling.aibrix.ai/v1alpha1
+kind: PodAutoscaler
+metadata:
+  name: deepseek-r1-distill-llama-8b-external-kpa
+  namespace: default
+  labels:
+    app.kubernetes.io/name: aibrix
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    kpa.autoscaling.aibrix.ai/scale-down-delay: 3m
+spec:
+  scalingStrategy: KPA
+  minReplicas: 1
+  maxReplicas: 8
+  metricsSources:
+    # Uses Kubernetes external.metrics.k8s.io. Do not set endpoint, path, or
+    # protocolType for this mode.
+    - metricSourceType: external
+      targetMetric: aibrix_running_requests
+      targetValue: "100"
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: deepseek-r1-distill-llama-8b

--- a/test/e2e/controller-manager/Dockerfile
+++ b/test/e2e/controller-manager/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY bin/controller-manager-e2e manager
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/test/e2e/external-metrics-adapter/Dockerfile
+++ b/test/e2e/external-metrics-adapter/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.22 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+COPY test/e2e/external-metrics-adapter/ test/e2e/external-metrics-adapter/
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o external-metrics-adapter ./test/e2e/external-metrics-adapter
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/external-metrics-adapter .
+USER 65532:65532
+
+ENTRYPOINT ["/external-metrics-adapter"]

--- a/test/e2e/external-metrics-adapter/Dockerfile.local
+++ b/test/e2e/external-metrics-adapter/Dockerfile.local
@@ -1,0 +1,6 @@
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY bin/external-metrics-adapter-e2e external-metrics-adapter
+USER 65532:65532
+
+ENTRYPOINT ["/external-metrics-adapter"]

--- a/test/e2e/external-metrics-adapter/main.go
+++ b/test/e2e/external-metrics-adapter/main.go
@@ -158,13 +158,15 @@ func writeJSON(w http.ResponseWriter, obj any) {
 func writeStatus(w http.ResponseWriter, code int, reason, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	writeJSON(w, metav1.Status{
+	if err := json.NewEncoder(w).Encode(metav1.Status{
 		TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
 		Status:   metav1.StatusFailure,
 		Reason:   metav1.StatusReason(reason),
 		Message:  message,
 		Code:     int32(code),
-	})
+	}); err != nil {
+		log.Printf("failed to write status response: %v", err)
+	}
 }
 
 func env(key, fallback string) string {

--- a/test/e2e/external-metrics-adapter/main.go
+++ b/test/e2e/external-metrics-adapter/main.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"log"
+	"math/big"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	externalmetricsv1beta1 "k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
+)
+
+const (
+	group      = "external.metrics.k8s.io"
+	version    = "v1beta1"
+	listKind   = "ExternalMetricValueList"
+	defaultKey = "source"
+)
+
+func main() {
+	metricName := env("METRIC_NAME", "aibrix_test_queue_depth")
+	metricValue := env("METRIC_VALUE", "100")
+	labelKey := env("METRIC_LABEL_KEY", defaultKey)
+	labelValue := env("METRIC_LABEL_VALUE", "aibrix-e2e")
+
+	cert, err := selfSignedCert()
+	if err != nil {
+		log.Fatalf("failed to create self-signed cert: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", writeOK)
+	mux.HandleFunc("/readyz", writeOK)
+	apiHandler := func(w http.ResponseWriter, r *http.Request) {
+		switch strings.TrimSuffix(r.URL.Path, "/") {
+		case "/apis":
+			writeJSON(w, metav1.APIGroupList{
+				Groups: []metav1.APIGroup{apiGroup()},
+			})
+		case "/apis/" + group:
+			writeJSON(w, apiGroup())
+		case "/apis/" + group + "/" + version:
+			writeJSON(w, metav1.APIResourceList{
+				TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+				GroupVersion: schema.GroupVersion{Group: group, Version: version}.String(),
+				APIResources: []metav1.APIResource{
+					{
+						Name:       metricName,
+						Namespaced: true,
+						Kind:       "ExternalMetricValue",
+						Verbs:      []string{"get", "list"},
+					},
+				},
+			})
+		default:
+			serveMetric(w, r, metricName, metricValue, labelKey, labelValue)
+		}
+	}
+	mux.HandleFunc("/apis", apiHandler)
+	mux.HandleFunc("/apis/", apiHandler)
+
+	server := &http.Server{
+		Addr:      ":8443",
+		Handler:   mux,
+		TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12},
+	}
+	log.Printf("serving fake external metrics API for %q on :8443", metricName)
+	log.Fatal(server.ListenAndServeTLS("", ""))
+}
+
+func serveMetric(w http.ResponseWriter, r *http.Request, metricName, metricValue, labelKey, labelValue string) {
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) != 6 ||
+		parts[0] != "apis" ||
+		parts[1] != group ||
+		parts[2] != version ||
+		parts[3] != "namespaces" ||
+		parts[5] != metricName {
+		writeStatus(w, http.StatusNotFound, "NotFound", "metric path not found")
+		return
+	}
+
+	value, err := strconv.ParseFloat(metricValue, 64)
+	if err != nil {
+		writeStatus(w, http.StatusInternalServerError, "InvalidMetricValue", err.Error())
+		return
+	}
+
+	writeJSON(w, externalmetricsv1beta1.ExternalMetricValueList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       listKind,
+			APIVersion: schema.GroupVersion{Group: group, Version: version}.String(),
+		},
+		Items: []externalmetricsv1beta1.ExternalMetricValue{
+			{
+				MetricName:   metricName,
+				MetricLabels: map[string]string{labelKey: labelValue},
+				Timestamp:    metav1.Now(),
+				Value:        resource.MustParse(strconv.FormatFloat(value, 'f', -1, 64)),
+			},
+		},
+	})
+}
+
+func apiGroup() metav1.APIGroup {
+	gv := metav1.GroupVersionForDiscovery{
+		GroupVersion: schema.GroupVersion{Group: group, Version: version}.String(),
+		Version:      version,
+	}
+	return metav1.APIGroup{
+		TypeMeta:         metav1.TypeMeta{Kind: "APIGroup", APIVersion: "v1"},
+		Name:             group,
+		Versions:         []metav1.GroupVersionForDiscovery{gv},
+		PreferredVersion: gv,
+	}
+}
+
+func writeOK(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func writeJSON(w http.ResponseWriter, obj any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(obj); err != nil {
+		log.Printf("failed to write json response: %v", err)
+	}
+}
+
+func writeStatus(w http.ResponseWriter, code int, reason, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	writeJSON(w, metav1.Status{
+		TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+		Status:   metav1.StatusFailure,
+		Reason:   metav1.StatusReason(reason),
+		Message:  message,
+		Code:     int32(code),
+	})
+}
+
+func env(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func selfSignedCert() (tls.Certificate, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "aibrix-external-metrics-adapter.aibrix-system.svc",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames: []string{
+			"aibrix-external-metrics-adapter",
+			"aibrix-external-metrics-adapter.aibrix-system",
+			"aibrix-external-metrics-adapter.aibrix-system.svc",
+		},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return tls.X509KeyPair(certPEM, keyPEM)
+}

--- a/test/e2e/external-metrics-adapter/main_test.go
+++ b/test/e2e/external-metrics-adapter/main_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWriteStatusSetsJSONContentType(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	writeStatus(recorder, http.StatusNotFound, "NotFound", "metric path not found")
+
+	if got := recorder.Code; got != http.StatusNotFound {
+		t.Fatalf("status code = %d, want %d", got, http.StatusNotFound)
+	}
+	if got := recorder.Header().Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+}

--- a/test/e2e/external_metrics_autoscaler_test.go
+++ b/test/e2e/external_metrics_autoscaler_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -26,15 +27,20 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/utils/ptr"
 
 	autoscalingv1alpha1 "github.com/vllm-project/aibrix/api/autoscaling/v1alpha1"
 	aibrixclientset "github.com/vllm-project/aibrix/pkg/client/clientset/versioned"
+	aibrixfake "github.com/vllm-project/aibrix/pkg/client/clientset/versioned/fake"
 	patypes "github.com/vllm-project/aibrix/pkg/controller/podautoscaler/types"
 )
 
@@ -66,6 +72,46 @@ func TestExternalMetricsAutoscaler(t *testing.T) {
 	createExternalMetricsScaleTarget(ctx, t, k8sClient)
 	createExternalMetricPodAutoscaler(ctx, t, aibrixClient)
 	waitForDeploymentReplicas(ctx, t, k8sClient, 2)
+}
+
+func TestCreateExternalMetricsScaleTargetUpdatesExistingResource(t *testing.T) {
+	existing := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            e2eTargetName,
+			Namespace:       e2ePANamespace,
+			ResourceVersion: "1",
+		},
+	}
+	k8sClient := k8sfake.NewSimpleClientset(existing)
+	k8sClient.PrependReactor("update", "deployments", requireUpdateResourceVersion)
+
+	createExternalMetricsScaleTarget(context.Background(), t, k8sClient)
+}
+
+func TestCreateExternalMetricPodAutoscalerUpdatesExistingResource(t *testing.T) {
+	existing := &autoscalingv1alpha1.PodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "external-metrics-e2e",
+			Namespace:       e2ePANamespace,
+			ResourceVersion: "1",
+		},
+	}
+	aibrixClient := aibrixfake.NewSimpleClientset(existing)
+	aibrixClient.PrependReactor("update", "podautoscalers", requireUpdateResourceVersion)
+
+	createExternalMetricPodAutoscaler(context.Background(), t, aibrixClient)
+}
+
+func requireUpdateResourceVersion(action k8stesting.Action) (bool, runtime.Object, error) {
+	update := action.(k8stesting.UpdateAction)
+	accessor, err := meta.Accessor(update.GetObject())
+	if err != nil {
+		return true, nil, err
+	}
+	if accessor.GetResourceVersion() == "" {
+		return true, nil, errors.New("resourceVersion required")
+	}
+	return false, nil, nil
 }
 
 func externalMetricsClients(t *testing.T) (*kubernetes.Clientset, *aibrixclientset.Clientset) {
@@ -107,7 +153,7 @@ func assertExternalMetricAPI(ctx context.Context, t *testing.T, k8sClient *kuber
 	}
 }
 
-func createExternalMetricsScaleTarget(ctx context.Context, t *testing.T, k8sClient *kubernetes.Clientset) {
+func createExternalMetricsScaleTarget(ctx context.Context, t *testing.T, k8sClient kubernetes.Interface) {
 	t.Helper()
 
 	replicas := int32(1)
@@ -154,6 +200,11 @@ func createExternalMetricsScaleTarget(ctx context.Context, t *testing.T, k8sClie
 
 	_, err := k8sClient.AppsV1().Deployments(e2ePANamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
+		current, getErr := k8sClient.AppsV1().Deployments(e2ePANamespace).Get(ctx, e2eTargetName, metav1.GetOptions{})
+		if getErr != nil {
+			t.Fatalf("failed to get existing scale target deployment: %v", getErr)
+		}
+		deployment.ResourceVersion = current.ResourceVersion
 		_, err = k8sClient.AppsV1().Deployments(e2ePANamespace).Update(ctx, deployment, metav1.UpdateOptions{})
 	}
 	if err != nil {
@@ -161,7 +212,7 @@ func createExternalMetricsScaleTarget(ctx context.Context, t *testing.T, k8sClie
 	}
 }
 
-func createExternalMetricPodAutoscaler(ctx context.Context, t *testing.T, aibrixClient *aibrixclientset.Clientset) {
+func createExternalMetricPodAutoscaler(ctx context.Context, t *testing.T, aibrixClient aibrixclientset.Interface) {
 	t.Helper()
 
 	pa := &autoscalingv1alpha1.PodAutoscaler{
@@ -193,6 +244,11 @@ func createExternalMetricPodAutoscaler(ctx context.Context, t *testing.T, aibrix
 
 	_, err := aibrixClient.AutoscalingV1alpha1().PodAutoscalers(e2ePANamespace).Create(ctx, pa, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
+		current, getErr := aibrixClient.AutoscalingV1alpha1().PodAutoscalers(e2ePANamespace).Get(ctx, pa.Name, metav1.GetOptions{})
+		if getErr != nil {
+			t.Fatalf("failed to get existing PodAutoscaler: %v", getErr)
+		}
+		pa.ResourceVersion = current.ResourceVersion
 		_, err = aibrixClient.AutoscalingV1alpha1().PodAutoscalers(e2ePANamespace).Update(ctx, pa, metav1.UpdateOptions{})
 	}
 	if err != nil {

--- a/test/e2e/external_metrics_autoscaler_test.go
+++ b/test/e2e/external_metrics_autoscaler_test.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/ptr"
+
+	autoscalingv1alpha1 "github.com/vllm-project/aibrix/api/autoscaling/v1alpha1"
+	aibrixclientset "github.com/vllm-project/aibrix/pkg/client/clientset/versioned"
+	patypes "github.com/vllm-project/aibrix/pkg/controller/podautoscaler/types"
+)
+
+const (
+	externalMetricName = "aibrix_test_queue_depth"
+	e2eTargetName      = "external-metrics-scale-target"
+	e2ePANamespace     = "default"
+)
+
+func TestExternalMetricsAutoscaler(t *testing.T) {
+	if strings.ToLower(strings.TrimSpace(envOrDefault("AIBRIX_EXTERNAL_METRICS_E2E", "false"))) != "true" {
+		t.Skip("set AIBRIX_EXTERNAL_METRICS_E2E=true to run the external metrics e2e test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	k8sClient, aibrixClient := externalMetricsClients(t)
+	cleanupExternalMetricsE2E(ctx, t, k8sClient, aibrixClient)
+	defer func() {
+		if t.Failed() && strings.ToLower(envOrDefault("AIBRIX_EXTERNAL_METRICS_E2E_KEEP_ON_FAILURE", "false")) == "true" {
+			t.Log("preserving external metrics e2e resources for failure diagnostics")
+			return
+		}
+		cleanupExternalMetricsE2E(context.Background(), t, k8sClient, aibrixClient)
+	}()
+
+	assertExternalMetricAPI(ctx, t, k8sClient)
+	createExternalMetricsScaleTarget(ctx, t, k8sClient)
+	createExternalMetricPodAutoscaler(ctx, t, aibrixClient)
+	waitForDeploymentReplicas(ctx, t, k8sClient, 2)
+}
+
+func externalMetricsClients(t *testing.T) (*kubernetes.Clientset, *aibrixclientset.Clientset) {
+	t.Helper()
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeConfig := os.Getenv("KUBECONFIG"); kubeConfig != "" {
+		loadingRules.ExplicitPath = kubeConfig
+	}
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
+	if err != nil {
+		t.Fatalf("failed to build kube config: %v", err)
+	}
+	k8sClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("failed to create Kubernetes client: %v", err)
+	}
+	aibrixClient, err := aibrixclientset.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("failed to create AIBrix client: %v", err)
+	}
+	return k8sClient, aibrixClient
+}
+
+func assertExternalMetricAPI(ctx context.Context, t *testing.T, k8sClient *kubernetes.Clientset) {
+	t.Helper()
+
+	body, err := k8sClient.Discovery().RESTClient().Get().
+		AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/default/" + externalMetricName).
+		DoRaw(ctx)
+	if err != nil {
+		t.Fatalf("external metrics API is not queryable: %v", err)
+	}
+	if !strings.Contains(string(body), externalMetricName) {
+		t.Fatalf("external metrics API response does not contain %q: %s", externalMetricName, string(body))
+	}
+}
+
+func createExternalMetricsScaleTarget(ctx context.Context, t *testing.T, k8sClient *kubernetes.Clientset) {
+	t.Helper()
+
+	replicas := int32(1)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      e2eTargetName,
+			Namespace: e2ePANamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": e2eTargetName},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": e2eTargetName},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "target",
+							Image:           "aibrix/external-metrics-adapter:e2e",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Ports: []corev1.ContainerPort{
+								{Name: "https", ContainerPort: 8443},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/readyz",
+										Port:   intstr.FromString("https"),
+										Scheme: corev1.URISchemeHTTPS,
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       5,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := k8sClient.AppsV1().Deployments(e2ePANamespace).Create(ctx, deployment, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		_, err = k8sClient.AppsV1().Deployments(e2ePANamespace).Update(ctx, deployment, metav1.UpdateOptions{})
+	}
+	if err != nil {
+		t.Fatalf("failed to create scale target deployment: %v", err)
+	}
+}
+
+func createExternalMetricPodAutoscaler(ctx context.Context, t *testing.T, aibrixClient *aibrixclientset.Clientset) {
+	t.Helper()
+
+	pa := &autoscalingv1alpha1.PodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "external-metrics-e2e",
+			Namespace: e2ePANamespace,
+			Annotations: map[string]string{
+				patypes.MaxScaleUpRateLabel: "4",
+			},
+		},
+		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+			ScaleTargetRef: corev1.ObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       e2eTargetName,
+			},
+			MinReplicas: ptr.To[int32](1),
+			MaxReplicas: 4,
+			MetricsSources: []autoscalingv1alpha1.MetricSource{
+				{
+					MetricSourceType: autoscalingv1alpha1.EXTERNAL,
+					TargetMetric:     externalMetricName,
+					TargetValue:      "40",
+				},
+			},
+			ScalingStrategy: autoscalingv1alpha1.APA,
+		},
+	}
+
+	_, err := aibrixClient.AutoscalingV1alpha1().PodAutoscalers(e2ePANamespace).Create(ctx, pa, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		_, err = aibrixClient.AutoscalingV1alpha1().PodAutoscalers(e2ePANamespace).Update(ctx, pa, metav1.UpdateOptions{})
+	}
+	if err != nil {
+		t.Fatalf("failed to create PodAutoscaler: %v", err)
+	}
+}
+
+func waitForDeploymentReplicas(ctx context.Context, t *testing.T, k8sClient *kubernetes.Clientset, minimum int32) {
+	t.Helper()
+
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		deployment, err := k8sClient.AppsV1().Deployments(e2ePANamespace).Get(ctx, e2eTargetName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas >= minimum {
+			return true, nil
+		}
+		current := int32(0)
+		if deployment.Spec.Replicas != nil {
+			current = *deployment.Spec.Replicas
+		}
+		t.Logf("waiting for %s replicas >= %d, current spec.replicas=%d", e2eTargetName, minimum, current)
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("deployment did not scale to at least %d replicas: %v", minimum, err)
+	}
+}
+
+func cleanupExternalMetricsE2E(
+	ctx context.Context,
+	t *testing.T,
+	k8sClient *kubernetes.Clientset,
+	aibrixClient *aibrixclientset.Clientset,
+) {
+	t.Helper()
+
+	err := aibrixClient.AutoscalingV1alpha1().
+		PodAutoscalers(e2ePANamespace).
+		Delete(ctx, "external-metrics-e2e", metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("failed to delete PodAutoscaler: %v", err)
+	}
+
+	err = k8sClient.AppsV1().Deployments(e2ePANamespace).Delete(ctx, e2eTargetName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("failed to delete scale target deployment: %v", err)
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := strings.TrimSpace(strings.Trim(os.Getenv(key), "\"")); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/test/e2e/external_metrics_autoscaler_test.go
+++ b/test/e2e/external_metrics_autoscaler_test.go
@@ -244,7 +244,9 @@ func createExternalMetricPodAutoscaler(ctx context.Context, t *testing.T, aibrix
 
 	_, err := aibrixClient.AutoscalingV1alpha1().PodAutoscalers(e2ePANamespace).Create(ctx, pa, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
-		current, getErr := aibrixClient.AutoscalingV1alpha1().PodAutoscalers(e2ePANamespace).Get(ctx, pa.Name, metav1.GetOptions{})
+		current, getErr := aibrixClient.AutoscalingV1alpha1().
+			PodAutoscalers(e2ePANamespace).
+			Get(ctx, pa.Name, metav1.GetOptions{})
 		if getErr != nil {
 			t.Fatalf("failed to get existing PodAutoscaler: %v", getErr)
 		}

--- a/test/e2e/external_metrics_autoscaler_test.go
+++ b/test/e2e/external_metrics_autoscaler_test.go
@@ -71,7 +71,7 @@ func TestExternalMetricsAutoscaler(t *testing.T) {
 	assertExternalMetricAPI(ctx, t, k8sClient)
 	createExternalMetricsScaleTarget(ctx, t, k8sClient)
 	createExternalMetricPodAutoscaler(ctx, t, aibrixClient)
-	waitForDeploymentReplicas(ctx, t, k8sClient, 2)
+	waitForDesiredReplicas(ctx, t, k8sClient, 2)
 }
 
 func TestCreateExternalMetricsScaleTargetUpdatesExistingResource(t *testing.T) {
@@ -258,7 +258,7 @@ func createExternalMetricPodAutoscaler(ctx context.Context, t *testing.T, aibrix
 	}
 }
 
-func waitForDeploymentReplicas(ctx context.Context, t *testing.T, k8sClient *kubernetes.Clientset, minimum int32) {
+func waitForDesiredReplicas(ctx context.Context, t *testing.T, k8sClient *kubernetes.Clientset, minimum int32) {
 	t.Helper()
 
 	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {

--- a/test/e2e/testdata/external-metrics-adapter/apiservice.yaml
+++ b/test/e2e/testdata/external-metrics-adapter/apiservice.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.external.metrics.k8s.io
+spec:
+  group: external.metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: aibrix-external-metrics-adapter
+    namespace: aibrix-system
+    port: 443
+  version: v1beta1
+  versionPriority: 100

--- a/test/e2e/testdata/external-metrics-adapter/deployment.yaml
+++ b/test/e2e/testdata/external-metrics-adapter/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aibrix-external-metrics-adapter
+  namespace: aibrix-system
+  labels:
+    app.kubernetes.io/name: aibrix-external-metrics-adapter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: aibrix-external-metrics-adapter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aibrix-external-metrics-adapter
+    spec:
+      containers:
+      - name: adapter
+        image: aibrix/external-metrics-adapter:e2e
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: METRIC_NAME
+          value: aibrix_test_queue_depth
+        - name: METRIC_VALUE
+          value: "100"
+        ports:
+        - name: https
+          containerPort: 8443
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 2
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/test/e2e/testdata/external-metrics-adapter/kustomization.yaml
+++ b/test/e2e/testdata/external-metrics-adapter/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- service.yaml
+- apiservice.yaml

--- a/test/e2e/testdata/external-metrics-adapter/service.yaml
+++ b/test/e2e/testdata/external-metrics-adapter/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aibrix-external-metrics-adapter
+  namespace: aibrix-system
+  labels:
+    app.kubernetes.io/name: aibrix-external-metrics-adapter
+spec:
+  selector:
+    app.kubernetes.io/name: aibrix-external-metrics-adapter
+  ports:
+  - name: https
+    port: 443
+    targetPort: https

--- a/test/e2e/testdata/external-metrics-autoscaler/aibrix/kustomization.yaml
+++ b/test/e2e/testdata/external-metrics-autoscaler/aibrix/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../../../config/standalone/autoscaler-controller
+
+images:
+- name: controller
+  newName: aibrix/controller-manager
+  newTag: external-metrics-e2e
+- name: aibrix/controller-manager
+  newName: aibrix/controller-manager
+  newTag: external-metrics-e2e

--- a/test/e2e/testdata/external-metrics-autoscaler/aibrix/kustomization.yaml
+++ b/test/e2e/testdata/external-metrics-autoscaler/aibrix/kustomization.yaml
@@ -5,9 +5,6 @@ resources:
 - ../../../../../config/standalone/autoscaler-controller
 
 images:
-- name: controller
-  newName: aibrix/controller-manager
-  newTag: external-metrics-e2e
 - name: aibrix/controller-manager
   newName: aibrix/controller-manager
   newTag: external-metrics-e2e

--- a/test/run-external-metrics-e2e.sh
+++ b/test/run-external-metrics-e2e.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+EXTERNAL_METRICS_E2E_CLUSTER="${EXTERNAL_METRICS_E2E_CLUSTER:-minikube}"
+EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER="${EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER:-false}"
+MINIKUBE_PROFILE="${MINIKUBE_PROFILE:-minikube}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-installation-test}"
+IMAGE_TAG="${IMAGE_TAG:-external-metrics-e2e}"
+CONTROLLER_IMAGE="aibrix/controller-manager:${IMAGE_TAG}"
+ADAPTER_IMAGE="aibrix/external-metrics-adapter:e2e"
+
+cleanup() {
+  kubectl delete -k test/e2e/testdata/external-metrics-adapter --ignore-not-found=true || true
+  if [ "${EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER}" != "true" ]; then
+    kubectl delete -k test/e2e/testdata/external-metrics-autoscaler/aibrix --ignore-not-found=true || true
+  fi
+}
+
+diagnose() {
+  echo "=== external metrics e2e diagnostics ===" >&2
+  kubectl get apiservice/v1beta1.external.metrics.k8s.io -o yaml || true
+  kubectl -n aibrix-system get pods,deploy,svc,endpoints || true
+  kubectl -n aibrix-system logs deploy/aibrix-controller-manager --tail=200 || true
+  kubectl -n aibrix-system logs deploy/aibrix-autoscaling-controller-manager --tail=200 || true
+  kubectl -n aibrix-system logs deploy/aibrix-external-metrics-adapter --tail=200 || true
+  kubectl -n default get podautoscaler,deploy,pods,events --sort-by=.lastTimestamp || true
+  kubectl -n default get podautoscaler external-metrics-e2e -o yaml || true
+  kubectl -n default get deploy external-metrics-scale-target -o yaml || true
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd go
+require_cmd kubectl
+
+case "${EXTERNAL_METRICS_E2E_CLUSTER}" in
+  minikube)
+    require_cmd minikube
+
+    if ! minikube status -p "${MINIKUBE_PROFILE}" >/dev/null 2>&1; then
+      minikube start -p "${MINIKUBE_PROFILE}"
+    fi
+
+    kubectl config use-context "${MINIKUBE_PROFILE}"
+    ;;
+  kind)
+    require_cmd kind
+
+    if ! kind get clusters | grep -qx "${KIND_CLUSTER_NAME}"; then
+      echo "kind cluster not found: ${KIND_CLUSTER_NAME}" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "unsupported EXTERNAL_METRICS_E2E_CLUSTER=${EXTERNAL_METRICS_E2E_CLUSTER}; expected kind or minikube" >&2
+    exit 1
+    ;;
+esac
+
+trap cleanup EXIT
+
+TARGETARCH="${TARGETARCH:-$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}')}"
+mkdir -p bin
+if [ "${EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER}" != "true" ]; then
+  CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" go build -tags="nozmq" -o bin/controller-manager-e2e cmd/controllers/main.go
+fi
+CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" go build -o bin/external-metrics-adapter-e2e ./test/e2e/external-metrics-adapter
+if [ "${EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER}" != "true" ]; then
+  docker build -t "${CONTROLLER_IMAGE}" -f test/e2e/controller-manager/Dockerfile .
+fi
+docker build -t "${ADAPTER_IMAGE}" -f test/e2e/external-metrics-adapter/Dockerfile.local .
+
+case "${EXTERNAL_METRICS_E2E_CLUSTER}" in
+  minikube)
+    if [ "${EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER}" != "true" ]; then
+      minikube image load -p "${MINIKUBE_PROFILE}" "${CONTROLLER_IMAGE}"
+    fi
+    minikube image load -p "${MINIKUBE_PROFILE}" "${ADAPTER_IMAGE}"
+    ;;
+  kind)
+    if [ "${EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER}" = "true" ]; then
+      kind load docker-image "${ADAPTER_IMAGE}" --name "${KIND_CLUSTER_NAME}"
+    else
+      kind load docker-image "${CONTROLLER_IMAGE}" "${ADAPTER_IMAGE}" --name "${KIND_CLUSTER_NAME}"
+    fi
+    ;;
+esac
+
+kubectl create namespace aibrix-system --dry-run=client -o yaml | kubectl apply -f -
+if [ "${EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER}" = "true" ]; then
+  kubectl -n aibrix-system rollout status deployment/aibrix-controller-manager --timeout=180s
+else
+  kubectl apply -k test/e2e/testdata/external-metrics-autoscaler/aibrix
+  kubectl -n aibrix-system rollout status deployment/aibrix-autoscaling-controller-manager --timeout=180s
+fi
+
+kubectl apply -k test/e2e/testdata/external-metrics-adapter
+kubectl -n aibrix-system rollout status deployment/aibrix-external-metrics-adapter --timeout=180s
+kubectl wait --for=condition=Available apiservice/v1beta1.external.metrics.k8s.io --timeout=180s
+
+if ! AIBRIX_EXTERNAL_METRICS_E2E=true AIBRIX_EXTERNAL_METRICS_E2E_KEEP_ON_FAILURE=true \
+  go test ./test/e2e -v -run TestExternalMetricsAutoscaler -count=1 -timeout=5m; then
+  diagnose
+  exit 1
+fi

--- a/test/run-external-metrics-e2e.sh
+++ b/test/run-external-metrics-e2e.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 EXTERNAL_METRICS_E2E_CLUSTER="${EXTERNAL_METRICS_E2E_CLUSTER:-minikube}"
 EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER="${EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER:-false}"
+EXTERNAL_METRICS_E2E_KEEP_ON_FAILURE="${EXTERNAL_METRICS_E2E_KEEP_ON_FAILURE:-false}"
 MINIKUBE_PROFILE="${MINIKUBE_PROFILE:-minikube}"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-installation-test}"
 IMAGE_TAG="${IMAGE_TAG:-external-metrics-e2e}"
@@ -15,6 +16,15 @@ cleanup() {
   if [ "${EXTERNAL_METRICS_E2E_USE_EXISTING_CONTROLLER}" != "true" ]; then
     kubectl delete -k test/e2e/testdata/external-metrics-autoscaler/aibrix --ignore-not-found=true || true
   fi
+}
+
+cleanup_on_exit() {
+  local status=$?
+  if [ "${status}" -ne 0 ] && [ "${EXTERNAL_METRICS_E2E_KEEP_ON_FAILURE}" = "true" ]; then
+    echo "preserving external metrics e2e resources for failure diagnostics" >&2
+    return
+  fi
+  cleanup
 }
 
 diagnose() {
@@ -64,7 +74,7 @@ case "${EXTERNAL_METRICS_E2E_CLUSTER}" in
     ;;
 esac
 
-trap cleanup EXIT
+trap cleanup_on_exit EXIT
 
 TARGETARCH="${TARGETARCH:-$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}')}"
 mkdir -p bin


### PR DESCRIPTION
## Summary
- Implement Kubernetes `external.metrics.k8s.io` fetching for `external` PodAutoscaler metrics when no HTTP endpoint is configured.
- Wire the external metrics client into the autoscaler controller and add RBAC for external metrics reads.
- Add unit coverage plus a minikube e2e harness with a fake external metrics adapter.

Fixes #1594

## Test Plan
- `go test ./pkg/controller/podautoscaler/... -count=1`
- `go test ./test/e2e -run TestExternalMetricsAutoscaler -count=1`
- `make test-e2e-external-metrics`