### PR TITLE
fix: correct batch status transitions in planner poll loop

### DIFF
--- a/apps/console/api/planner/impl/handlers.go
+++ b/apps/console/api/planner/impl/handlers.go
@@ -34,7 +34,7 @@ import (
 
 func isBatchRunning(s plannerapi.JobStatus) bool {
 	switch s {
-	case plannerapi.JobStatusSubmitting, plannerapi.JobStatusValidating, plannerapi.JobStatusInProgress, plannerapi.JobStatusFinalizing:
+	case plannerapi.JobStatusSubmitting, plannerapi.JobStatusScheduling, plannerapi.JobStatusValidating, plannerapi.JobStatusInProgress, plannerapi.JobStatusFinalizing:
 		return true
 	}
 	return false

--- a/python/aibrix/aibrix/batch/batch_manager.py
+++ b/python/aibrix/aibrix/batch/batch_manager.py
@@ -657,6 +657,7 @@ class BatchManager(RunningJobs, SchedulableJobs):
             new_category="_in_progress_jobs",
         )  # type: ignore[call-arg]
 
+        became_in_progress = False
         try:
             job_driver = create_job_driver(
                 self._context,
@@ -670,6 +671,7 @@ class BatchManager(RunningJobs, SchedulableJobs):
             if meta_data.status.state == BatchJobState.VALIDATING:
                 meta_data.status.in_progress_at = datetime.now(timezone.utc)
                 meta_data.status.state = BatchJobState.IN_PROGRESS
+                became_in_progress = True
         except Exception as e:
             logger.error("Job validation failed", job_id=job_id, exc_info=True)  # type: ignore[call-arg]
             error = (
@@ -685,6 +687,22 @@ class BatchManager(RunningJobs, SchedulableJobs):
             )
             return None
 
+        # Persist the VALIDATING->IN_PROGRESS transition. The metastore is the
+        # console's source of truth (see _resolve_batch_job); without this flush
+        # the job keeps its CREATED snapshot (surfaced as 'scheduling') until the
+        # terminal flush in mark_job_done, so in_progress/finalizing/completed all
+        # appear at once. Best-effort: a persist hiccup must not block admission —
+        # the terminal flush still carries the full status.
+        if became_in_progress and self._job_entity_manager:
+            try:
+                await self.apply_job_changes(meta_data, meta_data)
+            except Exception:
+                logger.warning(
+                    "Failed to persist IN_PROGRESS transition",
+                    job_id=job_id,
+                    exc_info=True,
+                )
+
         return job_driver
 
     async def get_job_endpoint(self, job_id: str) -> str:
@@ -696,6 +714,29 @@ class BatchManager(RunningJobs, SchedulableJobs):
             logger.info("Job is discarded", job_id=job_id)  # type: ignore[call-arg]
             return ""
         return str(job.spec.endpoint)
+
+    async def _complete_request_and_maybe_persist(
+        self, meta_data: JobMetaInfo, req_id: int, failed: bool = False
+    ) -> None:
+        """Complete one request and, if that flips the job into FINALIZING, flush
+        the transition to the metastore so the console shows 'finalizing' before
+        the terminal flush. Only the state transition is persisted (not every
+        request), keeping metastore writes to one per state change."""
+        was_finalizing = meta_data.status.state == BatchJobState.FINALIZING
+        meta_data.complete_one_request(req_id, failed)
+        if (
+            not was_finalizing
+            and meta_data.status.state == BatchJobState.FINALIZING
+            and self._job_entity_manager
+        ):
+            try:
+                await self.apply_job_changes(meta_data, meta_data)
+            except Exception:
+                logger.warning(
+                    "Failed to persist FINALIZING transition",
+                    job_id=meta_data.job_id,
+                    exc_info=True,
+                )
 
     async def mark_job_progress(self, job_id: str, req_id: int) -> Tuple[BatchJob, int]:
         """
@@ -710,7 +751,7 @@ class BatchManager(RunningJobs, SchedulableJobs):
         if req_id < 0 or req_id > meta_data.status.request_counts.total:
             raise ValueError(f"invalide request_id: {req_id}")
 
-        meta_data.complete_one_request(req_id)
+        await self._complete_request_and_maybe_persist(meta_data, req_id)
         return meta_data, meta_data.next_request_id()
 
     async def mark_jobs_progresses(
@@ -735,7 +776,7 @@ class BatchManager(RunningJobs, SchedulableJobs):
                     total=request_len,
                 )
                 continue
-            meta_data.complete_one_request(req_id)
+            await self._complete_request_and_maybe_persist(meta_data, req_id)
 
         return meta_data
 
@@ -778,7 +819,7 @@ class BatchManager(RunningJobs, SchedulableJobs):
         """
         meta_data = await self._meta_from_in_progress_job(job_id)
 
-        meta_data.complete_one_request(req_id)
+        await self._complete_request_and_maybe_persist(meta_data, req_id)
         return meta_data, meta_data.next_request_id()
 
     async def mark_job_total(self, job_id: str, total_requests: int) -> BatchJob:

--- a/python/aibrix/aibrix/logger.py
+++ b/python/aibrix/aibrix/logger.py
@@ -15,7 +15,6 @@
 import logging
 import os
 import sys
-from logging import Logger
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional
@@ -63,7 +62,7 @@ def logging_basic_config(settings: Optional[AIBrixSettings] = None) -> None:
     )
 
 
-def init_logger(name: str) -> Logger:
+def init_logger(name: str) -> structlog.stdlib.BoundLogger:
     logger = structlog.get_logger(name)
     logger.setLevel(active_settings.LOG_LEVEL)
     return logger

--- a/python/aibrix/tests/batch/test_job_manager.py
+++ b/python/aibrix/tests/batch/test_job_manager.py
@@ -520,6 +520,115 @@ async def test_expire_job_persists_via_entity_manager():
 
 
 @pytest.mark.asyncio
+async def test_admit_persists_in_progress_transition(monkeypatch):
+    """The VALIDATING->IN_PROGRESS transition in admit() must be flushed to the
+    metastore so the console reflects execution start. Without it the job
+    appears stuck at 'scheduling' (the CREATED mapping) until finalize flushes
+    every timestamp at once ("flash in")."""
+    recorded: List[BatchJob] = []
+
+    class _RecordingEM(MockJobEntityManager):
+        async def update_job_status(self, job: BatchJob) -> None:
+            recorded.append(job.model_copy(deep=True))
+
+    asyncio.get_running_loop().name = "test_admit_persists_in_progress"
+    job_manager = _job_manager()
+    await job_manager.set_job_entity_manager(_RecordingEM(delay=0.0))
+
+    async def _ok_validate(self, job):
+        return None
+
+    monkeypatch.setattr(
+        "aibrix.batch.job_driver.base.BaseJobDriver.validate_job",
+        _ok_validate,
+    )
+
+    batch_job = BatchJob(
+        typeMeta=TypeMeta(apiVersion="batch/v1", kind="Job"),
+        metadata=ObjectMeta(
+            name="admit-job",
+            namespace="default",
+            uid="admit-uid",
+            creationTimestamp=datetime.now(),
+        ),
+        spec=BatchJobSpec(
+            input_file_id="f-admit",
+            endpoint=BatchJobEndpoint.CHAT_COMPLETIONS.value,
+            completion_window=CompletionWindow.TWENTY_FOUR_HOURS.expires_at(),
+        ),
+        status=BatchJobStatus(
+            jobID="admit-job-id",
+            state=BatchJobState.CREATED,
+            createdAt=datetime.now(),
+            inProgressAt=None,
+        ),
+    )
+    job_manager._pending_jobs["admit-job-id"] = batch_job
+
+    driver = await job_manager.admit("admit-job-id")
+
+    assert driver is not None
+    meta = job_manager._in_progress_jobs["admit-job-id"]
+    assert meta.status.state == BatchJobState.IN_PROGRESS
+    assert meta.status.in_progress_at is not None
+    # The transition was persisted exactly once, carrying IN_PROGRESS.
+    assert len(recorded) == 1
+    assert recorded[0].status.state == BatchJobState.IN_PROGRESS
+    assert recorded[0].status.in_progress_at is not None
+
+
+@pytest.mark.asyncio
+async def test_finalizing_transition_persists():
+    """When the last request completes and the job flips IN_PROGRESS->FINALIZING,
+    that transition must be flushed to the metastore so the console can show
+    'finalizing' before the terminal flush, instead of all events appearing at
+    once."""
+    from aibrix.batch.state import JobMetaInfo
+
+    recorded: List[BatchJob] = []
+
+    class _RecordingEM(MockJobEntityManager):
+        async def update_job_status(self, job: BatchJob) -> None:
+            recorded.append(job.model_copy(deep=True))
+
+    asyncio.get_running_loop().name = "test_finalizing_persists"
+    job_manager = _job_manager()
+    await job_manager.set_job_entity_manager(_RecordingEM(delay=0.0))
+
+    batch_job = BatchJob(
+        typeMeta=TypeMeta(apiVersion="batch/v1", kind="Job"),
+        metadata=ObjectMeta(
+            name="fin-job",
+            namespace="default",
+            uid="fin-uid",
+            creationTimestamp=datetime.now(),
+        ),
+        spec=BatchJobSpec(
+            input_file_id="f-fin",
+            endpoint=BatchJobEndpoint.CHAT_COMPLETIONS.value,
+            completion_window=CompletionWindow.TWENTY_FOUR_HOURS.expires_at(),
+        ),
+        status=BatchJobStatus(
+            jobID="fin-job-id",
+            state=BatchJobState.IN_PROGRESS,
+            createdAt=datetime.now(),
+            inProgressAt=datetime.now(),
+        ),
+    )
+    batch_job.status.request_counts.total = 1
+    meta = JobMetaInfo(batch_job)
+    job_manager._in_progress_jobs["fin-job-id"] = meta
+
+    # Complete the single request -> tracker flips the job to FINALIZING.
+    await job_manager.mark_job_progress("fin-job-id", 0)
+
+    assert meta.status.state == BatchJobState.FINALIZING
+    assert meta.status.finalizing_at is not None
+    assert len(recorded) == 1
+    assert recorded[0].status.state == BatchJobState.FINALIZING
+
+
+@pytest.mark.asyncio
 async def test_async_create_job_with_timeout():
     """Test that create_job throws error when timeout occurs."""
     # Create mock entity manager with long delay (longer than timeout)


### PR DESCRIPTION
## Pull Request Description

- treat scheduling status as running in batch planner poll loop
- persist in_progress/finalizing transitions to batch metastore

## Related Issues
Resolves: https://github.com/vllm-project/aibrix/issues/2373



**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>