### PR TITLE
Fix console batch status sync

### DIFF
--- a/apps/console/api/planner/impl/handlers.go
+++ b/apps/console/api/planner/impl/handlers.go
@@ -87,7 +87,21 @@ func handleCleanup(ctx context.Context, p *Planner, job *queuedJob, sourceStatus
 	}
 
 	var batch *openai.Batch
-	if batchID != "" && targetStatus != plannerapi.JobStatusExpired && targetStatus != plannerapi.JobStatusCompleted {
+	switch {
+	case batchID == "":
+		// No MDS batch association yet (e.g. expiry/cancel before submission).
+	case targetStatus == plannerapi.JobStatusExpired || targetStatus == plannerapi.JobStatusCompleted:
+		// Natural terminal states are finalized by the runtime, which aggregates
+		// any already-completed requests into the output/error files. Read the
+		// finalized batch so a planner-side conclusion still records MDS output,
+		// counts, and timestamps instead of a stale in-progress snapshot.
+		var err error
+		if batch, err = p.bc.GetBatch(ctx, batchID); err != nil {
+			klog.Warningf("[planner] GetBatch on cleanup failed job_id=%q batch_id=%q: %v", jobID, batchID, err)
+		}
+	default:
+		// Cancellation is planner-initiated: tell MDS to cancel and adopt the
+		// returned batch.
 		klog.Infof("[planner] cancel submitted job_id=%q batch_id=%q", jobID, batchID)
 		var err error
 		if batch, err = p.bc.CancelBatch(ctx, batchID); err != nil {
@@ -98,8 +112,17 @@ func handleCleanup(ctx context.Context, p *Planner, job *queuedJob, sourceStatus
 	job.mu.Lock()
 	if !job.status.IsTerminal() {
 		job.provisionID = ""
-		job.batchID = ""
-		job.batch = batch
+		if batchID != "" {
+			// The MDS batch remains the source of truth for terminal output,
+			// counts, and timestamps. Keep the association so GetJob/ListJobs
+			// can still hydrate from MDS after the in-memory job is evicted.
+			if batch != nil {
+				job.batch = batch
+			}
+		} else {
+			job.batchID = ""
+			job.batch = batch
+		}
 		updateStatusUnsafe(job, targetStatus)
 	}
 	job.mu.Unlock()
@@ -382,8 +405,15 @@ func handleRunning(p *Planner, job *queuedJob) {
 	newStatus := plannerapi.JobStatus(batch.Status)
 
 	job.mu.Lock()
-	if job.status.IsTerminal() || job.status == plannerapi.JobStatusCancelling {
+	currentStatus := job.status
+	if currentStatus.IsTerminal() || currentStatus == plannerapi.JobStatusCancelling {
 		job.mu.Unlock()
+		return
+	}
+	if newStatus.IsTerminal() {
+		job.batch = batch
+		job.mu.Unlock()
+		handleCleanup(ctx, p, job, currentStatus, newStatus)
 		return
 	}
 	updateStatusUnsafe(job, newStatus)
@@ -398,7 +428,4 @@ func handleRunning(p *Planner, job *queuedJob) {
 		}
 	}
 
-	if newStatus.IsTerminal() {
-		handleCleanup(ctx, p, job, status, newStatus)
-	}
 }

--- a/apps/console/api/planner/impl/planner.go
+++ b/apps/console/api/planner/impl/planner.go
@@ -32,6 +32,7 @@ import (
 	pu "github.com/vllm-project/aibrix/apps/console/api/planner/utils"
 	"github.com/vllm-project/aibrix/apps/console/api/resource_manager/provisioner"
 	"github.com/vllm-project/aibrix/apps/console/api/store"
+	"github.com/vllm-project/aibrix/apps/console/api/store/models"
 	"github.com/vllm-project/aibrix/apps/console/api/utils"
 
 	"github.com/vllm-project/aibrix/apps/console/api/error_injection"
@@ -43,9 +44,19 @@ const (
 	defaultPlanningInterval = 60 * time.Second
 	defaultListJobsLimit    = 20
 
+	// expiryFinalizeGracePeriod bounds how long past the completion window the
+	// planner keeps polling MDS before forcing a planner-side expiry. The batch
+	// runtime finalizes expiry on its own deadline and aggregates any
+	// already-completed requests into the output/error files, so we prefer that
+	// terminal batch over a premature planner-side conclusion. The grace period
+	// only kicks in as a fallback when the runtime is unresponsive.
+	expiryFinalizeGracePeriod = 5 * time.Minute
+
 	metricConsolePlannerDuration  = "console.planner.duration"
 	metricConsolePlannerError     = "console.planner.error"
 	metricConsolePlannerJobFailed = "console.planner.job.failed"
+
+	listJobsRefreshWorkers = 8
 )
 
 // Planner is an asynchronous implementation of plannerapi.Planner.
@@ -255,6 +266,9 @@ func (q *Planner) persist(ctx context.Context, job *queuedJob) {
 	job.mu.RLock()
 	jobID := job.req.JobID
 	rec := jobToModel(job)
+	if job.batch != nil {
+		mergeBatchIntoModel(rec, job.batch)
+	}
 	job.mu.RUnlock()
 
 	if err := q.store.UpsertJob(ctx, rec); err != nil {
@@ -433,6 +447,9 @@ func (q *Planner) getJobFromStore(ctx context.Context, jobID string) (*plannerap
 		if err != nil {
 			return nil, err
 		}
+		if j.status.IsTerminal() && !plannerapi.JobStatus(batch.Status).IsTerminal() {
+			batch = getBatchOrPlaceholder(j.batch, j.req, j.status, j.queuedAt, terminalTime(j))
+		}
 		return &plannerapi.Job{JobID: jobID, Batch: batch, State: jobStateSnapshot(j)}, nil
 	}
 	return &plannerapi.Job{
@@ -440,6 +457,30 @@ func (q *Planner) getJobFromStore(ctx context.Context, jobID string) (*plannerap
 		Batch: getBatchOrPlaceholder(j.batch, j.req, j.status, j.queuedAt, terminalTime(j)),
 		State: jobStateSnapshot(j),
 	}, nil
+}
+
+func (q *Planner) refreshStoredJobFromMDS(ctx context.Context, rec *models.Job) *queuedJob {
+	j := modelToJob(rec)
+	if j.batchID == "" || j.status.IsTerminal() {
+		return j
+	}
+	batch, err := q.bc.GetBatch(ctx, j.batchID)
+	if err != nil {
+		klog.Warningf("[planner] ListJobs refresh failed job_id=%q batch_id=%q: %v",
+			j.req.JobID, j.batchID, err)
+		return j
+	}
+
+	j.status = plannerapi.JobStatus(batch.Status)
+	j.batch = batch
+	refreshed := jobToModel(j)
+	mergeBatchIntoModel(refreshed, batch)
+	if q.store != nil {
+		if err := q.store.UpsertJob(ctx, refreshed); err != nil {
+			klog.Warningf("[planner] ListJobs refresh persist job_id=%q: %v", j.req.JobID, err)
+		}
+	}
+	return modelToJob(refreshed)
 }
 
 // Cancel enqueues a cancel request for async processing.
@@ -521,9 +562,10 @@ func (q *Planner) ListJobs(ctx context.Context, req *plannerapi.ListJobsRequest)
 		return nil, err
 	}
 
+	jobs := q.refreshStoredJobsFromMDS(ctx, rows)
 	out := make([]*plannerapi.Job, 0, len(rows))
-	for _, row := range rows {
-		j := modelToJob(row)
+	for i, row := range rows {
+		j := jobs[i]
 		out = append(out, &plannerapi.Job{
 			JobID: row.ID,
 			Batch: getBatchOrPlaceholder(j.batch, j.req, j.status, j.queuedAt, terminalTime(j)),
@@ -532,6 +574,40 @@ func (q *Planner) ListJobs(ctx context.Context, req *plannerapi.ListJobsRequest)
 	}
 
 	return &plannerapi.ListJobsResponse{Data: out, HasMore: hasMore}, nil
+}
+
+func (q *Planner) refreshStoredJobsFromMDS(ctx context.Context, rows []*models.Job) []*queuedJob {
+	jobs := make([]*queuedJob, len(rows))
+	if len(rows) == 0 {
+		return jobs
+	}
+	if len(rows) == 1 {
+		jobs[0] = q.refreshStoredJobFromMDS(ctx, rows[0])
+		return jobs
+	}
+
+	workers := listJobsRefreshWorkers
+	if len(rows) < workers {
+		workers = len(rows)
+	}
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	for i, row := range rows {
+		wg.Add(1)
+		go func(i int, row *models.Job) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				jobs[i] = modelToJob(row)
+				return
+			}
+			jobs[i] = q.refreshStoredJobFromMDS(ctx, row)
+		}(i, row)
+	}
+	wg.Wait()
+	return jobs
 }
 
 // placeholderBatch builds the batch view for jobs without an MDS batch.ID.

--- a/apps/console/api/planner/impl/planner_test.go
+++ b/apps/console/api/planner/impl/planner_test.go
@@ -38,6 +38,8 @@ const (
 	// concurrentEnqueueTimeout is used by race-stress tests where SQLite upserts
 	// under -race can take hundreds of ms each on CI runners.
 	concurrentEnqueueTimeout = 30 * time.Second
+	testOutputFileID         = "file-output"
+	testErrorFileID          = "file-error"
 )
 
 // =============================================================================
@@ -469,7 +471,7 @@ func TestGetJobWithTerminalMDSBatchStillFetchesMDS(t *testing.T) {
 			return &openai.Batch{
 				ID:           batchID,
 				Status:       openai.BatchStatusCompleted,
-				OutputFileID: "file-output",
+				OutputFileID: testOutputFileID,
 			}, nil
 		},
 	}
@@ -492,7 +494,7 @@ func TestGetJobWithTerminalMDSBatchStillFetchesMDS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first GetJob: %v", err)
 	}
-	if first.Batch.Status != openai.BatchStatusCompleted || first.Batch.OutputFileID != "file-output" {
+	if first.Batch.Status != openai.BatchStatusCompleted || first.Batch.OutputFileID != testOutputFileID {
 		t.Fatalf("first GetJob batch = %+v, want completed with output file", first.Batch)
 	}
 
@@ -500,12 +502,221 @@ func TestGetJobWithTerminalMDSBatchStillFetchesMDS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second GetJob: %v", err)
 	}
-	if second.Batch.Status != openai.BatchStatusCompleted || second.Batch.OutputFileID != "file-output" {
+	if second.Batch.Status != openai.BatchStatusCompleted || second.Batch.OutputFileID != testOutputFileID {
 		t.Fatalf("second GetJob batch = %+v, want MDS batch, not placeholder", second.Batch)
 	}
 	if got := getCalls.Load(); got < 2 {
 		t.Fatalf("GetBatch calls = %d, want at least 2", got)
 	}
+}
+
+func TestCompletedBatchSurvivesCleanupAndStoreEviction(t *testing.T) {
+	prov := &fakeProvisioner{}
+	bc := &fakeBatchClient{
+		GetFn: func(ctx context.Context, batchID string) (*openai.Batch, error) {
+			batch := &openai.Batch{
+				ID:            batchID,
+				Status:        openai.BatchStatusCompleted,
+				OutputFileID:  testOutputFileID,
+				ErrorFileID:   testErrorFileID,
+				CompletedAt:   1_800_000_123,
+				RequestCounts: openai.BatchRequestCounts{Total: 10, Completed: 10, Failed: 0},
+			}
+			constructBatchJson(batch)
+			return batch, nil
+		},
+	}
+	q := newTestPlanner(t, bc, prov, 1)
+
+	if _, err := q.Enqueue(context.Background(), validReq("j-completed-cleanup")); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	waitFor(t, defaultTimeout, func() bool {
+		q.mu.RLock()
+		_, ok := q.jobs["j-completed-cleanup"]
+		q.mu.RUnlock()
+		return !ok
+	}, "expected terminal job to be evicted from memory")
+
+	got, err := q.GetJob(context.Background(), "j-completed-cleanup")
+	if err != nil {
+		t.Fatalf("GetJob after eviction: %v", err)
+	}
+	if got.Batch.ID != "batch-j-completed-cleanup" {
+		t.Fatalf("Batch.ID = %q, want persisted MDS batch ID", got.Batch.ID)
+	}
+	if got.Batch.Status != openai.BatchStatusCompleted {
+		t.Fatalf("Batch.Status = %s, want completed", got.Batch.Status)
+	}
+	if got.Batch.OutputFileID != testOutputFileID || got.Batch.ErrorFileID != testErrorFileID {
+		t.Fatalf("terminal files = output %q error %q, want file-output/file-error",
+			got.Batch.OutputFileID, got.Batch.ErrorFileID)
+	}
+	if got.Batch.RequestCounts.Total != 10 || got.Batch.RequestCounts.Completed != 10 || got.Batch.RequestCounts.Failed != 0 {
+		t.Fatalf("request counts = %+v, want 10/10/0", got.Batch.RequestCounts)
+	}
+	_, releases, _ := prov.snapshot()
+	if len(releases) != 1 || releases[0] != "prov-j-completed-cleanup" {
+		t.Fatalf("release calls = %v, want [prov-j-completed-cleanup]", releases)
+	}
+
+	list, err := q.ListJobs(context.Background(), &plannerapi.ListJobsRequest{})
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if len(list.Data) != 1 {
+		t.Fatalf("ListJobs returned %d jobs, want 1", len(list.Data))
+	}
+	listed := list.Data[0].Batch
+	if listed.ID != "batch-j-completed-cleanup" ||
+		listed.Status != openai.BatchStatusCompleted ||
+		listed.OutputFileID != testOutputFileID ||
+		listed.RequestCounts.Total != 10 ||
+		listed.RequestCounts.Completed != 10 ||
+		listed.RequestCounts.Failed != 0 {
+		t.Fatalf("ListJobs batch = %+v, want completed MDS fields preserved", listed)
+	}
+}
+
+// TestExpiredInProgressPreservesPartialOutput covers the batch that runs past
+// its completion window: the runtime finalizes expiry and aggregates the
+// already-completed requests into the output/error files. The planner must not
+// conclude a premature, output-less expiry on its own deadline; it keeps
+// polling MDS within the grace period and adopts the finalized terminal batch.
+func TestExpiredInProgressPreservesPartialOutput(t *testing.T) {
+	var finalized atomic.Bool
+	prov := &fakeProvisioner{}
+	bc := &fakeBatchClient{
+		GetFn: func(ctx context.Context, batchID string) (*openai.Batch, error) {
+			batch := &openai.Batch{
+				ID:            batchID,
+				Status:        openai.BatchStatusInProgress,
+				RequestCounts: openai.BatchRequestCounts{Total: 10, Completed: 4, Failed: 0},
+			}
+			if finalized.Load() {
+				batch.Status = openai.BatchStatusExpired
+				batch.OutputFileID = testOutputFileID
+				batch.ErrorFileID = testErrorFileID
+				batch.ExpiredAt = 1_800_000_500
+			}
+			constructBatchJson(batch)
+			return batch, nil
+		},
+	}
+	q := newTestPlanner(t, bc, prov, 1)
+
+	if _, err := q.Enqueue(context.Background(), validReq("j-expire-partial")); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	// Wait until the job is running and MDS has been polled at least once.
+	waitFor(t, defaultTimeout, func() bool {
+		q.mu.RLock()
+		job, ok := q.jobs["j-expire-partial"]
+		q.mu.RUnlock()
+		if !ok {
+			return false
+		}
+		job.mu.RLock()
+		defer job.mu.RUnlock()
+		return job.status == plannerapi.JobStatusInProgress
+	}, "expected job to reach in_progress")
+
+	// Simulate the completion window elapsing while the job is still running,
+	// within the finalize grace period.
+	q.mu.RLock()
+	job, ok := q.jobs["j-expire-partial"]
+	q.mu.RUnlock()
+	if !ok {
+		t.Fatal("job evicted before completion window elapsed")
+	}
+	job.mu.Lock()
+	job.expiresAt = time.Now().UTC().Add(-time.Minute)
+	job.mu.Unlock()
+
+	// While the runtime is still finalizing, the planner must not prematurely
+	// conclude an output-less expiry.
+	time.Sleep(300 * time.Millisecond)
+	got, err := q.GetJob(context.Background(), "j-expire-partial")
+	if err != nil {
+		t.Fatalf("GetJob during finalize: %v", err)
+	}
+	if got.Batch.Status == openai.BatchStatusExpired && got.Batch.OutputFileID == "" {
+		t.Fatal("planner concluded a premature expiry before the runtime finalized partial output")
+	}
+
+	// Runtime finishes finalizing: MDS now reports expired with partial output.
+	finalized.Store(true)
+
+	waitFor(t, defaultTimeout, func() bool {
+		g, err := q.GetJob(context.Background(), "j-expire-partial")
+		return err == nil && g.Batch.Status == openai.BatchStatusExpired
+	}, "expected job to reach expired")
+
+	got, err = q.GetJob(context.Background(), "j-expire-partial")
+	if err != nil {
+		t.Fatalf("GetJob after expiry: %v", err)
+	}
+	if got.Batch.OutputFileID != testOutputFileID || got.Batch.ErrorFileID != testErrorFileID {
+		t.Fatalf("expired batch files = output %q error %q, want partial output preserved",
+			got.Batch.OutputFileID, got.Batch.ErrorFileID)
+	}
+	if got.Batch.RequestCounts.Total != 10 || got.Batch.RequestCounts.Completed != 4 || got.Batch.RequestCounts.Failed != 0 {
+		t.Fatalf("expired request counts = %+v, want 10 total / 4 completed / 0 failed", got.Batch.RequestCounts)
+	}
+}
+
+// TestExpiredInProgressForcesExpiryAfterGracePeriod covers the fallback: when
+// the runtime is unresponsive past the completion window, the planner must
+// still force a planner-side expiry rather than leave the job running forever.
+func TestExpiredInProgressForcesExpiryAfterGracePeriod(t *testing.T) {
+	prov := &fakeProvisioner{}
+	bc := &fakeBatchClient{
+		// Runtime never finalizes: it keeps reporting in_progress.
+		GetFn: func(ctx context.Context, batchID string) (*openai.Batch, error) {
+			batch := &openai.Batch{
+				ID:            batchID,
+				Status:        openai.BatchStatusInProgress,
+				RequestCounts: openai.BatchRequestCounts{Total: 10, Completed: 4, Failed: 0},
+			}
+			constructBatchJson(batch)
+			return batch, nil
+		},
+	}
+	q := newTestPlanner(t, bc, prov, 1)
+
+	if _, err := q.Enqueue(context.Background(), validReq("j-expire-stuck")); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	waitFor(t, defaultTimeout, func() bool {
+		q.mu.RLock()
+		job, ok := q.jobs["j-expire-stuck"]
+		q.mu.RUnlock()
+		if !ok {
+			return false
+		}
+		job.mu.RLock()
+		defer job.mu.RUnlock()
+		return job.status == plannerapi.JobStatusInProgress
+	}, "expected job to reach in_progress")
+
+	// Completion window elapsed beyond the finalize grace period with an
+	// unresponsive runtime.
+	q.mu.RLock()
+	job, ok := q.jobs["j-expire-stuck"]
+	q.mu.RUnlock()
+	if !ok {
+		t.Fatal("job evicted before completion window elapsed")
+	}
+	job.mu.Lock()
+	job.expiresAt = time.Now().UTC().Add(-(expiryFinalizeGracePeriod + time.Minute))
+	job.mu.Unlock()
+
+	waitFor(t, defaultTimeout, func() bool {
+		g, err := q.GetJob(context.Background(), "j-expire-stuck")
+		return err == nil && g.Batch.Status == openai.BatchStatusExpired
+	}, "expected fallback planner-side expiry")
 }
 
 // =============================================================================
@@ -898,6 +1109,66 @@ func TestCancelSubmittedJobForwardsToMDSAndReleasesProvision(t *testing.T) {
 	}
 }
 
+func TestCancelledBatchSurvivesCleanupAndStoreEviction(t *testing.T) {
+	prov := &fakeProvisioner{}
+	var cancelled atomic.Bool
+	bc := &fakeBatchClient{
+		CancelFn: func(ctx context.Context, batchID string) (*openai.Batch, error) {
+			cancelled.Store(true)
+			batch := &openai.Batch{
+				ID:          batchID,
+				Status:      openai.BatchStatusCancelled,
+				CancelledAt: 1_800_000_456,
+			}
+			constructBatchJson(batch)
+			return batch, nil
+		},
+		GetFn: func(ctx context.Context, batchID string) (*openai.Batch, error) {
+			if !cancelled.Load() {
+				return &openai.Batch{ID: batchID, Status: openai.BatchStatusInProgress}, nil
+			}
+			batch := &openai.Batch{
+				ID:          batchID,
+				Status:      openai.BatchStatusCancelled,
+				CancelledAt: 1_800_000_456,
+			}
+			constructBatchJson(batch)
+			return batch, nil
+		},
+	}
+	q := newTestPlanner(t, bc, prov, 1)
+
+	if _, err := q.Enqueue(context.Background(), validReq("j-cancel-cleanup")); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	waitFor(t, defaultTimeout, func() bool {
+		creates, _ := bc.snapshot()
+		return len(creates) == 1
+	}, "CreateBatch never fired")
+
+	if _, err := q.Cancel(context.Background(), "j-cancel-cleanup"); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	waitFor(t, defaultTimeout, func() bool {
+		_, cancels := bc.snapshot()
+		return len(cancels) == 1
+	}, "CancelBatch never fired")
+	waitFor(t, defaultTimeout, func() bool {
+		q.mu.RLock()
+		_, ok := q.jobs["j-cancel-cleanup"]
+		q.mu.RUnlock()
+		return !ok
+	}, "expected terminal job to be evicted from memory")
+
+	got, err := q.GetJob(context.Background(), "j-cancel-cleanup")
+	if err != nil {
+		t.Fatalf("GetJob after eviction: %v", err)
+	}
+	if got.Batch.ID != "batch-j-cancel-cleanup" || got.Batch.Status != openai.BatchStatusCancelled {
+		t.Fatalf("Batch = %+v, want persisted cancelled MDS batch", got.Batch)
+	}
+}
+
 func TestCancelUnknownJobReturnsNotFound(t *testing.T) {
 	q := newTestPlanner(t, &fakeBatchClient{}, &fakeProvisioner{}, 1)
 	_, err := q.Cancel(context.Background(), "j-ghost")
@@ -1237,6 +1508,65 @@ func TestListJobsFromStoreOnly(t *testing.T) {
 	}
 	if len(resp.Data) != 0 {
 		t.Errorf("expected empty list with nil store, got %d items", len(resp.Data))
+	}
+}
+
+func TestListJobsRefreshesActiveStoredBatchFromMDS(t *testing.T) {
+	var getCalls atomic.Int32
+	bc := &fakeBatchClient{
+		GetFn: func(ctx context.Context, batchID string) (*openai.Batch, error) {
+			getCalls.Add(1)
+			batch := &openai.Batch{
+				ID:            batchID,
+				Status:        openai.BatchStatusCompleted,
+				OutputFileID:  "file-output-list",
+				RequestCounts: openai.BatchRequestCounts{Total: 25, Completed: 25, Failed: 0},
+			}
+			constructBatchJson(batch)
+			return batch, nil
+		},
+	}
+	q := newTestPlanner(t, bc, &fakeProvisioner{}, 1)
+
+	rec := jobToModel(&queuedJob{
+		req:         validReq("j-list-refresh"),
+		status:      plannerapi.JobStatusInProgress,
+		batchID:     "batch-j-list-refresh",
+		queuedAt:    time.Now().UTC(),
+		completedAt: time.Time{},
+	})
+	if err := q.store.UpsertJob(context.Background(), rec); err != nil {
+		t.Fatalf("seed store job: %v", err)
+	}
+
+	resp, err := q.ListJobs(context.Background(), &plannerapi.ListJobsRequest{})
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if getCalls.Load() != 1 {
+		t.Fatalf("GetBatch calls = %d, want 1", getCalls.Load())
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("ListJobs returned %d jobs, want 1", len(resp.Data))
+	}
+	batch := resp.Data[0].Batch
+	if batch.Status != openai.BatchStatusCompleted ||
+		batch.OutputFileID != "file-output-list" ||
+		batch.RequestCounts.Total != 25 ||
+		batch.RequestCounts.Completed != 25 ||
+		batch.RequestCounts.Failed != 0 {
+		t.Fatalf("ListJobs batch = %+v, want refreshed completed batch", batch)
+	}
+
+	stored, err := q.store.GetJob(context.Background(), "j-list-refresh")
+	if err != nil {
+		t.Fatalf("GetJob from store: %v", err)
+	}
+	if stored.Status != string(plannerapi.JobStatusCompleted) ||
+		stored.BatchID != "batch-j-list-refresh" ||
+		stored.OutputDataset != "file-output-list" {
+		t.Fatalf("stored row = status %q batch %q output %q, want completed/batch/file-output-list",
+			stored.Status, stored.BatchID, stored.OutputDataset)
 	}
 }
 

--- a/apps/console/api/planner/impl/planning_loop.go
+++ b/apps/console/api/planner/impl/planning_loop.go
@@ -212,10 +212,21 @@ func (w *planningLoop) processRunningQueue() {
 		}
 		job.mu.RUnlock()
 
-		if !deadline.IsZero() && deadline.Before(time.Now().UTC()) {
-			// Job expired
-			wp.Submit(func() { handleCleanup(ctx, w.planner, job, status, plannerapi.JobStatusExpired) })
-			return true
+		now := time.Now().UTC()
+		if !deadline.IsZero() && deadline.Before(now) {
+			// Past the completion window. The batch runtime finalizes expiry on
+			// its own deadline and aggregates any already-completed requests into
+			// the output/error files, so prefer that terminal batch over a
+			// planner-side conclusion. While the batch is still running and
+			// within the grace period, fall through to the normal MDS poll so
+			// handleRunning adopts the finalized terminal batch (with partial
+			// output/counts). Force a planner-side expiry only as a fallback once
+			// the runtime is unresponsive past the grace period.
+			if !isBatchRunning(status) || now.After(deadline.Add(expiryFinalizeGracePeriod)) {
+				wp.Submit(func() { handleCleanup(ctx, w.planner, job, status, plannerapi.JobStatusExpired) })
+				return true
+			}
+			// else: fall through to poll MDS for the runtime's finalized state.
 		}
 
 		switch status {

--- a/development/app/app.py
+++ b/development/app/app.py
@@ -8,8 +8,10 @@ import re
 import logging
 import struct
 import sys
+import threading
 import time
 from datetime import datetime
+from dataclasses import dataclass
 from random import randint
 import os
 import uuid
@@ -70,6 +72,27 @@ MAX_LOGGED_BODY_CHARS = int(os.getenv("MAX_LOGGED_BODY_CHARS", "4096"))
 MOCK_REQUEST_DURATION_SECONDS = float(
     os.getenv("MOCK_REQUEST_DURATION_SECONDS", "0.2")
 )
+MOCK_CAPACITY_AWARE_LATENCY = os.getenv(
+    "MOCK_CAPACITY_AWARE_LATENCY", "true"
+).lower() in ("true", "1", "yes")
+MOCK_SERVER_CAPACITY = int(os.getenv("MOCK_SERVER_CAPACITY", "1"))
+MOCK_BASE_LATENCY_SECONDS = float(os.getenv("MOCK_BASE_LATENCY_SECONDS", "0.05"))
+MOCK_TTFT_BASE_SECONDS = float(os.getenv("MOCK_TTFT_BASE_SECONDS", "0.03"))
+MOCK_PREFILL_SECONDS_PER_1K_TOKENS = float(
+    os.getenv("MOCK_PREFILL_SECONDS_PER_1K_TOKENS", "0.02")
+)
+MOCK_DECODE_SECONDS_PER_TOKEN = float(
+    os.getenv("MOCK_DECODE_SECONDS_PER_TOKEN", "0.002")
+)
+MOCK_OVERLOAD_PENALTY_SECONDS = float(
+    os.getenv("MOCK_OVERLOAD_PENALTY_SECONDS", "0.08")
+)
+MOCK_LATENCY_JITTER_SECONDS = float(os.getenv("MOCK_LATENCY_JITTER_SECONDS", "0.01"))
+
+_mock_capacity_lock = threading.Lock()
+_mock_capacity_inflight = 0
+_mock_capacity_max_inflight = 0
+_mock_capacity_requests = 0
 
 # Extract the api_key argument and prepare for authentication
 api_key = None
@@ -207,6 +230,104 @@ def _sleep_for_request_latency(started_at, simulated_latency):
         )
     elif MOCK_REQUEST_DURATION_SECONDS > overhead:
         time.sleep(MOCK_REQUEST_DURATION_SECONDS - overhead)
+
+
+@dataclass(frozen=True)
+class MockLatencySample:
+    latency_seconds: float
+    ttft_seconds: float
+    tpot_seconds: float
+    inflight: int
+    max_inflight: int
+    capacity: int
+    overload: int
+    request_index: int
+
+
+def _begin_capacity_aware_request(input_tokens, output_tokens):
+    """Return a latency sample and reserve one mock worker slot.
+
+    The model is intentionally simple but captures the core behavior needed by
+    smart-client tests: requests are cheap until per-pod capacity is exceeded,
+    then queueing pressure increases TTFT and end-to-end latency.
+    """
+    global _mock_capacity_inflight, _mock_capacity_max_inflight
+    global _mock_capacity_requests
+
+    input_token_count = max(int(input_tokens or 0), 0)
+    output_token_count = max(int(output_tokens or 0), 0)
+    capacity = max(MOCK_SERVER_CAPACITY, 1)
+    prompt_latency = (
+        input_token_count / 1000.0
+    ) * MOCK_PREFILL_SECONDS_PER_1K_TOKENS
+    decode_latency = output_token_count * MOCK_DECODE_SECONDS_PER_TOKEN
+    jitter = (
+        random.uniform(0.0, MOCK_LATENCY_JITTER_SECONDS)
+        if MOCK_LATENCY_JITTER_SECONDS > 0
+        else 0.0
+    )
+
+    with _mock_capacity_lock:
+        _mock_capacity_inflight += 1
+        _mock_capacity_requests += 1
+        _mock_capacity_max_inflight = max(
+            _mock_capacity_max_inflight, _mock_capacity_inflight
+        )
+        inflight = _mock_capacity_inflight
+        max_inflight = _mock_capacity_max_inflight
+        request_index = _mock_capacity_requests
+
+    overload = max(inflight - capacity, 0)
+    overload_latency = overload * MOCK_OVERLOAD_PENALTY_SECONDS
+    ttft = MOCK_TTFT_BASE_SECONDS + prompt_latency + overload_latency
+    latency = max(MOCK_BASE_LATENCY_SECONDS, ttft + decode_latency + jitter)
+    tpot = max((latency - ttft) / max(output_token_count, 1), 0.0)
+    return MockLatencySample(
+        latency_seconds=latency,
+        ttft_seconds=ttft,
+        tpot_seconds=tpot,
+        inflight=inflight,
+        max_inflight=max_inflight,
+        capacity=capacity,
+        overload=overload,
+        request_index=request_index,
+    )
+
+
+def _end_capacity_aware_request():
+    global _mock_capacity_inflight
+    with _mock_capacity_lock:
+        _mock_capacity_inflight = max(_mock_capacity_inflight - 1, 0)
+
+
+def _capacity_metrics(sample):
+    if sample is None:
+        return None
+    return {
+        "time_to_first_token_seconds": round(sample.ttft_seconds, 6),
+        "time_per_output_token_seconds": round(sample.tpot_seconds, 6),
+        "mock_latency_seconds": round(sample.latency_seconds, 6),
+        "mock_inflight_at_start": sample.inflight,
+        "mock_max_inflight": sample.max_inflight,
+        "mock_capacity": sample.capacity,
+        "mock_overload": sample.overload,
+        "mock_request_index": sample.request_index,
+        "mock_pod": POD_NAME,
+    }
+
+
+def _sleep_for_mock_latency(started_at, simulated_latency, input_tokens, output_tokens):
+    sample = None
+    try:
+        if MOCK_CAPACITY_AWARE_LATENCY:
+            sample = _begin_capacity_aware_request(input_tokens, output_tokens)
+            _sleep_for_request_latency(started_at, sample.latency_seconds)
+        else:
+            _sleep_for_request_latency(started_at, simulated_latency)
+        return sample
+    finally:
+        if sample is not None:
+            _end_capacity_aware_request()
 
 
 def read_configs(file_path):
@@ -586,7 +707,9 @@ def completion():
                 )
             )
 
-        _sleep_for_request_latency(start, latency)
+        latency_sample = _sleep_for_mock_latency(
+            start, latency, input_tokens, output_tokens
+        )
 
         simulated_text = simulated_message(model)
 
@@ -655,6 +778,7 @@ def completion():
                     "model": model,
                     "stream": True,
                     "content_preview": simulated_text,
+                    "metrics": _capacity_metrics(latency_sample),
                     "usage": {
                         "prompt_tokens": input_tokens,
                         "completion_tokens": output_tokens,
@@ -684,6 +808,9 @@ def completion():
                     "total_tokens": input_tokens + output_tokens,
                 },
             }
+            metrics = _capacity_metrics(latency_sample)
+            if metrics is not None:
+                response["metrics"] = metrics
 
             _apply_pd_prefill_fields(response, request.json, input_tokens)
 
@@ -758,7 +885,9 @@ def chat_completions():
                 )
             )
 
-        _sleep_for_request_latency(start, latency)
+        latency_sample = _sleep_for_mock_latency(
+            start, latency, input_tokens, output_tokens
+        )
 
         simulated_text = simulated_message(model, prefix="\n\n")
 
@@ -865,6 +994,7 @@ def chat_completions():
                     "model": model,
                     "stream": True,
                     "content_preview": simulated_text,
+                    "metrics": _capacity_metrics(latency_sample),
                     "usage": {
                         "prompt_tokens": input_tokens,
                         "completion_tokens": output_tokens,
@@ -941,6 +1071,9 @@ def chat_completions():
                     }
                 ],
             }
+            metrics = _capacity_metrics(latency_sample)
+            if metrics is not None:
+                response["metrics"] = metrics
 
             _apply_pd_prefill_fields(response, request.json, input_tokens)
 


### PR DESCRIPTION
## Pull Request Description
1. Refresh active stored jobs from MDS in ListJobs when batch_id exists.
2. Preserve MDS batch association during completed/expired cleanup.
3. Persist latest MDS batch fields when planner state is written to store.
4. Add some traffic support in mocked app for smart client verification

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>