### PR TITLE
feat(pd): roleset eligibility extraction, load-imbalance fixes, and tracker registration ordering

### DIFF
--- a/config/test/gateway/vtc-test-env-patch.yaml
+++ b/config/test/gateway/vtc-test-env-patch.yaml
@@ -24,3 +24,5 @@ spec:
           value: "1s"
         - name: AIBRIX_PREFIX_CACHE_BLOCK_SIZE
           value: "4"
+        - name: AIBRIX_PROMPT_LENGTH_BUCKETING
+          value: "true"

--- a/development/app/config/mock/kustomization.yaml
+++ b/development/app/config/mock/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
   - components.yaml
   - config-profile.yaml
   - vllm-pd-config.yaml
+  - vllm-pd-bucketing-config.yaml
   - sglang-pd-config.yaml
   - trtllm-pd-config.yaml
 

--- a/development/app/config/mock/vllm-pd-bucketing-config.yaml
+++ b/development/app/config/mock/vllm-pd-bucketing-config.yaml
@@ -1,0 +1,320 @@
+# vLLM PD prompt-length bucketing mock for e2e tests.
+#
+# Three StormServices share model llama2-7b-vllm-bucket:
+#   - bucket-short:  prefill+decode for prompts 0–15 tokens
+#   - bucket-medium: prefill+decode for prompts 16–32 tokens
+#   - pd-bkt-comb: "all" role (combined=true) for prompts >32 tokens
+#     StormService name is kept short so generated pod hostnames stay within the
+#     63-character Kubernetes DNS label limit.
+#
+# Requires AIBRIX_PROMPT_LENGTH_BUCKETING=true on the gateway plugin (see config/test/gateway).
+# Apply alongside components.yaml (provides mocked-app-sa and RBAC).
+---
+apiVersion: orchestration.aibrix.ai/v1alpha1
+kind: StormService
+metadata:
+  name: mock-llama2-7b-pd-bucket-short
+  namespace: default
+  labels:
+    model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+    model.aibrix.ai/port: "8000"
+spec:
+  replicas: 1
+  updateStrategy:
+    type: InPlaceUpdate
+  stateful: true
+  selector:
+    matchLabels:
+      app: "mock-llama2-7b-pd-bucket-short"
+  template:
+    metadata:
+      labels:
+        app: "mock-llama2-7b-pd-bucket-short"
+    spec:
+      roles:
+        - name: prefill
+          replicas: 1
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+                adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "promptLenBucketMinLength": 0,
+                          "promptLenBucketMaxLength": 15
+                        }
+                      }
+                    }
+                  }
+            spec:
+              serviceAccountName: mocked-app-sa
+              containers:
+                - name: llm-engine
+                  image: aibrix/vllm-mock:nightly
+                  ports:
+                    - containerPort: 8000
+                  env:
+                    - name: DEPLOYMENT_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['app']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: MY_POD_IP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+        - name: decode
+          replicas: 1
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+                adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "promptLenBucketMinLength": 0,
+                          "promptLenBucketMaxLength": 15
+                        }
+                      }
+                    }
+                  }
+            spec:
+              serviceAccountName: mocked-app-sa
+              containers:
+                - name: llm-engine
+                  image: aibrix/vllm-mock:nightly
+                  ports:
+                    - containerPort: 8000
+                  env:
+                    - name: DEPLOYMENT_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['app']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: MY_POD_IP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+---
+apiVersion: orchestration.aibrix.ai/v1alpha1
+kind: StormService
+metadata:
+  name: mock-llama2-7b-pd-bucket-medium
+  namespace: default
+  labels:
+    model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+    model.aibrix.ai/port: "8000"
+spec:
+  replicas: 1
+  updateStrategy:
+    type: InPlaceUpdate
+  stateful: true
+  selector:
+    matchLabels:
+      app: "mock-llama2-7b-pd-bucket-medium"
+  template:
+    metadata:
+      labels:
+        app: "mock-llama2-7b-pd-bucket-medium"
+    spec:
+      roles:
+        - name: prefill
+          replicas: 1
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+                adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "promptLenBucketMinLength": 16,
+                          "promptLenBucketMaxLength": 32
+                        }
+                      }
+                    }
+                  }
+            spec:
+              serviceAccountName: mocked-app-sa
+              containers:
+                - name: llm-engine
+                  image: aibrix/vllm-mock:nightly
+                  ports:
+                    - containerPort: 8000
+                  env:
+                    - name: DEPLOYMENT_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['app']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: MY_POD_IP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+        - name: decode
+          replicas: 1
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+                adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "promptLenBucketMinLength": 16,
+                          "promptLenBucketMaxLength": 32
+                        }
+                      }
+                    }
+                  }
+            spec:
+              serviceAccountName: mocked-app-sa
+              containers:
+                - name: llm-engine
+                  image: aibrix/vllm-mock:nightly
+                  ports:
+                    - containerPort: 8000
+                  env:
+                    - name: DEPLOYMENT_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['app']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: MY_POD_IP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+---
+apiVersion: orchestration.aibrix.ai/v1alpha1
+kind: StormService
+metadata:
+  name: mock-llama2-pd-bkt-comb
+  namespace: default
+  labels:
+    model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+    model.aibrix.ai/port: "8000"
+spec:
+  replicas: 1
+  updateStrategy:
+    type: InPlaceUpdate
+  stateful: true
+  selector:
+    matchLabels:
+      app: "mock-llama2-pd-bkt-comb"
+  template:
+    metadata:
+      labels:
+        app: "mock-llama2-pd-bkt-comb"
+    spec:
+      roles:
+        - name: all
+          replicas: 1
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+                adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "promptLenBucketMinLength": 0,
+                          "combined": true
+                        }
+                      }
+                    }
+                  }
+            spec:
+              serviceAccountName: mocked-app-sa
+              containers:
+                - name: llm-engine
+                  image: aibrix/vllm-mock:nightly
+                  ports:
+                    - containerPort: 8000
+                  env:
+                    - name: DEPLOYMENT_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['app']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: MY_POD_IP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP

--- a/development/app/config/mock/vllm-pd-config.yaml
+++ b/development/app/config/mock/vllm-pd-config.yaml
@@ -1,9 +1,9 @@
 # vLLM PD (Prefill-Decode) disaggregation mock StormService for e2e tests.
 #
-# A single StormService replica with two roles ("prefill" and "decode") backed
-# by the vllm-mock image.  The gateway PD router pairs pods from the same
-# roleset (auto-assigned by the StormService controller as "roleset-name") and
-# routes the prefill probe to the prefill pod before sending the full request
+# Two StormService replicas (2x1P1D): each roleset has one prefill and one decode
+# pod backed by the vllm-mock image.  The gateway PD router pairs pods from the
+# same roleset (auto-assigned by the StormService controller as "roleset-name")
+# and routes the prefill probe to the prefill pod before sending the full request
 # to the decode pod.
 #
 # Apply alongside components.yaml (provides mocked-app-sa and RBAC).
@@ -16,7 +16,7 @@ metadata:
     model.aibrix.ai/name: "llama2-7b-vllm"
     model.aibrix.ai/port: "8000"
 spec:
-  replicas: 1
+  replicas: 2
   updateStrategy:
     type: InPlaceUpdate
   stateful: true

--- a/pkg/plugins/gateway/algorithms/pd/decode_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/decode_scorer.go
@@ -65,7 +65,7 @@ var (
 type DecodePodInput struct {
 	RunningReqs     float64 // active decode requests on this pod (incl. pending)
 	Throughput      float64 // AvgGenerationThroughputToksPerS for the model
-	FreeGPUPercent  float64 // 100 - GPUCacheUsagePerc*100, floored at 0.1
+	FreeGPUPercent  float64 // 100 - KVCacheUsagePerc*100, floored at 0.1
 	MaxRequestCount float64 // max RunningReqs across the candidate decode pods
 	MaxThroughput   float64 // max Throughput across the candidate decode pods
 	MaxFreeGPUUsage float64 // max FreeGPUPercent across the candidate decode pods

--- a/pkg/plugins/gateway/algorithms/pd/prefill/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default.go
@@ -90,7 +90,8 @@ func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *
 		completionFields = append([]interface{}{}, fields...)
 	}
 
-	e.tracker.AddPrefillRequest(routingCtx.RequestID, prefillPod.Name)
+	// PrefillRequestTracker.AddPrefillRequest is called at pod selection time in
+	// filterPrefillDecodePods; this executor only removes the entry when prefill completes.
 	routingCtx.PrefillStartTime = time.Now()
 
 	if handler.IsAsync() {

--- a/pkg/plugins/gateway/algorithms/pd/prefill/executor.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/executor.go
@@ -28,8 +28,9 @@ type LogContext struct {
 }
 
 // PrefillExecutor executes the prefill phase of a disaggregated-inference request.
-// Implementations are responsible for payload preparation, HTTP dispatch (async or
-// sync depending on the engine), and tracker lifecycle.
+// Implementations are responsible for payload preparation and HTTP dispatch (async or
+// sync depending on the engine). PrefillRequestTracker registration happens at pod
+// selection time; the executor removes the entry when prefill completes.
 type PrefillExecutor interface {
 	Execute(routingCtx *types.RoutingContext, prefillPod *v1.Pod, llmEngine string, logCtx LogContext) error
 }

--- a/pkg/plugins/gateway/algorithms/pd/trackers.go
+++ b/pkg/plugins/gateway/algorithms/pd/trackers.go
@@ -42,9 +42,10 @@ func NewPrefillRequestTracker() *PrefillRequestTracker {
 	return &PrefillRequestTracker{}
 }
 
-// AddPrefillRequest records that requestID has been dispatched to podName and
-// increments that pod's active-request counter. Must be paired with a
-// corresponding RemovePrefillRequest call (typically via defer).
+// AddPrefillRequest records that requestID has been assigned to podName and
+// increments that pod's active-request counter. Called at prefill pod selection time
+// so concurrent routing sees in-flight assignments. Must be paired with
+// RemovePrefillRequest when prefill completes or the assignment is abandoned.
 func (t *PrefillRequestTracker) AddPrefillRequest(requestID, podName string) {
 	countInterface, _ := t.podRequestCounts.LoadOrStore(podName, &atomic.Int32{})
 	count := countInterface.(*atomic.Int32)

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -326,10 +326,39 @@ type Scores struct {
 	Score float64
 }
 
-// filterPrefillDecodePods filters pods into prefill and decode categories.
-// For multi-node tensor parallelism (e.g., TP=16 with node_rank=0 and node_rank=1),
-// only pods with PodGroupIndex="0" (node_rank=0) are selected as they run the HTTP server.
-// Pods without PodGroupIndex label are also included for backward compatibility.
+// filterPrefillDecodePods selects one prefill pod and one decode pod for the request.
+// For multi-node tensor parallelism, only pods with PodGroupIndex="0" run the HTTP
+// server and are routable; pods without that label are included for backward compatibility.
+//
+// Selection sequence:
+//
+//  1. collectAndBucketPods — partitions readyPods from eligible rolesets into prefill,
+//     decode, and (when bucketing is on) prompt-length-filtered and combined-role slices.
+//
+//  2. Pod availability check — errors immediately when no prefill or decode pods exist
+//     and no combined pod is available to cover the gap.
+//
+//  3. Bucketing path (AIBRIX_PROMPT_LENGTH_BUCKETING only) —
+//     a. No bucket match: prompt length falls outside every declared range.
+//     - Combined pods available → pick a random combined pod (no prefill HTTP call).
+//     - No combined pods → error; do not route to the wrong storm.
+//     b. Bucket match + load imbalance: prefill or decode pods are hot while a
+//     combined pod is idle → score and pick the best combined pod.
+//
+//  4. Prefill load-imbalance fast path — if outstanding prefill counts are skewed
+//     beyond aibrixPrefillLoadImbalanceMinSpread, narrow to the single least-loaded
+//     prefill pod and align decodePods to its roleset.
+//
+//  5. Decode load-imbalance fast path — three ordered checks (request-count spread,
+//     throughput spread, drain-rate ratio); the first that fires narrows decodePods
+//     to a single pod and aligns prefillPods to its roleset.
+//
+//  6. Score remaining candidates — scorePrefillPods and scoreDecodePods evaluate
+//     every roleset; finalPDScore picks the roleset with the lowest combined score.
+//
+//  7. Tracker registration — AddPrefillRequest and AddPendingDecode are called on
+//     the selected pods before returning so concurrent Route calls see up-to-date
+//     counts immediately.
 func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, readyPods []*v1.Pod) (*v1.Pod, *v1.Pod, error) {
 	var promptLength int
 	if aibrixPromptLengthBucketing {
@@ -345,17 +374,27 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 	if len(decodePods) == 0 && !combinedAvailable {
 		return nil, nil, fmt.Errorf("decode pods are not ready: prefill=%d, decode=%d", len(prefillPods), len(decodePods))
 	}
-	if combinedAvailable {
+
+	if aibrixPromptLengthBucketing {
 		if len(promptLengthBucketingPrefillPods) == 0 || len(promptLengthBucketingDecodePods) == 0 {
-			klog.InfoS("routing to combined pod", "requestId", routingCtx.RequestID, "promptLength", promptLength)
-			return nil, combinedPods[rand.Intn(len(combinedPods))], nil
+			// No bucket matches the request's prompt length.
+			if combinedAvailable {
+				// Combined pods cover any prompt length; pick one at random.
+				klog.InfoS("no bucket matches prompt length, routing to combined pod",
+					"requestId", routingCtx.RequestID, "promptLength", promptLength, "combinedPods", len(combinedPods),
+					"bucketPrefillPods", len(promptLengthBucketingPrefillPods), "bucketDecodePods", len(promptLengthBucketingDecodePods))
+				return nil, combinedPods[rand.Intn(len(combinedPods))], nil
+			}
+			// Do not fall back to unfiltered PD pods: each pod group (storm) is sized for a
+			// specific prompt-length range and cross-bucket routing produces incorrect results.
+			return nil, nil, fmt.Errorf("no prompt-length bucket matches prompt length %d and no combined pods available", promptLength)
 		}
 
+		// Bucket match exists; check if load imbalance favours a combined pod instead.
 		if r.shouldPickCombined(routingCtx, promptLengthBucketingPrefillPods, promptLengthBucketingDecodePods, combinedPods) {
 			combinedPod := r.scoreCombinedPods(routingCtx, combinedPods)
 			if combinedPod != nil {
-				klog.InfoS("load imbalance detected, selecting combined pod",
-					"requestId", routingCtx.RequestID, "selectedCombinedPod", combinedPod.Name)
+				klog.InfoS("load imbalance detected, selecting combined pod", "requestId", routingCtx.RequestID, "selectedCombinedPod", combinedPod.Name)
 				return nil, combinedPod, nil
 			}
 		}
@@ -914,7 +953,8 @@ func isPodWithHTTPServer(pod *v1.Pod) bool {
 func (r *pdRouter) isPodSuitableForPromptLength(routingCtx *types.RoutingContext, pod *v1.Pod, promptLength int) bool {
 	profile := configprofiles.ResolveProfileFromPod(pod, routingCtx.ReqConfigProfile)
 	if profile == nil {
-		return false
+		// Pods without model.aibrix.ai/config are not bucket-scoped; treat as any length.
+		return true
 	}
 	pdCfg := parsePDAlgorithmConfig(profile.RoutingConfig)
 	minLength, maxLength := pdCfg.PromptLenBucketMinLength, pdCfg.PromptLenBucketMaxLength

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -51,6 +52,8 @@ const (
 	LLMEngineIdentifier          string                 = constants.ModelLabelEngine
 	PDRoleSetIdentifier          string                 = "roleset-name"
 	PDRoleIdentifier             string                 = "role-name"
+	PDRolePrefill                string                 = "prefill"
+	PDRoleDecode                 string                 = "decode"
 	RoleReplicaIndex             string                 = "stormservice.orchestration.aibrix.ai/role-replica-index"
 	PodGroupIndex                string                 = "stormservice.orchestration.aibrix.ai/pod-group-index"
 	PromptLenBucketMinLength     string                 = "prompt-len-bucket-min-length"
@@ -183,8 +186,8 @@ func (r *pdRouter) effectiveScorePolicies(routingCtx *types.RoutingContext) (pd.
 	}
 	if strings.TrimSpace(cfg.PrefillScorePolicy) != "" || strings.TrimSpace(cfg.DecodeScorePolicy) != "" {
 		klog.V(4).InfoS("pd score policies from model config profile routingConfig",
-			"request_id", routingCtx.RequestID,
-			"prefill_policy", prefill.Name(), "decode_policy", decode.Name())
+			"request_id", routingCtx.RequestID, "prefill_policy", prefill.Name(),
+			"decode_policy", decode.Name())
 	}
 	return prefill, decode, nil
 }
@@ -231,8 +234,7 @@ func NewPDRouter() (types.Router, error) {
 		policy = newPrefixCachePrefillPolicy(sharedPrefixTable)
 	default:
 		klog.InfoS("pd_router unknown AIBRIX_PREFILL_SCORE_POLICY, using prefix_cache",
-			"value", aibrixPrefillScorePolicy,
-			"valid", []string{pd.PrefillScorePolicyPrefixCache, pd.PrefillScorePolicyLeastRequest})
+			"value", aibrixPrefillScorePolicy, "valid", []string{pd.PrefillScorePolicyPrefixCache, pd.PrefillScorePolicyLeastRequest})
 		policy = newPrefixCachePrefillPolicy(sharedPrefixTable)
 	}
 	klog.InfoS("pd_router prefill score policy", "policy", policy.Name())
@@ -240,8 +242,7 @@ func NewPDRouter() (types.Router, error) {
 	decodePol, _, unknownDecode := pd.ResolveDecodePolicy(aibrixDecodeScorePolicy)
 	if unknownDecode {
 		klog.InfoS("pd_router unknown AIBRIX_DECODE_SCORE_POLICY, using load_balancing",
-			"value", aibrixDecodeScorePolicy,
-			"valid", pd.ValidDecodePolicyNames())
+			"value", aibrixDecodeScorePolicy, "valid", pd.ValidDecodePolicyNames())
 	}
 	klog.InfoS("pd_router decode score policy", "policy", decodePol.Name(), "describe", decodePol.Describe())
 
@@ -276,8 +277,8 @@ func NewPDRouter() (types.Router, error) {
 
 func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) (string, error) {
 	readyPods := readyPodList.All()
-	// Validate engine consistency across all prefill pods
-	llmEngine, err := validateAndGetLLMEngine(readyPods)
+	prefillPodsForEngine := prefillPodsFromEligibleRolesets(readyPods)
+	llmEngine, err := validateAndGetLLMEngine(prefillPodsForEngine)
 	if err != nil {
 		metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
 			map[string]string{"status": pdRouteValidateLLMEngineFail, "status_code": "400"})
@@ -292,9 +293,12 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 	}
 
 	if prefillPod != nil {
-		klog.InfoS("selected prefill/decode pods", "request_id", ctx.RequestID, "prefill_pod", prefillPod.Name, "decode_pod", decodePod.Name)
-		r.pendingDecodeTracker.AddPendingDecode(ctx.RequestID, decodePod.Name)
+		// filterPrefillDecodePods registered pending prefill/decode during selection so
+		// concurrent requests see up-to-date counts. Always clean up pending decode when
+		// this request completes.
 		defer r.pendingDecodeTracker.RemovePendingDecode(ctx.RequestID)
+
+		klog.InfoS("selected prefill/decode pods", "request_id", ctx.RequestID, "prefill_pod", prefillPod.Name, "decode_pod", decodePod.Name)
 		if ctx.RespHeaders == nil {
 			ctx.RespHeaders = make(map[string]string)
 		}
@@ -302,6 +306,8 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		ctx.RespHeaders[HeaderPrefillTargetPodIP] = prefillPod.Status.PodIP
 		err = r.doPrefillRequest(ctx, prefillPod, llmEngine)
 		if err != nil {
+			// Remove is a no-op if the executor already cleaned up (e.g. sync HTTP failure).
+			r.prefillRequestTracker.RemovePrefillRequest(ctx.RequestID)
 			metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
 				map[string]string{"status": pdRoutePrefillRequestError, "status_code": "500"})
 			klog.ErrorS(err, pdRoutePrefillRequestError, "request_id", ctx.RequestID)
@@ -357,32 +363,60 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 
 	// check for prefill and decode imbalance
 	targetPod, isImbalanced := r.loadImbalanceSelectPrefillPod(prefillPods, r.prefillRequestTracker.GetPrefillRequestCountsForPods(prefillPods))
-	if isImbalanced {
-		klog.InfoS("load imbalance detected, selecting least-loaded prefill pod", "request_id", routingCtx.RequestID, "selected_prefill_pod", targetPod.Name)
+	if isImbalanced && targetPod != nil {
 		prefillPods = []*v1.Pod{targetPod}
 		decodePods = utils.FilterPodsByLabel(decodePods, PDRoleSetIdentifier, targetPod.Labels[PDRoleSetIdentifier])
+		klog.V(4).InfoS("load imbalance detected, selecting least-loaded prefill pod",
+			"request_id", routingCtx.RequestID, "selected_prefill_pod", targetPod.Name,
+			"roleset", targetPod.Labels[PDRoleSetIdentifier], "decode_pods_after_align", pdPodNames(decodePods),
+		)
 	}
 
 	targetPod, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage := r.loadImbalanceSelectDecodePod(routingCtx, decodePods)
 	if targetPod != nil {
-		klog.InfoS("load imbalance detected in decode pods", "request_id", routingCtx.RequestID, "selected_decode_pod", targetPod.Name)
 		decodePods = []*v1.Pod{targetPod}
-		if len(prefillPods) > 1 {
-			prefillPods = utils.FilterPodsByLabel(prefillPods, PDRoleSetIdentifier, targetPod.Labels[PDRoleSetIdentifier])
+		if aligned := utils.FilterPodsByLabel(prefillPods, PDRoleSetIdentifier, targetPod.Labels[PDRoleSetIdentifier]); len(aligned) > 0 {
+			prefillPods = aligned
 		}
+		klog.V(4).InfoS("load imbalance detected in decode pods",
+			"request_id", routingCtx.RequestID, "selected_decode_pod", targetPod.Name,
+			"roleset", targetPod.Labels[PDRoleSetIdentifier], "prefill_pods_after_align", pdPodNames(prefillPods),
+		)
 	}
 
 	prefillPol, decodePol, err := r.effectiveScorePolicies(routingCtx)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	prefillScores, maxPrefillScore, prefixHashes := r.scorePrefillPods(routingCtx, prefillPods, prefillPol)
 	decodeRun := r.scoreDecodePods(routingCtx, decodePods, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage, decodePol)
-	return r.finalPDScore(routingCtx, prefixHashes, prefillScores, maxPrefillScore, decodeRun)
+	selectedPrefill, selectedDecode, err := r.finalPDScore(routingCtx, prefixHashes, prefillScores, maxPrefillScore, decodeRun)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Register pending prefill/decode immediately after selection so concurrent routing
+	// calls read up-to-date counts when evaluating load imbalance and scoring.
+	r.prefillRequestTracker.AddPrefillRequest(routingCtx.RequestID, selectedPrefill.Name)
+	r.pendingDecodeTracker.AddPendingDecode(routingCtx.RequestID, selectedDecode.Name)
+	return selectedPrefill, selectedDecode, nil
 }
 
-// loadImbalanceSelectPrefillPod evaluates if the load is imbalanced based on the abs difference between
-// pods with min and max outstanding request counts
+// loadImbalanceSelectPrefillPod is a fast path that runs before scorePrefillPods when
+// outstanding prefill load is visibly skewed across readyPods.
+//
+// podRequestCount holds per-pod active prefill counts from PrefillRequestTracker (in-flight
+// prefill HTTP requests not yet completed). readyPods is shuffled before evaluation so ties
+// among least-loaded pods are broken randomly.
+//
+// If max(count) − min(count) is greater than aibrixPrefillLoadImbalanceMinSpread, returns
+// one pod tied for the minimum count and imbalance=true. Otherwise returns nil, false.
+// An empty podRequestCount map always returns nil, false.
+//
+// The caller (filterPrefillDecodePods) narrows decodePods to the selected pod's roleset.
+// PrefillRequestTracker is updated after finalPDScore (not inside this function); counts
+// seen here include requests that have been assigned a prefill pod but not yet completed.
 func (r *pdRouter) loadImbalanceSelectPrefillPod(readyPods []*v1.Pod, podRequestCount map[string]int32) (*v1.Pod, bool) {
 	var imbalance bool
 	var targetPod *v1.Pod
@@ -412,94 +446,112 @@ func (r *pdRouter) loadImbalanceSelectPrefillPod(readyPods []*v1.Pod, podRequest
 	if maxValue-minValue > aibrixPrefillLoadImbalanceMinSpread && len(targetPods) > 0 {
 		targetPod, _ = utils.FilterPodByName(targetPods[rand.Intn(len(targetPods))], readyPods)
 		imbalance = true
+		if targetPod != nil {
+			klog.V(4).InfoS("prefill request imbalance detected, selecting least-loaded pod",
+				"min_request_count", minValue, "max_request_count", maxValue,
+				"selected_prefill_pod", targetPod.Name, "roleset", targetPod.Labels[PDRoleSetIdentifier],
+				"candidate_pods", strings.Join(targetPods, ","),
+			)
+		}
 	}
 
 	return targetPod, imbalance
 }
 
-// loadImbalanceSelectDecodePod selects a decode pod when load imbalance is detected. It walks all
-// filtered decode pods once, filling podRequestCounts, podThroughputs, and podFreeGpuUsage, then
-// applies three ordered checks (each runs only if the previous did not return):
+// loadImbalanceSelectDecodePod is a fast path that runs before scoreDecodePods when decode
+// load is visibly skewed. It walks filteredDecodePods once, filling podRequestCounts,
+// podThroughputs, and podFreeGpuUsage for the scoring pass, then applies three ordered checks
+// (each runs only if the previous did not return):
 //
-//  1. Request imbalance (fast path): if max minus min running request count (RealtimeNumRequestsRunning
-//     plus pending decode count) is at least aibrixDecodeLoadImbalanceMinSpread, return the least-loaded pod.
+//  1. Request imbalance: among pods that report RealtimeNumRequestsRunning, compute
+//     effective count = running + PendingDecodeTracker pending count for that pod. If
+//     max − min effective count is at least aibrixDecodeLoadImbalanceMinSpread, return the
+//     least-loaded metric-bearing pod. Pods without a running-request metric are excluded
+//     from the spread (their pending count is still stored in podRequestCounts for scoring)
+//     so freshly restarted pods are not treated as idle and given a thundering herd.
 //
-//  2. Throughput spread: if max minus min AvgGenerationThroughputToksPerS (per model) is greater than
-//     aibrixDecodeThroughputImbalanceMinSpread (AIBRIX_DECODE_THROUGHPUT_IMBALANCE_MIN_SPREAD), return the pod with minimum
-//     throughput. Missing throughput is treated as 0, which can make that pod look like the minimum
-//     during scrape gaps or startup.
+//  2. Throughput spread: among pods that report AvgGenerationThroughputToksPerS (per model),
+//     if max − min throughput exceeds aibrixDecodeThroughputImbalanceMinSpread, return the
+//     lowest-throughput pod. Pods missing the metric are excluded from this check.
 //
-//  3. Drain rate scoring (soft path): if every pod has a positive RealtimeRunningRequestsDrainRate1m,
-//     compute time-to-drain score runningRequests/drainRate per pod. If maxScore/minScore exceeds
-//     aibrixDecodeScoreRatioThreshold, return the pod with the lowest score. If any drain rate is
-//     missing or non-positive, this check is skipped entirely.
+//  3. Drain-rate scoring: if every pod has a positive RealtimeRunningRequestsDrainRate1m,
+//     score each pod as effectiveRequestCount / drainRate. If maxScore/minScore exceeds
+//     aibrixDecodeScoreRatioThreshold, return the pod with the lowest score. Skipped when
+//     any drain rate is missing or non-positive.
 //
-// Returns nil when none of the above fire; the caller uses scoreDecodePods with the collected maps.
-// Non-nil pod returns also carry maxRequestCount, maxThroughput, and maxFreeGPUUsage from the same pass.
+// Returns nil when none of the checks fire; the caller falls through to scoreDecodePods with
+// the collected maps. A non-nil pod return also carries maxRequestCount, maxThroughput, and
+// maxFreeGPUUsage from the same pass (maxima include all pods, including those without metrics).
+// The caller narrows prefillPods to the selected pod's roleset.
 func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filteredDecodePods []*v1.Pod) (*v1.Pod, float64, float64, float64, map[string]float64, map[string]float64, map[string]float64) {
 	podRequestCounts := make(map[string]float64)
 	podThroughputs := make(map[string]float64)
 	podFreeGpuUsage := make(map[string]float64)
 
-	minRequestPod := filteredDecodePods[0]
-	minRequestCount := math.MaxFloat64
+	var minRequestPod *v1.Pod
 	maxRequestCount := float64(1)
-	minThroughputPod := filteredDecodePods[0]
-	minThroughput := float64(math.MaxFloat64)
+	var minThroughputPod *v1.Pod
 	maxThroughput := float64(1)
 	maxFreeGPUUsage := float64(1)
+	maxObservedRequestCount := float64(0)
+	minObservedRequestCount := math.MaxFloat64
+	maxObservedThroughput := float64(0)
+	minObservedThroughput := math.MaxFloat64
 	utils.CryptoShuffle(filteredDecodePods)
 
 	for _, pod := range filteredDecodePods {
-		runningReqs, err := r.cache.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
-		if err != nil {
-			runningReqs = &metrics.SimpleMetricValue{Value: 0}
+		runningReqs, runningErr := r.cache.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
+		requestCount := r.pendingDecodeTracker.GetPendingDecodeCount(pod.Name)
+		if runningErr != nil {
+			podRequestCounts[pod.Name] = requestCount
+		} else {
+			requestCount += runningReqs.GetSimpleValue()
+			podRequestCounts[pod.Name] = requestCount
+			if requestCount < minObservedRequestCount {
+				minObservedRequestCount = requestCount
+				minRequestPod = pod
+			}
+			maxObservedRequestCount = math.Max(maxObservedRequestCount, requestCount)
 		}
-		requestCount := runningReqs.GetSimpleValue() + r.pendingDecodeTracker.GetPendingDecodeCount(pod.Name)
-		podRequestCounts[pod.Name] = requestCount
-		if requestCount < minRequestCount {
-			minRequestCount = requestCount
-			minRequestPod = pod
-		}
-		maxRequestCount = math.Max(maxRequestCount, requestCount)
+		maxRequestCount = math.Max(maxRequestCount, podRequestCounts[pod.Name])
 
-		tokenThroughput, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.AvgGenerationThroughputToksPerS)
-		if err != nil {
-			tokenThroughput = &metrics.SimpleMetricValue{Value: 0}
+		tokenThroughput, throughputErr := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.AvgGenerationThroughputToksPerS)
+		if throughputErr != nil {
+			podThroughputs[pod.Name] = 0
+		} else {
+			throughput := tokenThroughput.GetSimpleValue()
+			podThroughputs[pod.Name] = throughput
+			if throughput < minObservedThroughput {
+				minObservedThroughput = throughput
+				minThroughputPod = pod
+			}
+			maxObservedThroughput = math.Max(maxObservedThroughput, throughput)
+			maxThroughput = math.Max(maxThroughput, throughput)
 		}
-		throughput := tokenThroughput.GetSimpleValue()
-		podThroughputs[pod.Name] = throughput
-		if throughput < minThroughput {
-			minThroughput = throughput
-			minThroughputPod = pod
-		}
-		maxThroughput = math.Max(maxThroughput, throughput)
 
-		gpuUsage, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.GPUCacheUsagePerc)
+		kvUsage, err := r.decodePodKVCacheUsagePerc(ctx, pod)
 		if err != nil {
-			gpuUsage = &metrics.SimpleMetricValue{Value: 0}
+			kvUsage = &metrics.SimpleMetricValue{Value: 0}
 		}
-		podFreeGpuUsage[pod.Name] = math.Round(100 - gpuUsage.GetSimpleValue()*100)
+		podFreeGpuUsage[pod.Name] = math.Round(100 - kvUsage.GetSimpleValue()*100)
 		if podFreeGpuUsage[pod.Name] <= 0 {
 			podFreeGpuUsage[pod.Name] = 0.1
 		}
 		maxFreeGPUUsage = math.Max(maxFreeGPUUsage, podFreeGpuUsage[pod.Name])
 	}
 
-	if maxRequestCount-minRequestCount >= aibrixDecodeLoadImbalanceMinSpread {
+	if minRequestPod != nil && maxObservedRequestCount-minObservedRequestCount >= aibrixDecodeLoadImbalanceMinSpread {
 		klog.V(4).InfoS("request imbalance at decode pods", "request_id", ctx.RequestID,
-			"min_request_count", minRequestCount, "max_request_count", maxRequestCount,
-			"free_gpu_percent", podFreeGpuUsage[minRequestPod.Name],
-			"decode_pod", minRequestPod.Name)
+			"min_request_count", minObservedRequestCount, "max_request_count", maxObservedRequestCount,
+			"free_gpu_percent", podFreeGpuUsage[minRequestPod.Name], "decode_pod", minRequestPod.Name)
 		return minRequestPod, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage
 	}
 
-	if maxThroughput-minThroughput > aibrixDecodeThroughputImbalanceMinSpread {
+	if minThroughputPod != nil && maxObservedThroughput-minObservedThroughput > aibrixDecodeThroughputImbalanceMinSpread {
 		klog.V(4).InfoS("throughput imbalance at decode pods", "request_id", ctx.RequestID,
-			"min_request_count", minRequestCount, "max_request_count", maxRequestCount,
-			"min_throughput", minThroughput, "max_throughput", maxThroughput,
-			"free_gpu_percent", podFreeGpuUsage[minThroughputPod.Name],
-			"decode_pod", minThroughputPod.Name)
+			"min_request_count", minObservedRequestCount, "max_request_count", maxObservedRequestCount,
+			"min_throughput", minObservedThroughput, "max_throughput", maxObservedThroughput,
+			"free_gpu_percent", podFreeGpuUsage[minThroughputPod.Name], "decode_pod", minThroughputPod.Name)
 		return minThroughputPod, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage
 	}
 
@@ -523,7 +575,7 @@ func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filte
 	}
 
 	if drainRatesAvailable && minScore > 0 && maxScore/minScore > aibrixDecodeScoreRatioThreshold {
-		klog.InfoS("drain rate imbalance at decode pods", "request_id", ctx.RequestID,
+		klog.V(4).InfoS("drain rate imbalance at decode pods", "request_id", ctx.RequestID,
 			"min_score", minScore, "max_score", maxScore,
 			"ratio", maxScore/minScore, "decode_pod", minScorePod.Name)
 		return minScorePod, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage
@@ -532,18 +584,33 @@ func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filte
 	return nil, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage
 }
 
-// scorePrefillPods scores candidate prefill pods using prefillPolicy. Pods whose
-// running-request count exceeds mean+stddev*factor are skipped as overloaded.
-// Returns a per-roleset map of the best (lowest-score) pod, the global max score
-// used by finalPDScore for normalization, and the prefix hashes from the scorer.
+// scorePrefillPods scores candidate prefill pods with prefillPolicy after any imbalance
+// fast path has narrowed the list. readyPods are shuffled before scoring.
+//
+// Active prefill counts come from PrefillRequestTracker. Pods whose count exceeds
+// mean + standardDeviationFactor×stddev (AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR)
+// are skipped as overloaded. Each remaining pod is scored via prefillPolicy; the
+// lowest-scoring pod per roleset (PDRoleSetIdentifier) is kept.
+//
+// Returns a per-roleset score map, maxPrefillScore (the maximum score among all pods
+// scored in this pass, used by finalPDScore for normalization), and prefix hashes
+// from the policy's Prepare step for asynchronous prefix-cache updates. Returns
+// nil, 0, nil when Prepare fails.
+//
+// Policy resolution: the policy argument, then r.prefillPolicy, then prefix_cache.
 func (r *pdRouter) scorePrefillPods(routingCtx *types.RoutingContext, prefillPods []*v1.Pod, prefillPolicy pd.PrefillScorePolicy) (map[string]*Scores, float64, []uint64) {
-	if prefillPolicy == nil {
-		klog.ErrorS(nil, "scorePrefillPods called with nil prefillPolicy; this is a programming error",
-			"request_id", routingCtx.RequestID)
-		return nil, 0, nil
+	policy := prefillPolicy
+	if policy == nil {
+		policy = r.prefillPolicy
+	}
+	if policy == nil {
+		tbl := r.prefixCacheIndexer
+		if tbl == nil {
+			tbl = prefixcacheindexer.GetSharedPrefixHashTable()
+		}
+		policy = newPrefixCachePrefillPolicy(tbl)
 	}
 	utils.CryptoShuffle(prefillPods)
-
 	podRequestCount := r.prefillRequestTracker.GetPrefillRequestCountsForPods(prefillPods)
 
 	var maxRequestCount float64 = 1
@@ -562,10 +629,10 @@ func (r *pdRouter) scorePrefillPods(routingCtx *types.RoutingContext, prefillPod
 	meanRequestCount := mean(requestCounts)
 	stdDevRequestCount := standardDeviation(requestCounts)
 
-	scorer, err := prefillPolicy.Prepare(routingCtx, prefillPods, readyPodsMap)
+	scorer, err := policy.Prepare(routingCtx, prefillPods, readyPodsMap)
 	if err != nil {
 		klog.ErrorS(err, "prefill scorer preparation failed",
-			"request_id", routingCtx.RequestID, "policy", prefillPolicy.Name(), "model", routingCtx.Model)
+			"request_id", routingCtx.RequestID, "policy", policy.Name(), "model", routingCtx.Model)
 		return nil, 0, nil
 	}
 
@@ -593,10 +660,24 @@ func (r *pdRouter) scorePrefillPods(routingCtx *types.RoutingContext, prefillPod
 	return prefillScores, maxPrefillScore, scorer.PrefixHashes()
 }
 
-// scoreDecodePods scores candidate decode pods using policy, falling back to
-// load_balancing for a nil policy or for individual pods whose primary score is
-// invalid (NaN). Returns a DecodeScoreRun with the best (lowest-score) pod per
-// roleset and the global max score used by finalPDScore for normalization.
+// scoreDecodePods scores candidate decode pods with policy after any imbalance fast path
+// has narrowed the list. filteredDecodePods are shuffled before scoring.
+//
+// Metric inputs (podRequestCounts, podThroughputs, podFreeGpuUsage and their batch
+// maxima) are normally populated by loadImbalanceSelectDecodePod; when that returns
+// nil, the caller still passes the maps built during that pass.
+//
+// Policy resolution: the policy argument, then r.decodePolicy, then load_balancing.
+// When at least one pod reports both RealtimeNumRequestsRunning and
+// AvgGenerationThroughputToksPerS, pods missing either metric are skipped so
+// freshly restarted pods are not favored with zero load. If no pod has both metrics,
+// all pods are scored (cold-start fallback).
+//
+// Lower score is better. The lowest-scoring pod per roleset is kept in DecodeScoreRun.
+// PerRoleset. Invalid (NaN) scores from the primary policy are retried once with
+// load_balancing; FallbackUsed is set when that happens. Pods still invalid after
+// fallback are skipped. MaxScore is the maximum score among pods scored in this pass
+// (minimum 0.01), used by finalPDScore for normalization.
 func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDecodePods []*v1.Pod,
 	maxRequestCount float64, maxThroughput float64, maxFreeGPUUsage float64,
 	podRequestCounts map[string]float64, podThroughputs map[string]float64, podFreeGpuUsage map[string]float64,
@@ -620,8 +701,37 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 
 	utils.CryptoShuffle(filteredDecodePods)
 
+	anyMetricsReady := false
+	for _, pod := range filteredDecodePods {
+		if r.decodePodMetricsReady(routingCtx, pod) {
+			anyMetricsReady = true
+			break
+		}
+	}
+
+	scoredPods := make([]string, 0, len(filteredDecodePods))
+	skippedPods := make([]string, 0, len(filteredDecodePods))
+
 	for _, pod := range filteredDecodePods {
 		rolesetName := pod.Labels[PDRoleSetIdentifier]
+		if anyMetricsReady && !r.decodePodMetricsReady(routingCtx, pod) {
+			// Cold-start: assign a neutral score (1.0 = idle warm pod) plus gateway-tracked
+			// pending requests so the roleset competes fairly instead of being excluded entirely.
+			// Once the pod's first request completes and metrics arrive, it transitions to full scoring.
+			pending := float64(r.pendingDecodeTracker.GetPendingDecodeCount(pod.Name))
+			coldScore := 1.0 + pending
+			scoredPods = append(scoredPods, fmt.Sprintf("%s:score=%.4f,roleset=%s(cold)", pod.Name, coldScore, rolesetName))
+			klog.V(4).InfoS("decode pod metrics not ready, using cold-start score",
+				"request_id", routingCtx.RequestID, "pod", pod.Name, "roleset", rolesetName,
+				"cold_score", coldScore, "pending", pending)
+			if existing, exists := out.PerRoleset[rolesetName]; !exists || coldScore < existing.Score {
+				out.PerRoleset[rolesetName] = pd.RolesetDecodePick{Pod: pod, Score: coldScore}
+			}
+			if coldScore > out.MaxScore {
+				out.MaxScore = coldScore
+			}
+			continue
+		}
 		in := pd.DecodePodInput{
 			RunningReqs:     podRequestCounts[pod.Name],
 			Throughput:      podThroughputs[pod.Name],
@@ -638,11 +748,15 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 				out.FallbackUsed = true
 			}
 			if pd.InvalidDecodeScore(decodeScore) {
-				klog.V(2).InfoS("decode score invalid after policy and load_balancing fallback, skipping pod",
-					"request_id", routingCtx.RequestID, "pod", pod.Name, "policy", policyName)
+				skippedPods = append(skippedPods, fmt.Sprintf("%s:invalid_score", pod.Name))
+				klog.V(4).InfoS("decode score invalid after policy and load_balancing fallback, skipping pod",
+					"request_id", routingCtx.RequestID, "pod", pod.Name, "policy", policyName,
+					"roleset", pod.Labels[PDRoleSetIdentifier])
 				continue
 			}
 		}
+
+		scoredPods = append(scoredPods, fmt.Sprintf("%s:score=%.4f,roleset=%s", pod.Name, decodeScore, rolesetName))
 
 		if existing, exists := out.PerRoleset[rolesetName]; !exists || decodeScore < existing.Score {
 			out.PerRoleset[rolesetName] = pd.RolesetDecodePick{Pod: pod, Score: decodeScore}
@@ -652,13 +766,40 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 		}
 	}
 
+	perRolesetBest := make([]string, 0, len(out.PerRoleset))
+	for roleset, pick := range out.PerRoleset {
+		perRolesetBest = append(perRolesetBest, fmt.Sprintf("%s:%s=%.4f", roleset, pick.Pod.Name, pick.Score))
+	}
+	sort.Strings(perRolesetBest)
+	klog.V(4).InfoS("decode_score_summary",
+		"request_id", routingCtx.RequestID, "policy", policyName,
+		"fallback_used", out.FallbackUsed, "any_metrics_ready", anyMetricsReady,
+		"scored", strings.Join(scoredPods, " "), "skipped", strings.Join(skippedPods, " "),
+		"per_roleset_best", strings.Join(perRolesetBest, " "),
+	)
+
 	return out
 }
 
-// finalPDScore selects the winning prefill/decode pod pair by normalizing each
-// roleset's prefill and decode scores by their respective maxima and picking the
-// roleset with the lowest combined score. Enqueues a prefix-cache update and
-// emits selection metrics before returning.
+// finalPDScore picks the winning prefill/decode pod pair after scorePrefillPods and
+// scoreDecodePods. Only rolesets with an entry in both prefillScores and
+// decodeRun.PerRoleset are considered, so prefill and decode always come from the
+// same roleset.
+//
+// For each eligible roleset, combined score is:
+//
+//	normalizedPrefill + normalizedDecode
+//	  = prefillScore.Score / maxPrefillScore + decodePick.Score / decodeRun.MaxScore
+//
+// Lower combined score wins. Ties retain whichever roleset was last seen with that
+// score (map iteration order). Emits per-roleset final_score V(4) logs.
+//
+// Returns an error when decodeRun.Err is set, when no roleset has both sides scored
+// (target prefill or decode pod nil), or when prefillScores is empty. On success,
+// enqueues a prefix-cache update when prefixHashes is non-empty, increments internal
+// selection counters, and emits PDSelectedPrefillPodTotal / PDSelectedDecodePodTotal.
+// The caller registers the chosen prefill/decode pods with PrefillRequestTracker and
+// PendingDecodeTracker after return.
 func (r *pdRouter) finalPDScore(routingCtx *types.RoutingContext,
 	prefixHashes []uint64,
 	prefillScores map[string]*Scores, maxPrefillScore float64,
@@ -674,6 +815,9 @@ func (r *pdRouter) finalPDScore(routingCtx *types.RoutingContext,
 	for roleset, prefillScore := range prefillScores {
 		decodePick, ok := decodeRun.PerRoleset[roleset]
 		if !ok {
+			klog.V(4).InfoS("final_score_skip_roleset",
+				"request_id", routingCtx.RequestID, "roleset", roleset,
+				"prefill_pod", prefillScore.Pod.Name, "reason", "no_decode_score_for_roleset")
 			continue
 		}
 
@@ -687,15 +831,13 @@ func (r *pdRouter) finalPDScore(routingCtx *types.RoutingContext,
 			targetDecodePod = decodePick.Pod
 		}
 
-		klog.V(4).InfoS(
-			"final_score",
-			"request_id", routingCtx.RequestID,
-			"roleset", roleset,
-			"final_score", final,
+		klog.V(4).InfoS("final_score",
+			"request_id", routingCtx.RequestID, "roleset", roleset,
+			"final_score", final, "prefill_pod", prefillScore.Pod.Name,
+			"decode_pod", decodePick.Pod.Name,
 			"prefill_score", prefillScore.Score, "normalized_prefill_score", normalizedPrefillScore,
 			"decode_score", decodePick.Score, "normalized_decode_score", normalizedDecodeScore,
-			"decode_policy", decodeRun.Policy,
-			"decode_fallback_used", decodeRun.FallbackUsed,
+			"decode_policy", decodeRun.Policy, "decode_fallback_used", decodeRun.FallbackUsed,
 		)
 	}
 
@@ -796,71 +938,42 @@ func (r *pdRouter) isPodSuitableForPromptLength(routingCtx *types.RoutingContext
 // for the given promptLength. Pods missing required PD labels or an HTTP server
 // are skipped.
 //
-// Phase 2 builds the output slices from rolesets that have both prefill and
-// decode pods (incomplete rolesets are excluded). When prompt-length bucketing
-// is enabled, it also produces filtered prefill/decode slices restricted to pods
-// whose capacity bucket covers promptLength; these filtered slices replace the
-// unfiltered ones in the primary return values when non-empty.
+// Phase 2 builds the output slices from replica-complete rolesets (all expected
+// prefill and decode replicas ready). When prompt-length bucketing is enabled, it
+// also produces filtered prefill/decode slices restricted to pods whose capacity
+// bucket covers promptLength; bucket-filtered prefill and decode slices are applied
+// together only when both sides have suitable pods.
 //
 // Returns (prefillPods, decodePods, promptLengthBucketingPrefillPods,
 // promptLengthBucketingDecodePods, combinedPods).
 func (r *pdRouter) collectAndBucketPods(routingCtx *types.RoutingContext, readyPods []*v1.Pod, promptLength int) ([]*v1.Pod, []*v1.Pod, []*v1.Pod, []*v1.Pod, []*v1.Pod) {
 	bucketingEnabled := aibrixPromptLengthBucketing
 
-	type rolesetBucket struct {
-		prefills []*v1.Pod
-		decodes  []*v1.Pod
-	}
-	byRoleset := make(map[string]*rolesetBucket)
 	var combinedPods []*v1.Pod
-
-	// Phase 1: single pass — group pods by roleset, collect combined pods.
-	// Applies all eligibility guards (labels, HTTP server) once per pod.
-	for _, pod := range readyPods {
-		roleSetID, hasRoleset := pod.Labels[PDRoleSetIdentifier]
-		if !hasRoleset {
-			continue
-		}
-		roleID, hasRole := pod.Labels[PDRoleIdentifier]
-		if !hasRole {
-			continue
-		}
-		// For multi-node scenarios, only select pods from node_rank=0 (PodGroupIndex=0)
-		// which have the HTTP server running.
-		if !isPodWithHTTPServer(pod) {
-			continue
-		}
-
-		switch roleID {
-		case "prefill":
-			b := byRoleset[roleSetID]
-			if b == nil {
-				b = &rolesetBucket{}
-				byRoleset[roleSetID] = b
+	if bucketingEnabled {
+		for _, pod := range readyPods {
+			_, hasRoleset := pod.Labels[PDRoleSetIdentifier]
+			if !hasRoleset {
+				continue
 			}
-			b.prefills = append(b.prefills, pod)
-		case "decode":
-			b := byRoleset[roleSetID]
-			if b == nil {
-				b = &rolesetBucket{}
-				byRoleset[roleSetID] = b
+			roleID, hasRole := pod.Labels[PDRoleIdentifier]
+			if !hasRole || roleID == PDRolePrefill || roleID == PDRoleDecode {
+				continue
 			}
-			b.decodes = append(b.decodes, pod)
-		default:
-			if bucketingEnabled && isCombinedPod(routingCtx, pod) && r.isPodSuitableForPromptLength(routingCtx, pod, promptLength) {
+			if !isPodWithHTTPServer(pod) {
+				continue
+			}
+			if isCombinedPod(routingCtx, pod) && r.isPodSuitableForPromptLength(routingCtx, pod, promptLength) {
 				combinedPods = append(combinedPods, pod)
 			}
 		}
 	}
 
-	// Phase 2: build output slices from rolesets that have both prefill and decode pods.
+	eligible := eligiblePDRolesets(readyPods)
 	var prefillPods, decodePods []*v1.Pod
 	var promptLengthBucketingPrefillPods, promptLengthBucketingDecodePods []*v1.Pod
 
-	for _, b := range byRoleset {
-		if len(b.prefills) == 0 || len(b.decodes) == 0 {
-			continue
-		}
+	for _, b := range eligible {
 		prefillPods = append(prefillPods, b.prefills...)
 		decodePods = append(decodePods, b.decodes...)
 
@@ -883,14 +996,10 @@ func (r *pdRouter) collectAndBucketPods(routingCtx *types.RoutingContext, readyP
 		}
 	}
 
-	// Override prefill/decode with bucket-filtered pods if bucketing produced results.
-	if bucketingEnabled {
-		if len(promptLengthBucketingPrefillPods) > 0 {
-			prefillPods = promptLengthBucketingPrefillPods
-		}
-		if len(promptLengthBucketingDecodePods) > 0 {
-			decodePods = promptLengthBucketingDecodePods
-		}
+	// Apply bucket-filtered pods atomically so prefill/decode stay roleset-aligned.
+	if bucketingEnabled && len(promptLengthBucketingPrefillPods) > 0 && len(promptLengthBucketingDecodePods) > 0 {
+		prefillPods = promptLengthBucketingPrefillPods
+		decodePods = promptLengthBucketingDecodePods
 	}
 
 	return prefillPods, decodePods, promptLengthBucketingPrefillPods, promptLengthBucketingDecodePods, combinedPods
@@ -959,6 +1068,28 @@ func isCombinedPod(routingCtx *types.RoutingContext, pod *v1.Pod) bool {
 	}
 	pdCfg := parsePDAlgorithmConfig(profile.RoutingConfig)
 	return pdCfg.Combined
+}
+
+func (r *pdRouter) decodePodMetricsReady(ctx *types.RoutingContext, pod *v1.Pod) bool {
+	if r == nil || r.cache == nil || ctx == nil || pod == nil {
+		return false
+	}
+	_, runningErr := r.cache.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
+	_, throughputErr := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.AvgGenerationThroughputToksPerS)
+	return runningErr == nil && throughputErr == nil
+}
+
+// decodePodKVCacheUsagePerc returns KV cache utilization (0–1). vLLM exposes
+// vllm:kv_cache_usage_perc; older engines may still publish gpu_cache_usage_perc.
+func (r *pdRouter) decodePodKVCacheUsagePerc(ctx *types.RoutingContext, pod *v1.Pod) (metrics.MetricValue, error) {
+	if r == nil || r.cache == nil || ctx == nil || pod == nil {
+		return nil, fmt.Errorf("kv cache metric unavailable")
+	}
+	kv, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.KVCacheUsagePerc)
+	if err == nil {
+		return kv, nil
+	}
+	return r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.GPUCacheUsagePerc)
 }
 
 func getLLMEngine(pod *v1.Pod, labelName string, defaultValue string) string {

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -277,13 +277,6 @@ func NewPDRouter() (types.Router, error) {
 
 func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) (string, error) {
 	readyPods := readyPodList.All()
-	prefillPodsForEngine := prefillPodsFromEligibleRolesets(readyPods)
-	llmEngine, err := validateAndGetLLMEngine(prefillPodsForEngine)
-	if err != nil {
-		metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
-			map[string]string{"status": pdRouteValidateLLMEngineFail, "status_code": "400"})
-		return "", fmt.Errorf("engine validation failed for request %s: %w", ctx.RequestID, err)
-	}
 
 	prefillPod, decodePod, err := r.podSelector.Select(ctx, readyPods)
 	if err != nil {
@@ -304,7 +297,7 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		}
 		ctx.RespHeaders[HeaderPrefillTargetPod] = prefillPod.Name
 		ctx.RespHeaders[HeaderPrefillTargetPodIP] = prefillPod.Status.PodIP
-		err = r.doPrefillRequest(ctx, prefillPod, llmEngine)
+		err = r.doPrefillRequest(ctx, prefillPod, ctx.Engine)
 		if err != nil {
 			// Remove is a no-op if the executor already cleaned up (e.g. sync HTTP failure).
 			r.prefillRequestTracker.RemovePrefillRequest(ctx.RequestID)
@@ -1140,20 +1133,19 @@ func getLLMEngine(pod *v1.Pod, labelName string, defaultValue string) string {
 	return labelTarget
 }
 
-// validateAndGetLLMEngine validates that all prefill pods use the same engine and returns it.
-func validateAndGetLLMEngine(prefillPods []*v1.Pod) (string, error) {
-	if len(prefillPods) == 0 {
-		return "", fmt.Errorf("no prefill pods provided")
+// ValidateAndGetLLMEngine validates that all pods use the same LLM engine label and returns it.
+func ValidateAndGetLLMEngine(pods []*v1.Pod) (string, error) {
+	if len(pods) == 0 {
+		return "", fmt.Errorf("no pods provided")
 	}
 
-	firstEngine := getLLMEngine(prefillPods[0], LLMEngineIdentifier, VLLMEngine)
+	firstEngine := getLLMEngine(pods[0], LLMEngineIdentifier, VLLMEngine)
 
-	// Validate all pods use the same engine
-	for i := 1; i < len(prefillPods); i++ {
-		engine := getLLMEngine(prefillPods[i], LLMEngineIdentifier, VLLMEngine)
+	for i := 1; i < len(pods); i++ {
+		engine := getLLMEngine(pods[i], LLMEngineIdentifier, VLLMEngine)
 		if engine != firstEngine {
 			return "", fmt.Errorf("inconsistent LLM engines detected: pod %s has %s, pod %s has %s",
-				prefillPods[0].Name, firstEngine, prefillPods[i].Name, engine)
+				pods[0].Name, firstEngine, pods[i].Name, engine)
 		}
 	}
 

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_benchmark_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_benchmark_test.go
@@ -184,6 +184,7 @@ func BenchmarkDoPrefillRequest(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				ctx.RequestID = fmt.Sprintf("bench-prefill-%s-%d", engine, i)
 				ctx.RequestTime = time.Now()
+				router.prefillRequestTracker.AddPrefillRequest(ctx.RequestID, prefillPod.Name)
 				if err := router.doPrefillRequest(ctx, prefillPod, engine); err != nil {
 					b.Fatalf("doPrefillRequest failed: %v", err)
 				}

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -110,6 +110,7 @@ func TestPDRouter_Route(t *testing.T) {
 
 			ctx := types.NewRoutingContext(context.Background(), "test", "model", "message", "test-request", "user")
 			ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
+			ctx.Engine = tt.llmEngine
 
 			result, err := r.Route(ctx, &utils.PodArray{Pods: tt.readyPods})
 

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -2549,6 +2549,7 @@ func TestFilterPrefillDecodePods_SelectCorrectBucketPods(t *testing.T) {
 		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
 		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
 		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
 		httpClient:            &http.Client{},
 		selectionCounts:       map[string]int64{},
 	}
@@ -2579,6 +2580,7 @@ func TestFilterPrefillDecodePods_CombinedFallbackBucketing(t *testing.T) {
 		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
 		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
 		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
 		httpClient:            &http.Client{},
 		selectionCounts:       map[string]int64{},
 	}
@@ -2610,6 +2612,7 @@ func TestFilterPrefillDecodePods_NoBucketMatchNoCombined(t *testing.T) {
 		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
 		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
 		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
 		httpClient:            &http.Client{},
 		selectionCounts:       map[string]int64{},
 	}

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -2599,6 +2599,32 @@ func TestFilterPrefillDecodePods_CombinedFallbackBucketing(t *testing.T) {
 	assert.Equal(t, 0, r.prefillRequestTracker.GetPrefillRequestCountsForPod("prefill-ok"))
 }
 
+func TestFilterPrefillDecodePods_NoBucketMatchNoCombined(t *testing.T) {
+	old := aibrixPromptLengthBucketing
+	aibrixPromptLengthBucketing = true
+	defer func() { aibrixPromptLengthBucketing = old }()
+
+	r := pdRouter{
+		cache:                 cache.NewForTest(),
+		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
+		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
+		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		httpClient:            &http.Client{},
+		selectionCounts:       map[string]int64{},
+	}
+
+	configBlocked := pdConfigAnnotation(0, 1, false)
+	prefillOK := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "prefill-ok", Labels: map[string]string{PDRoleSetIdentifier: "rs1", PDRoleIdentifier: "prefill"}, Annotations: map[string]string{constants.ModelAnnoConfig: configBlocked}}}
+	decodeOK := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "decode-ok", Labels: map[string]string{PDRoleSetIdentifier: "rs1", PDRoleIdentifier: "decode"}, Annotations: map[string]string{constants.ModelAnnoConfig: configBlocked}}}
+
+	ctx := types.NewRoutingContext(context.Background(), "pd", "test-model", "say test", "req-no-bucket", "user")
+	prefill, decode, err := r.filterPrefillDecodePods(ctx, []*v1.Pod{prefillOK, decodeOK})
+	assert.Error(t, err)
+	assert.Nil(t, prefill)
+	assert.Nil(t, decode)
+	assert.Contains(t, err.Error(), "no prompt-length bucket matches")
+}
+
 func TestFilterPrefillDecodePods_CombinedPickImbalance(t *testing.T) {
 	old := aibrixPromptLengthBucketing
 	aibrixPromptLengthBucketing = true

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -523,6 +523,36 @@ func TestScorePrefillPods_PrefixCachePolicy(t *testing.T) {
 	})
 }
 
+func TestScorePrefillPods_NilPolicyFallback(t *testing.T) {
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "hello world", "req-1", "user")
+	pod := func(name, roleset string) *v1.Pod { return makePDPod(name, roleset, "", nil) }
+
+	t.Run("falls back to router prefill policy", func(t *testing.T) {
+		tracker := pd.NewPrefillRequestTracker()
+		addRequests(tracker, "pod2", 5)
+
+		r := &pdRouter{
+			prefillPolicy:         pd.NewLeastRequestPrefillPolicy(),
+			prefillRequestTracker: tracker,
+		}
+
+		scores, _, _ := r.scorePrefillPods(ctx, []*v1.Pod{pod("pod1", "rs1"), pod("pod2", "rs1")}, nil)
+		assert.Len(t, scores, 1)
+		assert.Equal(t, "pod1", scores["rs1"].Pod.Name)
+	})
+
+	t.Run("falls back to prefix_cache when router policy is nil", func(t *testing.T) {
+		tracker := pd.NewPrefillRequestTracker()
+		addRequests(tracker, "pod2", 5)
+
+		r := &pdRouter{prefillRequestTracker: tracker}
+
+		scores, _, _ := r.scorePrefillPods(ctx, []*v1.Pod{pod("pod1", "rs1"), pod("pod2", "rs1")}, nil)
+		assert.Len(t, scores, 1)
+		assert.Equal(t, "pod1", scores["rs1"].Pod.Name)
+	})
+}
+
 func TestScorePrefillPods_LeastRequestPolicy(t *testing.T) {
 	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "hello world", "req-1", "user")
 
@@ -905,6 +935,7 @@ func TestDoPrefillRequest(t *testing.T) {
 			routingCtx := createRoutingCtx()
 			router := createRouter(prefillPods, tt.podMetrics)
 
+			router.prefillRequestTracker.AddPrefillRequest(routingCtx.RequestID, prefillPods[0].Name)
 			err := router.doPrefillRequest(routingCtx, prefillPods[0], tt.llmEngine)
 			if tt.expectError {
 				assert.Error(t, err)
@@ -1359,6 +1390,7 @@ func TestVLLMIntegrationWithTestServer(t *testing.T) {
 	}
 	router.prefillExecutor = prefill.NewDefaultExecutor(vllmClient, vllmTracker, prefillRequestTimeout)
 
+	vllmTracker.AddPrefillRequest(routingCtx.RequestID, prefillPods[0].Name)
 	err := router.doPrefillRequest(routingCtx, prefillPods[0], VLLMEngine)
 	assert.NoError(t, err)
 
@@ -1489,6 +1521,7 @@ func TestTensorRTIntegrationWithTestServer(t *testing.T) {
 	}
 	router.prefillExecutor = prefill.NewDefaultExecutor(trtClient, trtTracker, prefillRequestTimeout)
 
+	trtTracker.AddPrefillRequest(routingCtx.RequestID, prefillPods[0].Name)
 	err := router.doPrefillRequest(routingCtx, prefillPods[0], TensorRTLLM)
 	assert.NoError(t, err)
 
@@ -1859,12 +1892,12 @@ func TestLoadImbalanceSelectDecodePod(t *testing.T) {
 				"pod1": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 5},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 100},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.5},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.5},
 				},
 				"pod2": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 7},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 120},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.6},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.6},
 				},
 			},
 			expectTargetPod:        "",
@@ -1886,17 +1919,17 @@ func TestLoadImbalanceSelectDecodePod(t *testing.T) {
 				"pod1": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 2},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 100},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.3},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.3},
 				},
 				"pod2": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 40},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 120},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.8},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.8},
 				},
 				"pod3": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 35},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 110},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.7},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.7},
 				},
 			},
 			expectTargetPod:        "pod1",
@@ -1920,12 +1953,12 @@ func TestLoadImbalanceSelectDecodePod(t *testing.T) {
 				"pod1": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 10},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 50},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.4},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.4},
 				},
 				"pod2": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 12},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 3000},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.5},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.5},
 				},
 			},
 			expectTargetPod:        "pod1",
@@ -1949,12 +1982,12 @@ func TestLoadImbalanceSelectDecodePod(t *testing.T) {
 				"pod1": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 10},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 100},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.4},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.4},
 				},
 				"pod2": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 12},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 200},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.5},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.5},
 				},
 			},
 			expectTargetPod:        "",
@@ -1977,12 +2010,12 @@ func TestLoadImbalanceSelectDecodePod(t *testing.T) {
 				"pod1": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 0},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 100},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.2},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.2},
 				},
 				"pod2": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 5},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 120},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.3},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.3},
 				},
 			},
 			expectTargetPod:        "",
@@ -2021,12 +2054,12 @@ func TestLoadImbalanceSelectDecodePod(t *testing.T) {
 				"pod1": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 5},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 100},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.95},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.95},
 				},
 				"pod2": {
 					metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 7},
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 120},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 1.0},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 1.0},
 				},
 			},
 			expectTargetPod:        "",
@@ -2052,13 +2085,13 @@ func TestLoadImbalanceSelectDecodePod(t *testing.T) {
 					metrics.RealtimeNumRequestsRunning:         &metrics.SimpleMetricValue{Value: 8},
 					metrics.RealtimeRunningRequestsDrainRate1m: &metrics.SimpleMetricValue{Value: 2.0},
 					metrics.AvgGenerationThroughputToksPerS:    &metrics.SimpleMetricValue{Value: 200},
-					metrics.GPUCacheUsagePerc:                  &metrics.SimpleMetricValue{Value: 0.3},
+					metrics.KVCacheUsagePerc:                   &metrics.SimpleMetricValue{Value: 0.3},
 				},
 				"pod2": {
 					metrics.RealtimeNumRequestsRunning:         &metrics.SimpleMetricValue{Value: 6},
 					metrics.RealtimeRunningRequestsDrainRate1m: &metrics.SimpleMetricValue{Value: 0.3},
 					metrics.AvgGenerationThroughputToksPerS:    &metrics.SimpleMetricValue{Value: 30},
-					metrics.GPUCacheUsagePerc:                  &metrics.SimpleMetricValue{Value: 0.5},
+					metrics.KVCacheUsagePerc:                   &metrics.SimpleMetricValue{Value: 0.5},
 				},
 			},
 			expectTargetPod:        "pod1",
@@ -2082,13 +2115,13 @@ func TestLoadImbalanceSelectDecodePod(t *testing.T) {
 					metrics.RealtimeNumRequestsRunning:         &metrics.SimpleMetricValue{Value: 8},
 					metrics.RealtimeRunningRequestsDrainRate1m: &metrics.SimpleMetricValue{Value: 2.0},
 					metrics.AvgGenerationThroughputToksPerS:    &metrics.SimpleMetricValue{Value: 200},
-					metrics.GPUCacheUsagePerc:                  &metrics.SimpleMetricValue{Value: 0.3},
+					metrics.KVCacheUsagePerc:                   &metrics.SimpleMetricValue{Value: 0.3},
 				},
 				"pod2": {
 					metrics.RealtimeNumRequestsRunning:         &metrics.SimpleMetricValue{Value: 6},
 					metrics.RealtimeRunningRequestsDrainRate1m: &metrics.SimpleMetricValue{Value: 1.5},
 					metrics.AvgGenerationThroughputToksPerS:    &metrics.SimpleMetricValue{Value: 150},
-					metrics.GPUCacheUsagePerc:                  &metrics.SimpleMetricValue{Value: 0.4},
+					metrics.KVCacheUsagePerc:                   &metrics.SimpleMetricValue{Value: 0.4},
 				},
 			},
 			expectTargetPod:        "",
@@ -2111,13 +2144,13 @@ func TestLoadImbalanceSelectDecodePod(t *testing.T) {
 					metrics.RealtimeNumRequestsRunning:         &metrics.SimpleMetricValue{Value: 8},
 					metrics.RealtimeRunningRequestsDrainRate1m: &metrics.SimpleMetricValue{Value: 2.0},
 					metrics.AvgGenerationThroughputToksPerS:    &metrics.SimpleMetricValue{Value: 200},
-					metrics.GPUCacheUsagePerc:                  &metrics.SimpleMetricValue{Value: 0.3},
+					metrics.KVCacheUsagePerc:                   &metrics.SimpleMetricValue{Value: 0.3},
 				},
 				"pod2": {
 					metrics.RealtimeNumRequestsRunning: &metrics.SimpleMetricValue{Value: 6},
 					// RealtimeRunningRequestsDrainRate1m absent — unavailable
 					metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 30},
-					metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.5},
+					metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.5},
 				},
 			},
 			expectTargetPod:        "",
@@ -2250,10 +2283,18 @@ func TestIsPodSuitableForPromptLength(t *testing.T) {
 
 // makePDPod creates a minimal pod with PD role labels and optional annotations.
 func makePDPod(name, roleset, role string, annotations map[string]string) *v1.Pod {
+	return pdPodWithReplica(name, roleset, role, "", annotations)
+}
+
+func pdPodWithReplica(name, roleset, role, replicaIndex string, annotations map[string]string) *v1.Pod {
+	labels := map[string]string{PDRoleSetIdentifier: roleset, PDRoleIdentifier: role}
+	if replicaIndex != "" {
+		labels[RoleReplicaIndex] = replicaIndex
+	}
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Labels:      map[string]string{PDRoleSetIdentifier: roleset, PDRoleIdentifier: role},
+			Labels:      labels,
 			Annotations: annotations,
 		},
 	}
@@ -2341,6 +2382,23 @@ func TestCollectAndBucketPods(t *testing.T) {
 		prefills, decodes, _, _, _ := router.collectAndBucketPods(ctx, pods, 11)
 		assert.ElementsMatch(t, []string{"prefill-rs1", "prefill-rs2"}, podNames(prefills))
 		assert.ElementsMatch(t, []string{"decode-rs1", "decode-rs2"}, podNames(decodes))
+	})
+
+	t.Run("partial decode replicas still eligible when peer roleset has more decodes", func(t *testing.T) {
+		old := aibrixPromptLengthBucketing
+		aibrixPromptLengthBucketing = false
+		defer func() { aibrixPromptLengthBucketing = old }()
+
+		pods := []*v1.Pod{
+			pdPodWithReplica("prefill-rs1", "rs1", "prefill", "0", nil),
+			pdPodWithReplica("decode-rs1", "rs1", "decode", "0", nil),
+			pdPodWithReplica("prefill-rs2", "rs2", "prefill", "0", nil),
+			pdPodWithReplica("decode-rs2-a", "rs2", "decode", "0", nil),
+			pdPodWithReplica("decode-rs2-b", "rs2", "decode", "1", nil),
+		}
+		prefills, decodes, _, _, _ := router.collectAndBucketPods(ctx, pods, 11)
+		assert.ElementsMatch(t, []string{"prefill-rs1", "prefill-rs2"}, podNames(prefills))
+		assert.ElementsMatch(t, []string{"decode-rs1", "decode-rs2-a", "decode-rs2-b"}, podNames(decodes))
 	})
 
 	t.Run("bucketing: both sides suitable - roleset included in bucketed slices", func(t *testing.T) {
@@ -2509,6 +2567,7 @@ func TestFilterPrefillDecodePods_SelectCorrectBucketPods(t *testing.T) {
 	assert.NotNil(t, decode)
 	assert.Equal(t, "prefill-ok", prefill.Name)
 	assert.Equal(t, "decode-ok", decode.Name)
+	assert.Equal(t, int32(1), r.prefillRequestTracker.GetPrefillRequestCountsForPods([]*v1.Pod{prefill})[prefill.Name])
 }
 
 func TestFilterPrefillDecodePods_CombinedFallbackBucketing(t *testing.T) {
@@ -2537,6 +2596,7 @@ func TestFilterPrefillDecodePods_CombinedFallbackBucketing(t *testing.T) {
 	assert.Nil(t, prefill)
 	assert.NotNil(t, decode)
 	assert.Equal(t, "combined-1", decode.Name)
+	assert.Equal(t, 0, r.prefillRequestTracker.GetPrefillRequestCountsForPod("prefill-ok"))
 }
 
 func TestFilterPrefillDecodePods_CombinedPickImbalance(t *testing.T) {
@@ -2598,7 +2658,7 @@ func TestFilterPrefillDecodePods_CombinedPickImbalance(t *testing.T) {
 				metrics.DrainRate1m:                     &metrics.PrometheusMetricValue{Result: &drain100},
 				metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 1},
 				metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 100},
-				metrics.GPUCacheUsagePerc:               &metrics.SimpleMetricValue{Value: 0.5},
+				metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.5},
 			}
 			metricsMap[combined.Name] = map[string]metrics.MetricValue{
 				metrics.NumRequestsWaiting:          &metrics.SimpleMetricValue{Value: tt.combinedWait},

--- a/pkg/plugins/gateway/algorithms/pd_readme.md
+++ b/pkg/plugins/gateway/algorithms/pd_readme.md
@@ -409,6 +409,23 @@ collectAndBucketPods()
 If bucket-filtered lists are non-empty, they replace the unfiltered lists.
 ```
 
+### Model-level bucketing detection
+
+`modelUsesPromptLengthBucketing()` checks whether any ready pod for the model declares an explicit prompt-length bucket (non-default `promptLenBucketMinLength` / `promptLenBucketMaxLength`) or a `combined=true` role. When no pod has such config, standard PD routing applies even if `AIBRIX_PROMPT_LENGTH_BUCKETING` is globally enabled — so adding the feature flag to a cluster does not affect models that have not opted in.
+
+### No-match guard
+
+When bucketing is enabled **and** the model uses bucketing (has at least one pod with bucket config), but the request's prompt length does not fall within any pod's declared range, the router returns an error rather than silently falling back to the unfiltered prefill/decode pool. Routing to the wrong bucket's pods would be incorrect: each pod group (storm) is sized and configured for a specific prompt-length range, so cross-bucket routing would produce unpredictable KV cache behavior.
+
+```
+if AIBRIX_PROMPT_LENGTH_BUCKETING &&
+   modelUsesPromptLengthBucketing() &&
+   (bucketPrefills == 0 || bucketDecodes == 0):
+     → error: "no prompt-length bucket matches prompt length N and no combined pods available"
+```
+
+This guard fires only after the combined-pod path has already been exhausted (combined pods are checked first and also handle the no-bucket-match case when they exist).
+
 ### Combined Pods
 
 When bucketing is enabled, pods with `combined=true` in their config profile can act as both prefill and decode. The router falls back to a combined pod when:

--- a/pkg/plugins/gateway/algorithms/pd_readme.md
+++ b/pkg/plugins/gateway/algorithms/pd_readme.md
@@ -38,8 +38,10 @@ Route(ctx, readyPodList)
      │        ├─► scoreDecodePods()
      │        └─► finalPDScore()  →  (prefillPod, decodePod)
      │
+     │        (filterPrefillDecodePods registers pending prefill+decode immediately
+     │         after selection so concurrent scorers see up-to-date counts)
+     │
      ├─► [prefillPod != nil]
-     │        pendingDecodeTracker.AddPendingDecode(requestID, decodePod)
      │        doPrefillRequest(ctx, prefillPod, engine)
      │              ├─ SGLang   → async goroutine (bootstrap handshake)
      │              ├─ vLLM     → sync, extract kv_transfer_params from response
@@ -60,9 +62,45 @@ Pods are grouped using Kubernetes labels:
 | `roleset-name` | any string | Groups prefill+decode pairs into a "roleset" |
 | `role-name` | `prefill` / `decode` / other | Pod's role in PD disaggregation |
 | `stormservice.orchestration.aibrix.ai/pod-group-index` | `"0"` or absent | Only pods with index `"0"` (or no label) host the HTTP server (multi-node TP) |
+| `stormservice.orchestration.aibrix.ai/role-replica-index` | any string | Distinct replica index within a role; used by `roleReplicaCardinality` to count unique replicas across multi-node TP groups. When absent, each routable pod counts as its own replica. |
 | `model.aibrix.ai/engine` | `vllm` / `sglang` / `trtllm` | LLM engine type |
 
-Only rolesets with **both** at least one prefill pod and one decode pod are eligible. Incomplete rolesets are excluded.
+Only rolesets with **both** at least one prefill replica and one decode replica are eligible. Incomplete rolesets are excluded. See [Roleset Eligibility Utilities](#roleset-eligibility-utilities) for diagnostic functions.
+
+---
+
+## Roleset Eligibility Utilities
+
+`pd_roleset.go` provides helper functions used by both the router and the gateway's pod-readiness logic.
+
+### Replica cardinality
+
+A roleset's replica count is the number of **distinct** values of `stormservice.orchestration.aibrix.ai/role-replica-index`. When that label is absent on all pods of a role, each routable pod counts as its own replica. This correctly handles multi-node tensor-parallel groups where multiple pods share one logical replica slot.
+
+```
+roleReplicaCardinality(pods):
+  if any pod has role-replica-index label:
+    count distinct index values
+  else:
+    count routable pods
+```
+
+### Eligibility checks
+
+A roleset is **eligible** when it has ≥1 prefill replica **and** ≥1 decode replica.
+
+| Function | Use |
+|----------|-----|
+| `HasEligibleRoleset(readyPods)` | Gateway check: at least one roleset is fully ready for PD routing |
+| `eligiblePDRolesets(readyPods)` | Internal: returns only complete rolesets for scoring |
+| `DescribePDRolesetEligibility(readyPods)` | Diagnostics: per-roleset replica counts and eligibility flag |
+| `LogPDRolesetEligibility(requestID, readyPods, reason)` | Emits `klog.InfoS` for partial or missing rolesets |
+
+`filterPrefillDecodePods` calls `DescribePDRolesetEligibility` on every request and emits a log entry when any roleset is incomplete or no eligible roleset exists.
+
+### Engine validation scope
+
+`validateAndGetLLMEngine` checks **only prefill pods from eligible rolesets** (not all ready pods). This prevents a restarting or mis-labeled pod in an incomplete roleset from blocking routing on healthy rolesets.
 
 ---
 
@@ -74,7 +112,8 @@ collectAndBucketPods()
         ▼
 ┌───────────────────────────────┐
 │  prefillPods / decodePods     │
-│  (grouped by roleset)         │
+│  (grouped by eligible         │
+│   rolesets only)              │
 └───────────────────────────────┘
         │
         ▼
@@ -82,23 +121,30 @@ loadImbalanceSelectPrefillPod()
   ┌─────────────────────────────────────────────────────────┐
   │  max(outstanding_prefill_reqs) - min > MIN_SPREAD?      │
   │  → YES: narrow to single least-loaded prefill pod       │
+  │         align decodePods to selected pod's roleset      │
   │  → NO:  continue with all prefill pods                  │
   └─────────────────────────────────────────────────────────┘
         │
         ▼
-loadImbalanceSelectDecodePod()  (3 ordered checks)
+loadImbalanceSelectDecodePod()  (3 ordered checks, metrics-bearing pods only)
   ┌──────────────────────────────────────────────────────────────────┐
   │  Check 1 – Request count spread                                  │
-  │    max(running_reqs+pending) - min >= DECODE_LOAD_SPREAD?        │
-  │    → YES: return least-loaded decode pod                         │
+  │    Only pods with RealtimeNumRequestsRunning metric participate  │
+  │    (pods without the metric are excluded from spread; their      │
+  │     pending count is still stored for scoring — prevents         │
+  │     thundering-herd on freshly restarted pods)                   │
+  │    max(observed running+pending) - min >= DECODE_LOAD_SPREAD?    │
+  │    → YES: return least-loaded observed pod;                      │
+  │           align prefillPods to selected pod's roleset            │
   │                                                                  │
   │  Check 2 – Throughput spread                                     │
-  │    max(throughput_tok/s) - min > THROUGHPUT_SPREAD?              │
-  │    → YES: return lowest-throughput decode pod                    │
+  │    Only pods with AvgGenerationThroughputToksPerS participate    │
+  │    max(observed throughput) - min > THROUGHPUT_SPREAD?           │
+  │    → YES: return lowest-throughput observed pod                  │
   │                                                                  │
   │  Check 3 – Drain rate score (soft path)                          │
   │    all pods have drain_rate > 0?                                 │
-  │    score = running_reqs / drain_rate                             │
+  │    score = effective_running_reqs / drain_rate                   │
   │    max_score / min_score > DECODE_SCORE_RATIO?                   │
   │    → YES: return pod with lowest drain-rate score                │
   └──────────────────────────────────────────────────────────────────┘
@@ -118,6 +164,10 @@ scorePrefillPods()              (per roleset, best pod wins)
         ▼
 scoreDecodePods()  →  pd.DecodeScoreRun (per roleset best pod + MaxScore + policy metadata)
   ┌──────────────────────────────────────────────────────────────────┐
+  │  Cold-start (if some pods have metrics but this pod does not):   │
+  │    score = 1.0 + pending_decode_count                            │
+  │    (neutral idle-warm score; pod competes but is not favored)    │
+  │                                                                  │
   │  Policy: load_balancing (default)                                │
   │    norm_reqs     = running_reqs / max_running_reqs               │
   │    norm_thru     = 1 - throughput / max_throughput               │
@@ -185,7 +235,9 @@ Controlled by `AIBRIX_DECODE_SCORE_POLICY`, or overridden per request via **`rou
 Metrics are pulled from the cache per pod (same maps as `loadImbalanceSelectDecodePod`):
 - `RealtimeNumRequestsRunning` + `PendingDecodeTracker` count
 - `AvgGenerationThroughputToksPerS` (per model)
-- `GPUCacheUsagePerc` (free = 100 − usage%)
+- `KVCacheUsagePerc` (free = 100 − usage%; falls back to deprecated `GPUCacheUsagePerc`)
+
+**Cold-start gate**: if at least one pod has both `RealtimeNumRequestsRunning` and `AvgGenerationThroughputToksPerS`, pods that lack either metric are given a neutral **cold-start score** (`1.0 + pending_decode_count`) rather than being excluded. This lets a freshly restarted pod participate in roleset selection without being assigned zero-load status that would attract a thundering herd. When *no* pod has metrics yet, all pods are scored normally (full cold-start fallback).
 
 ### `load_balancing` (default)
 
@@ -326,12 +378,17 @@ Timeline:
 ```
 Route() called
   │
-  ├─ filterPrefillDecodePods() selects decodePod
-  ├─ AddPendingDecode(requestID, decodePod)   ← counts as +1 running
-  ├─ doPrefillRequest()                        (may take seconds)
+  ├─ filterPrefillDecodePods()
+  │     ├─ finalPDScore() selects decodePod
+  │     ├─ AddPrefillRequest(requestID, prefillPod)   ← registered before return
+  │     └─ AddPendingDecode(requestID, decodePod)     ← registered before return
+  │          (concurrent Route() calls now see correct counts during scoring)
+  │
+  ├─ defer RemovePendingDecode(requestID)   ← Route() registers cleanup
+  ├─ doPrefillRequest()                      (may take seconds)
+  │     └─ on error: RemovePrefillRequest(requestID) called immediately
   ├─ ctx.SetTargetPod(decodePod)
-  ├─ return address to caller
-  └─ defer RemovePendingDecode(requestID)      ← cleaned up after Route returns
+  └─ return address to caller
 ```
 
 ---
@@ -381,7 +438,7 @@ When a combined pod is selected, `prefillPod` is `nil` (no prefill HTTP call) an
 |----------|---------|-------------|
 | `AIBRIX_PREFILL_SCORE_POLICY` | `prefix_cache` | Prefill pod scoring: `prefix_cache` or `least_request`. Any other value logs a warning and falls back to `prefix_cache`. |
 | `AIBRIX_DECODE_SCORE_POLICY` | `load_balancing` | Decode pod scoring for `finalPDScore`: `load_balancing` or `least_request`. Any other value logs a warning and falls back to `load_balancing`. |
-| `AIBRIX_KV_CONNECTOR_TYPE` | `shfs` | KV transfer backend: `shfs` (GPU/SHFS) or `nixl` (Neuron) |
+| `AIBRIX_KV_CONNECTOR_TYPE` | `shfs` | KV transfer backend: `shfs` (GPU/SHFS), `nixl` (Neuron/NIXL), or `mooncake` (Mooncake) |
 | `AIBRIX_PREFILL_REQUEST_TIMEOUT` | `30` | Prefill HTTP request timeout in seconds |
 | `AIBRIX_PROMPT_LENGTH_BUCKETING` | `false` | Enable prompt-length-based pod bucketing |
 
@@ -482,4 +539,10 @@ NewPDRouter()
   ├─ NewPrefillRequestTracker()
   ├─ NewPendingDecodeTracker()
   └─ startPrefixUpdater()                 // background goroutine
+
+// pd_roleset.go (no per-router state; pure functions called on each request)
+HasEligibleRoleset(readyPods)             // gateway: skip PD when no complete roleset
+eligiblePDRolesets(readyPods)             // internal: filter to complete rolesets only
+DescribePDRolesetEligibility(readyPods)   // diagnostics: per-roleset replica counts
+LogPDRolesetEligibility(id, pods, reason) // info-level log on partial rolesets
 ```

--- a/pkg/plugins/gateway/algorithms/pd_roleset.go
+++ b/pkg/plugins/gateway/algorithms/pd_roleset.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"sort"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type pdRolesetBucket struct {
+	prefills []*v1.Pod
+	decodes  []*v1.Pod
+}
+
+func groupPDPodsByRoleset(readyPods []*v1.Pod) map[string]*pdRolesetBucket {
+	byRoleset := make(map[string]*pdRolesetBucket)
+	for _, pod := range readyPods {
+		roleSetID, hasRoleset := pod.Labels[PDRoleSetIdentifier]
+		if !hasRoleset {
+			continue
+		}
+		roleID, hasRole := pod.Labels[PDRoleIdentifier]
+		if !hasRole {
+			continue
+		}
+		if !isPodWithHTTPServer(pod) {
+			continue
+		}
+		switch roleID {
+		case PDRolePrefill, PDRoleDecode:
+			b := byRoleset[roleSetID]
+			if b == nil {
+				b = &pdRolesetBucket{}
+				byRoleset[roleSetID] = b
+			}
+			if roleID == PDRolePrefill {
+				b.prefills = append(b.prefills, pod)
+			} else {
+				b.decodes = append(b.decodes, pod)
+			}
+		}
+	}
+	return byRoleset
+}
+
+// roleReplicaCardinality returns how many distinct replicas of a role are present.
+// When role-replica-index labels exist, distinct index values are counted; otherwise
+// each routable pod is treated as its own replica.
+func roleReplicaCardinality(pods []*v1.Pod) int {
+	if len(pods) == 0 {
+		return 0
+	}
+	seen := make(map[string]struct{}, len(pods))
+	hasIndexLabel := false
+	for _, pod := range pods {
+		idx, ok := pod.Labels[RoleReplicaIndex]
+		if ok && idx != "" {
+			hasIndexLabel = true
+			seen[idx] = struct{}{}
+		}
+	}
+	if hasIndexLabel {
+		return len(seen)
+	}
+	return len(pods)
+}
+
+func fleetExpectedRoleCounts(byRoleset map[string]*pdRolesetBucket) (maxPrefill, maxDecode int) {
+	for _, b := range byRoleset {
+		if n := roleReplicaCardinality(b.prefills); n > maxPrefill {
+			maxPrefill = n
+		}
+		if n := roleReplicaCardinality(b.decodes); n > maxDecode {
+			maxDecode = n
+		}
+	}
+	return maxPrefill, maxDecode
+}
+
+func isPDRolesetEligible(b *pdRolesetBucket) bool {
+	return roleReplicaCardinality(b.prefills) > 0 && roleReplicaCardinality(b.decodes) > 0
+}
+
+// eligiblePDRolesets returns rolesets with at least one routable prefill and decode pod.
+func eligiblePDRolesets(readyPods []*v1.Pod) map[string]*pdRolesetBucket {
+	byRoleset := groupPDPodsByRoleset(readyPods)
+	eligible := make(map[string]*pdRolesetBucket, len(byRoleset))
+	for id, b := range byRoleset {
+		if isPDRolesetEligible(b) {
+			eligible[id] = b
+		}
+	}
+	return eligible
+}
+
+// HasEligibleRoleset reports whether at least one PD roleset has both a prefill and
+// decode pod ready for disaggregated routing.
+func HasEligibleRoleset(readyPods []*v1.Pod) bool {
+	return len(eligiblePDRolesets(readyPods)) > 0
+}
+
+func prefillPodsFromEligibleRolesets(readyPods []*v1.Pod) []*v1.Pod {
+	eligible := eligiblePDRolesets(readyPods)
+	out := make([]*v1.Pod, 0, len(eligible))
+	for _, b := range eligible {
+		out = append(out, b.prefills...)
+	}
+	return out
+}
+
+// PDRolesetEligibility describes one roleset's readiness for PD routing.
+type PDRolesetEligibility struct {
+	Roleset         string
+	PrefillReplicas int
+	DecodeReplicas  int
+	PrefillPods     string
+	DecodePods      string
+	Eligible        bool
+}
+
+func pdPodNames(pods []*v1.Pod) string {
+	if len(pods) == 0 {
+		return ""
+	}
+	names := make([]string, len(pods))
+	for i, p := range pods {
+		names[i] = p.Name
+	}
+	sort.Strings(names)
+	return strings.Join(names, ",")
+}
+
+// DescribePDRolesetEligibility returns fleet-wide max replica counts (for diagnostics)
+// and per-roleset eligibility (≥1 prefill and ≥1 decode).
+func DescribePDRolesetEligibility(readyPods []*v1.Pod) (fleetMaxPrefill, fleetMaxDecode int, statuses []PDRolesetEligibility, eligibleCount int) {
+	byRoleset := groupPDPodsByRoleset(readyPods)
+	fleetMaxPrefill, fleetMaxDecode = fleetExpectedRoleCounts(byRoleset)
+	statuses = make([]PDRolesetEligibility, 0, len(byRoleset))
+	for id, b := range byRoleset {
+		eligible := isPDRolesetEligible(b)
+		if eligible {
+			eligibleCount++
+		}
+		statuses = append(statuses, PDRolesetEligibility{
+			Roleset:         id,
+			PrefillReplicas: roleReplicaCardinality(b.prefills),
+			DecodeReplicas:  roleReplicaCardinality(b.decodes),
+			PrefillPods:     pdPodNames(b.prefills),
+			DecodePods:      pdPodNames(b.decodes),
+			Eligible:        eligible,
+		})
+	}
+	sort.Slice(statuses, func(i, j int) bool { return statuses[i].Roleset < statuses[j].Roleset })
+	return fleetMaxPrefill, fleetMaxDecode, statuses, eligibleCount
+}

--- a/pkg/plugins/gateway/algorithms/pd_roleset_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_roleset_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func pdPod(name, roleset, role, replicaIndex string) *v1.Pod {
+	labels := map[string]string{
+		PDRoleSetIdentifier: roleset,
+		PDRoleIdentifier:    role,
+	}
+	if replicaIndex != "" {
+		labels[RoleReplicaIndex] = replicaIndex
+	}
+	return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+}
+
+func TestHasEligibleRoleset(t *testing.T) {
+	t.Run("complete single roleset", func(t *testing.T) {
+		pods := []*v1.Pod{
+			pdPod("prefill-0", "rs1", "prefill", "0"),
+			pdPod("decode-0", "rs1", "decode", "0"),
+			pdPod("decode-1", "rs1", "decode", "1"),
+		}
+		assert.True(t, HasEligibleRoleset(pods))
+	})
+
+	t.Run("partial decode replicas still eligible with one decode", func(t *testing.T) {
+		pods := []*v1.Pod{
+			pdPod("prefill-rs1", "rs1", "prefill", "0"),
+			pdPod("decode-rs1", "rs1", "decode", "0"),
+			pdPod("prefill-rs2", "rs2", "prefill", "0"),
+			pdPod("decode-rs2-a", "rs2", "decode", "0"),
+			pdPod("decode-rs2-b", "rs2", "decode", "1"),
+		}
+		assert.True(t, HasEligibleRoleset(pods))
+		eligible := eligiblePDRolesets(pods)
+		assert.Contains(t, eligible, "rs1")
+		assert.Contains(t, eligible, "rs2")
+	})
+
+	t.Run("only prefill not eligible", func(t *testing.T) {
+		pods := []*v1.Pod{pdPod("prefill-only", "rs1", "prefill", "0")}
+		assert.False(t, HasEligibleRoleset(pods))
+	})
+
+	t.Run("only decode not eligible", func(t *testing.T) {
+		pods := []*v1.Pod{pdPod("decode-only", "rs1", "decode", "0")}
+		assert.False(t, HasEligibleRoleset(pods))
+	})
+
+	t.Run("mixed fleet sizes both eligible with one prefill and one decode", func(t *testing.T) {
+		// Mirrors production: 9svsx has more replicas than v8h7g; both should route.
+		pods := []*v1.Pod{
+			pdPod("9svsx-prefill-0", "vllm-qwen3-8b-tp-roleset-9svsx", "prefill", "0"),
+			pdPod("9svsx-prefill-1", "vllm-qwen3-8b-tp-roleset-9svsx", "prefill", "1"),
+			pdPod("9svsx-decode-0", "vllm-qwen3-8b-tp-roleset-9svsx", "decode", "0"),
+			pdPod("9svsx-decode-1", "vllm-qwen3-8b-tp-roleset-9svsx", "decode", "1"),
+			pdPod("9svsx-decode-2", "vllm-qwen3-8b-tp-roleset-9svsx", "decode", "2"),
+			pdPod("v8h7g-prefill-0", "vllm-qwen3-8b-tp-roleset-v8h7g", "prefill", "0"),
+			pdPod("v8h7g-prefill-1", "vllm-qwen3-8b-tp-roleset-v8h7g", "prefill", "1"),
+			pdPod("v8h7g-decode-0", "vllm-qwen3-8b-tp-roleset-v8h7g", "decode", "0"),
+			pdPod("v8h7g-decode-1", "vllm-qwen3-8b-tp-roleset-v8h7g", "decode", "1"),
+		}
+		_, _, statuses, eligibleCount := DescribePDRolesetEligibility(pods)
+		assert.Equal(t, 2, eligibleCount)
+		assert.Len(t, statuses, 2)
+		byRoleset := map[string]bool{}
+		for _, s := range statuses {
+			byRoleset[s.Roleset] = s.Eligible
+		}
+		assert.True(t, byRoleset["vllm-qwen3-8b-tp-roleset-9svsx"])
+		assert.True(t, byRoleset["vllm-qwen3-8b-tp-roleset-v8h7g"])
+	})
+}
+
+func TestPrefillPodsFromEligibleRolesets(t *testing.T) {
+	pods := []*v1.Pod{
+		pdPod("prefill-rs1", "rs1", "prefill", "0"),
+		pdPod("decode-rs1", "rs1", "decode", "0"),
+		pdPod("prefill-rs2", "rs2", "prefill", "0"),
+		pdPod("decode-rs2-a", "rs2", "decode", "0"),
+		pdPod("decode-rs2-b", "rs2", "decode", "1"),
+	}
+	out := prefillPodsFromEligibleRolesets(pods)
+	assert.Len(t, out, 2)
+	names := []string{out[0].Name, out[1].Name}
+	assert.ElementsMatch(t, []string{"prefill-rs1", "prefill-rs2"}, names)
+}

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -442,6 +442,14 @@ func (s *Server) selectTargetPod(ctx context.Context, routeCtx *types.RoutingCon
 		return "", fmt.Errorf("no ready pods for routing")
 	}
 
+	if routeCtx.Algorithm == routing.RouterPD {
+		engine, err := routing.ValidateAndGetLLMEngine(readyPods)
+		if err != nil {
+			return "", fmt.Errorf("engine validation failed for request %s: %w", routeCtx.RequestID, err)
+		}
+		routeCtx.Engine = engine
+	}
+
 	router, err := routing.Select(routeCtx)
 	if err != nil {
 		return "", err

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -426,17 +426,13 @@ func (s *Server) selectTargetPod(ctx context.Context, routeCtx *types.RoutingCon
 	_, span = tracer.Start(ctx, "selectTargetPod")
 	defer span.End()
 
-	router, err := routing.Select(routeCtx)
-	if err != nil {
-		return "", err
-	}
-
 	if pods.Len() == 0 {
 		return "", fmt.Errorf("no pods for routing")
 	}
 	readyPods := utils.FilterRoutablePods(pods.All())
 
 	// filter pod by header 'external-filter'
+	var err error
 	readyPods, err = utils.FilterPodsByLabelSelector(readyPods, externalFilterExpr)
 	if err != nil {
 		return "", fmt.Errorf("filter pods by label selector failed: %v", err)
@@ -445,7 +441,16 @@ func (s *Server) selectTargetPod(ctx context.Context, routeCtx *types.RoutingCon
 	if len(readyPods) == 0 {
 		return "", fmt.Errorf("no ready pods for routing")
 	}
-	if len(readyPods) == 1 && len(utils.GetPortsForPod(readyPods[0])) <= 1 {
+	if routeCtx.Algorithm == routing.RouterPD && !routing.HasEligibleRoleset(readyPods) {
+		return "", fmt.Errorf("no complete prefill-decode roleset available")
+	}
+
+	router, err := routing.Select(routeCtx)
+	if err != nil {
+		return "", err
+	}
+
+	if len(readyPods) == 1 && len(utils.GetPortsForPod(readyPods[0])) <= 1 && routeCtx.Algorithm != routing.RouterPD {
 		routeCtx.SetTargetPod(readyPods[0])
 		return routeCtx.TargetAddress(), nil
 	}
@@ -613,8 +618,10 @@ func (s *Server) responseErrorProcessing(ctx context.Context, routingCtx *types.
 func (s *Server) responseErrorProcessingWithHeaders(ctx context.Context, routingCtx *types.RoutingContext, headers []*configPb.HeaderValueOption, respErrorCode int,
 	model, requestID, errMsg string) *extProcPb.ProcessingResponse {
 	var httprouteErr error
-	// if use pd route Algorithm, we don't check httproute status
-	if routingCtx == nil || routingCtx.Algorithm != routing.RouterPD {
+	// Match HandleRequestBody: HTTPRoute is only used when no explicit routing algorithm is set.
+	// Do not validate HTTPRoute on errors for least-request, pd, random, etc. (avoids misleading
+	// "httproute not found" appended to real upstream errors like 404).
+	if routingCtx == nil || routingCtx.Algorithm == routing.RouterNotSet {
 		httprouteErr = s.validateHTTPRouteStatus(ctx, model)
 	}
 

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -441,9 +441,6 @@ func (s *Server) selectTargetPod(ctx context.Context, routeCtx *types.RoutingCon
 	if len(readyPods) == 0 {
 		return "", fmt.Errorf("no ready pods for routing")
 	}
-	if routeCtx.Algorithm == routing.RouterPD && !routing.HasEligibleRoleset(readyPods) {
-		return "", fmt.Errorf("no complete prefill-decode roleset available")
-	}
 
 	router, err := routing.Select(routeCtx)
 	if err != nil {

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -74,7 +74,7 @@ func Test_ValidateRoutingStrategy(t *testing.T) {
 			expectedValidation: false,
 		},
 	}
-	cache.NewForTest()
+	cache.InitForTest()
 	routing.Init()
 	for _, tt := range tests {
 		_, currentValidation := routing.Validate(tt.routingStrategy)
@@ -581,29 +581,6 @@ func Test_selectTargetPod(t *testing.T) {
 			mockRouter.AssertExpectations(subtest)
 		})
 	}
-}
-
-func Test_selectTargetPod_PDIncompleteRoleset(t *testing.T) {
-	routing.Init()
-	server := &Server{}
-	routeCtx := types.NewRoutingContext(context.Background(), routing.RouterPD, "test-model", "test-message", "test-request", "test-user")
-	pods := &utils.PodArray{Pods: []*v1.Pod{{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "prefill-only",
-			Labels: map[string]string{
-				"roleset-name": "rs1",
-				"role-name":    "prefill",
-			},
-		},
-		Status: v1.PodStatus{
-			PodIP:      "1.2.3.4",
-			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
-		},
-	}}}
-
-	_, err := server.selectTargetPod(context.Background(), routeCtx, pods, "")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no complete prefill-decode roleset")
 }
 
 func TestValidateHTTPRouteStatus(t *testing.T) {

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -583,6 +583,29 @@ func Test_selectTargetPod(t *testing.T) {
 	}
 }
 
+func Test_selectTargetPod_PDIncompleteRoleset(t *testing.T) {
+	routing.Init()
+	server := &Server{}
+	routeCtx := types.NewRoutingContext(context.Background(), routing.RouterPD, "test-model", "test-message", "test-request", "test-user")
+	pods := &utils.PodArray{Pods: []*v1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-only",
+			Labels: map[string]string{
+				"roleset-name": "rs1",
+				"role-name":    "prefill",
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP:      "1.2.3.4",
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+		},
+	}}}
+
+	_, err := server.selectTargetPod(context.Background(), routeCtx, pods, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no complete prefill-decode roleset")
+}
+
 func TestValidateHTTPRouteStatus(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -906,6 +929,21 @@ func Test_responseErrorProcessing_ErrorCodeAndMessage(t *testing.T) {
 		mockGW.AssertExpectations(t)
 		mockGWV1.AssertExpectations(t)
 		mockHTTP.AssertExpectations(t)
+	})
+
+	t.Run("explicit routing skips httproute on error path", func(t *testing.T) {
+		mockGW := &MockGatewayClient{}
+		s := &Server{gatewayClient: mockGW}
+		rctx := types.NewRoutingContext(context.Background(), routing.RouterLeastRequest, "m", "", "rid", "")
+		out := s.responseErrorProcessingWithHeaders(context.Background(), rctx, nil, 404, "m", "rid", `{"detail":"Not Found"}`)
+		ir := out.GetImmediateResponse()
+		if assert.NotNil(t, ir) {
+			var parsed map[string]any
+			assert.NoError(t, json.Unmarshal([]byte(ir.GetBody()), &parsed))
+			errObj := parsed["error"].(map[string]any)
+			assert.Equal(t, `{"detail":"Not Found"}`, errObj["message"])
+		}
+		mockGW.AssertNotCalled(t, "GatewayV1")
 	})
 
 	t.Run("503 maps to service_unavailable", func(t *testing.T) {

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/constants"
 	routing "github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
@@ -581,6 +582,65 @@ func Test_selectTargetPod(t *testing.T) {
 			mockRouter.AssertExpectations(subtest)
 		})
 	}
+}
+
+func Test_selectTargetPod_PDEngineValidation(t *testing.T) {
+	ready := func(name, ip, engine string) *v1.Pod {
+		labels := map[string]string{}
+		if engine != "" {
+			labels[constants.ModelLabelEngine] = engine
+		}
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+			Status: v1.PodStatus{
+				PodIP:      ip,
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			},
+		}
+	}
+
+	t.Run("rejects mismatched engines before Route", func(t *testing.T) {
+		mockRouter := new(mockRouter)
+		routing.Register(routing.RouterPD, func() (types.Router, error) {
+			return mockRouter, nil
+		})
+		routing.Init()
+
+		server := &Server{}
+		routeCtx := types.NewRoutingContext(context.Background(), routing.RouterPD, "test-model", "msg", "req-engine", "user")
+		pods := &utils.PodArray{Pods: []*v1.Pod{
+			ready("prefill-1", "10.0.0.1", "vllm"),
+			ready("decode-1", "10.0.0.2", "sglang"),
+		}}
+
+		_, err := server.selectTargetPod(context.Background(), routeCtx, pods, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "engine validation failed")
+		assert.Contains(t, err.Error(), "inconsistent LLM engines")
+		mockRouter.AssertNotCalled(t, "Route", mock.Anything, mock.Anything)
+	})
+
+	t.Run("sets engine on routing context when consistent", func(t *testing.T) {
+		mockRouter := new(mockRouter)
+		routing.Register(routing.RouterPD, func() (types.Router, error) {
+			return mockRouter, nil
+		})
+		routing.Init()
+		mockRouter.On("Route", mock.Anything, mock.Anything).Return("10.0.0.2:8000", nil)
+
+		server := &Server{}
+		routeCtx := types.NewRoutingContext(context.Background(), routing.RouterPD, "test-model", "msg", "req-engine-ok", "user")
+		pods := &utils.PodArray{Pods: []*v1.Pod{
+			ready("prefill-1", "10.0.0.1", "vllm"),
+			ready("decode-1", "10.0.0.2", "vllm"),
+		}}
+
+		addr, err := server.selectTargetPod(context.Background(), routeCtx, pods, "")
+		assert.NoError(t, err)
+		assert.Equal(t, "10.0.0.2:8000", addr)
+		assert.Equal(t, "vllm", routeCtx.Engine)
+		mockRouter.AssertExpectations(t)
+	})
 }
 
 func TestValidateHTTPRouteStatus(t *testing.T) {

--- a/test/e2e/pd_bucketing_test.go
+++ b/test/e2e/pd_bucketing_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/vllm-project/aibrix/pkg/utils"
+)
+
+const (
+	bucketShortStorm    = "mock-llama2-7b-pd-bucket-short"
+	bucketMediumStorm   = "mock-llama2-7b-pd-bucket-medium"
+	bucketCombinedStorm = "mock-llama2-pd-bkt-comb"
+)
+
+// promptWithTokenLength returns a string that tokenizes to exactly tokenCount tokens
+// using the same cl100k_base tokenizer as the gateway PD router.
+func promptWithTokenLength(t *testing.T, tokenCount int) string {
+	t.Helper()
+	s := ""
+	for len(s) < 4096 {
+		tokens, err := utils.TokenizeInputText(s)
+		require.NoError(t, err)
+		if len(tokens) == tokenCount {
+			return s
+		}
+		s += "a"
+	}
+	t.Fatalf("failed to build prompt with %d tokens", tokenCount)
+	return ""
+}
+
+func assertPDBucketingRoute(t *testing.T, prompt, stormName string, expectCombined bool) {
+	t.Helper()
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+
+	chatCompletion, err := client.Chat.Completions.New(context.TODO(), openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage(prompt),
+		},
+		Model: modelNameVLLMBucket,
+	})
+	require.NoError(t, err, "PD bucketing chat completion failed for storm %s", stormName)
+	assert.Equal(t, modelNameVLLMBucket, chatCompletion.Model)
+
+	decodePod := dst.Header.Get("target-pod")
+	prefillPod := dst.Header.Get("prefill-target-pod")
+	require.NotEmpty(t, decodePod, "target-pod header must be set")
+
+	if expectCombined {
+		assert.Empty(t, prefillPod, "combined routing should not set prefill-target-pod")
+		assert.True(t, strings.Contains(decodePod, bucketCombinedStorm),
+			"expected combined pod, got decode=%s", decodePod)
+	} else {
+		assert.NotEmpty(t, prefillPod, "prefill-target-pod header must be set for PD routing")
+		assert.True(t, strings.Contains(prefillPod, stormName),
+			"prefill pod %s should belong to storm %s", prefillPod, stormName)
+		assert.True(t, strings.Contains(decodePod, stormName),
+			"decode pod %s should belong to storm %s", decodePod, stormName)
+		assert.NotEqual(t, prefillPod, decodePod)
+	}
+
+	t.Logf("storm=%s combined=%v — prefill: %s, decode: %s", stormName, expectCombined, prefillPod, decodePod)
+}
+
+// TestPDDisaggregationVLLMBucketDecodeDownFallbackToCombined verifies that when the
+// medium-storm decode pod is deleted, a prompt of 20 tokens (which matches the 16–32
+// bucket) falls back to the combined pod instead of erroring or cross-routing.
+func TestPDDisaggregationVLLMBucketDecodeDownFallbackToCombined(t *testing.T) {
+	waitForPDDisaggregationRouting(t, modelNameVLLMBucket)
+
+	mediumPrompt := promptWithTokenLength(t, 20)
+	mediumTokens, err := utils.TokenizeInputText(mediumPrompt)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(mediumTokens), 16)
+	require.LessOrEqual(t, len(mediumTokens), 32)
+
+	ctx := context.Background()
+	k8sClient, _ := initializeClient(ctx, t)
+
+	initialPods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{})
+	require.NoError(t, err)
+	initialCount := len(initialPods.Items)
+
+	decodePods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{
+		LabelSelector: "role-name=decode,storm-service-name=" + bucketMediumStorm,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, decodePods.Items, "expected at least one decode pod in medium storm")
+
+	podToDelete := decodePods.Items[0].Name
+	t.Logf("deleting medium-storm decode pod: %s", podToDelete)
+	require.NoError(t, k8sClient.CoreV1().Pods("default").Delete(ctx, podToDelete, v1.DeleteOptions{}))
+
+	t.Cleanup(func() {
+		validateAllPodsAreReady(t, k8sClient, initialCount)
+		waitForPDDisaggregationRouting(t, modelNameVLLMBucket)
+		t.Logf("medium-storm decode pod %s has been recreated", podToDelete)
+	})
+
+	// Poll until the gateway observes the deletion and routes the medium prompt to combined.
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+				Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage(mediumPrompt)},
+				Model:    modelNameVLLMBucket,
+			})
+			if err != nil {
+				t.Logf("waiting for fallback routing: %v", err)
+				return false, nil
+			}
+			prefillPod := dst.Header.Get("prefill-target-pod")
+			decodePod := dst.Header.Get("target-pod")
+			if prefillPod != "" || !strings.Contains(decodePod, bucketCombinedStorm) {
+				t.Logf("not yet routing to combined: prefill=%s decode=%s", prefillPod, decodePod)
+				return false, nil
+			}
+			return true, nil
+		})
+	require.NoError(t, err, "medium prompt should fall back to combined pod when medium-storm decode is down")
+
+	prefillPod := dst.Header.Get("prefill-target-pod")
+	decodePod := dst.Header.Get("target-pod")
+	assert.Empty(t, prefillPod, "combined routing should not set prefill-target-pod")
+	assert.True(t, strings.Contains(decodePod, bucketCombinedStorm),
+		"expected combined pod, got decode=%s", decodePod)
+	t.Logf("fallback confirmed — decode: %s", decodePod)
+}
+
+// TestPDDisaggregationVLLMPromptLengthBucketing verifies that with
+// AIBRIX_PROMPT_LENGTH_BUCKETING enabled, the gateway routes prompts to the
+// correct StormService bucket: 0–15 and 16–32 use matching prefill/decode
+// rolesets; prompts above 32 fall back to the combined role.
+func TestPDDisaggregationVLLMPromptLengthBucketing(t *testing.T) {
+	waitForPDDisaggregationRouting(t, modelNameVLLMBucket)
+
+	shortPrompt := promptWithTokenLength(t, 10)
+	mediumPrompt := promptWithTokenLength(t, 20)
+	longPrompt := promptWithTokenLength(t, 40)
+
+	shortTokens, err := utils.TokenizeInputText(shortPrompt)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(shortTokens), 15)
+
+	mediumTokens, err := utils.TokenizeInputText(mediumPrompt)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(mediumTokens), 16)
+	require.LessOrEqual(t, len(mediumTokens), 32)
+
+	longTokens, err := utils.TokenizeInputText(longPrompt)
+	require.NoError(t, err)
+	require.Greater(t, len(longTokens), 32)
+
+	waitForPDCombinedRouting(t, modelNameVLLMBucket, bucketCombinedStorm, longPrompt)
+
+	assertPDBucketingRoute(t, shortPrompt, bucketShortStorm, false)
+	assertPDBucketingRoute(t, mediumPrompt, bucketMediumStorm, false)
+	assertPDBucketingRoute(t, longPrompt, bucketCombinedStorm, true)
+}

--- a/test/e2e/pd_test.go
+++ b/test/e2e/pd_test.go
@@ -130,6 +130,7 @@ func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, modelName, 
 
 	t.Cleanup(func() {
 		validateAllPodsAreReady(t, k8sClient, initialCount)
+		waitForPDDisaggregationRouting(t, modelName)
 		t.Logf("%s pod %s has been recreated and cluster is back to %d pods", roleLabel, podToDelete, initialCount)
 	})
 
@@ -184,6 +185,8 @@ func TestPDDisaggregationVLLMDecodePodFailure(t *testing.T) {
 // PD router consistently selects valid prefill/decode pod pairs across requests.
 func TestPDDisaggregationVLLMMultipleRequests(t *testing.T) {
 	const iterations = 5
+
+	waitForPDDisaggregationRouting(t, modelNameVLLM)
 
 	var dst *http.Response
 	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))

--- a/test/e2e/pd_test.go
+++ b/test/e2e/pd_test.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // assertPDDisaggregation sends a single PD-routed chat completion for the given model and
@@ -99,6 +101,106 @@ func TestPDDisaggregationTRTLLM(t *testing.T) {
 		"Say this is a test for TensorRT-LLM PD disaggregation",
 		"TRT-LLM PD chat completion request failed",
 		"TRT-LLM")
+}
+
+// TestPDDisaggregationVLLMPrefillPodFailure verifies that with 2x1P1D setup, taking down one
+// prefill pod still allows 10 requests to succeed via the remaining complete roleset.
+func TestPDDisaggregationVLLMPrefillPodFailure(t *testing.T) {
+	ctx := context.Background()
+	k8sClient, _ := initializeClient(ctx, t)
+
+	initialPods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{})
+	require.NoError(t, err)
+	initialCount := len(initialPods.Items)
+
+	prefillPods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{
+		LabelSelector: "role-name=prefill",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, prefillPods.Items, "expected at least one prefill pod")
+
+	podToDelete := prefillPods.Items[0].Name
+	t.Logf("deleting prefill pod: %s", podToDelete)
+
+	require.NoError(t, k8sClient.CoreV1().Pods("default").Delete(ctx, podToDelete, v1.DeleteOptions{}))
+
+	t.Cleanup(func() {
+		validateAllPodsAreReady(t, k8sClient, initialCount)
+		t.Logf("prefill pod %s has been recreated and cluster is back to %d pods", podToDelete, initialCount)
+	})
+
+	// Give the gateway time to detect the pod is gone.
+	time.Sleep(3 * time.Second)
+
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+
+	for i := 0; i < 10; i++ {
+		_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				openai.UserMessage("PD prefill-pod-failure resilience test"),
+			},
+			Model: modelNameVLLM,
+		})
+		require.NoError(t, err, "request %d failed after prefill pod deletion", i)
+
+		decodePod := dst.Header.Get("target-pod")
+		prefillPod := dst.Header.Get("prefill-target-pod")
+		assert.NotEmpty(t, decodePod, "request %d: target-pod header must be set", i)
+		assert.NotEmpty(t, prefillPod, "request %d: prefill-target-pod header must be set", i)
+		assert.NotEqual(t, prefillPod, decodePod, "request %d: prefill and decode pods should differ", i)
+		t.Logf("request %d — prefill: %s, decode: %s", i, prefillPod, decodePod)
+	}
+}
+
+// TestPDDisaggregationVLLMDecodePodFailure verifies that with 2x1P1D setup, taking down one
+// decode pod still allows 10 requests to succeed via the remaining complete roleset.
+func TestPDDisaggregationVLLMDecodePodFailure(t *testing.T) {
+	ctx := context.Background()
+	k8sClient, _ := initializeClient(ctx, t)
+
+	initialPods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{})
+	require.NoError(t, err)
+	initialCount := len(initialPods.Items)
+
+	decodePods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{
+		LabelSelector: "role-name=decode",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, decodePods.Items, "expected at least one decode pod")
+
+	podToDelete := decodePods.Items[0].Name
+	t.Logf("deleting decode pod: %s", podToDelete)
+
+	require.NoError(t, k8sClient.CoreV1().Pods("default").Delete(ctx, podToDelete, v1.DeleteOptions{}))
+
+	t.Cleanup(func() {
+		validateAllPodsAreReady(t, k8sClient, initialCount)
+		t.Logf("decode pod %s has been recreated and cluster is back to %d pods", podToDelete, initialCount)
+	})
+
+	// Give the gateway time to detect the pod is gone.
+	time.Sleep(3 * time.Second)
+
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+
+	for i := 0; i < 10; i++ {
+		_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				openai.UserMessage("PD decode-pod-failure resilience test"),
+			},
+			Model: modelNameVLLM,
+		})
+		require.NoError(t, err, "request %d failed after decode pod deletion", i)
+
+		decodePod := dst.Header.Get("target-pod")
+		prefillPod := dst.Header.Get("prefill-target-pod")
+		assert.NotEmpty(t, decodePod, "request %d: target-pod header must be set", i)
+		assert.NotEmpty(t, prefillPod, "request %d: prefill-target-pod header must be set", i)
+		assert.NotEqual(t, prefillPod, decodePod, "request %d: prefill and decode pods should differ", i)
+		t.Logf("request %d — prefill: %s, decode: %s", i, prefillPod, decodePod)
+	}
 }
 
 // TestPDDisaggregationVLLMMultipleRequests sends several requests to verify that the

--- a/test/e2e/pd_test.go
+++ b/test/e2e/pd_test.go
@@ -103,9 +103,10 @@ func TestPDDisaggregationTRTLLM(t *testing.T) {
 		"TRT-LLM")
 }
 
-// TestPDDisaggregationVLLMPrefillPodFailure verifies that with 2x1P1D setup, taking down one
-// prefill pod still allows 10 requests to succeed via the remaining complete roleset.
-func TestPDDisaggregationVLLMPrefillPodFailure(t *testing.T) {
+// assertPDDisaggregationAfterPodDeletion deletes one pod matching roleLabel, waits for the
+// gateway to notice, then verifies PD-routed requests still succeed via remaining pods.
+func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, prompt, requestErrMsg string) {
+	t.Helper()
 	ctx := context.Background()
 	k8sClient, _ := initializeClient(ctx, t)
 
@@ -113,20 +114,20 @@ func TestPDDisaggregationVLLMPrefillPodFailure(t *testing.T) {
 	require.NoError(t, err)
 	initialCount := len(initialPods.Items)
 
-	prefillPods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{
-		LabelSelector: "role-name=prefill",
+	rolePods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{
+		LabelSelector: "role-name=" + roleLabel,
 	})
 	require.NoError(t, err)
-	require.NotEmpty(t, prefillPods.Items, "expected at least one prefill pod")
+	require.NotEmpty(t, rolePods.Items, "expected at least one %s pod", roleLabel)
 
-	podToDelete := prefillPods.Items[0].Name
-	t.Logf("deleting prefill pod: %s", podToDelete)
+	podToDelete := rolePods.Items[0].Name
+	t.Logf("deleting %s pod: %s", roleLabel, podToDelete)
 
 	require.NoError(t, k8sClient.CoreV1().Pods("default").Delete(ctx, podToDelete, v1.DeleteOptions{}))
 
 	t.Cleanup(func() {
 		validateAllPodsAreReady(t, k8sClient, initialCount)
-		t.Logf("prefill pod %s has been recreated and cluster is back to %d pods", podToDelete, initialCount)
+		t.Logf("%s pod %s has been recreated and cluster is back to %d pods", roleLabel, podToDelete, initialCount)
 	})
 
 	// Give the gateway time to detect the pod is gone.
@@ -138,11 +139,11 @@ func TestPDDisaggregationVLLMPrefillPodFailure(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
 			Messages: []openai.ChatCompletionMessageParamUnion{
-				openai.UserMessage("PD prefill-pod-failure resilience test"),
+				openai.UserMessage(prompt),
 			},
 			Model: modelNameVLLM,
 		})
-		require.NoError(t, err, "request %d failed after prefill pod deletion", i)
+		require.NoError(t, err, requestErrMsg, i)
 
 		decodePod := dst.Header.Get("target-pod")
 		prefillPod := dst.Header.Get("prefill-target-pod")
@@ -153,54 +154,20 @@ func TestPDDisaggregationVLLMPrefillPodFailure(t *testing.T) {
 	}
 }
 
+// TestPDDisaggregationVLLMPrefillPodFailure verifies that with 2x1P1D setup, taking down one
+// prefill pod still allows 10 requests to succeed via the remaining complete roleset.
+func TestPDDisaggregationVLLMPrefillPodFailure(t *testing.T) {
+	assertPDDisaggregationAfterPodDeletion(t, "prefill",
+		"PD prefill-pod-failure resilience test",
+		"request %d failed after prefill pod deletion")
+}
+
 // TestPDDisaggregationVLLMDecodePodFailure verifies that with 2x1P1D setup, taking down one
 // decode pod still allows 10 requests to succeed via the remaining complete roleset.
 func TestPDDisaggregationVLLMDecodePodFailure(t *testing.T) {
-	ctx := context.Background()
-	k8sClient, _ := initializeClient(ctx, t)
-
-	initialPods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{})
-	require.NoError(t, err)
-	initialCount := len(initialPods.Items)
-
-	decodePods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{
-		LabelSelector: "role-name=decode",
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, decodePods.Items, "expected at least one decode pod")
-
-	podToDelete := decodePods.Items[0].Name
-	t.Logf("deleting decode pod: %s", podToDelete)
-
-	require.NoError(t, k8sClient.CoreV1().Pods("default").Delete(ctx, podToDelete, v1.DeleteOptions{}))
-
-	t.Cleanup(func() {
-		validateAllPodsAreReady(t, k8sClient, initialCount)
-		t.Logf("decode pod %s has been recreated and cluster is back to %d pods", podToDelete, initialCount)
-	})
-
-	// Give the gateway time to detect the pod is gone.
-	time.Sleep(3 * time.Second)
-
-	var dst *http.Response
-	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
-
-	for i := 0; i < 10; i++ {
-		_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
-			Messages: []openai.ChatCompletionMessageParamUnion{
-				openai.UserMessage("PD decode-pod-failure resilience test"),
-			},
-			Model: modelNameVLLM,
-		})
-		require.NoError(t, err, "request %d failed after decode pod deletion", i)
-
-		decodePod := dst.Header.Get("target-pod")
-		prefillPod := dst.Header.Get("prefill-target-pod")
-		assert.NotEmpty(t, decodePod, "request %d: target-pod header must be set", i)
-		assert.NotEmpty(t, prefillPod, "request %d: prefill-target-pod header must be set", i)
-		assert.NotEqual(t, prefillPod, decodePod, "request %d: prefill and decode pods should differ", i)
-		t.Logf("request %d — prefill: %s, decode: %s", i, prefillPod, decodePod)
-	}
+	assertPDDisaggregationAfterPodDeletion(t, "decode",
+		"PD decode-pod-failure resilience test",
+		"request %d failed after decode pod deletion")
 }
 
 // TestPDDisaggregationVLLMMultipleRequests sends several requests to verify that the

--- a/test/e2e/pd_test.go
+++ b/test/e2e/pd_test.go
@@ -103,9 +103,10 @@ func TestPDDisaggregationTRTLLM(t *testing.T) {
 		"TRT-LLM")
 }
 
-// assertPDDisaggregationAfterPodDeletion deletes one pod matching roleLabel, waits for the
-// gateway to notice, then verifies PD-routed requests still succeed via remaining pods.
-func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, prompt, requestErrMsg string) {
+// assertPDDisaggregationAfterPodDeletion deletes one pod for modelName and roleLabel,
+// waits for the gateway to notice, then verifies PD-routed requests still succeed via
+// remaining pods (requires at least two matching pods, i.e. 2x1P1D for that model).
+func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, modelName, prompt, requestErrMsg string) {
 	t.Helper()
 	ctx := context.Background()
 	k8sClient, _ := initializeClient(ctx, t)
@@ -114,14 +115,16 @@ func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, prompt, req
 	require.NoError(t, err)
 	initialCount := len(initialPods.Items)
 
+	labelSelector := "role-name=" + roleLabel + ",model.aibrix.ai/name=" + modelName
 	rolePods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{
-		LabelSelector: "role-name=" + roleLabel,
+		LabelSelector: labelSelector,
 	})
 	require.NoError(t, err)
-	require.NotEmpty(t, rolePods.Items, "expected at least one %s pod", roleLabel)
+	require.GreaterOrEqual(t, len(rolePods.Items), 2,
+		"expected at least two %s pods for model %s (2x1P1D); selector=%q", roleLabel, modelName, labelSelector)
 
 	podToDelete := rolePods.Items[0].Name
-	t.Logf("deleting %s pod: %s", roleLabel, podToDelete)
+	t.Logf("deleting %s pod for model %s: %s", roleLabel, modelName, podToDelete)
 
 	require.NoError(t, k8sClient.CoreV1().Pods("default").Delete(ctx, podToDelete, v1.DeleteOptions{}))
 
@@ -141,7 +144,7 @@ func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, prompt, req
 			Messages: []openai.ChatCompletionMessageParamUnion{
 				openai.UserMessage(prompt),
 			},
-			Model: modelNameVLLM,
+			Model: modelName,
 		})
 		require.NoError(t, err, requestErrMsg, i)
 
@@ -150,6 +153,13 @@ func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, prompt, req
 		assert.NotEmpty(t, decodePod, "request %d: target-pod header must be set", i)
 		assert.NotEmpty(t, prefillPod, "request %d: prefill-target-pod header must be set", i)
 		assert.NotEqual(t, prefillPod, decodePod, "request %d: prefill and decode pods should differ", i)
+		if roleLabel == "prefill" {
+			assert.NotEqual(t, podToDelete, prefillPod,
+				"request %d: should not route to deleted prefill pod %s", i, podToDelete)
+		} else {
+			assert.NotEqual(t, podToDelete, decodePod,
+				"request %d: should not route to deleted decode pod %s", i, podToDelete)
+		}
 		t.Logf("request %d — prefill: %s, decode: %s", i, prefillPod, decodePod)
 	}
 }
@@ -157,7 +167,7 @@ func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, prompt, req
 // TestPDDisaggregationVLLMPrefillPodFailure verifies that with 2x1P1D setup, taking down one
 // prefill pod still allows 10 requests to succeed via the remaining complete roleset.
 func TestPDDisaggregationVLLMPrefillPodFailure(t *testing.T) {
-	assertPDDisaggregationAfterPodDeletion(t, "prefill",
+	assertPDDisaggregationAfterPodDeletion(t, "prefill", modelNameVLLM,
 		"PD prefill-pod-failure resilience test",
 		"request %d failed after prefill pod deletion")
 }
@@ -165,7 +175,7 @@ func TestPDDisaggregationVLLMPrefillPodFailure(t *testing.T) {
 // TestPDDisaggregationVLLMDecodePodFailure verifies that with 2x1P1D setup, taking down one
 // decode pod still allows 10 requests to succeed via the remaining complete roleset.
 func TestPDDisaggregationVLLMDecodePodFailure(t *testing.T) {
-	assertPDDisaggregationAfterPodDeletion(t, "decode",
+	assertPDDisaggregationAfterPodDeletion(t, "decode", modelNameVLLM,
 		"PD decode-pod-failure resilience test",
 		"request %d failed after decode pod deletion")
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,14 +42,15 @@ import (
 )
 
 const (
-	gatewayURL      = "http://localhost:8888"
-	engineURL       = "http://localhost:8000"
-	apiKey          = "test-key-1234567890"
-	modelName       = "llama2-7b"
-	modelNameQwen3  = "qwen3-8b"
-	modelNameVLLM   = "llama2-7b-vllm"
-	modelNameSGLang = "llama2-7b-sglang"
-	modelNameTRTLLM = "llama2-7b-trtllm"
+	gatewayURL          = "http://localhost:8888"
+	engineURL           = "http://localhost:8000"
+	apiKey              = "test-key-1234567890"
+	modelName           = "llama2-7b"
+	modelNameQwen3      = "qwen3-8b"
+	modelNameVLLM       = "llama2-7b-vllm"
+	modelNameVLLMBucket = "llama2-7b-vllm-bucket"
+	modelNameSGLang     = "llama2-7b-sglang"
+	modelNameTRTLLM     = "llama2-7b-trtllm"
 )
 
 func initializeClient(ctx context.Context, t *testing.T) (*kubernetes.Clientset, *v1alpha1.Clientset) {
@@ -183,7 +185,7 @@ func validateInferenceWithClient(t *testing.T, client openai.Client, modelName s
 }
 
 func validateAllPodsAreReady(t *testing.T, client *kubernetes.Clientset, expectedPodCount int) {
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second,
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second,
 		true, func(ctx context.Context) (bool, error) {
 			podList, err := client.CoreV1().Pods("default").List(ctx, v1.ListOptions{})
 			if err != nil {
@@ -199,4 +201,66 @@ func validateAllPodsAreReady(t *testing.T, client *kubernetes.Clientset, expecte
 			return false, nil
 		})
 	assert.NoError(t, err, "timeout waiting for all pods to be ready")
+}
+
+// waitForPDDisaggregationRouting polls until the gateway can route a PD request for modelName.
+// Pod readiness alone is not enough: the gateway pod cache may lag after pod churn.
+func waitForPDDisaggregationRouting(t *testing.T, modelName string) {
+	t.Helper()
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second,
+		true, func(ctx context.Context) (bool, error) {
+			_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					openai.UserMessage("PD routing readiness check"),
+				},
+				Model: modelName,
+			})
+			if err != nil {
+				t.Logf("waiting for PD routing for model %s: %v", modelName, err)
+				return false, nil
+			}
+			prefillPod := dst.Header.Get("prefill-target-pod")
+			decodePod := dst.Header.Get("target-pod")
+			if prefillPod == "" || decodePod == "" || prefillPod == decodePod {
+				t.Logf("waiting for valid PD routing headers for model %s", modelName)
+				return false, nil
+			}
+			t.Logf("PD routing ready for model %s", modelName)
+			return true, nil
+		})
+	assert.NoError(t, err, "timeout waiting for PD routing to be ready for model %s", modelName)
+}
+
+// waitForPDCombinedRouting polls until the gateway routes a long prompt to a combined pod
+// (no prefill-target-pod header). Pod cache may lag behind Kubernetes readiness.
+func waitForPDCombinedRouting(t *testing.T, modelName, combinedStormName, longPrompt string) {
+	t.Helper()
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second,
+		true, func(ctx context.Context) (bool, error) {
+			_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					openai.UserMessage(longPrompt),
+				},
+				Model: modelName,
+			})
+			if err != nil {
+				t.Logf("waiting for combined PD routing for model %s: %v", modelName, err)
+				return false, nil
+			}
+			prefillPod := dst.Header.Get("prefill-target-pod")
+			decodePod := dst.Header.Get("target-pod")
+			if prefillPod != "" || decodePod == "" || !strings.Contains(decodePod, combinedStormName) {
+				t.Logf("waiting for combined routing for model %s: prefill=%s decode=%s", modelName, prefillPod, decodePod)
+				return false, nil
+			}
+			t.Logf("combined PD routing ready for model %s (decode=%s)", modelName, decodePod)
+			return true, nil
+		})
+	assert.NoError(t, err, "timeout waiting for combined PD routing for model %s", modelName)
 }


### PR DESCRIPTION
## Pull Request Description
This PR refactors and hardens the prefill-decode disaggregation routing path in several related areas:

### 1. Roleset Eligibility (`pd_roleset.go` — *new file*)
Extracts the "group pods by roleset and filter to complete pairs" logic into a dedicated file. Key additions include:
* `eligiblePDRolesets`: Returns rolesets that have ≥1 routable prefill and ≥1 routable decode pod.
* `HasEligibleRoleset`: Public helper used by the gateway for an early-exit check.
* `roleReplicaCardinality`: Counts distinct replicas using `role-replica-index` labels (correct for multi-node tensor-parallel setups where one logical replica spans several pods).
* `DescribePDRolesetEligibility`: Diagnostic view of per-roleset and fleet-wide replica counts.
* `pdPodNames`: Stable pod name string for structured logs.

### 2. Load-Imbalance Fixes (`pd_disaggregation.go`)
* **Decode imbalance (`loadImbalanceSelectDecodePod`):**
    * Pods that have no `RealtimeNumRequestsRunning` metric are now excluded from the spread calculation (they still contribute their pending-decode count to the scoring pass). This prevents a thundering herd to freshly restarted or scrape-gapped pods, which previously appeared artificially idle.
    * Throughput spread similarly excludes pods that have no metric, rather than treating missing throughput as 0.
    * `decodePodKVCacheUsagePerc` falls back from `kv_cache_usage_perc` to `gpu_cache_usage_perc` for backward-compatible KV cache utilization on older engines.
* **Prefill imbalance (`loadImbalanceSelectPrefillPod`):** Guard added so it only narrows decode candidates when a non-nil pod is actually selected.
* **Bucket filtering (`collectAndBucketPods`):** Prompt-length bucket overrides are now applied atomically. Both prefill and decode must have bucket-eligible pods before either list is replaced, keeping them roleset-aligned.
* **Combined-pod collection:** Combined (non-PD) pod scanning is gated on `bucketingEnabled` and refactored to use `PDRolePrefill`/`PDRoleDecode` constants.

### 3. Tracker Registration Ordering
* `filterPrefillDecodePods` now calls `AddPrefillRequest` and `AddPendingDecode` immediately after a pair is selected and before returning. 
* *Context:* Previously, `AddPendingDecode` was called in `Route` after `filterPrefillDecodePods` returned, so concurrent requests evaluating load imbalance saw stale counts. 
* The `defer RemovePendingDecode` is kept in `Route`. A cleanup call `RemovePrefillRequest` is added in the prefill-error path to avoid tracker leaks.

### 4. Prompt-Length Bucketing (`AIBRIX_PROMPT_LENGTH_BUCKETING`)

Adds routing support for deployments where pods are partitioned into prompt-length ranges (storms):

* **`filterPrefillDecodePods` restructured:** All bucketing logic now lives under a single `if aibrixPromptLengthBucketing` block with two sub-paths:
* **No bucket match:** If combined pods exist, pick one at random (no prefill HTTP call); otherwise, return an error instead of silently cross-routing to the wrong storm.
* **Bucket match + load imbalance:** If prefill/decode pods are hot while a combined pod is idle, score and pick the best combined pod.


* **Dead code removal:** Removed `modelUsesPromptLengthBucketing`. Its check was unreachable—if no bucket-matched pods exist, it means pods have explicit ranges that excluded the prompt, so the guard fires unconditionally.
* **Mock deployment config:** Added `vllm-pd-bucketing-config.yaml` for local and CI testing.
* **Documentation:** Updated `pd_readme.md` with bucketing flow, no-match guard rationale, and `modelUsesPromptLengthBucketing` explanation.

### 5. Tests

* `pd_disaggregation_test.go` — Unit tests for bucketing pod selection, no-match error, and combined-pod load-imbalance trigger.
* `pd_roleset_test.go` — Unit tests for roleset eligibility and replica cardinality.
* `test/e2e/pd_test.go` — E2E tests for vLLM, SGLang, and TRT-LLM PD routing; prefill/decode pod failure resilience (2×1P1D); multi-request consistency.
* `test/e2e/pd_bucketing_test.go` — E2E tests for bucket-matched routing, combined-pod fallback, and cross-bucket rejection.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>