### PR TITLE
fix(gateway): report async SGLang prefill outcomes

### DIFF
--- a/pkg/plugins/gateway/algorithms/pd/prefill/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default.go
@@ -35,7 +35,10 @@ import (
 )
 
 // trtllmEngine is kept local to avoid importing routingalgorithms (circular).
-const trtllmEngine = "trtllm"
+const (
+	trtllmEngine                = "trtllm"
+	prefillRequestSuccessStatus = "pd-prefill-request-success"
+)
 
 // DefaultExecutor is the standard PrefillExecutor. It owns the HTTP client and
 // the prefill-request tracker so that prefill logic can be tested in isolation
@@ -96,24 +99,40 @@ func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *
 	if handler.IsAsync() {
 		// SGLang uses a bootstrap handshake to coordinate KV transfer out-of-band;
 		// fire asynchronously and return immediately.
+		requestID := routingCtx.RequestID
+		requestTime := routingCtx.RequestTime
+		prefillStartTime := routingCtx.PrefillStartTime
+		prefillPodName := prefillPod.Name
+		prefillPodIP := prefillPod.Status.PodIP
+		asyncCtx := &types.RoutingContext{
+			Context:     routingCtx.Context,
+			RequestID:   requestID,
+			Model:       routingCtx.Model,
+			Engine:      routingCtx.Engine,
+			RequestTime: requestTime,
+			ReqHeaders:  cloneStringMap(routingCtx.ReqHeaders),
+		}
 		go func() {
-			defer e.tracker.RemovePrefillRequest(routingCtx.RequestID)
+			defer e.tracker.RemovePrefillRequest(requestID)
 
-			if _, err := e.executeHTTP(apiURL, routingCtx, payload); err != nil {
+			if _, err := e.executeHTTP(apiURL, asyncCtx, payload); err != nil {
 				klog.ErrorS(err, "prefill_request_failed",
-					"request_id", routingCtx.RequestID,
+					"request_id", requestID,
 					"llm_engine", llmEngine,
-					"prefill_pod", prefillPod.Name,
-					"prefill_pod_ip", prefillPod.Status.PodIP,
-					"elapsed", routingCtx.Elapsed(time.Now()))
+					"prefill_pod", prefillPodName,
+					"prefill_pod_ip", prefillPodIP,
+					"elapsed", time.Since(requestTime))
 				return
 			}
 
-			routingCtx.PrefillEndTime = time.Now()
+			metrics.EmitMetricToPrometheus(asyncCtx, nil, metrics.GatewayPrefillRequestSuccessTotal, &metrics.SimpleMetricValue{Value: 1.0},
+				map[string]string{"status": prefillRequestSuccessStatus, "status_code": "200"})
+
+			prefillEndTime := time.Now()
 			completionFields = append(completionFields,
-				"routing_time_taken", routingCtx.PrefillStartTime.Sub(routingCtx.RequestTime),
-				"prefill_time_taken", routingCtx.PrefillEndTime.Sub(routingCtx.PrefillStartTime),
-				"outstanding_prefill_requests", e.tracker.GetPrefillRequestCountsForPod(prefillPod.Name)-1)
+				"routing_time_taken", prefillStartTime.Sub(requestTime),
+				"prefill_time_taken", prefillEndTime.Sub(prefillStartTime),
+				"outstanding_prefill_requests", e.tracker.GetPrefillRequestCountsForPod(prefillPodName)-1)
 			klog.InfoS("prefill_request_end", completionFields...)
 		}()
 		return nil
@@ -217,4 +236,15 @@ func (e *DefaultExecutor) executeHTTP(url string, routingCtx *types.RoutingConte
 	}
 
 	return responseData, nil
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
 }

--- a/pkg/plugins/gateway/algorithms/pd/prefill/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"time"
 
@@ -105,12 +106,12 @@ func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *
 		prefillPodName := prefillPod.Name
 		prefillPodIP := prefillPod.Status.PodIP
 		asyncCtx := &types.RoutingContext{
-			Context:     routingCtx.Context,
+			Context:     context.WithoutCancel(routingCtx.Context),
 			RequestID:   requestID,
 			Model:       routingCtx.Model,
 			Engine:      routingCtx.Engine,
 			RequestTime: requestTime,
-			ReqHeaders:  cloneStringMap(routingCtx.ReqHeaders),
+			ReqHeaders:  maps.Clone(routingCtx.ReqHeaders),
 		}
 		go func() {
 			defer e.tracker.RemovePrefillRequest(requestID)
@@ -236,15 +237,4 @@ func (e *DefaultExecutor) executeHTTP(url string, routingCtx *types.RoutingConte
 	}
 
 	return responseData, nil
-}
-
-func cloneStringMap(src map[string]string) map[string]string {
-	if src == nil {
-		return nil
-	}
-	dst := make(map[string]string, len(src))
-	for key, value := range src {
-		dst[key] = value
-	}
-	return dst
 }

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -307,8 +307,10 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 			klog.ErrorS(err, pdRoutePrefillRequestError, "request_id", ctx.RequestID)
 			return "", fmt.Errorf("prefill request failed for request %s: %w", ctx.RequestID, err)
 		}
-		metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestSuccessTotal, &metrics.SimpleMetricValue{Value: 1.0},
-			map[string]string{"status": pdRoutePrefillRequestSuccess, "status_code": "200"})
+		if !engine.Resolve(llmEngine).IsAsync() {
+			metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestSuccessTotal, &metrics.SimpleMetricValue{Value: 1.0},
+				map[string]string{"status": pdRoutePrefillRequestSuccess, "status_code": "200"})
+		}
 	}
 
 	ctx.SetTargetPod(decodePod)

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -51,6 +51,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const testChatCompletionsPath = "/v1/chat/completions"
+
 // scorePrefillWithDefaultPolicy runs scorePrefillPods using the router's configured prefill policy (tests / benchmarks).
 func scorePrefillWithDefaultPolicy(r *pdRouter, ctx *types.RoutingContext, pods []*v1.Pod) (map[string]*Scores, float64, []uint64) {
 	return r.scorePrefillPods(ctx, pods, r.prefillPolicy)
@@ -201,7 +203,7 @@ func TestPDRouter_RouteDoesNotEmitAsyncPrefillSuccessBeforeHTTPCompletes(t *test
 	r.prefillExecutor = prefill.NewDefaultExecutor(client, tracker, prefillRequestTimeout)
 
 	ctx := types.NewRoutingContext(context.Background(), RouterPD, "test-model", "test", "async-prefill-success", "user")
-	ctx.ReqPath = "/v1/chat/completions"
+	ctx.ReqPath = testChatCompletionsPath
 	ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
 
 	result, err := r.Route(ctx, &utils.PodArray{Pods: pods})
@@ -288,7 +290,7 @@ func TestPDRouter_RouteRecordsAsyncPrefillFailureWithoutSuccess(t *testing.T) {
 	r.prefillExecutor = prefill.NewDefaultExecutor(client, tracker, prefillRequestTimeout)
 
 	ctx := types.NewRoutingContext(context.Background(), RouterPD, "test-model", "test", "async-prefill-fail", "user")
-	ctx.ReqPath = "/v1/chat/completions"
+	ctx.ReqPath = testChatCompletionsPath
 	ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
 
 	result, err := r.Route(ctx, &utils.PodArray{Pods: pods})
@@ -958,7 +960,7 @@ func TestDoPrefillRequest(t *testing.T) {
 		return &types.RoutingContext{
 			RequestID: "test-request",
 			Model:     "test-model",
-			ReqPath:   "/v1/chat/completions",
+			ReqPath:   testChatCompletionsPath,
 			ReqBody:   []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`),
 			ReqHeaders: map[string]string{
 				"Authorization": "Bearer test-1234",
@@ -1533,7 +1535,7 @@ func TestVLLMIntegrationWithTestServer(t *testing.T) {
 	routingCtx := &types.RoutingContext{
 		RequestID:  "integration-test",
 		Model:      "test-model",
-		ReqPath:    "/v1/chat/completions",
+		ReqPath:    testChatCompletionsPath,
 		ReqBody:    []byte(`{"messages":[{"role":"user","content":"test"}]}`),
 		ReqHeaders: map[string]string{"Authorization": "Bearer test"},
 		Context:    context.Background(),
@@ -1663,7 +1665,7 @@ func TestTensorRTIntegrationWithTestServer(t *testing.T) {
 	routingCtx := &types.RoutingContext{
 		RequestID:  "integration-test",
 		Model:      "test-model",
-		ReqPath:    "/v1/chat/completions",
+		ReqPath:    testChatCompletionsPath,
 		ReqBody:    []byte(`{"messages":[{"role":"user","content":"test"}]}`),
 		ReqHeaders: map[string]string{"Authorization": "Bearer test"},
 		Context:    context.Background(),

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -27,7 +27,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
@@ -202,7 +201,9 @@ func TestPDRouter_RouteDoesNotEmitAsyncPrefillSuccessBeforeHTTPCompletes(t *test
 	r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
 	r.prefillExecutor = prefill.NewDefaultExecutor(client, tracker, prefillRequestTimeout)
 
-	ctx := types.NewRoutingContext(context.Background(), RouterPD, "test-model", "test", "async-prefill-success", "user")
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+	defer cancelParent()
+	ctx := types.NewRoutingContext(parentCtx, RouterPD, "test-model", "test", "async-prefill-success", "user")
 	ctx.ReqPath = testChatCompletionsPath
 	ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
 
@@ -213,6 +214,7 @@ func TestPDRouter_RouteDoesNotEmitAsyncPrefillSuccessBeforeHTTPCompletes(t *test
 	assert.Equal(t, 0.0, testutil.ToFloat64(successCounter.WithLabelValues("", "test-model", pdRoutePrefillRequestSuccess, "200")))
 
 	<-prefillStarted
+	cancelParent()
 	close(releasePrefill)
 	releasedPrefill = true
 	assert.Eventually(t, func() bool {
@@ -233,15 +235,11 @@ func TestPDRouter_RouteRecordsAsyncPrefillFailureWithoutSuccess(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	var metricsMu sync.Mutex
-	metricCounts := map[string]float64{}
-	originalFn := metrics.IncrementCounterMetricFnForTest
-	metrics.IncrementCounterMetricFnForTest = func(name string, help string, value float64, labels []string, labelValues ...string) {
-		metricsMu.Lock()
-		defer metricsMu.Unlock()
-		metricCounts[name] += value
-	}
-	defer func() { metrics.IncrementCounterMetricFnForTest = originalFn }()
+	failCounter, cleanup := metrics.SetupCounterMetricsForTest(
+		metrics.GatewayPrefillRequestFailTotal,
+		[]string{"gateway_pod", "model", "status", "status_code"},
+	)
+	defer cleanup()
 
 	pods := []*v1.Pod{
 		{
@@ -298,14 +296,8 @@ func TestPDRouter_RouteRecordsAsyncPrefillFailureWithoutSuccess(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "127.0.0.2:8000", result)
 	assert.Eventually(t, func() bool {
-		metricsMu.Lock()
-		defer metricsMu.Unlock()
-		return metricCounts[metrics.GatewayPrefillRequestFailTotal] == 1.0
+		return testutil.ToFloat64(failCounter.WithLabelValues("", "test-model", "http_error", "500")) == 1.0
 	}, time.Second, 10*time.Millisecond)
-
-	metricsMu.Lock()
-	defer metricsMu.Unlock()
-	assert.Equal(t, 0.0, metricCounts[metrics.GatewayPrefillRequestSuccessTotal])
 }
 
 func listenerPort(t *testing.T, l net.Listener) string {

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -27,10 +27,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/vllm-project/aibrix/pkg/cache"
@@ -121,6 +123,195 @@ func TestPDRouter_Route(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPDRouter_RouteDoesNotEmitAsyncPrefillSuccessBeforeHTTPCompletes(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	prefillPort := listenerPort(t, l)
+
+	releasePrefill := make(chan struct{})
+	releasedPrefill := false
+	prefillStarted := make(chan struct{})
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(prefillStarted)
+		<-releasePrefill
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	ts.Listener = l
+	ts.Start()
+	defer ts.Close()
+	defer func() {
+		if !releasedPrefill {
+			close(releasePrefill)
+		}
+	}()
+
+	successCounter, cleanup := metrics.SetupCounterMetricsForTest(
+		metrics.GatewayPrefillRequestSuccessTotal,
+		[]string{"gateway_pod", "model", "status", "status_code"},
+	)
+	defer cleanup()
+
+	pods := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "prefill-1",
+				Labels: map[string]string{
+					PDRoleSetIdentifier:      "test",
+					PDRoleIdentifier:         "prefill",
+					LLMEngineIdentifier:      SGLangEngine,
+					constants.ModelLabelPort: prefillPort,
+				},
+			},
+			Status: v1.PodStatus{
+				PodIP:      "127.0.0.1",
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "decode-1",
+				Labels: map[string]string{
+					PDRoleSetIdentifier: "test",
+					PDRoleIdentifier:    "decode",
+					LLMEngineIdentifier: SGLangEngine,
+				},
+			},
+			Status: v1.PodStatus{
+				PodIP:      "127.0.0.2",
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			},
+		},
+	}
+
+	tracker := pd.NewPrefillRequestTracker()
+	client := &http.Client{}
+	r := pdRouter{
+		cache:                 cache.NewForTest(),
+		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
+		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
+		prefillRequestTracker: tracker,
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
+		httpClient:            client,
+		selectionCounts:       map[string]int64{},
+	}
+	r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
+	r.prefillExecutor = prefill.NewDefaultExecutor(client, tracker, prefillRequestTimeout)
+
+	ctx := types.NewRoutingContext(context.Background(), RouterPD, "test-model", "test", "async-prefill-success", "user")
+	ctx.ReqPath = "/v1/chat/completions"
+	ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
+
+	result, err := r.Route(ctx, &utils.PodArray{Pods: pods})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.2:8000", result)
+	assert.Equal(t, 0.0, testutil.ToFloat64(successCounter.WithLabelValues("", "test-model", pdRoutePrefillRequestSuccess, "200")))
+
+	<-prefillStarted
+	close(releasePrefill)
+	releasedPrefill = true
+	assert.Eventually(t, func() bool {
+		return testutil.ToFloat64(successCounter.WithLabelValues("", "test-model", pdRoutePrefillRequestSuccess, "200")) == 1.0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestPDRouter_RouteRecordsAsyncPrefillFailureWithoutSuccess(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	prefillPort := listenerPort(t, l)
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("server error"))
+	}))
+	ts.Listener = l
+	ts.Start()
+	defer ts.Close()
+
+	var metricsMu sync.Mutex
+	metricCounts := map[string]float64{}
+	originalFn := metrics.IncrementCounterMetricFnForTest
+	metrics.IncrementCounterMetricFnForTest = func(name string, help string, value float64, labels []string, labelValues ...string) {
+		metricsMu.Lock()
+		defer metricsMu.Unlock()
+		metricCounts[name] += value
+	}
+	defer func() { metrics.IncrementCounterMetricFnForTest = originalFn }()
+
+	pods := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "prefill-1",
+				Labels: map[string]string{
+					PDRoleSetIdentifier:      "test",
+					PDRoleIdentifier:         "prefill",
+					LLMEngineIdentifier:      SGLangEngine,
+					constants.ModelLabelPort: prefillPort,
+				},
+			},
+			Status: v1.PodStatus{
+				PodIP:      "127.0.0.1",
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "decode-1",
+				Labels: map[string]string{
+					PDRoleSetIdentifier: "test",
+					PDRoleIdentifier:    "decode",
+					LLMEngineIdentifier: SGLangEngine,
+				},
+			},
+			Status: v1.PodStatus{
+				PodIP:      "127.0.0.2",
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			},
+		},
+	}
+
+	tracker := pd.NewPrefillRequestTracker()
+	client := &http.Client{}
+	r := pdRouter{
+		cache:                 cache.NewForTest(),
+		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
+		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
+		prefillRequestTracker: tracker,
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
+		httpClient:            client,
+		selectionCounts:       map[string]int64{},
+	}
+	r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
+	r.prefillExecutor = prefill.NewDefaultExecutor(client, tracker, prefillRequestTimeout)
+
+	ctx := types.NewRoutingContext(context.Background(), RouterPD, "test-model", "test", "async-prefill-fail", "user")
+	ctx.ReqPath = "/v1/chat/completions"
+	ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
+
+	result, err := r.Route(ctx, &utils.PodArray{Pods: pods})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.2:8000", result)
+	assert.Eventually(t, func() bool {
+		metricsMu.Lock()
+		defer metricsMu.Unlock()
+		return metricCounts[metrics.GatewayPrefillRequestFailTotal] == 1.0
+	}, time.Second, 10*time.Millisecond)
+
+	metricsMu.Lock()
+	defer metricsMu.Unlock()
+	assert.Equal(t, 0.0, metricCounts[metrics.GatewayPrefillRequestSuccessTotal])
+}
+
+func listenerPort(t *testing.T, l net.Listener) string {
+	t.Helper()
+	_, port, err := net.SplitHostPort(l.Addr().String())
+	assert.NoError(t, err)
+	assert.NotEmpty(t, port)
+	return port
 }
 
 func TestFilterPrefillDecodePods(t *testing.T) {

--- a/pkg/plugins/gateway/algorithms/pd_readme.md
+++ b/pkg/plugins/gateway/algorithms/pd_readme.md
@@ -41,7 +41,7 @@ Route(ctx, readyPodList)
      ├─► [prefillPod != nil]
      │        pendingDecodeTracker.AddPendingDecode(requestID, decodePod)
      │        doPrefillRequest(ctx, prefillPod, engine)
-     │              ├─ SGLang   → async goroutine (bootstrap handshake)
+     │              ├─ SGLang   → async goroutine (bootstrap handshake; Route does not wait for completion)
      │              ├─ vLLM     → sync, extract kv_transfer_params from response
      │              └─ TRT-LLM  → sync, extract disaggregated_params from response
      │
@@ -274,6 +274,11 @@ Gateway ──POST (async goroutine)──────────────�
 Gateway ──POST /v1/... (updated body)─────────────────────────────────────────────► Decode Pod
 ```
 
+For SGLang, `Route()` returning a decode pod means the gateway has dispatched
+the asynchronous prefill worker, not that the prefill HTTP request has already
+completed. Prefill success/failure metrics are emitted by the async worker after
+the prefill HTTP request returns.
+
 ### TensorRT-LLM
 
 ```
@@ -430,7 +435,7 @@ SGLang uses a bootstrap mechanism for prefill/decode coordination. The port is r
 | Metric | When |
 |--------|------|
 | `GatewayPrefillRequestFailTotal` | Engine validation fail, pod filter fail, prefill HTTP error |
-| `GatewayPrefillRequestSuccessTotal` | Prefill HTTP succeeded |
+| `GatewayPrefillRequestSuccessTotal` | Prefill HTTP succeeded. For SGLang, this is emitted asynchronously after the background prefill request completes, not when `Route()` returns. |
 | `PDSelectedPrefillPodTotal` | Prefill pod selected (per pod label) |
 | `PDSelectedDecodePodTotal` | Decode pod selected (per pod label) |
 

--- a/pkg/plugins/gateway/gateway_rsp_body.go
+++ b/pkg/plugins/gateway/gateway_rsp_body.go
@@ -346,30 +346,34 @@ func (s *Server) requestEndHelper(routingCtx *types.RoutingContext, arrival time
 
 	if routingCtx.Algorithm == "pd" {
 		routingTime := routingCtx.PrefillStartTime.Sub(routingCtx.RequestTime)
-		prefillTime := routingCtx.PrefillEndTime.Sub(routingCtx.PrefillStartTime)
-		kvTransferTime := ttft - routingCtx.PrefillEndTime.Sub(routingCtx.RequestTime)
-		decodeTime := time.Since(routingCtx.PrefillEndTime)
 		fields = append(fields,
 			"routing_time_taken", routingTime,
-			"prefill_time_taken", prefillTime,
-			"kv_transfer_time_taken", kvTransferTime,
 			"ttft", ttft,
-			"decode_time_taken", decodeTime,
 		)
 		metrics.EmitMetricToPrometheus(routingCtx, targetPod, metrics.GatewayRoutingTimeBucketTotal, &metrics.SimpleMetricValue{Value: 1.0}, map[string]string{"bucket": durationBucketLabel(routingTime)})
-		metrics.EmitMetricToPrometheus(routingCtx, targetPod, metrics.GatewayPrefillTimeBucketTotal, &metrics.SimpleMetricValue{Value: 1.0}, map[string]string{"bucket": durationBucketLabel(prefillTime)})
-		metrics.EmitMetricToPrometheus(routingCtx, targetPod, metrics.GatewayKVTransferTimeBucketTotal, &metrics.SimpleMetricValue{Value: 1.0}, map[string]string{"bucket": durationBucketLabel(kvTransferTime)})
-		metrics.EmitMetricToPrometheus(routingCtx, targetPod, metrics.GatewayDecodeTimeBucketTotal, &metrics.SimpleMetricValue{Value: 1.0}, map[string]string{"bucket": durationBucketLabel(decodeTime)})
-		if ttft > ttftThreshold {
-			metrics.EmitMetricToPrometheus(routingCtx, nil, metrics.GatewayFirstTokenDelayOver1sTotal, &metrics.SimpleMetricValue{Value: 1.0}, map[string]string{
-				"request_id": requestID,
-				"p_bucket":   pBucket, "c_bucket": cBucket,
-				"routing_time_taken":     fmt.Sprintf("%v", routingTime),
-				"prefill_time_taken":     fmt.Sprintf("%v", prefillTime),
-				"kv_transfer_time_taken": fmt.Sprintf("%v", kvTransferTime),
-				"ttft":                   fmt.Sprintf("%v", ttft),
-				"decode_time_taken":      fmt.Sprintf("%v", decodeTime),
-			})
+		if !routingCtx.PrefillEndTime.IsZero() {
+			prefillTime := routingCtx.PrefillEndTime.Sub(routingCtx.PrefillStartTime)
+			kvTransferTime := ttft - routingCtx.PrefillEndTime.Sub(routingCtx.RequestTime)
+			decodeTime := time.Since(routingCtx.PrefillEndTime)
+			fields = append(fields,
+				"prefill_time_taken", prefillTime,
+				"kv_transfer_time_taken", kvTransferTime,
+				"decode_time_taken", decodeTime,
+			)
+			metrics.EmitMetricToPrometheus(routingCtx, targetPod, metrics.GatewayPrefillTimeBucketTotal, &metrics.SimpleMetricValue{Value: 1.0}, map[string]string{"bucket": durationBucketLabel(prefillTime)})
+			metrics.EmitMetricToPrometheus(routingCtx, targetPod, metrics.GatewayKVTransferTimeBucketTotal, &metrics.SimpleMetricValue{Value: 1.0}, map[string]string{"bucket": durationBucketLabel(kvTransferTime)})
+			metrics.EmitMetricToPrometheus(routingCtx, targetPod, metrics.GatewayDecodeTimeBucketTotal, &metrics.SimpleMetricValue{Value: 1.0}, map[string]string{"bucket": durationBucketLabel(decodeTime)})
+			if ttft > ttftThreshold {
+				metrics.EmitMetricToPrometheus(routingCtx, nil, metrics.GatewayFirstTokenDelayOver1sTotal, &metrics.SimpleMetricValue{Value: 1.0}, map[string]string{
+					"request_id": requestID,
+					"p_bucket":   pBucket, "c_bucket": cBucket,
+					"routing_time_taken":     fmt.Sprintf("%v", routingTime),
+					"prefill_time_taken":     fmt.Sprintf("%v", prefillTime),
+					"kv_transfer_time_taken": fmt.Sprintf("%v", kvTransferTime),
+					"ttft":                   fmt.Sprintf("%v", ttft),
+					"decode_time_taken":      fmt.Sprintf("%v", decodeTime),
+				})
+			}
 		}
 	} else if routingCtx.Algorithm != "" {
 		fields = append(fields, "routing_time_taken", routingCtx.GetRoutingDelay())

--- a/pkg/plugins/gateway/gateway_rsp_body_test.go
+++ b/pkg/plugins/gateway/gateway_rsp_body_test.go
@@ -23,9 +23,11 @@ import (
 	"time"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 )
@@ -318,6 +320,67 @@ func TestHandleResponseBody_NonStreamNoTokens(t *testing.T) {
 	assert.True(t, complete)
 	assert.NotNil(t, resp)
 	assert.NotNil(t, resp.GetResponseBody())
+}
+
+func TestHandleResponseBody_PDPrefillTimingMetricsRequirePrefillEndTime(t *testing.T) {
+	tests := []struct {
+		name             string
+		prefillEndOffset time.Duration
+		wantBucket       string
+		wantCount        float64
+	}{
+		{
+			name:       "skips prefill timing metric when prefill end is unset",
+			wantBucket: "0-1ms",
+			wantCount:  0.0,
+		},
+		{
+			name:             "emits prefill timing metric when prefill end is set",
+			prefillEndOffset: 50 * time.Millisecond,
+			wantBucket:       "50-100ms",
+			wantCount:        1.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefillCounter, cleanup := metrics.SetupCounterMetricsForTest(
+				metrics.GatewayPrefillTimeBucketTotal,
+				[]string{"gateway_pod", "model", "bucket"},
+			)
+			defer cleanup()
+
+			mockCache := &MockCache{Cache: cache.NewForTest()}
+			mockCache.On("DoneRequestTrace", mock.Anything, "test-req-id", "test-model", int64(10), int64(5), int64(0)).Maybe()
+
+			server := &Server{cache: mockCache}
+			requestTime := time.Now().Add(-200 * time.Millisecond)
+			prefillStartTime := requestTime.Add(20 * time.Millisecond)
+			routerCtx := types.NewRoutingContext(context.Background(), "pd", "test-model", "", "test-req-id", "")
+			routerCtx.ReqPath = PathChatCompletions
+			routerCtx.RequestTime = requestTime
+			routerCtx.PrefillStartTime = prefillStartTime
+			if tt.prefillEndOffset > 0 {
+				routerCtx.PrefillEndTime = prefillStartTime.Add(tt.prefillEndOffset)
+			}
+
+			req := &extProcPb.ProcessingRequest{
+				Request: &extProcPb.ProcessingRequest_ResponseBody{
+					ResponseBody: &extProcPb.HttpBody{
+						Body:        []byte(`{"model": "test-model", "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}}`),
+						EndOfStream: true,
+					},
+				},
+			}
+
+			resp, complete := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", false, 0, false)
+
+			assert.True(t, complete)
+			assert.NotNil(t, resp)
+			assert.Equal(t, tt.wantCount, testutil.ToFloat64(prefillCounter.WithLabelValues("", "test-model", tt.wantBucket)))
+			mockCache.AssertExpectations(t)
+		})
+	}
 }
 
 func TestHandleResponseBody_WithUserAndTPM(t *testing.T) {


### PR DESCRIPTION
## Summary
- Stop emitting `GatewayPrefillRequestSuccessTotal` from `Route()` for async SGLang prefill before the prefill HTTP request has completed.
- Emit SGLang async prefill success from the background prefill worker after the HTTP request succeeds; existing HTTP failure handling continues to emit fail metrics from the async path.
- Add regression tests for delayed async success and async HTTP failure, and document that SGLang success/failure metrics are emitted asynchronously.

## Notes
This addresses the metric/outcome visibility part of #2289 without changing SGLang's required async prefill/decode dispatch model. A separate bootstrap ACK or quick-fail gate would be needed for gateway-side fail-fast semantics.

## Test Plan
- go test ./pkg/plugins/gateway/algorithms -run 'TestPDRouter_Route(DoesNotEmitAsyncPrefillSuccessBeforeHTTPCompletes|RecordsAsyncPrefillFailureWithoutSuccess)' -count=1\n- go test ./pkg/plugins/gateway/algorithms -count=1\n- go test ./pkg/plugins/gateway/... -count=1\n- git diff --check