### PR TITLE
feat(gateway): add conductor algorithm as prefill/decode score policy for PD router

### DIFF
--- a/docs/source/features/pd-disaggregation.rst
+++ b/docs/source/features/pd-disaggregation.rst
@@ -272,12 +272,62 @@ Configure the range in the pod's ``routingConfig``:
    * - ``combined``
      - ``true`` = this pod is a standard inference pod (runs both prefill and decode). Default: ``false``.
    * - ``prefillScorePolicy``
-     - How to score prefill pods. ``prefix_cache`` (default) or ``least_request``.
+     - How to score prefill pods. ``prefix_cache`` (default), ``least_request``, or ``conductor``.
    * - ``decodeScorePolicy``
-     - How to score decode pods. ``load_balancing`` (default) or ``least_request``.
+     - How to score decode pods. ``load_balancing`` (default), ``least_request``, or ``conductor``.
 
 .. note::
     Bucketing only takes effect when ``AIBRIX_PROMPT_LENGTH_BUCKETING=true`` is set on the gateway plugin.
+
+
+Conductor Scoring Policy
+-------------------------
+
+The ``conductor`` scoring policy selects pods by estimating latency for both prefill and decode phases, combining real-time metrics with workload characteristics.
+
+**Prefill Scoring**
+
+Estimates Time To First Token (TTFT) by considering:
+
+- **Queue time** — Time waiting behind currently running requests
+- **Prefix time** — Time to process tokens already in the KV prefix cache
+- **Prefill time** — Time to compute tokens that do not match the cache (accounts for attention complexity)
+
+**Decode Scoring**
+
+Estimates Time Between Tokens (TBT) by considering:
+
+- **Current throughput** — Derived from real-time generation metrics
+- **Batch scaling** — TBT increases as batch size grows
+- **GPU pressure** — Applies a penalty when cache usage exceeds 90%
+
+**Configuration**
+
+Enable conductor via the routing config:
+
+.. code-block:: yaml
+
+    annotations:
+      model.aibrix.ai/config: |
+        {
+          "profiles": {
+            "default": {
+              "routingStrategy": "pd",
+              "routingConfig": {
+                "prefillScorePolicy": "conductor",
+                "decodeScorePolicy": "conductor"
+              }
+            }
+          }
+        }
+
+Or set gateway-wide via ``AIBRIX_PREFILL_SCORE_POLICY`` and ``AIBRIX_DECODE_SCORE_POLICY``.
+
+**When to use conductor:**
+
+- You want routing based on predicted latency rather than just request count
+- Your workload has variable prompt lengths and mixed cache-hit patterns
+- You need to account for GPU memory pressure in decode routing
 
 
 Complete Example
@@ -388,10 +438,10 @@ These are set on the **gateway plugin** deployment.
      - Seconds before a prefill request to a prefill pod times out.
    * - ``AIBRIX_PREFILL_SCORE_POLICY``
      - ``prefix_cache``
-     - Default scoring policy for selecting prefill pods. ``prefix_cache`` or ``least_request``.
+     - Default scoring policy for selecting prefill pods. ``prefix_cache``, ``least_request``, or ``conductor``.
    * - ``AIBRIX_DECODE_SCORE_POLICY``
      - ``load_balancing``
-     - Default scoring policy for selecting decode pods.
+     - Default scoring policy for selecting decode pods. ``load_balancing``, ``least_request``, or ``conductor``.
    * - ``AIBRIX_KV_CONNECTOR_TYPE``
      - ``shfs``
      - KV transfer backend. ``shfs`` for GPU (SHFS/KVCacheManager), ``nixl`` for Neuron (TensorRT-LLM).

--- a/pkg/plugins/gateway/algorithms/pd/decode_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/decode_scorer.go
@@ -40,11 +40,10 @@ const (
 	// requests (including pending requests not yet reflected in metrics).
 	DecodePolicyLeastRequest DecodePolicyName = "least_request"
 
-	// DecodePolicyConductor routes to the pod with the best combined score of
-	// normalized running-request count, inverse throughput, and free GPU
-	// headroom. Compared to load_balancing, conductor weights free-GPU more
-	// aggressively and adds a small "cold-pod boost" for pods with very low
-	// request counts.
+	// DecodePolicyConductor routes to the pod with the lowest estimated TBT
+	// (time between tokens) after adding the request, accounting for GPU-cache
+	// pressure. Uses throughput-derived TBT, sublinear batch-size scaling, and
+	// a penalty for pods above the GPU-cache utilization threshold.
 	DecodePolicyConductor DecodePolicyName = "conductor"
 )
 
@@ -52,6 +51,13 @@ const (
 	ScorePolicyLoadBalancing = string(DecodePolicyLoadBalancing)
 	ScorePolicyLeastRequest  = string(DecodePolicyLeastRequest)
 	ScorePolicyConductor     = string(DecodePolicyConductor)
+)
+
+// Default values for ConductorDecodePolicy.
+const (
+	DefaultGPUCachePressureThreshold = 0.9
+	DefaultGPUCachePressurePenalty   = 1.5
+	DefaultDecodeTBTFallbackMs       = 20.0
 )
 
 // Weights for the load_balancing score numerator:
@@ -172,19 +178,45 @@ func (LeastRequestDecodePolicy) ScoreDecodePod(routingCtx *types.RoutingContext,
 	return in.RunningReqs
 }
 
-// ConductorDecodePolicy is left empty. LoadBalancingDecodePolicy serves as the default.
+// ConductorDecodePolicy scores decode pods by estimated TBT
+// after adding the request, with a GPU-cache pressure penalty.
+//
+//	estimated_TBT = current_TBT * (1 + 1 / max(running_reqs, 1))
+//	if gpu_cache_usage > threshold: estimated_TBT *= penalty
+//
+// Lower score is better.
 type ConductorDecodePolicy struct{}
 
 func (ConductorDecodePolicy) Name() DecodePolicyName { return DecodePolicyConductor }
 
 func (ConductorDecodePolicy) Describe() string {
-	return "TODO: not implemented yet"
+	return fmt.Sprintf("conductor: estimated TBT after adding request; gpu_penalty=%gx above %.0f%% usage",
+		DefaultGPUCachePressurePenalty, DefaultGPUCachePressureThreshold*100)
 }
 
 func (ConductorDecodePolicy) ScoreDecodePod(routingCtx *types.RoutingContext, pod *v1.Pod, in DecodePodInput) float64 {
-	_ = pod
-	_ = in
-	return 0
+	currentTBTMs := DefaultDecodeTBTFallbackMs
+	if in.Throughput > 0 {
+		currentTBTMs = 1000.0 / in.Throughput
+	}
+
+	// TBT after adding one request to a decode pod.
+	runningReqs := math.Max(in.RunningReqs, 1.0)
+	estimatedTBT := currentTBTMs * (1.0 + 1.0/runningReqs)
+
+	// GPU-cache pressure penalty.
+	gpuCacheUsage := 1.0 - in.FreeGPUPercent/100.0
+	if gpuCacheUsage > DefaultGPUCachePressureThreshold {
+		estimatedTBT *= DefaultGPUCachePressurePenalty
+	}
+
+	klog.V(4).InfoS("decode_score", "request_id", routingCtx.RequestID, "pod_name", pod.Name,
+		"policy", DecodePolicyConductor, "decode_score", estimatedTBT,
+		"current_tbt_ms", currentTBTMs, "running_reqs", in.RunningReqs,
+		"gpu_cache_usage", gpuCacheUsage, "throughput", in.Throughput,
+		"free_gpu_percent", in.FreeGPUPercent)
+
+	return estimatedTBT
 }
 
 // decodePolicyFactories is the immutable registry of built-in decode scoring
@@ -246,11 +278,11 @@ func ResolveDecodePolicy(raw string) (policy DecodeScorePolicy, canonical Decode
 // policy names, including both built-in and dynamically registered custom ones.
 // Used in log/error messages to guide operators toward valid values.
 func ValidDecodePolicyNames() []string {
-	names := []string{string(DecodePolicyLoadBalancing), string(DecodePolicyLeastRequest)}
+	names := []string{string(DecodePolicyLoadBalancing), string(DecodePolicyLeastRequest), string(DecodePolicyConductor)}
 	decodePolicyRegistryMu.RLock()
 	defer decodePolicyRegistryMu.RUnlock()
 	for name := range decodePolicyRegistryCustom {
-		if name != string(DecodePolicyLoadBalancing) && name != string(DecodePolicyLeastRequest) {
+		if name != string(DecodePolicyLoadBalancing) && name != string(DecodePolicyLeastRequest) && name != string(DecodePolicyConductor) {
 			names = append(names, name)
 		}
 	}

--- a/pkg/plugins/gateway/algorithms/pd/decode_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/decode_scorer.go
@@ -39,11 +39,19 @@ const (
 	// DecodePolicyLeastRequest routes to the pod with the fewest active decode
 	// requests (including pending requests not yet reflected in metrics).
 	DecodePolicyLeastRequest DecodePolicyName = "least_request"
+
+	// DecodePolicyConductor routes to the pod with the best combined score of
+	// normalized running-request count, inverse throughput, and free GPU
+	// headroom. Compared to load_balancing, conductor weights free-GPU more
+	// aggressively and adds a small "cold-pod boost" for pods with very low
+	// request counts.
+	DecodePolicyConductor DecodePolicyName = "conductor"
 )
 
 const (
 	ScorePolicyLoadBalancing = string(DecodePolicyLoadBalancing)
 	ScorePolicyLeastRequest  = string(DecodePolicyLeastRequest)
+	ScorePolicyConductor     = string(DecodePolicyConductor)
 )
 
 // Weights for the load_balancing score numerator:
@@ -164,12 +172,28 @@ func (LeastRequestDecodePolicy) ScoreDecodePod(routingCtx *types.RoutingContext,
 	return in.RunningReqs
 }
 
+// ConductorDecodePolicy is left empty. LoadBalancingDecodePolicy serves as the default.
+type ConductorDecodePolicy struct{}
+
+func (ConductorDecodePolicy) Name() DecodePolicyName { return DecodePolicyConductor }
+
+func (ConductorDecodePolicy) Describe() string {
+	return "TODO: not implemented yet"
+}
+
+func (ConductorDecodePolicy) ScoreDecodePod(routingCtx *types.RoutingContext, pod *v1.Pod, in DecodePodInput) float64 {
+	_ = pod
+	_ = in
+	return 0
+}
+
 // decodePolicyFactories is the immutable registry of built-in decode scoring
 // policies. Custom policies registered at runtime go into decodePolicyRegistryCustom
 // so that the built-in map never needs a mutex.
 var decodePolicyFactories = map[string]func() DecodeScorePolicy{
 	string(DecodePolicyLoadBalancing): func() DecodeScorePolicy { return LoadBalancingDecodePolicy{} },
 	string(DecodePolicyLeastRequest):  func() DecodeScorePolicy { return LeastRequestDecodePolicy{} },
+	string(DecodePolicyConductor):     func() DecodeScorePolicy { return ConductorDecodePolicy{} },
 }
 
 // RegisterDecodePolicy registers a custom decode scoring policy factory under

--- a/pkg/plugins/gateway/algorithms/pd/decode_scorer_conductor_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/decode_scorer_conductor_test.go
@@ -36,8 +36,7 @@ func makeDecodePod(name, namespace string) *v1.Pod {
 
 func makeDecodeRoutingContext() *types.RoutingContext {
 	return &types.RoutingContext{
-		Model:     "test-model",
-		RequestID: "test-req-1",
+		Model: testModelName,
 	}
 }
 
@@ -54,13 +53,6 @@ func TestConductorDecodePolicy_NameAndDescribe(t *testing.T) {
 	assert.Contains(t, d, "conductor")
 }
 
-func TestConductorDecodePolicy_Describe(t *testing.T) {
-	p := ConductorDecodePolicy{}
-	d := p.Describe()
-	assert.NotEmpty(t, d)
-	assert.Contains(t, d, "conductor")
-}
-
 // ============================================================
 // ConductorDecodePolicy: ScoreDecodePod — basic TBT estimation
 // ============================================================
@@ -68,7 +60,7 @@ func TestConductorDecodePolicy_Describe(t *testing.T) {
 func TestConductorDecodePolicy_BasicTBT(t *testing.T) {
 	p := ConductorDecodePolicy{}
 	ctx := makeDecodeRoutingContext()
-	pod := makeDecodePod("pod-1", "default")
+	pod := makeDecodePod(testPodName, testNamespace)
 
 	in := DecodePodInput{
 		RunningReqs:     4.0,
@@ -95,7 +87,7 @@ func TestConductorDecodePolicy_BasicTBT(t *testing.T) {
 func TestConductorDecodePolicy_ZeroThroughputFallback(t *testing.T) {
 	p := ConductorDecodePolicy{}
 	ctx := makeDecodeRoutingContext()
-	pod := makeDecodePod("pod-1", "default")
+	pod := makeDecodePod(testPodName, testNamespace)
 
 	in := DecodePodInput{
 		RunningReqs:     2.0,
@@ -121,7 +113,7 @@ func TestConductorDecodePolicy_ZeroThroughputFallback(t *testing.T) {
 func TestConductorDecodePolicy_ZeroRunningReqsFloor(t *testing.T) {
 	p := ConductorDecodePolicy{}
 	ctx := makeDecodeRoutingContext()
-	pod := makeDecodePod("pod-1", "default")
+	pod := makeDecodePod(testPodName, testNamespace)
 
 	in := DecodePodInput{
 		RunningReqs:     0.0,

--- a/pkg/plugins/gateway/algorithms/pd/decode_scorer_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/decode_scorer_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func makeDecodePod(name, namespace string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func makeDecodeRoutingContext() *types.RoutingContext {
+	return &types.RoutingContext{
+		Model:     "test-model",
+		RequestID: "test-req-1",
+	}
+}
+
+// ============================================================
+// ConductorDecodePolicy: Name / Describe
+// ============================================================
+
+func TestConductorDecodePolicy_NameAndDescribe(t *testing.T) {
+	p := ConductorDecodePolicy{}
+	name := p.Name()
+	assert.Equal(t, DecodePolicyConductor, name)
+	d := p.Describe()
+	assert.NotEmpty(t, d)
+	assert.Contains(t, d, "conductor")
+}
+
+func TestConductorDecodePolicy_Describe(t *testing.T) {
+	p := ConductorDecodePolicy{}
+	d := p.Describe()
+	assert.NotEmpty(t, d)
+	assert.Contains(t, d, "conductor")
+}
+
+// ============================================================
+// ConductorDecodePolicy: ScoreDecodePod — basic TBT estimation
+// ============================================================
+
+func TestConductorDecodePolicy_BasicTBT(t *testing.T) {
+	p := ConductorDecodePolicy{}
+	ctx := makeDecodeRoutingContext()
+	pod := makeDecodePod("pod-1", "default")
+
+	in := DecodePodInput{
+		RunningReqs:     4.0,
+		Throughput:      50.0,
+		FreeGPUPercent:  5.0,
+		MaxRequestCount: 10.0,
+		MaxThroughput:   100.0,
+		MaxFreeGPUUsage: 90.0,
+	}
+
+	score := p.ScoreDecodePod(ctx, pod, in)
+
+	// currentTBTMs = 1000 / 50 = 20ms
+	// estimatedTBT = 20 * (1 + 1/4) = 20 * 1.25 = 25ms
+	// gpuCacheUsage = 1 - 5/100 = 0.95 > 0.9 -> penalty x1.5
+	// final = 25 * 1.5 = 37.5ms
+	assert.InDelta(t, 37.5, score, 1e-9)
+}
+
+// ============================================================
+// ConductorDecodePolicy: ScoreDecodePod — zero throughput fallback
+// ============================================================
+
+func TestConductorDecodePolicy_ZeroThroughputFallback(t *testing.T) {
+	p := ConductorDecodePolicy{}
+	ctx := makeDecodeRoutingContext()
+	pod := makeDecodePod("pod-1", "default")
+
+	in := DecodePodInput{
+		RunningReqs:     2.0,
+		Throughput:      0.0,
+		FreeGPUPercent:  50.0,
+		MaxRequestCount: 10.0,
+		MaxThroughput:   100.0,
+		MaxFreeGPUUsage: 90.0,
+	}
+
+	score := p.ScoreDecodePod(ctx, pod, in)
+
+	// currentTBTMs = DefaultDecodeTBTFallbackMs = 20ms
+	// estimatedTBT = 20 * (1 + 1/2) = 20 * 1.5 = 30ms
+	// gpuCacheUsage = 0.5 < 0.9 -> no penalty
+	assert.InDelta(t, 30.0, score, 1e-9)
+}
+
+// ============================================================
+// ConductorDecodePolicy: ScoreDecodePod — zero running reqs uses floor of 1
+// ============================================================
+
+func TestConductorDecodePolicy_ZeroRunningReqsFloor(t *testing.T) {
+	p := ConductorDecodePolicy{}
+	ctx := makeDecodeRoutingContext()
+	pod := makeDecodePod("pod-1", "default")
+
+	in := DecodePodInput{
+		RunningReqs:     0.0,
+		Throughput:      50.0,
+		FreeGPUPercent:  50.0,
+		MaxRequestCount: 10.0,
+		MaxThroughput:   100.0,
+		MaxFreeGPUUsage: 90.0,
+	}
+
+	score := p.ScoreDecodePod(ctx, pod, in)
+
+	// runningReqs = max(0, 1) = 1
+	// currentTBTMs = 1000 / 50 = 20ms
+	// estimatedTBT = 20 * (1 + 1/1) = 20 * 2 = 40ms
+	assert.InDelta(t, 40.0, score, 1e-9)
+}

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
@@ -54,6 +54,17 @@ const (
 	// PrefillScorePolicyConductor selects the conductor scoring policy, which
 	// estimates the TTFT (contains queue, prefix, and prefill) for each pod
 	PrefillScorePolicyConductor = "conductor"
+
+	// Default TTFT estimation coefficients for conductor policy.
+	// Units: time in milliseconds, tokens are unitless.
+	//
+	// Prefix time model: T = PrefixTimeCoeffA * tokens + PrefixTimeCoeffB
+	DefaultPrefixTimeCoeffA = 0.005
+	DefaultPrefixTimeCoeffB = 1.0
+	// Prefill time model: T = PrefillTimeCoeffA * tokens^PrefillTimeCoeffB + PrefillTimeCoeffC
+	DefaultPrefillTimeCoeffA = 0.001
+	DefaultPrefillTimeCoeffB = 1.5
+	DefaultPrefillTimeCoeffC = 5.0
 )
 
 // PrefillScorer is a request-scoped scorer created by PrefillScorePolicy. Prepare
@@ -186,24 +197,57 @@ func (s leastRequestScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
 	return reqCnt
 }
 
+// ConductorPrefillPolicyConfig contains TTFT estimation coefficients for the conductor policy.
+// These coefficients are used to model the time taken for prefix processing and prefill computation.
+type ConductorPrefillPolicyConfig struct {
+	// PrefixTimeCoeffA is the linear coefficient for prefix time estimation.
+	// Prefix time model: T = PrefixTimeCoeffA * tokens + PrefixTimeCoeffB
+	PrefixTimeCoeffA float64
+	// PrefixTimeCoeffB is the constant offset for prefix time estimation.
+	PrefixTimeCoeffB float64
+	// PrefillTimeCoeffA is the scaling coefficient for prefill time estimation.
+	// Prefill time model: T = PrefillTimeCoeffA * tokens^PrefillTimeCoeffB + PrefillTimeCoeffC
+	PrefillTimeCoeffA float64
+	// PrefillTimeCoeffB is the exponent for prefill time estimation (accounts for attention complexity).
+	PrefillTimeCoeffB float64
+	// PrefillTimeCoeffC is the constant offset for prefill time estimation.
+	PrefillTimeCoeffC float64
+}
+
+// NewConductorPrefillPolicyConfig returns a config with default coefficients.
+// different GPU device may have different default coefficients
+// A possible solution: add 'device' arg to ConductorPrefillPolicyConfig.
+// like ConductorPrefillPolicyConfig("default"), ConductorPrefillPolicyConfig("a100")
+//
+// now only support default config. arg not applied.
+func NewConductorPrefillPolicyConfig() ConductorPrefillPolicyConfig {
+	return ConductorPrefillPolicyConfig{
+		PrefixTimeCoeffA:  DefaultPrefixTimeCoeffA,
+		PrefixTimeCoeffB:  DefaultPrefixTimeCoeffB,
+		PrefillTimeCoeffA: DefaultPrefillTimeCoeffA,
+		PrefillTimeCoeffB: DefaultPrefillTimeCoeffB,
+		PrefillTimeCoeffC: DefaultPrefillTimeCoeffC,
+	}
+}
+
 // conductorPrefillPolicy estimates TTFT by summing three per-pod components
-//   estimated_TTFT(pod) = 	queue(reqCnt, PrefillTimePerRequest)
-// 						 	+ prefix(matched_tokens) 
-// 						 	+ prefill(unmatched_tokens)
+// estimated_TTFT(pod) = queue(reqCnt, PrefillTimePerRequest) + prefix(matched_tokens) + prefill(unmatched_tokens)
 // metricCache is used to get real-time info PrefillTimePerRequest.
 type conductorPrefillPolicy struct {
 	tok                tokenizer.Tokenizer
 	prefixCacheIndexer *prefixcacheindexer.PrefixHashTable
 	metricCache        cache.MetricCache
+	config             ConductorPrefillPolicyConfig
 }
 
 // NewConductorPrefillPolicy constructs a conductor PrefillScorePolicy with the
-// given tokenizer, shared prefix-hash table, and metric cache.
-func NewConductorPrefillPolicy(tok tokenizer.Tokenizer, prefixCacheIndexer *prefixcacheindexer.PrefixHashTable, metricCache cache.MetricCache) PrefillScorePolicy {
+// given tokenizer, shared prefix-hash table, metric cache, and TTFT estimation config.
+func NewConductorPrefillPolicy(tok tokenizer.Tokenizer, prefixCacheIndexer *prefixcacheindexer.PrefixHashTable, metricCache cache.MetricCache, config ConductorPrefillPolicyConfig) PrefillScorePolicy {
 	return &conductorPrefillPolicy{
 		tok:                tok,
 		prefixCacheIndexer: prefixCacheIndexer,
 		metricCache:        metricCache,
+		config:             config,
 	}
 }
 
@@ -222,6 +266,7 @@ func (p *conductorPrefillPolicy) Prepare(routingCtx *types.RoutingContext, _ []*
 		totalTokens: len(tokens),
 		metricCache: p.metricCache,
 		modelName:   routingCtx.Model,
+		config:      p.config,
 	}, nil
 }
 
@@ -234,54 +279,61 @@ type conductorScorer struct {
 	totalTokens int
 	metricCache cache.MetricCache
 	modelName   string
+	config      ConductorPrefillPolicyConfig
 }
 
 func (s *conductorScorer) PrefixHashes() []uint64 { return s.hashes }
 
-// estimateQueue estimates the queue-wait component of TTFT as a simple linear function
+// estimateQueue estimates the queue-wait component of TTFT (in ms) as a simple linear function
 // of the pod's currently running request count.
 //
-//	queue_estimate = reqCnt * avgPrefillTime
-func (s *conductorScorer) estimateQueue(reqCnt float64, avgPrefillTimeSeconds float64) float64 {
-	return reqCnt * avgPrefillTimeSeconds
+// queue_estimate = reqCnt * avgPrefillTimeMs
+func (s *conductorScorer) estimateQueue(reqCnt float64, avgPrefillTimeMs float64) float64 {
+	if reqCnt <= 0 {
+		return 0.0
+	}
+	return reqCnt * avgPrefillTimeMs
 }
 
-// estimatePrefix estimates the prefix-cache portion of TTFT based on the number of
+// estimatePrefix estimates the prefix-cache portion of TTFT (in ms) based on the number of
 // tokens already matched in the pod.
 //
-//	use model: T = A * tokens + B (linear)
+// use model: T = A * tokens + B (linear)
 func (s *conductorScorer) estimatePrefix(matchedTokens float64) float64 {
-	PrefixTimeCoeffA := 0.005
-	PrefixTimeCoeffB := 1.0
-	return PrefixTimeCoeffA * matchedTokens + PrefixTimeCoeffB
+	if matchedTokens <= 0 {
+		return 0.0
+	}
+	return s.config.PrefixTimeCoeffA*matchedTokens + s.config.PrefixTimeCoeffB
 }
 
-// estimatePrefill estimates the prefill-compute portion of TTFT in milliseconds 
+// estimatePrefill estimates the prefill-compute portion of TTFT (in ms)
 // for the tokens that did not match the prefix cache.
 //
 // Uses model: T = A * tokens^B + C (superlinear due to attention complexity).
 func (s *conductorScorer) estimatePrefill(unmatchedTokens float64) float64 {
-	PrefillTimeCoeffA := 0.001
-	PrefillTimeCoeffB := 1.5
-	PrefillTimeCoeffC := 5.0
-	return PrefillTimeCoeffA * math.Pow(unmatchedTokens, PrefillTimeCoeffB) + PrefillTimeCoeffC
+	if unmatchedTokens <= 0 {
+		return 0.0
+	}
+	return s.config.PrefillTimeCoeffA*math.Pow(unmatchedTokens, s.config.PrefillTimeCoeffB) + s.config.PrefillTimeCoeffC
 }
 
-// ScorePod returns the estimated TTFT for a single pod by summing the queue,
+// ScorePod returns the estimated TTFT (in ms) for a single pod by summing the queue,
 // prefix, and prefill components. Lower scores are preferred by the router.
 func (s *conductorScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
 	matchPct := float64(s.matchedPods[pod.Name]) // 0..100, 0 when the pod is not in matchedPods
 	matchedTokens := float64(s.totalTokens) * matchPct / 100.0
 	unmatchedTokens := float64(s.totalTokens) - matchedTokens
 
+	// default value applied if metric lookup fails
+	// assume it's 512 tokens' prefill time under config
+	avgPrefillTimeMs := s.estimatePrefill(512)
 	avgPrefillTimeSecondsMetric, err := s.metricCache.GetMetricValueByPodModel(pod.Name, pod.Namespace, s.modelName, metrics.RequestPrefillTimeSeconds)
-	avgPrefillTimeSeconds := float64(0.5) // default value if metric lookup fails
 	if err != nil {
 		klog.V(4).ErrorS(err, "error getting RequestPrefillTimeSeconds")
 	} else if hist := avgPrefillTimeSecondsMetric.GetHistogramValue(); hist != nil && hist.Count > 0 {
-		avgPrefillTimeSeconds = hist.GetMean()
+		avgPrefillTimeMs = hist.GetMean() * 1000
 	}
-	queueEst := s.estimateQueue(reqCnt, avgPrefillTimeSeconds)
+	queueEst := s.estimateQueue(reqCnt, avgPrefillTimeMs)
 	prefixEst := s.estimatePrefix(matchedTokens)
 	prefillEst := s.estimatePrefill(unmatchedTokens)
 	score := queueEst + prefixEst + prefillEst

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
@@ -29,6 +29,7 @@ package pd
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
@@ -47,6 +48,13 @@ const (
 	// which routes prefill requests purely by the lowest running-request count
 	// without consulting the prefix cache.
 	PrefillScorePolicyLeastRequest = "least_request"
+
+	// PrefillScorePolicyConductor selects the conductor scoring policy, which
+	// combines prefix-cache matching with both running-request count and a
+	// pod-load indicator (reqCnt/maxRequestCount). It is intended as a
+	// drop-in refinement of prefix_cache that places more emphasis on
+	// load balance when cache matches are close.
+	PrefillScorePolicyConductor = "conductor"
 )
 
 // PrefillScorer is a request-scoped scorer created by PrefillScorePolicy. Prepare
@@ -177,4 +185,119 @@ func (s leastRequestScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
 		"policy", PrefillScorePolicyLeastRequest,
 		"running_reqs", reqCnt)
 	return reqCnt
+}
+
+// conductorPrefillPolicy estimates TTFT by summing three per-pod components
+// (queue + prefix + prefill). Estimators are extracted as plain linear
+// functions so tuning and future updates. Lower estimates:
+//
+//   estimated_TTFT(pod) = queue(reqCnt) + prefix(matched_tokens) + prefill(unmatched_tokens)
+//
+// Each linear forms:
+//
+//   queue(n)      = k_queue * n
+//   prefix(m)      = k_prefix * m + b_prefix
+//   prefill(u)     = k_prefill * u + b_prefill
+//
+// with k_prefill > k_prefix so that cache-hit pods score lower than cache-miss ones.
+// Matched prefix length is derived from the prefix-cache match percentage
+// returned by PrefixHashTable. Unmatched length is what remains after the
+// matched prefix. The request is tokenized once in Prepare so per-pod scoring
+// stays cheap on the hot path.
+type conductorPrefillPolicy struct {
+	tok                tokenizer.Tokenizer
+	prefixCacheIndexer *prefixcacheindexer.PrefixHashTable
+}
+
+// NewConductorPrefillPolicy constructs a conductor PrefillScorePolicy with the
+// given tokenizer and shared prefix-hash table.
+func NewConductorPrefillPolicy(tok tokenizer.Tokenizer, prefixCacheIndexer *prefixcacheindexer.PrefixHashTable) PrefillScorePolicy {
+	return &conductorPrefillPolicy{
+		tok:                tok,
+		prefixCacheIndexer: prefixCacheIndexer,
+	}
+}
+
+// Prepare tokenizes routingCtx.Message and performs a prefix-cache lookup against the
+// ready-pod set, keeping the input token count so downstream ScorePod can derive
+// matched/unmatched lengths from the per-pod match percentage.
+func (p *conductorPrefillPolicy) Prepare(routingCtx *types.RoutingContext, _ []*v1.Pod, readyPodsMap map[string]struct{}) (PrefillScorer, error) {
+	tokens, err := p.tok.TokenizeInputText(routingCtx.Message)
+	if err != nil {
+		return nil, err
+	}
+	matchedPods, hashes := p.prefixCacheIndexer.MatchPrefix(tokens, routingCtx.Model, readyPodsMap)
+	return &conductorScorer{
+		matchedPods: matchedPods,
+		hashes:      hashes,
+		totalTokens: len(tokens),
+	}, nil
+}
+
+func (p *conductorPrefillPolicy) Name() string { return PrefillScorePolicyConductor }
+
+// conductorScorer is the request-scoped scorer produced by conductorPrefillPolicy.
+type conductorScorer struct {
+	matchedPods map[string]int
+	hashes      []uint64
+	totalTokens int
+}
+
+func (s *conductorScorer) PrefixHashes() []uint64 { return s.hashes }
+
+// estimateQueue estimates the queue-wait component of TTFT as a simple linear function
+// of the pod's currently running request count.
+//
+//	queue_estimate = reqCnt * avgPrefillTime
+func (s *conductorScorer) estimateQueue(reqCnt float64) float64 {
+	// TODO: fetch real-time value, but current scorer interface signature does not allow it
+	avgPrefillTimeSeconds := 100.0 
+	return reqCnt * avgPrefillTimeSeconds
+}
+
+// estimatePrefix estimates the prefix-cache portion of TTFT based on the number of
+// tokens already matched in the pod.
+//
+//	use model: T = A * tokens + B (linear)
+func (s *conductorScorer) estimatePrefix(matchedTokens float64) float64 {
+	PrefixTimeCoeffA := 0.005
+	PrefixTimeCoeffB := 1.0
+	return PrefixTimeCoeffA * matchedTokens + PrefixTimeCoeffB
+}
+
+// estimatePrefill estimates the prefill-compute portion of TTFT in milliseconds 
+// for the tokens that did not match the prefix cache.
+//
+// Uses model: T = A * tokens^B + C (superlinear due to attention complexity).
+func (s *conductorScorer) estimatePrefill(unmatchedTokens float64) float64 {
+	PrefillTimeCoeffA := 0.001
+	PrefillTimeCoeffB := 1.5
+	PrefillTimeCoeffC := 5.0
+	return PrefillTimeCoeffA * math.Pow(unmatchedTokens, PrefillTimeCoeffB) + PrefillTimeCoeffC
+}
+
+// ScorePod returns the estimated TTFT for a single pod by summing the queue,
+// prefix, and prefill components. Lower scores are preferred by the router.
+func (s *conductorScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
+	matchPct := float64(s.matchedPods[pod.Name]) // 0..100, 0 when the pod is not in matchedPods
+	matchedTokens := float64(s.totalTokens) * matchPct / 100.0
+	unmatchedTokens := float64(s.totalTokens) - matchedTokens
+
+	queueEst := s.estimateQueue(reqCnt)
+	prefixEst := s.estimatePrefix(matchedTokens)
+	prefillEst := s.estimatePrefill(unmatchedTokens)
+	score := queueEst + prefixEst + prefillEst
+
+	klog.V(4).InfoS("prefill_score", "pod_name", pod.Name,
+		"policy", PrefillScorePolicyConductor,
+		"score", score,
+		"running_reqs", reqCnt,
+		"total_tokens", s.totalTokens,
+		"prefix_match_percent", matchPct,
+		"matched_tokens", matchedTokens,
+		"unmatched_tokens", unmatchedTokens,
+		"queue_estimate", queueEst,
+		"prefix_estimate", prefixEst,
+		"prefill_estimate", prefillEst)
+	return score
 }

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
@@ -52,10 +52,7 @@ const (
 	PrefillScorePolicyLeastRequest = "least_request"
 
 	// PrefillScorePolicyConductor selects the conductor scoring policy, which
-	// combines prefix-cache matching with both running-request count and a
-	// pod-load indicator (reqCnt/maxRequestCount). It is intended as a
-	// drop-in refinement of prefix_cache that places more emphasis on
-	// load balance when cache matches are close.
+	// estimates the TTFT (contains queue, prefix, and prefill) for each pod
 	PrefillScorePolicyConductor = "conductor"
 )
 
@@ -190,22 +187,10 @@ func (s leastRequestScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
 }
 
 // conductorPrefillPolicy estimates TTFT by summing three per-pod components
-// (queue + prefix + prefill). Estimators are extracted as plain linear
-// functions so tuning and future updates. Lower estimates:
-//
-//   estimated_TTFT(pod) = queue(reqCnt) + prefix(matched_tokens) + prefill(unmatched_tokens)
-//
-// Each linear forms:
-//
-//   queue(n)      = k_queue * n
-//   prefix(m)      = k_prefix * m + b_prefix
-//   prefill(u)     = k_prefill * u + b_prefill
-//
-// with k_prefill > k_prefix so that cache-hit pods score lower than cache-miss ones.
-// Matched prefix length is derived from the prefix-cache match percentage
-// returned by PrefixHashTable. Unmatched length is what remains after the
-// matched prefix. The request is tokenized once in Prepare so per-pod scoring
-// stays cheap on the hot path.
+//   estimated_TTFT(pod) = 	queue(reqCnt, PrefillTimePerRequest)
+// 						 	+ prefix(matched_tokens) 
+// 						 	+ prefill(unmatched_tokens)
+// metricCache is used to get real-time info PrefillTimePerRequest.
 type conductorPrefillPolicy struct {
 	tok                tokenizer.Tokenizer
 	prefixCacheIndexer *prefixcacheindexer.PrefixHashTable
@@ -213,7 +198,7 @@ type conductorPrefillPolicy struct {
 }
 
 // NewConductorPrefillPolicy constructs a conductor PrefillScorePolicy with the
-// given tokenizer and shared prefix-hash table.
+// given tokenizer, shared prefix-hash table, and metric cache.
 func NewConductorPrefillPolicy(tok tokenizer.Tokenizer, prefixCacheIndexer *prefixcacheindexer.PrefixHashTable, metricCache cache.MetricCache) PrefillScorePolicy {
 	return &conductorPrefillPolicy{
 		tok:                tok,
@@ -293,8 +278,8 @@ func (s *conductorScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
 	avgPrefillTimeSeconds := float64(0.5) // default value if metric lookup fails
 	if err != nil {
 		klog.V(4).ErrorS(err, "error getting RequestPrefillTimeSeconds")
-	} else {
-		avgPrefillTimeSeconds = avgPrefillTimeSecondsMetric.GetSimpleValue()
+	} else if hist := avgPrefillTimeSecondsMetric.GetHistogramValue(); hist != nil && hist.Count > 0 {
+		avgPrefillTimeSeconds = hist.GetMean()
 	}
 	queueEst := s.estimateQueue(reqCnt, avgPrefillTimeSeconds)
 	prefixEst := s.estimatePrefix(matchedTokens)

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
@@ -317,6 +317,20 @@ func (s *conductorScorer) estimatePrefill(unmatchedTokens float64) float64 {
 	return s.config.PrefillTimeCoeffA*math.Pow(unmatchedTokens, s.config.PrefillTimeCoeffB) + s.config.PrefillTimeCoeffC
 }
 
+// getAvgPrefillTimeMs returns the average prefill time (in ms) for the given pod.
+// Returns -1 if the metric lookup fails for any reason.
+func (s *conductorScorer) getAvgPrefillTimeMs(podName, podNamespace, modelName string) float64 {
+	histogramMetric, err := s.metricCache.GetMetricValueByPodModel(podName, podNamespace, modelName, metrics.RequestPrefillTimeSeconds)
+	if err != nil || histogramMetric == nil {
+		return -1
+	}
+	histogram := histogramMetric.GetHistogramValue()
+	if histogram == nil || histogram.Count <= 0 {
+		return -1
+	}
+	return histogram.GetMean() * 1000.0
+}
+
 // ScorePod returns the estimated TTFT (in ms) for a single pod by summing the queue,
 // prefix, and prefill components. Lower scores are preferred by the router.
 func (s *conductorScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
@@ -326,12 +340,10 @@ func (s *conductorScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
 
 	// default value applied if metric lookup fails
 	// assume it's 512 tokens' prefill time under config
-	avgPrefillTimeMs := s.estimatePrefill(512)
-	avgPrefillTimeSecondsMetric, err := s.metricCache.GetMetricValueByPodModel(pod.Name, pod.Namespace, s.modelName, metrics.RequestPrefillTimeSeconds)
-	if err != nil {
-		klog.V(4).ErrorS(err, "error getting RequestPrefillTimeSeconds")
-	} else if hist := avgPrefillTimeSecondsMetric.GetHistogramValue(); hist != nil && hist.Count > 0 {
-		avgPrefillTimeMs = hist.GetMean() * 1000
+	avgPrefillTimeMs := s.getAvgPrefillTimeMs(pod.Name, pod.Namespace, s.modelName)
+	if avgPrefillTimeMs < 0 {
+		klog.V(4).InfoS("failed to get RequestPrefillTimeSeconds for pod", "pod", pod.Name)
+		avgPrefillTimeMs = s.estimatePrefill(512)
 	}
 	queueEst := s.estimateQueue(reqCnt, avgPrefillTimeMs)
 	prefixEst := s.estimatePrefix(matchedTokens)

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
@@ -31,6 +31,8 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
 	"github.com/vllm-project/aibrix/pkg/utils/tokenizer"
@@ -207,14 +209,16 @@ func (s leastRequestScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
 type conductorPrefillPolicy struct {
 	tok                tokenizer.Tokenizer
 	prefixCacheIndexer *prefixcacheindexer.PrefixHashTable
+	metricCache        cache.MetricCache
 }
 
 // NewConductorPrefillPolicy constructs a conductor PrefillScorePolicy with the
 // given tokenizer and shared prefix-hash table.
-func NewConductorPrefillPolicy(tok tokenizer.Tokenizer, prefixCacheIndexer *prefixcacheindexer.PrefixHashTable) PrefillScorePolicy {
+func NewConductorPrefillPolicy(tok tokenizer.Tokenizer, prefixCacheIndexer *prefixcacheindexer.PrefixHashTable, metricCache cache.MetricCache) PrefillScorePolicy {
 	return &conductorPrefillPolicy{
 		tok:                tok,
 		prefixCacheIndexer: prefixCacheIndexer,
+		metricCache:        metricCache,
 	}
 }
 
@@ -231,6 +235,8 @@ func (p *conductorPrefillPolicy) Prepare(routingCtx *types.RoutingContext, _ []*
 		matchedPods: matchedPods,
 		hashes:      hashes,
 		totalTokens: len(tokens),
+		metricCache: p.metricCache,
+		modelName:   routingCtx.Model,
 	}, nil
 }
 
@@ -241,6 +247,8 @@ type conductorScorer struct {
 	matchedPods map[string]int
 	hashes      []uint64
 	totalTokens int
+	metricCache cache.MetricCache
+	modelName   string
 }
 
 func (s *conductorScorer) PrefixHashes() []uint64 { return s.hashes }
@@ -249,9 +257,7 @@ func (s *conductorScorer) PrefixHashes() []uint64 { return s.hashes }
 // of the pod's currently running request count.
 //
 //	queue_estimate = reqCnt * avgPrefillTime
-func (s *conductorScorer) estimateQueue(reqCnt float64) float64 {
-	// TODO: fetch real-time value, but current scorer interface signature does not allow it
-	avgPrefillTimeSeconds := 100.0 
+func (s *conductorScorer) estimateQueue(reqCnt float64, avgPrefillTimeSeconds float64) float64 {
 	return reqCnt * avgPrefillTimeSeconds
 }
 
@@ -283,7 +289,14 @@ func (s *conductorScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
 	matchedTokens := float64(s.totalTokens) * matchPct / 100.0
 	unmatchedTokens := float64(s.totalTokens) - matchedTokens
 
-	queueEst := s.estimateQueue(reqCnt)
+	avgPrefillTimeSecondsMetric, err := s.metricCache.GetMetricValueByPodModel(pod.Name, pod.Namespace, s.modelName, metrics.RequestPrefillTimeSeconds)
+	avgPrefillTimeSeconds := float64(0.5) // default value if metric lookup fails
+	if err != nil {
+		klog.V(4).ErrorS(err, "error getting RequestPrefillTimeSeconds")
+	} else {
+		avgPrefillTimeSeconds = avgPrefillTimeSecondsMetric.GetSimpleValue()
+	}
+	queueEst := s.estimateQueue(reqCnt, avgPrefillTimeSeconds)
 	prefixEst := s.estimatePrefix(matchedTokens)
 	prefillEst := s.estimatePrefill(unmatchedTokens)
 	score := queueEst + prefixEst + prefillEst

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer_conductor_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer_conductor_test.go
@@ -18,7 +18,6 @@ package pd
 
 import (
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,7 +110,7 @@ func TestNewConductorPrefillPolicy(t *testing.T) {
 	pt := prefixcacheindexer.NewPrefixHashTable()
 	mc := newMockMetricCache()
 
-	policy := NewConductorPrefillPolicy(tok, pt, mc)
+	policy := NewConductorPrefillPolicy(tok, pt, mc, NewConductorPrefillPolicyConfig())
 
 	assert.NotNil(t, policy)
 	assert.Equal(t, PrefillScorePolicyConductor, policy.Name())
@@ -127,7 +126,7 @@ func TestConductorPrepare_Basic(t *testing.T) {
 	pt := prefixcacheindexer.NewPrefixHashTable()
 	mc := newMockMetricCache()
 
-	policy := NewConductorPrefillPolicy(tok, pt, mc)
+	policy := NewConductorPrefillPolicy(tok, pt, mc, NewConductorPrefillPolicyConfig())
 
 	ctx := makeRoutingContext("test-model", "hello world")
 	pods := []*v1.Pod{makeTestPod("pod-1", "default")}
@@ -154,13 +153,13 @@ func TestConductorScorePod_WithHistogramMetric(t *testing.T) {
 	pt := prefixcacheindexer.NewPrefixHashTable()
 	mc := newMockMetricCache()
 
-	policy := NewConductorPrefillPolicy(tok, pt, mc)
+	policy := NewConductorPrefillPolicy(tok, pt, mc, NewConductorPrefillPolicyConfig())
 
 	model := "test-model"
 	pod := makeTestPod("pod-1", "default")
 
-	// Set up histogram: sum=200, count=100 -> mean=2.0 seconds
-	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 200.0, 100.0)
+	// Set up histogram: sum=0.2ms, count=100 -> mean=0.02ms
+	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 0.2, 100.0)
 
 	ctx := makeRoutingContext(model, "test")
 	readyMap := map[string]struct{}{"pod-1": {}}
@@ -169,12 +168,45 @@ func TestConductorScorePod_WithHistogramMetric(t *testing.T) {
 	assert.NoError(t, err)
 
 	score := scorer.ScorePod(pod, 3.0, 10.0)
+	// tokenLen = 4, where 0 matched, 4 unmatched
+	// queue 3 * 0.2s / 100 = 6ms
+	// prefix = 0 + 1 = 1ms
+	// prefill = 0.001 * 4^1.5 + 5 = 5.008ms
+	// total = 6 + 1 + 5.008 = 12.008ms
+	assert.InDelta(t, 12.008, score, 1e-9)
+}
 
-	// queue 3 * 200 / 100 = 6.0
-	// prefix = 0 + 1 = 1
-	// prefill = 0.001 * 4^1.5 + 5 = 5.008
-	// total = 6 + 1 + 5.008 = 12.008
-	assert.Greater(t, 1e-6, math.Abs(score-12.008))
+// ============================================================
+// Test: ScorePod with zero tokens (empty message)
+// ============================================================
+// Verifies that an empty message (totalTokens = 0) results in
+// both prefix and prefill estimates short-circuit to 0.
+// The score reduces to purely the queue component.
+func TestConductorScorePod_EmptyMessage(t *testing.T) {
+	tok := tokenizer.NewCharacterTokenizer()
+	pt := prefixcacheindexer.NewPrefixHashTable()
+	mc := newMockMetricCache()
+
+	policy := NewConductorPrefillPolicy(tok, pt, mc, NewConductorPrefillPolicyConfig())
+
+	model := "test-model"
+	pod := makeTestPod("pod-1", "default")
+
+	// Set up histogram: sum=0.2s, count=100 -> mean=0.002s = 2ms
+	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 0.2, 100.0)
+
+	// Empty message -> totalTokens = 0
+	ctx := makeRoutingContext(model, "")
+	readyMap := map[string]struct{}{"pod-1": {}}
+
+	scorer, err := policy.Prepare(ctx, []*v1.Pod{pod}, readyMap)
+	assert.NoError(t, err)
+
+	conductorScorer := scorer.(*conductorScorer)
+	assert.Equal(t, 0, conductorScorer.totalTokens)
+
+	score := scorer.ScorePod(pod, 3.0, 10.0)
+	assert.InDelta(t, 6.0, score, 1e-9)
 }
 
 // ============================================================
@@ -189,13 +221,13 @@ func TestConductorScorePod_CacheUpdateReflected(t *testing.T) {
 	pt := prefixcacheindexer.NewPrefixHashTable()
 	mc := newMockMetricCache()
 
-	policy := NewConductorPrefillPolicy(tok, pt, mc)
+	policy := NewConductorPrefillPolicy(tok, pt, mc, NewConductorPrefillPolicyConfig())
 
 	model := "test-model"
 	pod := makeTestPod("pod-1", "default")
 
 	// Phase 1: Initial state - avgPrefillTime = 1.0s
-	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 100.0, 100.0)
+	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 0.1, 100.0)
 
 	ctx := makeRoutingContext(model, "hello")
 	readyMap := map[string]struct{}{"pod-1": {}}
@@ -206,7 +238,7 @@ func TestConductorScorePod_CacheUpdateReflected(t *testing.T) {
 	score1 := scorer1.ScorePod(pod, 5.0, 10.0)
 
 	// Phase 2: Update cache - avgPrefillTime becomes 10.0s (10x slower)
-	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 1000.0, 100.0)
+	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 1.0, 100.0)
 
 	// Create a NEW scorer via Prepare (simulating a new routing request)
 	scorer2, err := policy.Prepare(ctx, []*v1.Pod{pod}, readyMap)

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer_conductor_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer_conductor_test.go
@@ -18,6 +18,7 @@ package pd
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,13 @@ import (
 	"github.com/vllm-project/aibrix/pkg/utils/tokenizer"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testModelName = "test-model"
+	testMessage   = "test"
+	testNamespace = "default"
+	testPodName   = "pod-1"
 )
 
 var _ cache.MetricCache = (*mockMetricCache)(nil)
@@ -94,9 +102,9 @@ func makeTestPod(name, namespace string) *v1.Pod {
 }
 
 // Helper to create a routing context
-func makeRoutingContext(model, message string) *types.RoutingContext {
+func makePrefillRoutingContext(message string) *types.RoutingContext {
 	return &types.RoutingContext{
-		Model:   model,
+		Model:   testModelName,
 		Message: message,
 	}
 }
@@ -128,9 +136,9 @@ func TestConductorPrepare_Basic(t *testing.T) {
 
 	policy := NewConductorPrefillPolicy(tok, pt, mc, NewConductorPrefillPolicyConfig())
 
-	ctx := makeRoutingContext("test-model", "hello world")
-	pods := []*v1.Pod{makeTestPod("pod-1", "default")}
-	readyMap := map[string]struct{}{"pod-1": {}}
+	ctx := makePrefillRoutingContext(testMessage)
+	pods := []*v1.Pod{makeTestPod(testPodName, testNamespace)}
+	readyMap := map[string]struct{}{testPodName: {}}
 
 	scorer, err := policy.Prepare(ctx, pods, readyMap)
 
@@ -138,8 +146,8 @@ func TestConductorPrepare_Basic(t *testing.T) {
 	assert.NotNil(t, scorer)
 
 	conductorScorer := scorer.(*conductorScorer)
-	assert.Equal(t, "test-model", conductorScorer.modelName)
-	assert.Equal(t, len("hello world"), conductorScorer.totalTokens)
+	assert.Equal(t, testModelName, conductorScorer.modelName)
+	assert.Equal(t, len(testMessage), conductorScorer.totalTokens)
 	assert.Equal(t, mc, conductorScorer.metricCache)
 }
 
@@ -155,14 +163,13 @@ func TestConductorScorePod_WithHistogramMetric(t *testing.T) {
 
 	policy := NewConductorPrefillPolicy(tok, pt, mc, NewConductorPrefillPolicyConfig())
 
-	model := "test-model"
-	pod := makeTestPod("pod-1", "default")
+	pod := makeTestPod(testPodName, testNamespace)
 
 	// Set up histogram: sum=0.2ms, count=100 -> mean=0.02ms
-	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 0.2, 100.0)
+	mc.SetHistogram(testPodName, testNamespace, testModelName, metrics.RequestPrefillTimeSeconds, 0.2, 100.0)
 
-	ctx := makeRoutingContext(model, "test")
-	readyMap := map[string]struct{}{"pod-1": {}}
+	ctx := makePrefillRoutingContext(testMessage)
+	readyMap := map[string]struct{}{testPodName: {}}
 
 	scorer, err := policy.Prepare(ctx, []*v1.Pod{pod}, readyMap)
 	assert.NoError(t, err)
@@ -170,10 +177,10 @@ func TestConductorScorePod_WithHistogramMetric(t *testing.T) {
 	score := scorer.ScorePod(pod, 3.0, 10.0)
 	// tokenLen = 4, where 0 matched, 4 unmatched
 	// queue 3 * 0.2s / 100 = 6ms
-	// prefix = 0 + 1 = 1ms
+	// prefix = 0ms
 	// prefill = 0.001 * 4^1.5 + 5 = 5.008ms
-	// total = 6 + 1 + 5.008 = 12.008ms
-	assert.InDelta(t, 12.008, score, 1e-9)
+	// total = 6 + 0 + 5.008 = 11.008ms
+	assert.InDelta(t, 11.008, score, 1e-9)
 }
 
 // ============================================================
@@ -189,15 +196,14 @@ func TestConductorScorePod_EmptyMessage(t *testing.T) {
 
 	policy := NewConductorPrefillPolicy(tok, pt, mc, NewConductorPrefillPolicyConfig())
 
-	model := "test-model"
-	pod := makeTestPod("pod-1", "default")
+	pod := makeTestPod(testPodName, testNamespace)
 
 	// Set up histogram: sum=0.2s, count=100 -> mean=0.002s = 2ms
-	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 0.2, 100.0)
+	mc.SetHistogram(testPodName, testNamespace, testModelName, metrics.RequestPrefillTimeSeconds, 0.2, 100.0)
 
 	// Empty message -> totalTokens = 0
-	ctx := makeRoutingContext(model, "")
-	readyMap := map[string]struct{}{"pod-1": {}}
+	ctx := makePrefillRoutingContext("")
+	readyMap := map[string]struct{}{testPodName: {}}
 
 	scorer, err := policy.Prepare(ctx, []*v1.Pod{pod}, readyMap)
 	assert.NoError(t, err)
@@ -223,14 +229,13 @@ func TestConductorScorePod_CacheUpdateReflected(t *testing.T) {
 
 	policy := NewConductorPrefillPolicy(tok, pt, mc, NewConductorPrefillPolicyConfig())
 
-	model := "test-model"
-	pod := makeTestPod("pod-1", "default")
+	pod := makeTestPod(testPodName, testNamespace)
 
 	// Phase 1: Initial state - avgPrefillTime = 1.0s
-	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 0.1, 100.0)
+	mc.SetHistogram(testPodName, testNamespace, testModelName, metrics.RequestPrefillTimeSeconds, 0.1, 100.0)
 
-	ctx := makeRoutingContext(model, "hello")
-	readyMap := map[string]struct{}{"pod-1": {}}
+	ctx := makePrefillRoutingContext(testMessage)
+	readyMap := map[string]struct{}{testPodName: {}}
 
 	scorer1, err := policy.Prepare(ctx, []*v1.Pod{pod}, readyMap)
 	assert.NoError(t, err)
@@ -238,7 +243,7 @@ func TestConductorScorePod_CacheUpdateReflected(t *testing.T) {
 	score1 := scorer1.ScorePod(pod, 5.0, 10.0)
 
 	// Phase 2: Update cache - avgPrefillTime becomes 10.0s (10x slower)
-	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 1.0, 100.0)
+	mc.SetHistogram(testPodName, testNamespace, testModelName, metrics.RequestPrefillTimeSeconds, 1.0, 100.0)
 
 	// Create a NEW scorer via Prepare (simulating a new routing request)
 	scorer2, err := policy.Prepare(ctx, []*v1.Pod{pod}, readyMap)
@@ -249,4 +254,84 @@ func TestConductorScorePod_CacheUpdateReflected(t *testing.T) {
 	// Score should be much higher now because avgPrefillTime increased
 	// Queue component went from 5*1.0=5.0 to 5*10.0=50.0
 	assert.Greater(t, score2, score1)
+}
+
+// ============================================================
+// Test: ScorePod falls back to default when metric lookup fails
+// ============================================================
+// Covers all failure modes of getAvgPrefillTimeMs:
+// 1. metric not found (GetMetricValueByPodModel returns error)
+// 2. metric value is nil (cache returns nil without error)
+// 3. metric exists but is not a histogram type (GetHistogramValue returns nil)
+// 4. histogram exists but has zero count
+// In all cases, ScorePod should not panic and should fall back to
+// the estimated prefill time based on the config model.
+func TestConductorScorePod_MetricFallback(t *testing.T) {
+	tok := tokenizer.NewCharacterTokenizer()
+	pt := prefixcacheindexer.NewPrefixHashTable()
+	cfg := NewConductorPrefillPolicyConfig()
+
+	pod := makeTestPod(testPodName, testNamespace)
+	ctx := makePrefillRoutingContext(testMessage)
+	readyMap := map[string]struct{}{testPodName: {}}
+
+	// expected fallback value: prefill time for 512 tokens
+	expectedFallbackMs := cfg.PrefillTimeCoeffA*math.Pow(512, cfg.PrefillTimeCoeffB) + cfg.PrefillTimeCoeffC
+
+	tests := []struct {
+		name  string
+		setup func(*mockMetricCache)
+	}{
+		{
+			name: "metric not found (error)",
+			setup: func(mc *mockMetricCache) {
+				// do nothing -> key not in map -> returns error
+			},
+		},
+		{
+			name: "metric value is nil (no error)",
+			setup: func(mc *mockMetricCache) {
+				mc.values[mc.key(testPodName, testNamespace, testModelName, metrics.RequestPrefillTimeSeconds)] = nil
+			},
+		},
+		{
+			name: "metric is not a histogram (simple value)",
+			setup: func(mc *mockMetricCache) {
+				mc.SetSimple(testPodName, testNamespace, testModelName, metrics.RequestPrefillTimeSeconds, 42.0)
+			},
+		},
+		{
+			name: "histogram with zero count",
+			setup: func(mc *mockMetricCache) {
+				mc.SetHistogram(testPodName, testNamespace, testModelName, metrics.RequestPrefillTimeSeconds, 0.0, 0.0)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := newMockMetricCache()
+			policy := NewConductorPrefillPolicy(tok, pt, mc, cfg)
+
+			tt.setup(mc)
+
+			scorer, err := policy.Prepare(ctx, []*v1.Pod{pod}, readyMap)
+			assert.NoError(t, err)
+
+			// With reqCnt=0, queue component is 0.
+			// With 0 matched prefix, prefix component is 0.
+			// score = 0 + 0 + estimatePrefill(totalTokens)
+			// but we're testing fallback uses expectedFallbackMs for the queue component.
+			// Let's use reqCnt=1 so queue component = fallback value.
+			scoreWithReq := scorer.ScorePod(pod, 1.0, 10.0)
+
+			// totalTokens = len(testMessage) = 4
+			// prefix = 0 (no match)
+			prefillEst := cfg.PrefillTimeCoeffA*math.Pow(float64(len(testMessage)), cfg.PrefillTimeCoeffB) + cfg.PrefillTimeCoeffC
+			// queue = 1 * expectedFallbackMs
+			expectedScore := expectedFallbackMs + 0 + prefillEst
+			assert.InDelta(t, expectedScore, scoreWithReq, 1e-9,
+				"score should use fallback prefill time when metric is unavailable")
+		})
+	}
 }

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer_conductor_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer_conductor_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pd
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/metrics"
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
+	"github.com/vllm-project/aibrix/pkg/utils/tokenizer"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ cache.MetricCache = (*mockMetricCache)(nil)
+
+// mockMetricCache is a mock implementation of cache.MetricCache for testing.
+// It only implements the methods used by conductor policy.
+type mockMetricCache struct {
+	// key: podName/podNamespace/modelName/metricName -> MetricValue
+	values map[string]metrics.MetricValue
+}
+
+func newMockMetricCache() *mockMetricCache {
+	return &mockMetricCache{
+		values: make(map[string]metrics.MetricValue),
+	}
+}
+
+func (m *mockMetricCache) key(podName, podNamespace, modelName, metricName string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", podName, podNamespace, modelName, metricName)
+}
+
+func (m *mockMetricCache) SetHistogram(podName, podNamespace, modelName, metricName string, sum, count float64) {
+	m.values[m.key(podName, podNamespace, modelName, metricName)] = &metrics.HistogramMetricValue{
+		Sum:   sum,
+		Count: count,
+	}
+}
+
+func (m *mockMetricCache) SetSimple(podName, podNamespace, modelName, metricName string, value float64) {
+	m.values[m.key(podName, podNamespace, modelName, metricName)] = &metrics.SimpleMetricValue{
+		Value: value,
+	}
+}
+
+func (m *mockMetricCache) Clear(podName, podNamespace, modelName, metricName string) {
+	delete(m.values, m.key(podName, podNamespace, modelName, metricName))
+}
+
+func (m *mockMetricCache) GetMetricValueByPod(podName, podNamespace, metricName string) (metrics.MetricValue, error) {
+	return nil, fmt.Errorf("not implemented in mock")
+}
+
+func (m *mockMetricCache) GetMetricValueByPodModel(podName, podNamespace, modelName, metricName string) (metrics.MetricValue, error) {
+	key := m.key(podName, podNamespace, modelName, metricName)
+	val, ok := m.values[key]
+	if !ok {
+		return nil, fmt.Errorf("metric not found: %s", key)
+	}
+	return val, nil
+}
+
+func (m *mockMetricCache) AddSubscriber(subscriber metrics.MetricSubscriber) {
+	// no-op for testing
+}
+
+// Helper to create a test pod
+func makeTestPod(name, namespace string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// Helper to create a routing context
+func makeRoutingContext(model, message string) *types.RoutingContext {
+	return &types.RoutingContext{
+		Model:   model,
+		Message: message,
+	}
+}
+
+// ============================================================
+// Test: NewConductorPrefillPolicy
+// ============================================================
+// Verifies that the policy is created correctly with all dependencies.
+func TestNewConductorPrefillPolicy(t *testing.T) {
+	tok := tokenizer.NewCharacterTokenizer()
+	pt := prefixcacheindexer.NewPrefixHashTable()
+	mc := newMockMetricCache()
+
+	policy := NewConductorPrefillPolicy(tok, pt, mc)
+
+	assert.NotNil(t, policy)
+	assert.Equal(t, PrefillScorePolicyConductor, policy.Name())
+}
+
+// ============================================================
+// Test: Prepare basic functionality
+// ============================================================
+// Verifies that Prepare correctly tokenizes and creates a scorer
+// with the right model name and metric cache reference.
+func TestConductorPrepare_Basic(t *testing.T) {
+	tok := tokenizer.NewCharacterTokenizer()
+	pt := prefixcacheindexer.NewPrefixHashTable()
+	mc := newMockMetricCache()
+
+	policy := NewConductorPrefillPolicy(tok, pt, mc)
+
+	ctx := makeRoutingContext("test-model", "hello world")
+	pods := []*v1.Pod{makeTestPod("pod-1", "default")}
+	readyMap := map[string]struct{}{"pod-1": {}}
+
+	scorer, err := policy.Prepare(ctx, pods, readyMap)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, scorer)
+
+	conductorScorer := scorer.(*conductorScorer)
+	assert.Equal(t, "test-model", conductorScorer.modelName)
+	assert.Equal(t, len("hello world"), conductorScorer.totalTokens)
+	assert.Equal(t, mc, conductorScorer.metricCache)
+}
+
+// ============================================================
+// Test: ScorePod with valid histogram metric
+// ============================================================
+// Verifies that ScorePod correctly extracts avgPrefillTime from
+// a histogram metric using GetMean().
+func TestConductorScorePod_WithHistogramMetric(t *testing.T) {
+	tok := tokenizer.NewCharacterTokenizer()
+	pt := prefixcacheindexer.NewPrefixHashTable()
+	mc := newMockMetricCache()
+
+	policy := NewConductorPrefillPolicy(tok, pt, mc)
+
+	model := "test-model"
+	pod := makeTestPod("pod-1", "default")
+
+	// Set up histogram: sum=200, count=100 -> mean=2.0 seconds
+	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 200.0, 100.0)
+
+	ctx := makeRoutingContext(model, "test")
+	readyMap := map[string]struct{}{"pod-1": {}}
+
+	scorer, err := policy.Prepare(ctx, []*v1.Pod{pod}, readyMap)
+	assert.NoError(t, err)
+
+	score := scorer.ScorePod(pod, 3.0, 10.0)
+
+	// queue 3 * 200 / 100 = 6.0
+	// prefix = 0 + 1 = 1
+	// prefill = 0.001 * 4^1.5 + 5 = 5.008
+	// total = 6 + 1 + 5.008 = 12.008
+	assert.Greater(t, 1e-6, math.Abs(score-12.008))
+}
+
+// ============================================================
+// Test: External cache change is reflected in new Prepare() calls
+// ============================================================
+// KEY TEST: Verifies that when the external cache values change,
+// a new Prepare() call picks up the updated values.
+// This validates that policy holds a reference to cache (not a snapshot),
+// and each scorer gets fresh data from cache at ScorePod time.
+func TestConductorScorePod_CacheUpdateReflected(t *testing.T) {
+	tok := tokenizer.NewCharacterTokenizer()
+	pt := prefixcacheindexer.NewPrefixHashTable()
+	mc := newMockMetricCache()
+
+	policy := NewConductorPrefillPolicy(tok, pt, mc)
+
+	model := "test-model"
+	pod := makeTestPod("pod-1", "default")
+
+	// Phase 1: Initial state - avgPrefillTime = 1.0s
+	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 100.0, 100.0)
+
+	ctx := makeRoutingContext(model, "hello")
+	readyMap := map[string]struct{}{"pod-1": {}}
+
+	scorer1, err := policy.Prepare(ctx, []*v1.Pod{pod}, readyMap)
+	assert.NoError(t, err)
+
+	score1 := scorer1.ScorePod(pod, 5.0, 10.0)
+
+	// Phase 2: Update cache - avgPrefillTime becomes 10.0s (10x slower)
+	mc.SetHistogram("pod-1", "default", model, metrics.RequestPrefillTimeSeconds, 1000.0, 100.0)
+
+	// Create a NEW scorer via Prepare (simulating a new routing request)
+	scorer2, err := policy.Prepare(ctx, []*v1.Pod{pod}, readyMap)
+	assert.NoError(t, err)
+
+	score2 := scorer2.ScorePod(pod, 5.0, 10.0)
+
+	// Score should be much higher now because avgPrefillTime increased
+	// Queue component went from 5*1.0=5.0 to 5*10.0=50.0
+	assert.Greater(t, score2, score1)
+}

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -38,7 +38,6 @@ import (
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
-	"github.com/vllm-project/aibrix/pkg/utils/tokenizer"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -207,23 +206,11 @@ type pdRouter struct {
 }
 
 func newPrefixCachePrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHashTable) pd.PrefillScorePolicy {
-	var tok tokenizer.Tokenizer
-	if tokenizerType == tokenizerTypeTiktoken {
-		tok = tokenizer.NewTiktokenTokenizer()
-	} else {
-		tok = tokenizer.NewCharacterTokenizer()
-	}
-	return pd.NewPrefixCachePrefillPolicy(tok, sharedPrefixTable)
+	return pd.NewPrefixCachePrefillPolicy(newTokenizer(), sharedPrefixTable)
 }
 
 func newConductorPrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHashTable, metricCache cache.MetricCache) pd.PrefillScorePolicy {
-	var tok tokenizer.Tokenizer
-	if tokenizerType == tokenizerTypeTiktoken {
-		tok = tokenizer.NewTiktokenTokenizer()
-	} else {
-		tok = tokenizer.NewCharacterTokenizer()
-	}
-	return pd.NewConductorPrefillPolicy(tok, sharedPrefixTable, metricCache)
+	return pd.NewConductorPrefillPolicy(newTokenizer(), sharedPrefixTable, metricCache, pd.NewConductorPrefillPolicyConfig())
 }
 
 func NewPDRouter() (types.Router, error) {

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -164,10 +164,12 @@ func (r *pdRouter) effectiveScorePolicies(routingCtx *types.RoutingContext) (pd.
 			prefill = pd.NewLeastRequestPrefillPolicy()
 		case pd.PrefillScorePolicyPrefixCache:
 			prefill = newPrefixCachePrefillPolicy(r.prefixCacheIndexer)
+		case pd.PrefillScorePolicyConductor:
+			prefill = newConductorPrefillPolicy(r.prefixCacheIndexer)
 		default:
 			klog.InfoS("unknown prefillScorePolicy in routingConfig, keeping env-based policy",
 				"request_id", routingCtx.RequestID, "value", s,
-				"valid", []string{pd.PrefillScorePolicyPrefixCache, pd.PrefillScorePolicyLeastRequest})
+				"valid", []string{pd.PrefillScorePolicyPrefixCache, pd.PrefillScorePolicyLeastRequest, pd.PrefillScorePolicyConductor})
 			prefill = r.prefillPolicy
 		}
 	}
@@ -214,6 +216,16 @@ func newPrefixCachePrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHas
 	return pd.NewPrefixCachePrefillPolicy(tok, sharedPrefixTable)
 }
 
+func newConductorPrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHashTable) pd.PrefillScorePolicy {
+	var tok tokenizer.Tokenizer
+	if tokenizerType == tokenizerTypeTiktoken {
+		tok = tokenizer.NewTiktokenTokenizer()
+	} else {
+		tok = tokenizer.NewCharacterTokenizer()
+	}
+	return pd.NewConductorPrefillPolicy(tok, sharedPrefixTable)
+}
+
 func NewPDRouter() (types.Router, error) {
 	c, err := cache.Get()
 	if err != nil {
@@ -229,10 +241,12 @@ func NewPDRouter() (types.Router, error) {
 		policy = pd.NewLeastRequestPrefillPolicy()
 	case pd.PrefillScorePolicyPrefixCache:
 		policy = newPrefixCachePrefillPolicy(sharedPrefixTable)
+	case pd.PrefillScorePolicyConductor:
+		policy = newConductorPrefillPolicy(sharedPrefixTable)
 	default:
 		klog.InfoS("pd_router unknown AIBRIX_PREFILL_SCORE_POLICY, using prefix_cache",
 			"value", aibrixPrefillScorePolicy,
-			"valid", []string{pd.PrefillScorePolicyPrefixCache, pd.PrefillScorePolicyLeastRequest})
+			"valid", []string{pd.PrefillScorePolicyPrefixCache, pd.PrefillScorePolicyLeastRequest, pd.PrefillScorePolicyConductor})
 		policy = newPrefixCachePrefillPolicy(sharedPrefixTable)
 	}
 	klog.InfoS("pd_router prefill score policy", "policy", policy.Name())

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -165,7 +165,7 @@ func (r *pdRouter) effectiveScorePolicies(routingCtx *types.RoutingContext) (pd.
 		case pd.PrefillScorePolicyPrefixCache:
 			prefill = newPrefixCachePrefillPolicy(r.prefixCacheIndexer)
 		case pd.PrefillScorePolicyConductor:
-			prefill = newConductorPrefillPolicy(r.prefixCacheIndexer)
+			prefill = newConductorPrefillPolicy(r.prefixCacheIndexer, r.cache)
 		default:
 			klog.InfoS("unknown prefillScorePolicy in routingConfig, keeping env-based policy",
 				"request_id", routingCtx.RequestID, "value", s,
@@ -216,14 +216,14 @@ func newPrefixCachePrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHas
 	return pd.NewPrefixCachePrefillPolicy(tok, sharedPrefixTable)
 }
 
-func newConductorPrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHashTable) pd.PrefillScorePolicy {
+func newConductorPrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHashTable, metricCache cache.MetricCache) pd.PrefillScorePolicy {
 	var tok tokenizer.Tokenizer
 	if tokenizerType == tokenizerTypeTiktoken {
 		tok = tokenizer.NewTiktokenTokenizer()
 	} else {
 		tok = tokenizer.NewCharacterTokenizer()
 	}
-	return pd.NewConductorPrefillPolicy(tok, sharedPrefixTable)
+	return pd.NewConductorPrefillPolicy(tok, sharedPrefixTable, metricCache)
 }
 
 func NewPDRouter() (types.Router, error) {
@@ -242,7 +242,7 @@ func NewPDRouter() (types.Router, error) {
 	case pd.PrefillScorePolicyPrefixCache:
 		policy = newPrefixCachePrefillPolicy(sharedPrefixTable)
 	case pd.PrefillScorePolicyConductor:
-		policy = newConductorPrefillPolicy(sharedPrefixTable)
+		policy = newConductorPrefillPolicy(sharedPrefixTable, c)
 	default:
 		klog.InfoS("pd_router unknown AIBRIX_PREFILL_SCORE_POLICY, using prefix_cache",
 			"value", aibrixPrefillScorePolicy,

--- a/pkg/plugins/gateway/algorithms/prefix_cache.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache.go
@@ -217,6 +217,13 @@ func (p *panicTokenizer) TokenizeInputText(text string) ([]byte, error) {
 		"Use the model-aware getTokenizerForRequest(ctx) helper method instead.")
 }
 
+func newTokenizer() tokenizer.Tokenizer {
+	if tokenizerType == tokenizerTypeTiktoken {
+		return tokenizer.NewTiktokenTokenizer()
+	}
+	return tokenizer.NewCharacterTokenizer()
+}
+
 func NewPrefixCacheRouter() (types.Router, error) {
 	// Initialize prefix cache metrics if enabled
 	if err := initializePrefixCacheMetrics(); err != nil {
@@ -271,12 +278,7 @@ func NewPrefixCacheRouter() (types.Router, error) {
 		}
 
 		// Create default tokenizer based on configured type
-		var defaultTokenizer tokenizer.Tokenizer
-		if tokenizerType == tokenizerTypeTiktoken {
-			defaultTokenizer = tokenizer.NewTiktokenTokenizer()
-		} else {
-			defaultTokenizer = tokenizer.NewCharacterTokenizer()
-		}
+		var defaultTokenizer = newTokenizer()
 		poolConfig.DefaultTokenizer = defaultTokenizer
 
 		// Create the pool
@@ -290,11 +292,7 @@ func NewPrefixCacheRouter() (types.Router, error) {
 		klog.Info("TokenizerPool initialized with remote tokenizer support")
 	} else {
 		// Fallback to local tokenizer (existing behavior when disabled)
-		if tokenizerType == tokenizerTypeTiktoken {
-			tokenizerObj = tokenizer.NewTiktokenTokenizer()
-		} else {
-			tokenizerObj = tokenizer.NewCharacterTokenizer()
-		}
+		tokenizerObj = newTokenizer()
 	}
 
 	// Log final configuration


### PR DESCRIPTION
## Pull Request Description
I implemented the **conductor** scheduling algorithm  referenced in the Fast'25 paper [Mooncake: A KVCache-centric Disaggregated Architecture for LLM Serving](https://www.usenix.org/system/files/fast25-qin.pdf), Chapter 4 Scheduling (without KV transfer mentioned in paper, as it's not supported currently).

Conductor is configuerd as `ConductorPrefillPolicy` under interface `PrefillPolicy` and init with PD router. It will work if prefill policy set "conductor". (routing algorithm remains "pd")

Add test files for the conductor, check basic functions and cache data updating normally. (Conductor requires additional real-time statistics like `RequestPrefillTime`)

## Related Issues
Resolves: #1421 

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>