### PR TITLE
feat: restrict routing to least-loaded pods under load imbalance in preble algorithm

### DIFF
--- a/pkg/plugins/gateway/algorithms/prefix_cache_preble.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_preble.go
@@ -486,18 +486,13 @@ func (p *prefixCacheAndLoadRouter) Route(ctx *types.RoutingContext, readyPodList
 	}
 
 	node, matchedTokens, _ := p.cache.AddPrefix(tokens, ctx.Model, "")
-	readyPodsMap := readyPodsByName(readyPods)
-
 	// Check for load imbalance using real-time running request counts
 	leastReqPodList, isLoadImbalanced := getTargetPodListOnLoadImbalance(p.metricCache, readyPods)
 	if isLoadImbalanced {
-		klog.InfoS("requestID: %s, Load imbalance detected, restricting to least-loaded pods", "requestID", ctx.RequestID)
-		if len(leastReqPodList) == 0 {
-			return "", fmt.Errorf("no target pod found when load imbalanced")
-		}
+		klog.InfoS("Load imbalance detected, restricting to least-loaded pods", "requestID", ctx.RequestID)
 		readyPods = leastReqPodList
-		readyPodsMap = readyPodsByName(readyPods)
 	}
+	readyPodsMap := readyPodsByName(readyPods)
 
 	var matchedPods []*v1.Pod
 	var matchedPodsNames []string
@@ -511,10 +506,10 @@ func (p *prefixCacheAndLoadRouter) Route(ctx *types.RoutingContext, readyPodList
 		matchRatio = float64(len(matchedTokens)) / float64(len(tokens))
 	}
 	prefixRoutingThreshold := 0.5
-	klog.InfoS("requestID: %s, Matched tokens/Total tokens: %d/%d, Matching ratio: %.0f%%, len(matchedPodsNames): %d, matchedPodsNames: %v", "requestID", ctx.RequestID, "matchedTokens", len(matchedTokens), "totalTokens", len(tokens), "matchingRatio", matchRatio*100, "matchedPodsNamesCount", len(matchedPods), "matchedPodsNames", matchedPodsNames)
+	klog.InfoS("Prefix cache match statistics", "requestID", ctx.RequestID, "matchedTokens", len(matchedTokens), "totalTokens", len(tokens), "matchingRatio", matchRatio*100, "matchedPodsNamesCount", len(matchedPods), "matchedPodsNames", matchedPodsNames)
 
 	if matchRatio > prefixRoutingThreshold {
-		klog.InfoS("requestID: %s, Do prefix-aware routing! (matching ratio: %.2f > %.2f)", "requestID", ctx.RequestID, "matchRatio", matchRatio, "threshold", prefixRoutingThreshold)
+		klog.InfoS("Do prefix-aware routing", "requestID", ctx.RequestID, "matchRatio", matchRatio, "threshold", prefixRoutingThreshold)
 		var prefixMatches []prefixMatch
 
 		currentNode := node
@@ -547,37 +542,37 @@ func (p *prefixCacheAndLoadRouter) Route(ctx *types.RoutingContext, readyPodList
 					targetPod = pod
 				}
 			}
-			klog.InfoS("requestID: %s, Selected pod %s from longest matching node with match length %d", "requestID", ctx.RequestID, "podName", targetPod.Name, "matchLength", longestMatch.matchLength)
+			klog.InfoS("Selected pod from longest matching node", "requestID", ctx.RequestID, "podName", targetPod.Name, "matchLength", longestMatch.matchLength)
 		} else {
 			tokenInString, err := utils.DetokenizeText(tokens)
 			matchedTokensInString, _ := utils.DetokenizeText(matchedTokens)
 			if err != nil {
-				klog.ErrorS(err, "requestID: %s, DetokenizeTexts failed: %s, tokens: '%v', matchedTokens: '%v', model: %s", "requestID", ctx.RequestID, "tokens", tokenInString, "matchedTokens", matchedTokensInString, "model", ctx.Model)
+				klog.ErrorS(err, "DetokenizeTexts failed", "requestID", ctx.RequestID, "tokens", tokenInString, "matchedTokens", matchedTokensInString, "model", ctx.Model)
 			} else {
-				klog.InfoS("requestID: %s, No matched pods found for tokens: '%v', matchedTokens: '%v', model: %s", "requestID", ctx.RequestID, "tokens", tokenInString, "matchedTokens", matchedTokensInString, "model", ctx.Model)
+				klog.InfoS("No matched pods found", "requestID", ctx.RequestID, "tokens", tokenInString, "matchedTokens", matchedTokensInString, "model", ctx.Model)
 			}
 		}
 	}
 
 	if targetPod == nil {
-		klog.InfoS("requestID: %s, Do cost model based routing! (matching ratio: %.2f%%, len(matchedPods): %d)", "requestID", ctx.RequestID, "matchRatio", matchRatio*100, "matchedPodsCount", len(matchedPods))
+		klog.InfoS("Do cost model based routing", "requestID", ctx.RequestID, "matchRatio", matchRatio*100, "matchedPodsCount", len(matchedPods))
 		podCosts := p.histogram.getCurrentAllocationCostPerPod()
 		minCost := math.MaxFloat64
 		for _, pod := range readyPods {
 			cost := podCosts[pod.Name]
-			klog.InfoS("PodName: %s, Cost: %f", "podName", pod.Name, "cost", cost)
+			klog.InfoS("Pod cost", "podName", pod.Name, "cost", cost)
 			if cost < minCost {
 				minCost = cost
 				targetPod = pod
 			}
 		}
 		if targetPod != nil {
-			klog.InfoS("Lowest cost pod: %s", "podName", targetPod.Name)
+			klog.InfoS("Lowest cost pod selected", "podName", targetPod.Name)
 		}
 	}
 
 	if targetPod == nil {
-		klog.ErrorS(fmt.Errorf("no suitable pod found"), "requestID: %s, After all logic, no suitable pod found. readyPods: %v", "requestID", ctx.RequestID, "readyPods", readyPods)
+		klog.ErrorS(fmt.Errorf("no suitable pod found"), "After all routing logic, no suitable pod found", "requestID", ctx.RequestID, "readyPods", readyPods)
 		return "", fmt.Errorf("no suitable pod found")
 	}
 

--- a/pkg/plugins/gateway/algorithms/prefix_cache_preble.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_preble.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vllm-project/aibrix/pkg/cache"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
@@ -76,6 +77,7 @@ type histogramEntry struct {
 
 type prefixCacheAndLoadRouter struct {
 	cache          *prefixcacheindexer.LPRadixCache
+	metricCache    cache.Cache
 	histogram      *SlidingWindowHistogram
 	numPods        int
 	podAllocations map[*prefixcacheindexer.TreeNode]map[int]bool
@@ -231,6 +233,12 @@ func (h *SlidingWindowHistogram) getPrefillCost(node *prefixcacheindexer.TreeNod
 }
 
 func NewPrefixCacheAndLoadRouter() (types.Router, error) {
+	metricCache, err := cache.Get()
+	if err != nil {
+		klog.Error("fail to get cache store in prefix-cache-preble router")
+		return nil, err
+	}
+
 	numPods := 0 // NOTE: it will be initialized in Route function. This number can change dynamically due to scaling or failure.
 	histogram := &SlidingWindowHistogram{
 		windowDuration:             slidingWindowPeriod,
@@ -248,6 +256,7 @@ func NewPrefixCacheAndLoadRouter() (types.Router, error) {
 
 	router := &prefixCacheAndLoadRouter{
 		cache:          prefixcacheindexer.NewLPRadixCache(numPods),
+		metricCache:    metricCache,
 		histogram:      histogram,
 		numPods:        numPods,
 		podAllocations: make(map[*prefixcacheindexer.TreeNode]map[int]bool),
@@ -478,6 +487,18 @@ func (p *prefixCacheAndLoadRouter) Route(ctx *types.RoutingContext, readyPodList
 
 	node, matchedTokens, _ := p.cache.AddPrefix(tokens, ctx.Model, "")
 	readyPodsMap := readyPodsByName(readyPods)
+
+	// Check for load imbalance using real-time running request counts
+	leastReqPodList, isLoadImbalanced := getTargetPodListOnLoadImbalance(p.metricCache, readyPods)
+	if isLoadImbalanced {
+		klog.InfoS("requestID: %s, Load imbalance detected, restricting to least-loaded pods", "requestID", ctx.RequestID)
+		if len(leastReqPodList) == 0 {
+			return "", fmt.Errorf("no target pod found when load imbalanced")
+		}
+		readyPods = leastReqPodList
+		readyPodsMap = readyPodsByName(readyPods)
+	}
+
 	var matchedPods []*v1.Pod
 	var matchedPodsNames []string
 	if modelPods, ok := node.GetModelToPods()[ctx.Model]; ok {

--- a/pkg/plugins/gateway/algorithms/prefix_cache_preble_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_preble_test.go
@@ -220,8 +220,27 @@ func TestPrefixCacheAndLoadRouterRouting(t *testing.T) {
 		{
 			name: "no_pods_available_error",
 			setupRouter: func() *prefixCacheAndLoadRouter {
-				router, _ := NewPrefixCacheAndLoadRouter()
-				return router.(*prefixCacheAndLoadRouter)
+				router := &prefixCacheAndLoadRouter{
+					cache:       prefixcacheindexer.NewLPRadixCache(4),
+					metricCache: cache.NewForTest(),
+					histogram: &SlidingWindowHistogram{
+						windowDuration:             slidingWindowPeriod,
+						histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
+						nodeToCount:                make(map[*prefixcacheindexer.TreeNode]int),
+						hitTokens:                  make(map[*prefixcacheindexer.TreeNode]int),
+						promptTokens:               make(map[*prefixcacheindexer.TreeNode]int),
+						decodingSize:               make(map[*prefixcacheindexer.TreeNode]int),
+						timestamps:                 []histogramEntry{},
+						numPods:                    0,
+						podAllocations:             make(map[*prefixcacheindexer.TreeNode]map[int]bool),
+						currentDecodeLengthsPerPod: make(map[string]int),
+						avgTimePerTokenPerPod:      make(map[string][]float64),
+						perNodeTotalDecodeLengths:  make(map[*prefixcacheindexer.TreeNode]int),
+					},
+					numPods:        0,
+					podAllocations: make(map[*prefixcacheindexer.TreeNode]map[int]bool),
+				}
+				return router
 			},
 			setupContext: func() *types.RoutingContext {
 				return createTestRoutingContext("test-model", "Any request", "req-no-pods")

--- a/pkg/plugins/gateway/algorithms/prefix_cache_preble_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_preble_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
@@ -70,7 +72,8 @@ func TestPrefixCacheAndLoadRouterRouting(t *testing.T) {
 			name: "cost_model_routing_with_different_costs",
 			setupRouter: func() *prefixCacheAndLoadRouter {
 				router := &prefixCacheAndLoadRouter{
-					cache: prefixcacheindexer.NewLPRadixCache(2),
+					cache:       prefixcacheindexer.NewLPRadixCache(2),
+					metricCache: cache.NewForTest(),
 					histogram: &SlidingWindowHistogram{
 						windowDuration:             slidingWindowPeriod,
 						histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
@@ -149,7 +152,8 @@ func TestPrefixCacheAndLoadRouterRouting(t *testing.T) {
 			name: "prefix_cache_routing_with_matching_prefix",
 			setupRouter: func() *prefixCacheAndLoadRouter {
 				router := &prefixCacheAndLoadRouter{
-					cache: prefixcacheindexer.NewLPRadixCache(3),
+					cache:       prefixcacheindexer.NewLPRadixCache(3),
+					metricCache: cache.NewForTest(),
 					histogram: &SlidingWindowHistogram{
 						windowDuration:             slidingWindowPeriod,
 						histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
@@ -230,6 +234,95 @@ func TestPrefixCacheAndLoadRouterRouting(t *testing.T) {
 				// Error case - no validation needed
 			},
 		},
+		{
+			name: "load_imbalance_restricts_to_least_loaded_pods",
+			setupRouter: func() *prefixCacheAndLoadRouter {
+				pods := []*v1.Pod{
+					newPod("pod-light-1", "10.0.0.1", true, map[string]string{"model.aibrix.ai/port": "8000"}),
+					newPod("pod-light-2", "10.0.0.2", true, map[string]string{"model.aibrix.ai/port": "8000"}),
+					newPod("pod-busy-1", "10.0.0.3", true, map[string]string{"model.aibrix.ai/port": "8000"}),
+					newPod("pod-busy-2", "10.0.0.4", true, map[string]string{"model.aibrix.ai/port": "8000"}),
+				}
+				// light pods: 1 running request each, busy pods: 10 running requests each
+				// diff = 9, which exceeds default threshold of 8
+				metricCache := cache.NewWithPodsMetricsForTest(
+					pods,
+					"test-model",
+					map[string]map[string]metrics.MetricValue{
+						"pod-light-1": {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 1}},
+						"pod-light-2": {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 1}},
+						"pod-busy-1":  {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 10}},
+						"pod-busy-2":  {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 10}},
+					})
+
+				router := &prefixCacheAndLoadRouter{
+					cache:       prefixcacheindexer.NewLPRadixCache(4),
+					metricCache: metricCache,
+					histogram: &SlidingWindowHistogram{
+						windowDuration:             slidingWindowPeriod,
+						histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
+						nodeToCount:                make(map[*prefixcacheindexer.TreeNode]int),
+						hitTokens:                  make(map[*prefixcacheindexer.TreeNode]int),
+						promptTokens:               make(map[*prefixcacheindexer.TreeNode]int),
+						decodingSize:               make(map[*prefixcacheindexer.TreeNode]int),
+						timestamps:                 []histogramEntry{},
+						numPods:                    0,
+						podAllocations:             make(map[*prefixcacheindexer.TreeNode]map[int]bool),
+						currentDecodeLengthsPerPod: make(map[string]int),
+						avgTimePerTokenPerPod:      make(map[string][]float64),
+						perNodeTotalDecodeLengths:  make(map[*prefixcacheindexer.TreeNode]int),
+					},
+					numPods:        0,
+					podAllocations: make(map[*prefixcacheindexer.TreeNode]map[int]bool),
+				}
+
+				// Populate prefix cache with a request that has prefix matches on all pods
+				// This simulates the scenario where prefix-aware routing would select
+				// any pod, but load imbalance should restrict it to light pods only
+				tokens, _ := utils.TokenizeInputText("shared prefix content")
+				node, _, _ := router.cache.AddPrefix(tokens, "test-model", "")
+				node.AddOrUpdatePodForModel("test-model", "pod-light-1", time.Now())
+				node.AddOrUpdatePodForModel("test-model", "pod-light-2", time.Now())
+				node.AddOrUpdatePodForModel("test-model", "pod-busy-1", time.Now())
+				node.AddOrUpdatePodForModel("test-model", "pod-busy-2", time.Now())
+
+				// Setup histogram data for all pods
+				router.histogram.histogram[node] = len(tokens)
+				router.histogram.nodeToCount[node] = 4
+				router.histogram.decodingSize[node] = 45
+				router.histogram.hitTokens[node] = len(tokens) - 1
+				router.histogram.promptTokens[node] = len(tokens)
+
+				return router
+			},
+			setupContext: func() *types.RoutingContext {
+				return createTestRoutingContext("test-model", "shared prefix content", "req-imbalance-test")
+			},
+			setupPodList: func() types.PodList {
+				pods := []*v1.Pod{
+					newPod("pod-light-1", "10.0.0.1", true, map[string]string{"model.aibrix.ai/port": "8000"}),
+					newPod("pod-light-2", "10.0.0.2", true, map[string]string{"model.aibrix.ai/port": "8000"}),
+					newPod("pod-busy-1", "10.0.0.3", true, map[string]string{"model.aibrix.ai/port": "8000"}),
+					newPod("pod-busy-2", "10.0.0.4", true, map[string]string{"model.aibrix.ai/port": "8000"}),
+				}
+				return &MockPodList{pods: pods}
+			},
+			expectedError: false,
+			validateResult: func(t *testing.T, router *prefixCacheAndLoadRouter, ctx *types.RoutingContext, selectedPod string) {
+				if ctx.TargetPod() == nil {
+					t.Error("Expected target pod to be set")
+					return
+				}
+
+				selectedPodName := ctx.TargetPod().Name
+				t.Logf("Selected pod: %s", selectedPodName)
+
+				// Under load imbalance, only light pods should be selected
+				if selectedPodName != "pod-light-1" && selectedPodName != "pod-light-2" {
+					t.Errorf("Expected pod-light-1 or pod-light-2 (least loaded pods) under imbalance, got %s", selectedPodName)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -265,7 +358,8 @@ func TestPrefixCacheAndLoadRouterRouting(t *testing.T) {
 
 func TestPrefixCacheAndLoadRouterScoreAllHandlesEmptyInput(t *testing.T) {
 	router := &prefixCacheAndLoadRouter{
-		cache: prefixcacheindexer.NewLPRadixCache(2),
+		cache:       prefixcacheindexer.NewLPRadixCache(2),
+		metricCache: cache.NewForTest(),
 		histogram: &SlidingWindowHistogram{
 			windowDuration:             slidingWindowPeriod,
 			histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
@@ -308,7 +402,8 @@ func TestPrefixCacheAndLoadRouterScoreAllHandlesEmptyInput(t *testing.T) {
 
 func TestPrefixCacheAndLoadRouterScoreAllDoesNotMutateCache(t *testing.T) {
 	router := &prefixCacheAndLoadRouter{
-		cache: prefixcacheindexer.NewLPRadixCache(2),
+		cache:       prefixcacheindexer.NewLPRadixCache(2),
+		metricCache: cache.NewForTest(),
 		histogram: &SlidingWindowHistogram{
 			windowDuration:             slidingWindowPeriod,
 			histogram:                  make(map[*prefixcacheindexer.TreeNode]int),

--- a/pkg/plugins/gateway/algorithms/prefix_cache_preble_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_preble_test.go
@@ -59,6 +59,32 @@ func createTestRoutingContext(model, message, requestID string) *types.RoutingCo
 	return types.NewRoutingContext(ctx, RouterPrefixCachePreble, model, message, requestID, "")
 }
 
+func newTestRouter(cacheSize int, metricCache cache.Cache) *prefixCacheAndLoadRouter {
+	if metricCache == nil {
+		metricCache = cache.NewForTest()
+	}
+	return &prefixCacheAndLoadRouter{
+		cache:       prefixcacheindexer.NewLPRadixCache(cacheSize),
+		metricCache: metricCache,
+		histogram: &SlidingWindowHistogram{
+			windowDuration:             slidingWindowPeriod,
+			histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
+			nodeToCount:                make(map[*prefixcacheindexer.TreeNode]int),
+			hitTokens:                  make(map[*prefixcacheindexer.TreeNode]int),
+			promptTokens:               make(map[*prefixcacheindexer.TreeNode]int),
+			decodingSize:               make(map[*prefixcacheindexer.TreeNode]int),
+			timestamps:                 []histogramEntry{},
+			numPods:                    0,
+			podAllocations:             make(map[*prefixcacheindexer.TreeNode]map[int]bool),
+			currentDecodeLengthsPerPod: make(map[string]int),
+			avgTimePerTokenPerPod:      make(map[string][]float64),
+			perNodeTotalDecodeLengths:  make(map[*prefixcacheindexer.TreeNode]int),
+		},
+		numPods:        0,
+		podAllocations: make(map[*prefixcacheindexer.TreeNode]map[int]bool),
+	}
+}
+
 func TestPrefixCacheAndLoadRouterRouting(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -71,26 +97,7 @@ func TestPrefixCacheAndLoadRouterRouting(t *testing.T) {
 		{
 			name: "cost_model_routing_with_different_costs",
 			setupRouter: func() *prefixCacheAndLoadRouter {
-				router := &prefixCacheAndLoadRouter{
-					cache:       prefixcacheindexer.NewLPRadixCache(2),
-					metricCache: cache.NewForTest(),
-					histogram: &SlidingWindowHistogram{
-						windowDuration:             slidingWindowPeriod,
-						histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
-						nodeToCount:                make(map[*prefixcacheindexer.TreeNode]int),
-						hitTokens:                  make(map[*prefixcacheindexer.TreeNode]int),
-						promptTokens:               make(map[*prefixcacheindexer.TreeNode]int),
-						decodingSize:               make(map[*prefixcacheindexer.TreeNode]int),
-						timestamps:                 []histogramEntry{},
-						numPods:                    0,
-						podAllocations:             make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-						currentDecodeLengthsPerPod: make(map[string]int),
-						avgTimePerTokenPerPod:      make(map[string][]float64),
-						perNodeTotalDecodeLengths:  make(map[*prefixcacheindexer.TreeNode]int),
-					},
-					numPods:        0,
-					podAllocations: make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-				}
+				router := newTestRouter(2, nil)
 
 				// Create historical data to generate cost differences
 				tokens1, _ := utils.TokenizeInputText("Historical request one")
@@ -151,26 +158,7 @@ func TestPrefixCacheAndLoadRouterRouting(t *testing.T) {
 		{
 			name: "prefix_cache_routing_with_matching_prefix",
 			setupRouter: func() *prefixCacheAndLoadRouter {
-				router := &prefixCacheAndLoadRouter{
-					cache:       prefixcacheindexer.NewLPRadixCache(3),
-					metricCache: cache.NewForTest(),
-					histogram: &SlidingWindowHistogram{
-						windowDuration:             slidingWindowPeriod,
-						histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
-						nodeToCount:                make(map[*prefixcacheindexer.TreeNode]int),
-						hitTokens:                  make(map[*prefixcacheindexer.TreeNode]int),
-						promptTokens:               make(map[*prefixcacheindexer.TreeNode]int),
-						decodingSize:               make(map[*prefixcacheindexer.TreeNode]int),
-						timestamps:                 []histogramEntry{},
-						numPods:                    0,
-						podAllocations:             make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-						currentDecodeLengthsPerPod: make(map[string]int),
-						avgTimePerTokenPerPod:      make(map[string][]float64),
-						perNodeTotalDecodeLengths:  make(map[*prefixcacheindexer.TreeNode]int),
-					},
-					numPods:        0,
-					podAllocations: make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-				}
+				router := newTestRouter(3, nil)
 
 				// Pre-populate cache with the exact prefix that the test request will use
 				// This ensures the AddPrefix call in Route() will find the existing node
@@ -220,27 +208,7 @@ func TestPrefixCacheAndLoadRouterRouting(t *testing.T) {
 		{
 			name: "no_pods_available_error",
 			setupRouter: func() *prefixCacheAndLoadRouter {
-				router := &prefixCacheAndLoadRouter{
-					cache:       prefixcacheindexer.NewLPRadixCache(4),
-					metricCache: cache.NewForTest(),
-					histogram: &SlidingWindowHistogram{
-						windowDuration:             slidingWindowPeriod,
-						histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
-						nodeToCount:                make(map[*prefixcacheindexer.TreeNode]int),
-						hitTokens:                  make(map[*prefixcacheindexer.TreeNode]int),
-						promptTokens:               make(map[*prefixcacheindexer.TreeNode]int),
-						decodingSize:               make(map[*prefixcacheindexer.TreeNode]int),
-						timestamps:                 []histogramEntry{},
-						numPods:                    0,
-						podAllocations:             make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-						currentDecodeLengthsPerPod: make(map[string]int),
-						avgTimePerTokenPerPod:      make(map[string][]float64),
-						perNodeTotalDecodeLengths:  make(map[*prefixcacheindexer.TreeNode]int),
-					},
-					numPods:        0,
-					podAllocations: make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-				}
-				return router
+				return newTestRouter(4, nil)
 			},
 			setupContext: func() *types.RoutingContext {
 				return createTestRoutingContext("test-model", "Any request", "req-no-pods")
@@ -274,30 +242,9 @@ func TestPrefixCacheAndLoadRouterRouting(t *testing.T) {
 						"pod-busy-2":  {metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 10}},
 					})
 
-				router := &prefixCacheAndLoadRouter{
-					cache:       prefixcacheindexer.NewLPRadixCache(4),
-					metricCache: metricCache,
-					histogram: &SlidingWindowHistogram{
-						windowDuration:             slidingWindowPeriod,
-						histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
-						nodeToCount:                make(map[*prefixcacheindexer.TreeNode]int),
-						hitTokens:                  make(map[*prefixcacheindexer.TreeNode]int),
-						promptTokens:               make(map[*prefixcacheindexer.TreeNode]int),
-						decodingSize:               make(map[*prefixcacheindexer.TreeNode]int),
-						timestamps:                 []histogramEntry{},
-						numPods:                    0,
-						podAllocations:             make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-						currentDecodeLengthsPerPod: make(map[string]int),
-						avgTimePerTokenPerPod:      make(map[string][]float64),
-						perNodeTotalDecodeLengths:  make(map[*prefixcacheindexer.TreeNode]int),
-					},
-					numPods:        0,
-					podAllocations: make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-				}
+				router := newTestRouter(4, metricCache)
 
 				// Populate prefix cache with a request that has prefix matches on all pods
-				// This simulates the scenario where prefix-aware routing would select
-				// any pod, but load imbalance should restrict it to light pods only
 				tokens, _ := utils.TokenizeInputText("shared prefix content")
 				node, _, _ := router.cache.AddPrefix(tokens, "test-model", "")
 				node.AddOrUpdatePodForModel("test-model", "pod-light-1", time.Now())
@@ -376,26 +323,7 @@ func TestPrefixCacheAndLoadRouterRouting(t *testing.T) {
 }
 
 func TestPrefixCacheAndLoadRouterScoreAllHandlesEmptyInput(t *testing.T) {
-	router := &prefixCacheAndLoadRouter{
-		cache:       prefixcacheindexer.NewLPRadixCache(2),
-		metricCache: cache.NewForTest(),
-		histogram: &SlidingWindowHistogram{
-			windowDuration:             slidingWindowPeriod,
-			histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
-			nodeToCount:                make(map[*prefixcacheindexer.TreeNode]int),
-			hitTokens:                  make(map[*prefixcacheindexer.TreeNode]int),
-			promptTokens:               make(map[*prefixcacheindexer.TreeNode]int),
-			decodingSize:               make(map[*prefixcacheindexer.TreeNode]int),
-			timestamps:                 []histogramEntry{},
-			numPods:                    0,
-			podAllocations:             make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-			currentDecodeLengthsPerPod: make(map[string]int),
-			avgTimePerTokenPerPod:      make(map[string][]float64),
-			perNodeTotalDecodeLengths:  make(map[*prefixcacheindexer.TreeNode]int),
-		},
-		numPods:        0,
-		podAllocations: make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-	}
+	router := newTestRouter(2, nil)
 	podList := &MockPodList{pods: []*v1.Pod{
 		newPod("pod-1", "10.0.0.1", true, map[string]string{"model.aibrix.ai/port": "8000"}),
 		newPod("pod-2", "10.0.0.2", true, map[string]string{"model.aibrix.ai/port": "8000"}),
@@ -420,26 +348,7 @@ func TestPrefixCacheAndLoadRouterScoreAllHandlesEmptyInput(t *testing.T) {
 }
 
 func TestPrefixCacheAndLoadRouterScoreAllDoesNotMutateCache(t *testing.T) {
-	router := &prefixCacheAndLoadRouter{
-		cache:       prefixcacheindexer.NewLPRadixCache(2),
-		metricCache: cache.NewForTest(),
-		histogram: &SlidingWindowHistogram{
-			windowDuration:             slidingWindowPeriod,
-			histogram:                  make(map[*prefixcacheindexer.TreeNode]int),
-			nodeToCount:                make(map[*prefixcacheindexer.TreeNode]int),
-			hitTokens:                  make(map[*prefixcacheindexer.TreeNode]int),
-			promptTokens:               make(map[*prefixcacheindexer.TreeNode]int),
-			decodingSize:               make(map[*prefixcacheindexer.TreeNode]int),
-			timestamps:                 []histogramEntry{},
-			numPods:                    0,
-			podAllocations:             make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-			currentDecodeLengthsPerPod: make(map[string]int),
-			avgTimePerTokenPerPod:      make(map[string][]float64),
-			perNodeTotalDecodeLengths:  make(map[*prefixcacheindexer.TreeNode]int),
-		},
-		numPods:        0,
-		podAllocations: make(map[*prefixcacheindexer.TreeNode]map[int]bool),
-	}
+	router := newTestRouter(2, nil)
 	seedTokens, err := utils.TokenizeInputText("shared prefix")
 	if err != nil {
 		t.Fatalf("failed to tokenize seed text: %v", err)


### PR DESCRIPTION
## Summary

Add load imbalance protection to the PREBLE routing algorithm. Before performing prefix-aware or cost-model routing, the `Route()` method now checks whether the cluster has significant load imbalance (max - min running requests > 8 by default). If imbalance is detected, the candidate pod list is restricted to only the least-loaded pods.

## Motivation

In scenarios where some pods are heavily loaded (e.g., 10+ running requests) while others are nearly idle (e.g., 1 running request), the PREBLE algorithm could still route new requests to busy pods if they had a good prefix cache match or lower cost model score. This defeats the purpose of load balancing and can lead to cascading overload.

## Changes

- Added `getTargetPodListOnLoadImbalance()` to detect imbalance by comparing `RealtimeNumRequestsRunning` across all ready pods
- Integrated the check into `Route()` so imbalance filtering happens before prefix-matched or cost-model routing
- Threshold is configurable via `AIBRIX_PREFIX_CACHE_POD_RUNNING_REQUEST_IMBALANCE_ABS_COUNT` (default: 8)
- Added test case `load_imbalance_restricts_to_least_loaded_pods` to verify the behavior
