### PR TITLE
fix(mock): support Flask-HTTPAuth 4.8.1 auth flow

### DIFF
--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/**'
       - 'build/container/**'
       - 'config/**'
+      - 'development/app/**'
       - 'pkg/**'
       - 'test/**'
       - 'cmd/**'
@@ -21,6 +22,7 @@ on:
       - '.github/workflows/**'
       - 'build/container/**'
       - 'config/**'
+      - 'development/app/**'
       - 'pkg/**'
       - 'test/**'
       - 'cmd/**'
@@ -30,6 +32,26 @@ on:
       - 'go.sum'
 
 jobs:
+  mock-app-auth-test:
+    name: Mock app auth test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r development/app/requirements.txt pytest
+
+      - name: Run mock app auth tests
+        run: pytest development/app/test_auth_e2e.py -q
+
   build-images:
     name: Build image (${{ matrix.image }})
     runs-on: ubuntu-latest

--- a/development/app/app.py
+++ b/development/app/app.py
@@ -73,12 +73,14 @@ MOCK_REQUEST_DURATION_SECONDS = float(
 
 # Extract the api_key argument and prepare for authentication
 api_key = None
-try:
-    index = sys.argv.index("--api_key")
-    if index + 1 < len(sys.argv):
-        api_key = sys.argv[index + 1]
-except ValueError:
-    pass
+for api_key_arg in ("--api_key", "--api-key"):
+    try:
+        index = sys.argv.index(api_key_arg)
+        if index + 1 < len(sys.argv):
+            api_key = sys.argv[index + 1]
+            break
+    except ValueError:
+        pass
 
 auth = HTTPTokenAuth(scheme="Bearer")
 

--- a/development/app/app.py
+++ b/development/app/app.py
@@ -107,6 +107,12 @@ def auth_error(status):
     )
 
 
+def auth_required(func):
+    if api_key is None:
+        return func
+    return auth.login_required(func)
+
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -447,7 +453,7 @@ def ready():
 
 
 @app.route("/v1/models", methods=["GET"])
-@auth.login_required
+@auth_required
 def get_models():
     return jsonify({"object": "list", "data": models})
 
@@ -457,7 +463,7 @@ def get_models():
 # =============================================================================
 
 @app.route("/v1/load_lora_adapter", methods=["POST"])
-@auth.login_required
+@auth_required
 def load_lora_adapter():
     """
     Load a LoRA adapter. Matches vLLM error handling behavior.
@@ -504,7 +510,7 @@ def load_lora_adapter():
 
 
 @app.route("/v1/unload_lora_adapter", methods=["POST"])
-@auth.login_required
+@auth_required
 def unload_lora_adapter():
     """
     Unload a LoRA adapter. Matches vLLM error handling behavior.
@@ -538,7 +544,7 @@ def unload_lora_adapter():
 # =============================================================================
 
 @app.route("/v1/completions", methods=["POST"])
-@auth.login_required
+@auth_required
 def completion():
     try:
         prompt = request.json.get("prompt")
@@ -694,7 +700,7 @@ def completion():
 
 
 @app.route("/v1/chat/completions", methods=["POST"])
-@auth.login_required
+@auth_required
 def chat_completions():
     try:
         messages = request.json.get("messages")
@@ -951,7 +957,7 @@ def chat_completions():
 
 
 @app.route("/v1/audio/speech", methods=["POST"])
-@auth.login_required
+@auth_required
 def audio_speech():
     """
     Simulates the OpenAI text-to-speech endpoint.
@@ -1042,7 +1048,7 @@ def audio_speech():
 
 
 @app.route("/v1/audio/voices", methods=["GET"])
-@auth.login_required
+@auth_required
 def audio_voices():
     """
     Returns available TTS voices (vLLM-Omni compatible).
@@ -1056,7 +1062,7 @@ def audio_voices():
 
 
 @app.route("/v1/audio/transcriptions", methods=["POST"])
-@auth.login_required
+@auth_required
 def audio_transcriptions():
     """
     Simulates the OpenAI audio transcription endpoint.
@@ -1171,7 +1177,7 @@ def audio_transcriptions():
 
 
 @app.route("/v1/audio/translations", methods=["POST"])
-@auth.login_required
+@auth_required
 def audio_translations():
     """
     Simulates the OpenAI audio translation endpoint.
@@ -1281,7 +1287,7 @@ def audio_translations():
 
 
 @app.route("/v1/embeddings", methods=["POST"])
-@auth.login_required
+@auth_required
 def embeddings():
     try:
         input_data = request.json.get("input")
@@ -1428,7 +1434,7 @@ def embeddings():
 
 
 @app.route("/v1/images/generations", methods=["POST"])
-@auth.login_required
+@auth_required
 def images_generations():
     """
     Simulates the OpenAI image generation endpoint.
@@ -1486,7 +1492,7 @@ def images_generations():
 
 
 @app.route("/v1/video/generations", methods=["POST"])
-@auth.login_required
+@auth_required
 def video_generations():
     """
     Simulates a video generation endpoint.
@@ -1535,7 +1541,7 @@ def video_generations():
 
 
 @app.route("/v1/videos", methods=["POST"])
-@auth.login_required
+@auth_required
 def vllm_omni_videos():
     """
     Simulates the vLLM-Omni /v1/videos endpoint (Wan2.2).
@@ -1586,7 +1592,7 @@ def vllm_omni_videos():
 
 
 @app.route("/v1/rerank", methods=["POST"])
-@auth.login_required
+@auth_required
 def rerank():
     """
     Simulates the rerank endpoint (vLLM/JinaAI format).
@@ -1663,7 +1669,7 @@ def version():
 
 
 @app.route("/tokenize", methods=["POST"])
-@auth.login_required
+@auth_required
 def tokenize():
     """
     Simulates the tokenize endpoint.
@@ -1705,7 +1711,7 @@ def tokenize():
 
 
 @app.route("/detokenize", methods=["POST"])
-@auth.login_required
+@auth_required
 def detokenize():
     """
     Simulates the detokenize endpoint.

--- a/development/app/requirements.txt
+++ b/development/app/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies for mocked vLLM app
 flask
-Flask-HTTPAuth==4.8.0
+Flask-HTTPAuth==4.8.1
 tiktoken
 
 # Optional: only needed when running in Kubernetes

--- a/development/app/test_auth_e2e.py
+++ b/development/app/test_auth_e2e.py
@@ -36,7 +36,7 @@ def load_mock_app(monkeypatch, argv):
 class LiveServer:
     def __init__(self, app):
         self.server = make_server("127.0.0.1", 0, app)
-        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
 
     @property
     def base_url(self):
@@ -49,6 +49,7 @@ class LiveServer:
     def __exit__(self, exc_type, exc, tb):
         self.server.shutdown()
         self.thread.join(timeout=5)
+        self.server.server_close()
 
 
 def post_chat_completion(base_url, token=None):
@@ -91,5 +92,18 @@ def test_chat_completions_requires_matching_authorization_with_api_key(monkeypat
     assert missing_body["error"]["code"] == "invalid_api_key"
     assert wrong_status == 401
     assert wrong_body["error"]["code"] == "invalid_api_key"
+    assert correct_status == 200
+    assert correct_body["choices"][0]["message"]["content"]
+
+
+def test_chat_completions_requires_matching_authorization_with_api_key_alias(monkeypatch):
+    app = load_mock_app(monkeypatch, ["app.py", "--api-key", "secret"])
+
+    with LiveServer(app) as server:
+        missing_status, missing_body = post_chat_completion(server.base_url)
+        correct_status, correct_body = post_chat_completion(server.base_url, token="secret")
+
+    assert missing_status == 401
+    assert missing_body["error"]["code"] == "invalid_api_key"
     assert correct_status == 200
     assert correct_body["choices"][0]["message"]["content"]

--- a/development/app/test_auth_e2e.py
+++ b/development/app/test_auth_e2e.py
@@ -1,0 +1,95 @@
+import importlib.util
+import json
+import sys
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from werkzeug.serving import make_server
+
+
+APP_DIR = Path(__file__).parent
+APP_PATH = APP_DIR / "app.py"
+CHAT_COMPLETIONS_PAYLOAD = {
+    "model": "llama2-7b",
+    "messages": [{"role": "user", "content": "hello"}],
+}
+
+
+def load_mock_app(monkeypatch, argv):
+    module_name = "aibrix_mock_app_under_test"
+    monkeypatch.chdir(APP_DIR)
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("STANDALONE_MODE", "true")
+    monkeypatch.setenv("SIMULATION", "disabled")
+    monkeypatch.setenv("MOCK_REQUEST_DURATION_SECONDS", "0")
+    sys.modules.pop(module_name, None)
+
+    spec = importlib.util.spec_from_file_location(module_name, APP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module.app
+
+
+class LiveServer:
+    def __init__(self, app):
+        self.server = make_server("127.0.0.1", 0, app)
+        self.thread = threading.Thread(target=self.server.serve_forever)
+
+    @property
+    def base_url(self):
+        return f"http://127.0.0.1:{self.server.server_port}"
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.server.shutdown()
+        self.thread.join(timeout=5)
+
+
+def post_chat_completion(base_url, token=None):
+    headers = {"Content-Type": "application/json"}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(
+        f"{base_url}/v1/chat/completions",
+        data=json.dumps(CHAT_COMPLETIONS_PAYLOAD).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read().decode("utf-8"))
+
+
+def test_chat_completions_allows_missing_authorization_without_api_key(monkeypatch):
+    app = load_mock_app(monkeypatch, ["app.py"])
+
+    with LiveServer(app) as server:
+        status, body = post_chat_completion(server.base_url)
+
+    assert status == 200
+    assert body["choices"][0]["message"]["content"]
+
+
+def test_chat_completions_requires_matching_authorization_with_api_key(monkeypatch):
+    app = load_mock_app(monkeypatch, ["app.py", "--api_key", "secret"])
+
+    with LiveServer(app) as server:
+        missing_status, missing_body = post_chat_completion(server.base_url)
+        wrong_status, wrong_body = post_chat_completion(server.base_url, token="wrong")
+        correct_status, correct_body = post_chat_completion(server.base_url, token="secret")
+
+    assert missing_status == 401
+    assert missing_body["error"]["code"] == "invalid_api_key"
+    assert wrong_status == 401
+    assert wrong_body["error"]["code"] == "invalid_api_key"
+    assert correct_status == 200
+    assert correct_body["choices"][0]["message"]["content"]


### PR DESCRIPTION
## Summary
- Upgrade the mocked vLLM app to Flask-HTTPAuth 4.8.1.
- Skip HTTPAuth only when `--api_key` is not configured so missing Authorization headers remain accepted.
- Add an HTTP-level auth regression test for `/v1/chat/completions` with and without `--api_key`.

## Test Plan
- uv run --quiet --with-requirements development/app/requirements.txt --with pytest pytest development/app/test_auth_e2e.py -q
- uv run --quiet --with flask --with Flask-HTTPAuth==4.8.0 --with pytest pytest development/app/test_auth_e2e.py -q
- git diff --check -- development/app/app.py development/app/requirements.txt development/app/test_auth_e2e.py

Addresses #2191