### PR TITLE
Storage small file multi-upload optimization for large batch job finalization

### DIFF
--- a/python/aibrix/aibrix/storage/base.py
+++ b/python/aibrix/aibrix/storage/base.py
@@ -32,9 +32,17 @@ class StorageConfig:
     max_retries: int = 3
     timeout: int = 30
 
-    # Upload configuration
+    # Upload/session configuration
     multipart_threshold: int = 5 * 1024 * 1024  # 5MB
-    max_concurrency: int = 10
+    # Backend-specific total connection-pool sizing. Only S3 uses this today.
+    max_concurrency: int = 100
+    # Per-operation/session concurrency examples: staged-part prefetch fanout,
+    # and multipart part fanout. This does not
+    # impose a storage-wide total GET/PUT concurrency cap.
+    max_session_concurrency: int = 10
+    # Per-request multi-object delete batch size for backends such as S3/TOS.
+    multi_object_delete_limit: int = 1000
+    strict_multipart_min_part_size: Optional[bool] = None
 
     # Read configuration
     range_chunksize: int = 1024 * 1024  # 1MB for range reads
@@ -194,6 +202,18 @@ class BaseStorage(ABC):
             key: Object key/path
         """
         pass
+
+    async def delete_objects(self, keys: list[str]) -> None:
+        """Delete multiple objects from storage.
+
+        Backends may override this to use a native batch-delete API. The default
+        implementation preserves compatibility by deleting sequentially.
+
+        Args:
+            keys: Object keys/paths to delete
+        """
+        for key in keys:
+            await self.delete_object(key)
 
     @abstractmethod
     async def list_objects(
@@ -527,7 +547,7 @@ class BaseStorage(ABC):
 
         # Store part as individual object
         await self.put_object(
-            self._multipart_upload_key(upload_id, f"part_{part_number:05d}"),
+            self._multipart_upload_part_key(upload_id, part_number),
             part_data,
             content_type="application/octet-stream",
         )
@@ -580,7 +600,7 @@ class BaseStorage(ABC):
             part_number = part["part_number"]
             try:
                 part_data = await self.get_object(
-                    self._multipart_upload_key(upload_id, f"part_{part_number:05d}")
+                    self._multipart_upload_part_key(upload_id, int(part_number))
                 )
                 aggregated_data.write(part_data)
             except Exception:
@@ -814,6 +834,10 @@ class BaseStorage(ABC):
     def _multipart_upload_key(self, upload_id: str, subkey: str = "metadata") -> str:
         """Return the key for multipart upload metadata. For small parts multipart upload only."""
         return f".multipart/{upload_id}/{subkey}"
+
+    def _multipart_upload_part_key(self, upload_id: str, part_number: int) -> str:
+        """Return the key for a staged multipart part object."""
+        return self._multipart_upload_key(upload_id, f"part_{part_number:05d}")
 
     def _wrap_data(self, data: Union[bytes, str, BinaryIO, TextIO, Reader]) -> Reader:
         """Wrap data in Reader if necessary."""

--- a/python/aibrix/aibrix/storage/base.py
+++ b/python/aibrix/aibrix/storage/base.py
@@ -41,6 +41,7 @@ class StorageConfig:
     # impose a storage-wide total GET/PUT concurrency cap.
     max_session_concurrency: int = 10
     # Per-request multi-object delete batch size for backends such as S3/TOS.
+    # Do not increase this value for S3/TOS, and do so if you know what you are doing.
     multi_object_delete_limit: int = 1000
     strict_multipart_min_part_size: Optional[bool] = None
 

--- a/python/aibrix/aibrix/storage/base2.py
+++ b/python/aibrix/aibrix/storage/base2.py
@@ -1,3 +1,4 @@
+import ast
 import asyncio
 from io import BytesIO
 from typing import AsyncIterator, Union
@@ -41,12 +42,26 @@ class BaseStorage2(BaseStorage):
             chunk_keys = staged_part_keys[
                 chunk_start : chunk_start + prefetch_concurrency
             ]
-            chunk_results = await asyncio.gather(
-                *(
+            tasks = [
+                asyncio.create_task(
                     _load_part(int(part["part_number"]), staged_part_key)
-                    for part, staged_part_key in zip(chunk_parts, chunk_keys)
                 )
-            )
+                for part, staged_part_key in zip(chunk_parts, chunk_keys)
+            ]
+            try:
+                chunk_results = await asyncio.gather(*tasks)
+            except Exception:
+                # TODO: Add a config option to allow faulty aggregation so callers
+                # can choose whether failed staged-part reads should fail the
+                # whole chunk or be tolerated best-effort.
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                # Drain cancelled sibling tasks so they do not keep running or
+                # surface unhandled exceptions after we re-raise the first error.
+                await asyncio.gather(*tasks, return_exceptions=True)
+                raise
+
             for part_number, part_data in chunk_results:
                 yield part_number, part_data
 
@@ -59,7 +74,7 @@ class BaseStorage2(BaseStorage):
         """Complete small-parts uploads using bounded native multipart reassembly."""
         try:
             metadata_data = await self.get_object(self._multipart_upload_key(upload_id))
-            upload_metadata = eval(metadata_data.decode("utf-8"))
+            upload_metadata = ast.literal_eval(metadata_data.decode("utf-8"))
         except Exception:
             if self.is_native_multipart_supported():
                 return await self._native_complete_multipart_upload(
@@ -135,7 +150,8 @@ class BaseStorage2(BaseStorage):
                         aggregated_parts,
                     )
 
-                assert native_upload_id is not None
+                if native_upload_id is None:
+                    raise ValueError("Native upload ID was not initialized")
                 await self._native_complete_multipart_upload(
                     key, native_upload_id, aggregated_parts
                 )
@@ -203,7 +219,7 @@ class BaseStorage2(BaseStorage):
         if flush_size is None:
             flush_size = len(buffer)
         chunk = bytes(buffer[:flush_size])
-        del buffer[:flush_size]
         etag = await self._native_upload_part(key, upload_id, part_number, chunk)
+        del buffer[:flush_size]
         parts.append({"part_number": part_number, "etag": etag})
         return part_number + 1

--- a/python/aibrix/aibrix/storage/base2.py
+++ b/python/aibrix/aibrix/storage/base2.py
@@ -1,0 +1,209 @@
+import asyncio
+from io import BytesIO
+from typing import AsyncIterator, Union
+
+from aibrix.storage.base import BaseStorage
+
+
+class BaseStorage2(BaseStorage):
+    """Alternative BaseStorage with bounded-buffer small-part aggregation."""
+
+    def _is_strict_multipart_min_part_size_enabled(self) -> bool:
+        """Return whether native multipart uploads must avoid undersized tails."""
+        return bool(self.config.strict_multipart_min_part_size)
+
+    async def _iter_prefetched_staged_parts(
+        self,
+        upload_id: str,
+        parts: list[dict[str, Union[str, int]]],
+        staged_part_keys: list[str],
+    ) -> AsyncIterator[tuple[int, bytes]]:
+        prefetch_concurrency = max(
+            1,
+            min(
+                self.config.max_session_concurrency,
+                len(parts),
+            ),
+        )
+
+        async def _load_part(
+            part_number: int, staged_part_key: str
+        ) -> tuple[int, bytes]:
+            try:
+                return part_number, await self.get_object(staged_part_key)
+            except Exception as exc:
+                raise ValueError(
+                    f"Failed to retrieve part {part_number} for upload {upload_id}"
+                ) from exc
+
+        for chunk_start in range(0, len(parts), prefetch_concurrency):
+            chunk_parts = parts[chunk_start : chunk_start + prefetch_concurrency]
+            chunk_keys = staged_part_keys[
+                chunk_start : chunk_start + prefetch_concurrency
+            ]
+            chunk_results = await asyncio.gather(
+                *(
+                    _load_part(int(part["part_number"]), staged_part_key)
+                    for part, staged_part_key in zip(chunk_parts, chunk_keys)
+                )
+            )
+            for part_number, part_data in chunk_results:
+                yield part_number, part_data
+
+    async def complete_multipart_upload(
+        self,
+        key: str,
+        upload_id: str,
+        parts: list[dict[str, Union[str, int]]],
+    ) -> None:
+        """Complete small-parts uploads using bounded native multipart reassembly."""
+        try:
+            metadata_data = await self.get_object(self._multipart_upload_key(upload_id))
+            upload_metadata = eval(metadata_data.decode("utf-8"))
+        except Exception:
+            if self.is_native_multipart_supported():
+                return await self._native_complete_multipart_upload(
+                    key, upload_id, parts
+                )
+            raise ValueError(f"Upload ID {upload_id} not found or corrupted")
+
+        content_type = upload_metadata.get("content_type")
+        metadata = upload_metadata.get("metadata", {})
+        sorted_parts = sorted(parts, key=lambda p: p["part_number"])
+        staged_part_keys = [
+            self._multipart_upload_part_key(upload_id, int(part["part_number"]))
+            for part in sorted_parts
+        ]
+
+        if not sorted_parts:
+            await self.put_object(key, b"", content_type, metadata)
+            await self.abort_multipart_upload(key, upload_id)
+            return
+
+        if self.is_native_multipart_supported():
+            strict_min_part_size = self._is_strict_multipart_min_part_size_enabled()
+            threshold = max(self.config.multipart_threshold, 1)
+            native_upload_id: str | None = None
+            aggregated_parts: list[dict[str, Union[str, int]]] = []
+            buffer = bytearray()
+            native_part_number = 1
+
+            try:
+                async for _, part_data in self._iter_prefetched_staged_parts(
+                    upload_id, sorted_parts, staged_part_keys
+                ):
+                    buffer.extend(part_data)
+                    flush_threshold = (
+                        threshold * 2 if strict_min_part_size else threshold
+                    )
+                    while len(buffer) >= flush_threshold:
+                        if native_upload_id is None:
+                            native_upload_id = (
+                                await self._native_create_multipart_upload(
+                                    key, content_type, metadata
+                                )
+                            )
+                        native_part_number = await self._flush_native_aggregate_part(
+                            key,
+                            native_upload_id,
+                            buffer,
+                            native_part_number,
+                            aggregated_parts,
+                            flush_size=threshold,
+                        )
+
+                if strict_min_part_size and len(buffer) < threshold:
+                    if aggregated_parts:
+                        raise ValueError(
+                            "Strict multipart aggregation produced an undersized "
+                            "final part"
+                        )
+                    await self.put_object(key, bytes(buffer), content_type, metadata)
+                    await self.abort_multipart_upload(key, upload_id)
+                    return
+
+                if buffer or not aggregated_parts:
+                    if native_upload_id is None:
+                        native_upload_id = await self._native_create_multipart_upload(
+                            key, content_type, metadata
+                        )
+                    await self._flush_native_aggregate_part(
+                        key,
+                        native_upload_id,
+                        buffer,
+                        native_part_number,
+                        aggregated_parts,
+                    )
+
+                assert native_upload_id is not None
+                await self._native_complete_multipart_upload(
+                    key, native_upload_id, aggregated_parts
+                )
+            except Exception:
+                if native_upload_id is not None:
+                    await self._native_abort_multipart_upload(key, native_upload_id)
+                raise
+
+            await self.abort_multipart_upload(key, upload_id)
+            return
+
+        aggregated_data = BytesIO()
+        async for _, part_data in self._iter_prefetched_staged_parts(
+            upload_id, sorted_parts, staged_part_keys
+        ):
+            aggregated_data.write(part_data)
+
+        aggregated_data.seek(0)
+        await self.put_object(key, aggregated_data, content_type, metadata)
+        await self.abort_multipart_upload(key, upload_id)
+
+    async def abort_multipart_upload(
+        self,
+        key: str,
+        upload_id: str,
+    ) -> None:
+        """Abort multipart upload with best-effort cleanup for base2 small parts."""
+        prefix = self._multipart_upload_key(upload_id, "")
+        no_multipart_data = True
+        try:
+            objects_to_delete, _ = await self.list_objects(prefix)
+
+            if objects_to_delete:
+                no_multipart_data = False
+                try:
+                    await self.delete_objects(objects_to_delete)
+                except Exception:
+                    for obj_key in objects_to_delete:
+                        try:
+                            await self.delete_object(obj_key)
+                        except Exception:
+                            pass
+        except Exception:
+            try:
+                await self.delete_object(self._multipart_upload_key(upload_id))
+                no_multipart_data = False
+            except Exception:
+                pass
+
+        if no_multipart_data and self.is_native_multipart_supported():
+            await self._native_abort_multipart_upload(key, upload_id)
+
+    async def _flush_native_aggregate_part(
+        self,
+        key: str,
+        upload_id: str,
+        buffer: bytearray,
+        part_number: int,
+        parts: list[dict[str, Union[str, int]]],
+        flush_size: int | None = None,
+    ) -> int:
+        if not buffer:
+            return part_number
+
+        if flush_size is None:
+            flush_size = len(buffer)
+        chunk = bytes(buffer[:flush_size])
+        del buffer[:flush_size]
+        etag = await self._native_upload_part(key, upload_id, part_number, chunk)
+        parts.append({"part_number": part_number, "etag": etag})
+        return part_number + 1

--- a/python/aibrix/aibrix/storage/local.py
+++ b/python/aibrix/aibrix/storage/local.py
@@ -20,19 +20,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncIterator, BinaryIO, Optional, TextIO, Union
 
-from aibrix.storage.base import (
-    BaseStorage,
-    PutObjectOptions,
-    StorageConfig,
-    StorageType,
-)
+from aibrix.storage.base import PutObjectOptions, StorageConfig, StorageType
+from aibrix.storage.base2 import BaseStorage2
 from aibrix.storage.reader import Reader
 from aibrix.storage.utils import ObjectMetadata, _sanitize_key, generate_filename
 
 LOCAL_STORAGE_PATH_VAR = "STORAGE_LOCAL_PATH"
 
 
-class LocalStorage(BaseStorage):
+class LocalStorage(BaseStorage2):
     """Local filesystem storage implementation."""
 
     def __init__(

--- a/python/aibrix/aibrix/storage/redis.py
+++ b/python/aibrix/aibrix/storage/redis.py
@@ -17,17 +17,13 @@ import time
 from typing import BinaryIO, Optional, TextIO, Union
 
 import aibrix.client.redis as redis
-from aibrix.storage.base import (
-    BaseStorage,
-    PutObjectOptions,
-    StorageConfig,
-    StorageType,
-)
+from aibrix.storage.base import PutObjectOptions, StorageConfig, StorageType
+from aibrix.storage.base2 import BaseStorage2
 from aibrix.storage.reader import Reader
 from aibrix.storage.utils import ObjectMetadata
 
 
-class RedisStorage(BaseStorage):
+class RedisStorage(BaseStorage2):
     """Redis storage implementation.
 
     This implementation uses Redis as a key-value store with the following features:

--- a/python/aibrix/aibrix/storage/s3.py
+++ b/python/aibrix/aibrix/storage/s3.py
@@ -20,17 +20,13 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
-from aibrix.storage.base import (
-    BaseStorage,
-    PutObjectOptions,
-    StorageConfig,
-    StorageType,
-)
+from aibrix.storage.base import PutObjectOptions, StorageConfig, StorageType
+from aibrix.storage.base2 import BaseStorage2
 from aibrix.storage.reader import Reader
 from aibrix.storage.utils import ObjectMetadata
 
 
-class S3Storage(BaseStorage):
+class S3Storage(BaseStorage2):
     """AWS S3 storage implementation with multipart upload and range get support."""
 
     def __init__(
@@ -194,6 +190,32 @@ class S3Storage(BaseStorage):
         await asyncio.get_event_loop().run_in_executor(
             None, lambda: self.client.delete_object(Bucket=self.bucket_name, Key=key)
         )
+
+    async def delete_objects(self, keys: list[str]) -> None:
+        """Delete multiple objects from S3 using native batch delete."""
+        if not keys:
+            return
+        delete_limit = min(self.config.multi_object_delete_limit, len(keys))
+
+        def _delete_chunk(chunk: list[str]) -> None:
+            response = self.client.delete_objects(
+                Bucket=self.bucket_name,
+                Delete={
+                    "Objects": [{"Key": key} for key in chunk],
+                    "Quiet": False,
+                },
+            )
+            errors = [
+                error
+                for error in response.get("Errors", [])
+                if error.get("Code") not in {"NoSuchKey", "404", "NotFound"}
+            ]
+            if errors:
+                raise ValueError(f"Failed to delete S3 objects: {errors}")
+
+        for chunk_start in range(0, len(keys), delete_limit):
+            chunk = keys[chunk_start : chunk_start + delete_limit]
+            await asyncio.get_event_loop().run_in_executor(None, _delete_chunk, chunk)
 
     async def list_objects(
         self,

--- a/python/aibrix/aibrix/storage/s3.py
+++ b/python/aibrix/aibrix/storage/s3.py
@@ -195,7 +195,7 @@ class S3Storage(BaseStorage2):
         """Delete multiple objects from S3 using native batch delete."""
         if not keys:
             return
-        delete_limit = min(self.config.multi_object_delete_limit, len(keys))
+        delete_limit = max(1, min(self.config.multi_object_delete_limit, len(keys)))
 
         def _delete_chunk(chunk: list[str]) -> None:
             response = self.client.delete_objects(

--- a/python/aibrix/aibrix/storage/tos.py
+++ b/python/aibrix/aibrix/storage/tos.py
@@ -13,18 +13,15 @@
 # limitations under the License.
 
 import asyncio
+from dataclasses import replace
 from io import BytesIO
 from typing import BinaryIO, Optional, TextIO, Union
 
 import tos
 from tos.exceptions import TosClientError, TosServerError
 
-from aibrix.storage.base import (
-    BaseStorage,
-    PutObjectOptions,
-    StorageConfig,
-    StorageType,
-)
+from aibrix.storage.base import PutObjectOptions, StorageConfig, StorageType
+from aibrix.storage.base2 import BaseStorage2
 from aibrix.storage.reader import Reader
 from aibrix.storage.utils import ObjectMetadata
 
@@ -37,7 +34,7 @@ class TOSPart:
         self.etag = etag
 
 
-class TOSStorage(BaseStorage):
+class TOSStorage(BaseStorage2):
     """TOS (Volcano Object Storage) implementation with multipart upload and range get support."""
 
     def __init__(
@@ -49,7 +46,12 @@ class TOSStorage(BaseStorage):
         region: str,
         config: Optional[StorageConfig] = None,
     ):
-        super().__init__(config)
+        resolved_config = config or StorageConfig()
+        if resolved_config.strict_multipart_min_part_size is None:
+            resolved_config = replace(
+                resolved_config, strict_multipart_min_part_size=True
+            )
+        super().__init__(resolved_config)
         self.bucket_name = bucket_name
 
         try:
@@ -160,6 +162,38 @@ class TOSStorage(BaseStorage):
                     raise ValueError(f"Failed to delete object {key}: {e}")
 
         await asyncio.get_event_loop().run_in_executor(None, _delete_object)
+
+    async def delete_objects(self, keys: list[str]) -> None:
+        """Delete multiple objects from TOS using native batch delete."""
+        if not keys:
+            return
+        delete_limit = min(self.config.multi_object_delete_limit, len(keys))
+
+        def _delete_chunk(chunk: list[str]) -> None:
+            try:
+                result = self.client.delete_multi_objects(
+                    bucket=self.bucket_name,
+                    objects=[tos.models2.ObjectTobeDeleted(key=key) for key in chunk],
+                    quiet=False,
+                )
+            except (TosClientError, TosServerError) as e:
+                raise ValueError(f"Failed to delete TOS objects: {e}")
+
+            errors = [
+                {
+                    "key": error.key,
+                    "code": error.code,
+                    "message": error.message,
+                }
+                for error in result.error
+                if error.code not in {"NoSuchKey", "404", "NotFound"}
+            ]
+            if errors:
+                raise ValueError(f"Failed to delete TOS objects: {errors}")
+
+        for chunk_start in range(0, len(keys), delete_limit):
+            chunk = keys[chunk_start : chunk_start + delete_limit]
+            await asyncio.get_event_loop().run_in_executor(None, _delete_chunk, chunk)
 
     async def list_objects(
         self,

--- a/python/aibrix/aibrix/storage/tos.py
+++ b/python/aibrix/aibrix/storage/tos.py
@@ -167,7 +167,7 @@ class TOSStorage(BaseStorage2):
         """Delete multiple objects from TOS using native batch delete."""
         if not keys:
             return
-        delete_limit = min(self.config.multi_object_delete_limit, len(keys))
+        delete_limit = max(1, min(self.config.multi_object_delete_limit, len(keys)))
 
         def _delete_chunk(chunk: list[str]) -> None:
             try:
@@ -185,7 +185,7 @@ class TOSStorage(BaseStorage2):
                     "code": error.code,
                     "message": error.message,
                 }
-                for error in result.error
+                for error in (result.error or [])
                 if error.code not in {"NoSuchKey", "404", "NotFound"}
             ]
             if errors:

--- a/python/aibrix/tests/storage/test_base2.py
+++ b/python/aibrix/tests/storage/test_base2.py
@@ -1,0 +1,541 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the alternative BaseStorage2 aggregation path."""
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, Union
+
+import pytest
+import tos
+
+from aibrix.storage.base import StorageConfig
+from aibrix.storage.base2 import BaseStorage2
+from aibrix.storage.reader import Reader
+from aibrix.storage.s3 import S3Storage
+from aibrix.storage.tos import TOSStorage
+from aibrix.storage.types import StorageType
+from aibrix.storage.utils import ObjectMetadata
+
+
+class FakeS3Client:
+    def __init__(self, responses: list[dict] | None = None) -> None:
+        self.responses = responses or [{}]
+        self.calls: list[dict] = []
+
+    def delete_objects(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+class FakeTOSClient:
+    def __init__(self, responses: list[object] | None = None) -> None:
+        self.responses = responses or [SimpleNamespace(error=[])]
+        self.calls: list[dict] = []
+
+    def delete_multi_objects(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+class NativeMultipartTestStorage(BaseStorage2):
+    """In-memory storage double for the alternative buffered aggregation path."""
+
+    def __init__(
+        self,
+        multipart_threshold: int = 8,
+        fail_native_complete: bool = False,
+        strict_multipart_min_part_size: bool | None = None,
+    ) -> None:
+        super().__init__(
+            StorageConfig(
+                multipart_threshold=multipart_threshold,
+                strict_multipart_min_part_size=strict_multipart_min_part_size,
+            )
+        )
+        self.fail_native_complete = fail_native_complete
+        self.objects: dict[str, bytes] = {}
+        self.object_metadata: dict[str, ObjectMetadata] = {}
+        self.put_object_calls: list[str] = []
+        self.delete_object_calls: list[str] = []
+        self.list_objects_calls: list[str] = []
+        self.native_create_calls: list[dict[str, object]] = []
+        self.native_upload_part_calls: list[dict[str, object]] = []
+        self.native_complete_calls: list[dict[str, object]] = []
+        self.native_abort_calls: list[dict[str, str]] = []
+        self.native_uploads: dict[str, dict[str, object]] = {}
+        self._native_upload_counter = 0
+
+    def get_type(self) -> StorageType:
+        return StorageType.LOCAL
+
+    async def put_object(
+        self,
+        key: str,
+        data: Any,
+        content_type: str | None = None,
+        metadata: dict[str, str] | None = None,
+        options: Any = None,
+    ) -> bool:
+        reader = self._wrap_data(data)
+        payload = reader.read_all()
+        if not isinstance(data, Reader):
+            reader.close()
+
+        self.put_object_calls.append(key)
+        self.objects[key] = payload
+        self.object_metadata[key] = ObjectMetadata(
+            content_length=len(payload),
+            content_type=content_type,
+            metadata=metadata or {},
+        )
+        return True
+
+    async def get_object(
+        self,
+        key: str,
+        range_start: int | None = None,
+        range_end: int | None = None,
+    ) -> bytes:
+        if key not in self.objects:
+            raise FileNotFoundError(f"Object not found: {key}")
+
+        data = self.objects[key]
+        start = 0 if range_start is None else range_start
+        end = len(data) - 1 if range_end is None else range_end
+        return data[start : end + 1]
+
+    async def delete_object(self, key: str) -> None:
+        self.delete_object_calls.append(key)
+        self.objects.pop(key, None)
+        self.object_metadata.pop(key, None)
+
+    async def list_objects(
+        self,
+        prefix: str = "",
+        delimiter: str | None = None,
+        limit: int | None = None,
+        continuation_token: str | None = None,
+        after_key: str | None = None,
+    ) -> tuple[list[str], str | None]:
+        self.list_objects_calls.append(prefix)
+        keys = sorted(key for key in self.objects if key.startswith(prefix))
+        if limit is not None:
+            keys = keys[:limit]
+        return keys, None
+
+    async def object_exists(self, key: str) -> bool:
+        return key in self.objects
+
+    async def get_object_size(self, key: str) -> int:
+        return len(await self.get_object(key))
+
+    async def head_object(self, key: str) -> ObjectMetadata:
+        if key not in self.object_metadata:
+            raise FileNotFoundError(f"Object not found: {key}")
+        return self.object_metadata[key]
+
+    def is_native_multipart_supported(self) -> bool:
+        return True
+
+    async def _native_create_multipart_upload(
+        self,
+        key: str,
+        content_type: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> str:
+        self._native_upload_counter += 1
+        upload_id = f"native-{self._native_upload_counter}"
+        self.native_create_calls.append(
+            {
+                "key": key,
+                "content_type": content_type,
+                "metadata": metadata or {},
+                "upload_id": upload_id,
+            }
+        )
+        self.native_uploads[upload_id] = {
+            "key": key,
+            "content_type": content_type,
+            "metadata": metadata or {},
+            "parts": {},
+        }
+        return upload_id
+
+    async def _native_upload_part(
+        self,
+        key: str,
+        upload_id: str,
+        part_number: int,
+        data: Any,
+    ) -> str:
+        reader = self._wrap_data(data)
+        payload = reader.read_all()
+        if not isinstance(data, Reader):
+            reader.close()
+
+        self.native_upload_part_calls.append(
+            {
+                "key": key,
+                "upload_id": upload_id,
+                "part_number": part_number,
+                "size": len(payload),
+            }
+        )
+        upload = self.native_uploads[upload_id]
+        upload_parts = upload["parts"]
+        assert isinstance(upload_parts, dict)
+        upload_parts[part_number] = payload
+        return f"native-etag-{part_number}"
+
+    async def _native_complete_multipart_upload(
+        self,
+        key: str,
+        upload_id: str,
+        parts: list[dict[str, Union[str, int]]],
+    ) -> None:
+        self.native_complete_calls.append(
+            {"key": key, "upload_id": upload_id, "parts": list(parts)}
+        )
+        if self.fail_native_complete:
+            raise ValueError("native completion failed")
+
+        upload = self.native_uploads[upload_id]
+        upload_parts = upload["parts"]
+        assert isinstance(upload_parts, dict)
+        final_data = b"".join(
+            upload_parts[int(part["part_number"])]
+            for part in sorted(parts, key=lambda item: int(item["part_number"]))
+        )
+        self.objects[key] = final_data
+        self.object_metadata[key] = ObjectMetadata(
+            content_length=len(final_data),
+            content_type=upload["content_type"]
+            if isinstance(upload["content_type"], str) or upload["content_type"] is None
+            else None,
+            metadata=upload["metadata"]
+            if isinstance(upload["metadata"], dict)
+            else None,
+        )
+
+    async def _native_abort_multipart_upload(self, key: str, upload_id: str) -> None:
+        self.native_abort_calls.append({"key": key, "upload_id": upload_id})
+        self.native_uploads.pop(upload_id, None)
+
+
+class DelayedMultipartTestStorage(NativeMultipartTestStorage):
+    """Storage double that delays staged part reads to expose concurrency."""
+
+    def __init__(
+        self, multipart_threshold: int = 8, max_session_concurrency: int = 3
+    ) -> None:
+        super().__init__(multipart_threshold=multipart_threshold)
+        self.config.max_session_concurrency = max_session_concurrency
+        self.active_part_gets = 0
+        self.max_parallel_part_gets = 0
+
+    async def get_object(
+        self,
+        key: str,
+        range_start: int | None = None,
+        range_end: int | None = None,
+    ) -> bytes:
+        is_staged_part = ".multipart/" in key and "/part_" in key
+        if is_staged_part:
+            self.active_part_gets += 1
+            self.max_parallel_part_gets = max(
+                self.max_parallel_part_gets, self.active_part_gets
+            )
+            await asyncio.sleep(0.01)
+        try:
+            return await super().get_object(key, range_start, range_end)
+        finally:
+            if is_staged_part:
+                self.active_part_gets -= 1
+
+
+class TestBaseStorage2:
+    @pytest.mark.asyncio
+    async def test_small_parts_completion_uses_native_buffered_aggregation(self):
+        storage = NativeMultipartTestStorage(multipart_threshold=8)
+        key = "test/native_small_parts.txt"
+
+        upload_id = await storage.create_multipart_upload(
+            key,
+            content_type="text/plain",
+            metadata={"source": "batch"},
+            small_parts=True,
+        )
+
+        parts: list[dict[str, Union[str, int]]] = []
+        for part_number, payload in enumerate((b"abc", b"def", b"ghi", b"jk"), start=1):
+            etag = await storage.upload_part(key, upload_id, part_number, payload)
+            parts.append({"part_number": part_number, "etag": etag})
+
+        await storage.complete_multipart_upload(key, upload_id, parts)
+
+        assert await storage.get_object(key) == b"abcdefghijk"
+        assert key not in storage.put_object_calls
+        assert len(storage.native_create_calls) == 1
+        assert [call["size"] for call in storage.native_upload_part_calls] == [8, 3]
+
+        final_metadata = await storage.head_object(key)
+        assert final_metadata.content_type == "text/plain"
+        assert final_metadata.metadata == {"source": "batch"}
+
+        multipart_prefix = storage._multipart_upload_key(upload_id, "")
+        assert storage.list_objects_calls == [multipart_prefix]
+        assert not [
+            obj_key
+            for obj_key in storage.objects
+            if obj_key.startswith(multipart_prefix)
+        ]
+        assert storage.delete_object_calls == [
+            storage._multipart_upload_key(upload_id),
+            storage._multipart_upload_part_key(upload_id, 1),
+            storage._multipart_upload_part_key(upload_id, 2),
+            storage._multipart_upload_part_key(upload_id, 3),
+            storage._multipart_upload_part_key(upload_id, 4),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_small_parts_native_completion_failure_preserves_staged_parts(self):
+        storage = NativeMultipartTestStorage(
+            multipart_threshold=8, fail_native_complete=True
+        )
+        key = "test/native_small_parts_failure.txt"
+
+        upload_id = await storage.create_multipart_upload(
+            key,
+            content_type="text/plain",
+            metadata={"source": "batch"},
+            small_parts=True,
+        )
+
+        parts: list[dict[str, Union[str, int]]] = []
+        for part_number, payload in enumerate((b"abc", b"def", b"ghi", b"jk"), start=1):
+            etag = await storage.upload_part(key, upload_id, part_number, payload)
+            parts.append({"part_number": part_number, "etag": etag})
+
+        with pytest.raises(ValueError, match="native completion failed"):
+            await storage.complete_multipart_upload(key, upload_id, parts)
+
+        assert not await storage.object_exists(key)
+        assert storage.native_abort_calls == [
+            {
+                "key": key,
+                "upload_id": storage.native_create_calls[0]["upload_id"],
+            }
+        ]
+        assert storage.delete_object_calls == []
+        assert await storage.object_exists(storage._multipart_upload_key(upload_id))
+        assert await storage.object_exists(
+            storage._multipart_upload_part_key(upload_id, 1)
+        )
+        assert await storage.object_exists(
+            storage._multipart_upload_part_key(upload_id, 2)
+        )
+        assert await storage.object_exists(
+            storage._multipart_upload_part_key(upload_id, 3)
+        )
+        assert await storage.object_exists(
+            storage._multipart_upload_part_key(upload_id, 4)
+        )
+
+    @pytest.mark.asyncio
+    async def test_small_parts_completion_prefetches_staged_part_reads(self):
+        storage = DelayedMultipartTestStorage(
+            multipart_threshold=64, max_session_concurrency=3
+        )
+        key = "test/native_small_parts_prefetch.txt"
+
+        upload_id = await storage.create_multipart_upload(
+            key,
+            content_type="text/plain",
+            metadata={"source": "batch"},
+            small_parts=True,
+        )
+
+        parts: list[dict[str, Union[str, int]]] = []
+        for part_number, payload in enumerate((b"ab", b"cd", b"ef", b"gh"), start=1):
+            etag = await storage.upload_part(key, upload_id, part_number, payload)
+            parts.append({"part_number": part_number, "etag": etag})
+
+        await storage.complete_multipart_upload(key, upload_id, parts)
+
+        assert await storage.get_object(key) == b"abcdefgh"
+        assert storage.max_parallel_part_gets >= 2
+        assert storage.max_parallel_part_gets <= storage.config.max_session_concurrency
+
+    @pytest.mark.asyncio
+    async def test_strict_small_parts_completion_avoids_small_final_native_part(self):
+        storage = NativeMultipartTestStorage(
+            multipart_threshold=8, strict_multipart_min_part_size=True
+        )
+        key = "test/native_small_parts_strict.txt"
+
+        upload_id = await storage.create_multipart_upload(
+            key,
+            content_type="text/plain",
+            metadata={"source": "batch"},
+            small_parts=True,
+        )
+
+        parts: list[dict[str, Union[str, int]]] = []
+        for part_number, payload in enumerate(
+            (b"abc", b"def", b"ghi", b"jklmno", b"pq"),
+            start=1,
+        ):
+            etag = await storage.upload_part(key, upload_id, part_number, payload)
+            parts.append({"part_number": part_number, "etag": etag})
+
+        await storage.complete_multipart_upload(key, upload_id, parts)
+
+        assert await storage.get_object(key) == b"abcdefghijklmnopq"
+        assert [call["size"] for call in storage.native_upload_part_calls] == [8, 9]
+        assert key not in storage.put_object_calls
+
+    @pytest.mark.asyncio
+    async def test_strict_small_parts_completion_falls_back_to_put_object(self):
+        storage = NativeMultipartTestStorage(
+            multipart_threshold=8, strict_multipart_min_part_size=True
+        )
+        key = "test/native_small_parts_strict_fallback.txt"
+
+        upload_id = await storage.create_multipart_upload(
+            key,
+            content_type="text/plain",
+            metadata={"source": "batch"},
+            small_parts=True,
+        )
+
+        parts: list[dict[str, Union[str, int]]] = []
+        for part_number, payload in enumerate((b"ab", b"cd", b"efg"), start=1):
+            etag = await storage.upload_part(key, upload_id, part_number, payload)
+            parts.append({"part_number": part_number, "etag": etag})
+
+        await storage.complete_multipart_upload(key, upload_id, parts)
+
+        assert await storage.get_object(key) == b"abcdefg"
+        assert storage.put_object_calls[-1] == key
+        assert storage.native_create_calls == []
+        assert storage.native_upload_part_calls == []
+        assert storage.native_complete_calls == []
+        assert storage.native_abort_calls == []
+
+
+class TestTOSStorageConfig:
+    def test_tos_storage_enables_strict_min_part_size_by_default(self, monkeypatch):
+        mock_client = object()
+        monkeypatch.setattr(tos, "TosClientV2", lambda *args: mock_client)
+
+        storage = TOSStorage(
+            bucket_name="bucket",
+            access_key="ak",
+            secret_key="sk",
+            endpoint="https://tos.example.com",
+            region="cn-beijing",
+        )
+
+        assert storage.config.strict_multipart_min_part_size is True
+
+    def test_tos_storage_preserves_explicit_strict_override(self, monkeypatch):
+        mock_client = object()
+        monkeypatch.setattr(tos, "TosClientV2", lambda *args: mock_client)
+
+        storage = TOSStorage(
+            bucket_name="bucket",
+            access_key="ak",
+            secret_key="sk",
+            endpoint="https://tos.example.com",
+            region="cn-beijing",
+            config=StorageConfig(strict_multipart_min_part_size=False),
+        )
+
+        assert storage.config.strict_multipart_min_part_size is False
+
+
+class TestBackendBulkDelete:
+    @pytest.mark.asyncio
+    async def test_s3_delete_objects_uses_native_batch_request(self):
+        storage = object.__new__(S3Storage)
+        storage.config = StorageConfig()
+        storage.bucket_name = "bucket"
+        storage.client = FakeS3Client()
+
+        await storage.delete_objects(["a", "b"])
+
+        assert storage.client.calls == [
+            {
+                "Bucket": "bucket",
+                "Delete": {
+                    "Objects": [{"Key": "a"}, {"Key": "b"}],
+                    "Quiet": False,
+                },
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_s3_delete_objects_raises_on_batch_errors(self):
+        storage = object.__new__(S3Storage)
+        storage.config = StorageConfig()
+        storage.bucket_name = "bucket"
+        storage.client = FakeS3Client(
+            responses=[{"Errors": [{"Key": "b", "Code": "AccessDenied"}]}]
+        )
+
+        with pytest.raises(ValueError, match="Failed to delete S3 objects"):
+            await storage.delete_objects(["a", "b"])
+
+    @pytest.mark.asyncio
+    async def test_tos_delete_objects_uses_native_batch_request(self):
+        storage = object.__new__(TOSStorage)
+        storage.config = StorageConfig()
+        storage.bucket_name = "bucket"
+        storage.client = FakeTOSClient()
+
+        await storage.delete_objects(["a", "b"])
+
+        assert len(storage.client.calls) == 1
+        call = storage.client.calls[0]
+        assert call["bucket"] == "bucket"
+        assert call["quiet"] is False
+        assert [obj.key for obj in call["objects"]] == ["a", "b"]
+        assert all(
+            isinstance(obj, tos.models2.ObjectTobeDeleted) for obj in call["objects"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_tos_delete_objects_raises_on_batch_errors(self):
+        storage = object.__new__(TOSStorage)
+        storage.config = StorageConfig()
+        storage.bucket_name = "bucket"
+        storage.client = FakeTOSClient(
+            responses=[
+                SimpleNamespace(
+                    error=[
+                        tos.models2.DeleteError(
+                            key="b",
+                            version_id=None,
+                            code="AccessDenied",
+                            message="denied",
+                        )
+                    ]
+                )
+            ]
+        )
+
+        with pytest.raises(ValueError, match="Failed to delete TOS objects"):
+            await storage.delete_objects(["a", "b"])

--- a/python/aibrix/tests/storage/test_factory.py
+++ b/python/aibrix/tests/storage/test_factory.py
@@ -54,7 +54,9 @@ class TestStorageFactory:
         """Test creating storage with custom configuration."""
         config = StorageConfig(
             multipart_threshold=1024 * 1024,  # 1MB
-            max_concurrency=5,
+            max_concurrency=7,
+            max_session_concurrency=5,
+            multi_object_delete_limit=123,
             range_chunksize=512 * 1024,  # 512KB
         )
 
@@ -65,7 +67,9 @@ class TestStorageFactory:
 
             assert isinstance(storage, LocalStorage)
             assert storage.config.multipart_threshold == 1024 * 1024
-            assert storage.config.max_concurrency == 5
+            assert storage.config.max_concurrency == 7
+            assert storage.config.max_session_concurrency == 5
+            assert storage.config.multi_object_delete_limit == 123
             assert storage.config.range_chunksize == 512 * 1024
 
     def test_create_s3_storage_missing_bucket(self):

--- a/python/aibrix/tests/storage/test_small_parts_benchmark.py
+++ b/python/aibrix/tests/storage/test_small_parts_benchmark.py
@@ -1,0 +1,489 @@
+# Copyright 2024 The Aibrix Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+import tracemalloc
+from collections import defaultdict
+from types import MethodType
+
+import pytest
+
+from aibrix.storage.base import BaseStorage
+from aibrix.storage.base2 import BaseStorage2
+from aibrix.storage.tos import TOSStorage
+
+_RUN_BENCHMARK_ENV = "AIBRIX_RUN_STORAGE_BENCHMARK"
+_LINE_COUNT = 1000
+_LINE_SIZE_BYTES = 1024
+
+
+def _emit_pytest_log(pytestconfig: pytest.Config, message: str) -> None:
+    terminal_reporter = pytestconfig.pluginmanager.get_plugin("terminalreporter")
+    if terminal_reporter is not None:
+        terminal_reporter.write_line(message)
+
+
+def _make_benchmark_line(index: int) -> bytes:
+    prefix = f"line-{index:05d}:"
+    payload_size = _LINE_SIZE_BYTES - len(prefix) - 1
+    if payload_size <= 0:
+        raise ValueError("Benchmark line prefix exceeds configured line size")
+    return (prefix + ("x" * payload_size) + "\n").encode("utf-8")
+
+
+class TestSmallPartsBenchmark:
+    async def _run_small_parts_benchmark(
+        self,
+        tos_storage: TOSStorage,
+        monkeypatch: pytest.MonkeyPatch,
+        pytestconfig: pytest.Config,
+        *,
+        use_base2: bool,
+    ) -> None:
+        if use_base2:
+            monkeypatch.setattr(
+                tos_storage,
+                "complete_multipart_upload",
+                MethodType(BaseStorage2.complete_multipart_upload, tos_storage),
+            )
+            monkeypatch.setattr(
+                tos_storage,
+                "_flush_native_aggregate_part",
+                MethodType(BaseStorage2._flush_native_aggregate_part, tos_storage),
+                raising=False,
+            )
+            monkeypatch.setattr(
+                tos_storage,
+                "_iter_prefetched_staged_parts",
+                MethodType(BaseStorage2._iter_prefetched_staged_parts, tos_storage),
+                raising=False,
+            )
+            monkeypatch.setattr(
+                tos_storage,
+                "abort_multipart_upload",
+                MethodType(BaseStorage2.abort_multipart_upload, tos_storage),
+            )
+        else:
+            monkeypatch.setattr(
+                tos_storage,
+                "upload_part",
+                MethodType(BaseStorage.upload_part, tos_storage),
+            )
+            monkeypatch.setattr(
+                tos_storage,
+                "complete_multipart_upload",
+                MethodType(BaseStorage.complete_multipart_upload, tos_storage),
+            )
+            monkeypatch.setattr(
+                tos_storage,
+                "abort_multipart_upload",
+                MethodType(BaseStorage.abort_multipart_upload, tos_storage),
+            )
+
+        benchmark_target = "base2" if use_base2 else "legacy"
+
+        if os.getenv(_RUN_BENCHMARK_ENV) != "1":
+            pytest.skip(f"Set {_RUN_BENCHMARK_ENV}=1 to run the storage benchmark")
+
+        key = f"benchmark/small-parts-{benchmark_target}-5000-lines.txt"
+        upload_id = await tos_storage.create_multipart_upload(
+            key,
+            content_type="text/plain",
+            metadata={
+                "benchmark": "small-parts",
+                "line_count": str(_LINE_COUNT),
+                "line_size_bytes": str(_LINE_SIZE_BYTES),
+                "benchmark_target": benchmark_target,
+            },
+            small_parts=True,
+        )
+        multipart_prefix = tos_storage._multipart_upload_key(upload_id, "")
+        metadata_key = tos_storage._multipart_upload_key(upload_id)
+
+        profile_enabled = False
+        profile_stats: defaultdict[str, float] = defaultdict(float)
+        profile_counts: defaultdict[str, int] = defaultdict(int)
+
+        original_get_object = tos_storage.get_object
+        original_put_object = tos_storage.put_object
+        original_list_objects = tos_storage.list_objects
+        original_delete_object = tos_storage.delete_object
+        original_delete_objects = tos_storage.delete_objects
+        original_abort_multipart_upload = tos_storage.abort_multipart_upload
+        original_native_create_multipart_upload = (
+            tos_storage._native_create_multipart_upload
+        )
+        original_native_upload_part = tos_storage._native_upload_part
+        original_native_complete_multipart_upload = (
+            tos_storage._native_complete_multipart_upload
+        )
+        original_native_abort_multipart_upload = (
+            tos_storage._native_abort_multipart_upload
+        )
+        original_iter_prefetched_staged_parts = getattr(
+            tos_storage, "_iter_prefetched_staged_parts", None
+        )
+
+        async def profiled_get_object(
+            obj_key: str, range_start: int | None = None, range_end: int | None = None
+        ) -> bytes:
+            started = time.perf_counter()
+            result = await original_get_object(obj_key, range_start, range_end)
+            elapsed = time.perf_counter() - started
+            if profile_enabled:
+                if obj_key == metadata_key:
+                    profile_stats["metadata_get_elapsed_seconds"] += elapsed
+                    profile_counts["metadata_get_count"] += 1
+                elif obj_key.startswith(multipart_prefix):
+                    profile_stats["part_get_elapsed_seconds"] += elapsed
+                    profile_counts["part_get_count"] += 1
+                    profile_stats["part_get_bytes"] += len(result)
+                else:
+                    profile_stats["other_get_elapsed_seconds"] += elapsed
+                    profile_counts["other_get_count"] += 1
+            return result
+
+        async def profiled_put_object(
+            obj_key: str,
+            data,
+            content_type: str | None = None,
+            metadata: dict[str, str] | None = None,
+            options=None,
+        ) -> bool:
+            started = time.perf_counter()
+            result = await original_put_object(
+                obj_key, data, content_type, metadata, options
+            )
+            elapsed = time.perf_counter() - started
+            if profile_enabled:
+                if obj_key == key:
+                    profile_stats["final_put_elapsed_seconds"] += elapsed
+                    profile_counts["final_put_count"] += 1
+                    if hasattr(data, "seek") and hasattr(data, "tell"):
+                        current_pos = data.tell()
+                        data.seek(0, 2)
+                        profile_stats["final_put_bytes"] += data.tell()
+                        data.seek(current_pos)
+                else:
+                    profile_stats["other_put_elapsed_seconds"] += elapsed
+                    profile_counts["other_put_count"] += 1
+            return result
+
+        async def profiled_native_create_multipart_upload(
+            obj_key: str,
+            content_type: str | None = None,
+            metadata: dict[str, str] | None = None,
+        ) -> str:
+            started = time.perf_counter()
+            result = await original_native_create_multipart_upload(
+                obj_key, content_type, metadata
+            )
+            elapsed = time.perf_counter() - started
+            if profile_enabled:
+                profile_stats["native_create_elapsed_seconds"] += elapsed
+                profile_counts["native_create_count"] += 1
+            return result
+
+        async def profiled_native_upload_part(
+            obj_key: str,
+            target_upload_id: str,
+            part_number: int,
+            data,
+        ) -> str:
+            started = time.perf_counter()
+            result = await original_native_upload_part(
+                obj_key, target_upload_id, part_number, data
+            )
+            elapsed = time.perf_counter() - started
+            if profile_enabled and target_upload_id != upload_id:
+                profile_stats["native_part_upload_elapsed_seconds"] += elapsed
+                profile_counts["native_part_upload_count"] += 1
+                if hasattr(data, "seek") and hasattr(data, "tell"):
+                    current_pos = data.tell()
+                    data.seek(0, 2)
+                    profile_stats["native_part_upload_bytes"] += data.tell()
+                    data.seek(current_pos)
+            return result
+
+        async def profiled_native_complete_multipart_upload(
+            obj_key: str,
+            target_upload_id: str,
+            completed_parts: list[dict[str, str | int]],
+        ) -> None:
+            started = time.perf_counter()
+            await original_native_complete_multipart_upload(
+                obj_key, target_upload_id, completed_parts
+            )
+            elapsed = time.perf_counter() - started
+            if profile_enabled and target_upload_id != upload_id:
+                profile_stats["native_complete_elapsed_seconds"] += elapsed
+                profile_counts["native_complete_count"] += 1
+
+        async def profiled_native_abort_multipart_upload(
+            obj_key: str, target_upload_id: str
+        ) -> None:
+            started = time.perf_counter()
+            await original_native_abort_multipart_upload(obj_key, target_upload_id)
+            elapsed = time.perf_counter() - started
+            if profile_enabled and target_upload_id != upload_id:
+                profile_stats["native_abort_elapsed_seconds"] += elapsed
+                profile_counts["native_abort_count"] += 1
+
+        async def profiled_abort_multipart_upload(
+            obj_key: str, target_upload_id: str
+        ) -> None:
+            started = time.perf_counter()
+            await original_abort_multipart_upload(obj_key, target_upload_id)
+            elapsed = time.perf_counter() - started
+            if profile_enabled and target_upload_id == upload_id:
+                profile_stats["cleanup_total_elapsed_seconds"] += elapsed
+                profile_counts["cleanup_total_count"] += 1
+
+        async def profiled_delete_objects(keys: list[str]) -> None:
+            started = time.perf_counter()
+            await original_delete_objects(keys)
+            elapsed = time.perf_counter() - started
+            if profile_enabled:
+                profile_stats["cleanup_bulk_delete_elapsed_seconds"] += elapsed
+                profile_counts["cleanup_bulk_delete_count"] += 1
+                profile_counts["cleanup_bulk_deleted_objects"] += len(keys)
+
+        async def profiled_list_objects(
+            prefix: str = "",
+            delimiter: str | None = None,
+            limit: int | None = None,
+            continuation_token: str | None = None,
+            after_key: str | None = None,
+        ):
+            started = time.perf_counter()
+            result = await original_list_objects(
+                prefix, delimiter, limit, continuation_token, after_key
+            )
+            elapsed = time.perf_counter() - started
+            if profile_enabled and prefix == multipart_prefix:
+                profile_stats["cleanup_list_elapsed_seconds"] += elapsed
+                profile_counts["cleanup_list_count"] += 1
+                profile_counts["cleanup_listed_objects"] += len(result[0])
+            return result
+
+        async def profiled_delete_object(obj_key: str) -> None:
+            started = time.perf_counter()
+            await original_delete_object(obj_key)
+            elapsed = time.perf_counter() - started
+            if profile_enabled and obj_key.startswith(multipart_prefix):
+                profile_stats["cleanup_delete_elapsed_seconds"] += elapsed
+                profile_counts["cleanup_delete_count"] += 1
+
+        if original_iter_prefetched_staged_parts is not None:
+
+            async def profiled_iter_prefetched_staged_parts(
+                current_upload_id: str,
+                current_parts: list[dict[str, str | int]],
+                current_staged_part_keys: list[str],
+            ):
+                started = time.perf_counter()
+                async for item in original_iter_prefetched_staged_parts(
+                    current_upload_id, current_parts, current_staged_part_keys
+                ):
+                    yield item
+                elapsed = time.perf_counter() - started
+                if profile_enabled:
+                    profile_stats["part_fetch_wall_clock_seconds"] += elapsed
+                    profile_counts["part_fetch_window_count"] += 1
+
+        monkeypatch.setattr(tos_storage, "get_object", profiled_get_object)
+        monkeypatch.setattr(tos_storage, "put_object", profiled_put_object)
+        monkeypatch.setattr(tos_storage, "list_objects", profiled_list_objects)
+        monkeypatch.setattr(tos_storage, "delete_object", profiled_delete_object)
+        monkeypatch.setattr(tos_storage, "delete_objects", profiled_delete_objects)
+        monkeypatch.setattr(
+            tos_storage, "abort_multipart_upload", profiled_abort_multipart_upload
+        )
+        monkeypatch.setattr(
+            tos_storage,
+            "_native_create_multipart_upload",
+            profiled_native_create_multipart_upload,
+        )
+        monkeypatch.setattr(
+            tos_storage,
+            "_native_upload_part",
+            profiled_native_upload_part,
+        )
+        monkeypatch.setattr(
+            tos_storage,
+            "_native_complete_multipart_upload",
+            profiled_native_complete_multipart_upload,
+        )
+        monkeypatch.setattr(
+            tos_storage,
+            "_native_abort_multipart_upload",
+            profiled_native_abort_multipart_upload,
+        )
+        if original_iter_prefetched_staged_parts is not None:
+            monkeypatch.setattr(
+                tos_storage,
+                "_iter_prefetched_staged_parts",
+                profiled_iter_prefetched_staged_parts,
+            )
+
+        parts: list[dict[str, str | int]] = []
+        lines = [_make_benchmark_line(index) for index in range(_LINE_COUNT)]
+
+        upload_started = time.perf_counter()
+        for part_number, line in enumerate(lines, start=1):
+            etag = await tos_storage.upload_part(key, upload_id, part_number, line)
+            parts.append({"part_number": part_number, "etag": etag})
+        upload_elapsed = time.perf_counter() - upload_started
+
+        complete_started = time.perf_counter()
+        tracemalloc.start()
+        profile_enabled = True
+        await tos_storage.complete_multipart_upload(key, upload_id, parts)
+        profile_enabled = False
+        current_traced_bytes, peak_traced_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        complete_elapsed = time.perf_counter() - complete_started
+
+        total_elapsed = upload_elapsed + complete_elapsed
+        result = await tos_storage.get_object(key)
+        expected = b"".join(lines)
+
+        assert result == expected
+        used_native_reassembly = profile_counts["native_create_count"] > 0
+        used_legacy_reassembly = profile_counts["final_put_count"] > 0
+
+        assert used_native_reassembly or used_legacy_reassembly
+        if used_native_reassembly:
+            assert profile_counts["native_create_count"] == 1
+            assert profile_counts["native_complete_count"] == 1
+            assert profile_counts["native_part_upload_count"] >= 1
+            assert profile_counts["final_put_count"] == 0
+        if used_legacy_reassembly:
+            assert profile_counts["final_put_count"] == 1
+            assert profile_counts["native_create_count"] == 0
+            assert profile_counts["native_complete_count"] == 0
+            assert profile_counts["native_part_upload_count"] == 0
+            assert profile_counts["cleanup_total_count"] == 1
+
+        if used_native_reassembly:
+            part_fetch_wall_clock_seconds = profile_stats[
+                "part_fetch_wall_clock_seconds"
+            ]
+        else:
+            # Legacy path reads staged parts sequentially, so sum latency is also wall clock.
+            part_fetch_wall_clock_seconds = profile_stats["part_get_elapsed_seconds"]
+
+        complete_accounted_wall_clock_seconds = (
+            profile_stats["metadata_get_elapsed_seconds"]
+            + part_fetch_wall_clock_seconds
+            + profile_stats["final_put_elapsed_seconds"]
+            + profile_stats["native_create_elapsed_seconds"]
+            + profile_stats["native_part_upload_elapsed_seconds"]
+            + profile_stats["native_complete_elapsed_seconds"]
+            + profile_stats["native_abort_elapsed_seconds"]
+            + profile_stats["cleanup_total_elapsed_seconds"]
+        )
+        complete_residual_seconds = (
+            complete_elapsed - complete_accounted_wall_clock_seconds
+        )
+        implementation_name = (
+            "bounded-native-reassembly"
+            if used_native_reassembly
+            else "legacy-put-object"
+        )
+
+        _emit_pytest_log(
+            pytestconfig,
+            (
+                "[storage-benchmark] "
+                f"backend=tos, benchmark_target={benchmark_target}, "
+                f"implementation={implementation_name}, lines={_LINE_COUNT}, "
+                f"line_size_bytes={_LINE_SIZE_BYTES}, input_bytes={len(expected)}"
+            ),
+        )
+        _emit_pytest_log(
+            pytestconfig,
+            (
+                "[storage-benchmark] "
+                f"upload_elapsed_seconds={upload_elapsed:.6f}, "
+                f"complete_elapsed_seconds={complete_elapsed:.6f}, "
+                f"total_elapsed_seconds={total_elapsed:.6f}, "
+                f"complete_peak_traced_bytes={peak_traced_bytes}, "
+                f"complete_current_traced_bytes={current_traced_bytes}"
+            ),
+        )
+        _emit_pytest_log(
+            pytestconfig,
+            (
+                "[storage-benchmark] "
+                f"complete_breakdown="
+                f"metadata_get={profile_stats['metadata_get_elapsed_seconds']:.6f}s/"
+                f"{profile_counts['metadata_get_count']} calls, "
+                f"part_get_sum_latency={profile_stats['part_get_elapsed_seconds']:.6f}s/"
+                f"{profile_counts['part_get_count']} calls/"
+                f"{int(profile_stats['part_get_bytes'])} bytes, "
+                f"part_fetch_wall_clock={part_fetch_wall_clock_seconds:.6f}s/"
+                f"{profile_counts['part_fetch_window_count']} windows, "
+                f"final_put={profile_stats['final_put_elapsed_seconds']:.6f}s/"
+                f"{profile_counts['final_put_count']} calls/"
+                f"{int(profile_stats['final_put_bytes'])} bytes, "
+                f"native_create={profile_stats['native_create_elapsed_seconds']:.6f}s/"
+                f"{profile_counts['native_create_count']} calls, "
+                f"native_part_upload={profile_stats['native_part_upload_elapsed_seconds']:.6f}s/"
+                f"{profile_counts['native_part_upload_count']} calls/"
+                f"{int(profile_stats['native_part_upload_bytes'])} bytes, "
+                f"native_complete={profile_stats['native_complete_elapsed_seconds']:.6f}s/"
+                f"{profile_counts['native_complete_count']} calls, "
+                f"native_abort={profile_stats['native_abort_elapsed_seconds']:.6f}s/"
+                f"{profile_counts['native_abort_count']} calls"
+            ),
+        )
+        _emit_pytest_log(
+            pytestconfig,
+            (
+                "[storage-benchmark] "
+                f"cleanup_breakdown="
+                f"list={profile_stats['cleanup_list_elapsed_seconds']:.6f}s/"
+                f"{profile_counts['cleanup_list_count']} calls/"
+                f"{profile_counts['cleanup_listed_objects']} listed, "
+                f"bulk_delete={profile_stats['cleanup_bulk_delete_elapsed_seconds']:.6f}s/"
+                f"{profile_counts['cleanup_bulk_delete_count']} calls/"
+                f"{profile_counts['cleanup_bulk_deleted_objects']} objects, "
+                f"cleanup_total={profile_stats['cleanup_total_elapsed_seconds']:.6f}s/"
+                f"{profile_counts['cleanup_total_count']} calls, "
+                f"delete={profile_stats['cleanup_delete_elapsed_seconds']:.6f}s/"
+                f"{profile_counts['cleanup_delete_count']} deletes, "
+                f"complete_residual_seconds={complete_residual_seconds:.6f}s, "
+                f"complete_accounted_wall_clock={complete_accounted_wall_clock_seconds:.6f}s"
+            ),
+        )
+
+        await tos_storage.delete_object(key)
+
+    @pytest.mark.asyncio
+    async def test_complete_multipart_upload_benchmark_5000_small_parts_legacy(
+        self, tos_storage: TOSStorage, monkeypatch: pytest.MonkeyPatch, pytestconfig
+    ) -> None:
+        await self._run_small_parts_benchmark(
+            tos_storage, monkeypatch, pytestconfig, use_base2=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_complete_multipart_upload_benchmark_5000_small_parts_base2(
+        self, tos_storage: TOSStorage, monkeypatch: pytest.MonkeyPatch, pytestconfig
+    ) -> None:
+        await self._run_small_parts_benchmark(
+            tos_storage, monkeypatch, pytestconfig, use_base2=True
+        )


### PR DESCRIPTION
## Pull Request Description
Existing python metadata storage implementation is not optimal for large batch job finalization. We applied following techniques to accelerate finalization speed:
1. Bounded-memory buffer for streaming small file aggregation. (memory consumption)
2. Batch temporary file deletion/clean up. (time)
3. Concurrency-bound temporary file loading (time)

The following result show different techniques' improvements (for TOS): Noted the result is based on public network, so the part scale is limited to 1000. Bounded-memory only take affects when aggregate files size >= 5M, which is not reflected on the result shown here.

### Baseline

100 lines per part
1024 bytes per line

[storage-benchmark] backend=tos, benchmark_target=legacy, implementation=legacy-put-object, lines=100, line_size_bytes=1024, input_bytes=102400
[storage-benchmark] upload_elapsed_seconds=36.308681, **complete_elapsed_seconds=90.559161,** total_elapsed_seconds=126.867842, complete_peak_traced_bytes=653698, complete_current_traced_bytes=383279
[storage-benchmark] complete_breakdown=metadata_get=0.189149s/1 calls, **part_get_sum_latency=17.418489s/100 calls/102400 bytes**, part_fetch_wall_clock=17.418489s/0 windows, final_put=0.491016s/1 calls/102400 bytes, native_create=0.000000s/0 calls, native_part_upload=0.000000s/0 calls/0 bytes, native_complete=0.000000s/0 calls, native_abort=0.000000s/0 calls
[storage-benchmark] cleanup_breakdown=list=0.509183s/1 calls/101 listed, bulk_delete=0.000000s/0 calls/0 objects, cleanup_total=72.457028s/1 calls, **delete=71.946850s/101 deletes**, complete_residual_seconds=0.003479s, complete_accounted_wall_clock=90.555683s

1000 lines per part
1024 bytes per line

[storage-benchmark] backend=tos, benchmark_target=legacy, implementation=legacy-put-object, lines=1000, line_size_bytes=1024, input_bytes=1024000
[storage-benchmark] upload_elapsed_seconds=359.413956, **complete_elapsed_seconds=886.013346**, total_elapsed_seconds=1245.427302, complete_peak_traced_bytes=3009734, complete_current_traced_bytes=286638
[storage-benchmark] complete_breakdown=metadata_get=0.199654s/1 calls, **part_get_sum_latency=179.993581s/1000 calls/1024000 bytes**, part_fetch_wall_clock=179.993581s/0 windows, final_put=1.175166s/1 calls/1024000 bytes, native_create=0.000000s/0 calls, native_part_upload=0.000000s/0 calls/0 bytes, native_complete=0.000000s/0 calls, native_abort=0.000000s/0 calls
[storage-benchmark] cleanup_breakdown=list=1.042932s/1 calls/1000 listed, bulk_delete=0.000000s/0 calls/0 objects, cleanup_total=704.607575s/1 calls, **delete=703.543388s/1000 deletes**, complete_residual_seconds=0.037371s, complete_accounted_wall_clock=885.975976s

### Optimization 1: Memory consumption

100 lines per part
1024 bytes per line

[storage-benchmark] backend=tos, benchmark_target=base2, implementation=bounded-native-reassembly, lines=100, line_size_bytes=1024, input_bytes=102400
[storage-benchmark] upload_elapsed_seconds=36.028959, complete_elapsed_seconds=88.618595, total_elapsed_seconds=124.647554, complete_peak_traced_bytes=256470, complete_current_traced_bytes=179768
[storage-benchmark] complete_breakdown=metadata_get=0.200085s/1 calls, part_get=17.699747s/100 calls/102400 bytes, final_put=0.000000s/0 calls/0 bytes, native_create=0.168779s/1 calls, native_part_upload=0.506624s/1 calls/102400 bytes, native_complete=0.191426s/1 calls, native_abort=0.000000s/0 calls
[storage-benchmark] cleanup_breakdown=list=0.000000s/0 calls/0 listed, cleanup_total=0.000000s/0 calls, delete=69.842865s/101 deletes, unattributed_complete_seconds=0.009068s

### Optimization 2: Batch deletion (including O1)

100 lines per part
1024 bytes per line

[storage-benchmark] backend=tos, benchmark_target=base2, implementation=bounded-native-reassembly, lines=100, line_size_bytes=1024, input_bytes=102400
[storage-benchmark] upload_elapsed_seconds=35.260762, **complete_elapsed_seconds=19.697809,** total_elapsed_seconds=54.958571, complete_peak_traced_bytes=564382, complete_current_traced_bytes=397461
[storage-benchmark] complete_breakdown=metadata_get=0.200601s/1 calls, part_get=17.931393s/100 calls/102400 bytes, final_put=0.000000s/0 calls/0 bytes, native_create=0.169602s/1 calls, native_part_upload=0.505475s/1 calls/102400 bytes, native_complete=0.198891s/1 calls, native_abort=0.000000s/0 calls
[storage-benchmark] cleanup_breakdown=list=0.357464s/1 calls/101 listed, **cleanup_total=0.684893s/1 calls, delete=0.000000s/0 deletes**, unattributed_complete_seconds=0.006954s

### Optimization 3: Parallel getting parts (including O1,O2)

100 lines per part
1024 bytes per line

[storage-benchmark] backend=tos, benchmark_target=base2, implementation=bounded-native-reassembly, lines=100, line_size_bytes=1024, input_bytes=102400
[storage-benchmark] upload_elapsed_seconds=34.673670, **complete_elapsed_seconds=4.470186**, total_elapsed_seconds=39.143856, complete_peak_traced_bytes=692823, complete_current_traced_bytes=518821
[storage-benchmark] complete_breakdown=metadata_get=0.199311s/1 calls, part_get_sum_latency=25.851627s/100 calls/102400 bytes, **part_fetch_wall_clock=2.756125s/1 windows**, final_put=0.000000s/0 calls/0 bytes, native_create=0.166907s/1 calls, native_part_upload=0.508895s/1 calls/102400 bytes, native_complete=0.188818s/1 calls, native_abort=0.000000s/0 calls
[storage-benchmark] cleanup_breakdown=list=0.362511s/1 calls/101 listed, **bulk_delete=0.286453s/1 calls/101 objects, cleanup_total=0.649003s/1 calls**, delete=0.000000s/0 deletes, complete_residual_seconds=0.001128s, complete_accounted_wall_clock=4.469059s

1000 lines per part
1024 bytes per line

[storage-benchmark] backend=tos, benchmark_target=base2, implementation=bounded-native-reassembly, lines=1000, line_size_bytes=1024, input_bytes=1024000
[storage-benchmark] upload_elapsed_seconds=349.055292, **complete_elapsed_seconds=26.635582**, total_elapsed_seconds=375.690874, complete_peak_traced_bytes=3186475, complete_current_traced_bytes=417619
[storage-benchmark] complete_breakdown=metadata_get=0.186530s/1 calls, part_get_sum_latency=218.428844s/1000 calls/1024000 bytes, **part_fetch_wall_clock=23.088905s/1 windows**, final_put=0.000000s/0 calls/0 bytes, native_create=0.169664s/1 calls, native_part_upload=0.970022s/1 calls/1024000 bytes, native_complete=0.259417s/1 calls, native_abort=0.000000s/0 calls
[storage-benchmark] cleanup_breakdown=list=1.053053s/1 calls/1000 listed, **bulk_delete=0.902551s/1 calls/1000 objects, cleanup_total=1.955723s/1 calls**, delete=0.000000s/0 deletes, complete_residual_seconds=0.005320s, complete_accounted_wall_clock=26.630262s

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>