### PR TITLE
feat(pd): roleset eligibility extraction, load-imbalance fixes, and tracker registration ordering

### DIFF
--- a/config/test/gateway/vtc-test-env-patch.yaml
+++ b/config/test/gateway/vtc-test-env-patch.yaml
@@ -24,3 +24,5 @@ spec:
           value: "1s"
         - name: AIBRIX_PREFIX_CACHE_BLOCK_SIZE
           value: "4"
+        - name: AIBRIX_PROMPT_LENGTH_BUCKETING
+          value: "true"

--- a/development/app/config/mock/kustomization.yaml
+++ b/development/app/config/mock/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
   - components.yaml
   - config-profile.yaml
   - vllm-pd-config.yaml
+  - vllm-pd-bucketing-config.yaml
   - sglang-pd-config.yaml
   - trtllm-pd-config.yaml
 

--- a/development/app/config/mock/vllm-pd-bucketing-config.yaml
+++ b/development/app/config/mock/vllm-pd-bucketing-config.yaml
@@ -1,0 +1,320 @@
+# vLLM PD prompt-length bucketing mock for e2e tests.
+#
+# Three StormServices share model llama2-7b-vllm-bucket:
+#   - bucket-short:  prefill+decode for prompts 0–15 tokens
+#   - bucket-medium: prefill+decode for prompts 16–32 tokens
+#   - pd-bkt-comb: "all" role (combined=true) for prompts >32 tokens
+#     StormService name is kept short so generated pod hostnames stay within the
+#     63-character Kubernetes DNS label limit.
+#
+# Requires AIBRIX_PROMPT_LENGTH_BUCKETING=true on the gateway plugin (see config/test/gateway).
+# Apply alongside components.yaml (provides mocked-app-sa and RBAC).
+---
+apiVersion: orchestration.aibrix.ai/v1alpha1
+kind: StormService
+metadata:
+  name: mock-llama2-pd-bkt-sht
+  namespace: default
+  labels:
+    model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+    model.aibrix.ai/port: "8000"
+spec:
+  replicas: 1
+  updateStrategy:
+    type: InPlaceUpdate
+  stateful: true
+  selector:
+    matchLabels:
+      app: "mock-llama2-pd-bkt-sht"
+  template:
+    metadata:
+      labels:
+        app: "mock-llama2-pd-bkt-sht"
+    spec:
+      roles:
+        - name: prefill
+          replicas: 1
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+                adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "promptLenBucketMinLength": 0,
+                          "promptLenBucketMaxLength": 15
+                        }
+                      }
+                    }
+                  }
+            spec:
+              serviceAccountName: mocked-app-sa
+              containers:
+                - name: llm-engine
+                  image: aibrix/vllm-mock:nightly
+                  ports:
+                    - containerPort: 8000
+                  env:
+                    - name: DEPLOYMENT_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['app']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: MY_POD_IP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+        - name: decode
+          replicas: 1
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+                adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "promptLenBucketMinLength": 0,
+                          "promptLenBucketMaxLength": 15
+                        }
+                      }
+                    }
+                  }
+            spec:
+              serviceAccountName: mocked-app-sa
+              containers:
+                - name: llm-engine
+                  image: aibrix/vllm-mock:nightly
+                  ports:
+                    - containerPort: 8000
+                  env:
+                    - name: DEPLOYMENT_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['app']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: MY_POD_IP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+---
+apiVersion: orchestration.aibrix.ai/v1alpha1
+kind: StormService
+metadata:
+  name: mock-llama2-pd-bkt-med
+  namespace: default
+  labels:
+    model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+    model.aibrix.ai/port: "8000"
+spec:
+  replicas: 1
+  updateStrategy:
+    type: InPlaceUpdate
+  stateful: true
+  selector:
+    matchLabels:
+      app: "mock-llama2-pd-bkt-med"
+  template:
+    metadata:
+      labels:
+        app: "mock-llama2-pd-bkt-med"
+    spec:
+      roles:
+        - name: prefill
+          replicas: 1
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+                adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "promptLenBucketMinLength": 16,
+                          "promptLenBucketMaxLength": 32
+                        }
+                      }
+                    }
+                  }
+            spec:
+              serviceAccountName: mocked-app-sa
+              containers:
+                - name: llm-engine
+                  image: aibrix/vllm-mock:nightly
+                  ports:
+                    - containerPort: 8000
+                  env:
+                    - name: DEPLOYMENT_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['app']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: MY_POD_IP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+        - name: decode
+          replicas: 1
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+                adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "promptLenBucketMinLength": 16,
+                          "promptLenBucketMaxLength": 32
+                        }
+                      }
+                    }
+                  }
+            spec:
+              serviceAccountName: mocked-app-sa
+              containers:
+                - name: llm-engine
+                  image: aibrix/vllm-mock:nightly
+                  ports:
+                    - containerPort: 8000
+                  env:
+                    - name: DEPLOYMENT_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['app']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: MY_POD_IP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+---
+apiVersion: orchestration.aibrix.ai/v1alpha1
+kind: StormService
+metadata:
+  name: mock-llama2-pd-bkt-comb
+  namespace: default
+  labels:
+    model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+    model.aibrix.ai/port: "8000"
+spec:
+  replicas: 1
+  updateStrategy:
+    type: InPlaceUpdate
+  stateful: true
+  selector:
+    matchLabels:
+      app: "mock-llama2-pd-bkt-comb"
+  template:
+    metadata:
+      labels:
+        app: "mock-llama2-pd-bkt-comb"
+    spec:
+      roles:
+        - name: all
+          replicas: 1
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: "llama2-7b-vllm-bucket"
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+                adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "promptLenBucketMinLength": 0,
+                          "combined": true
+                        }
+                      }
+                    }
+                  }
+            spec:
+              serviceAccountName: mocked-app-sa
+              containers:
+                - name: llm-engine
+                  image: aibrix/vllm-mock:nightly
+                  ports:
+                    - containerPort: 8000
+                  env:
+                    - name: DEPLOYMENT_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['app']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: MY_POD_IP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP

--- a/development/app/config/mock/vllm-pd-config.yaml
+++ b/development/app/config/mock/vllm-pd-config.yaml
@@ -1,9 +1,9 @@
 # vLLM PD (Prefill-Decode) disaggregation mock StormService for e2e tests.
 #
-# A single StormService replica with two roles ("prefill" and "decode") backed
-# by the vllm-mock image.  The gateway PD router pairs pods from the same
-# roleset (auto-assigned by the StormService controller as "roleset-name") and
-# routes the prefill probe to the prefill pod before sending the full request
+# Two StormService replicas (2x1P1D): each roleset has one prefill and one decode
+# pod backed by the vllm-mock image.  The gateway PD router pairs pods from the
+# same roleset (auto-assigned by the StormService controller as "roleset-name")
+# and routes the prefill probe to the prefill pod before sending the full request
 # to the decode pod.
 #
 # Apply alongside components.yaml (provides mocked-app-sa and RBAC).
@@ -16,7 +16,7 @@ metadata:
     model.aibrix.ai/name: "llama2-7b-vllm"
     model.aibrix.ai/port: "8000"
 spec:
-  replicas: 1
+  replicas: 2
   updateStrategy:
     type: InPlaceUpdate
   stateful: true

--- a/docs/source/features/pd-disaggregation.rst
+++ b/docs/source/features/pd-disaggregation.rst
@@ -86,7 +86,7 @@ How PD Disaggregation Works
 2. The KV cache is transferred to a **decode pod** via a high-speed interconnect (SHFS for GPU, NIXL for Neuron).
 3. The decode pod streams the generated tokens back to the client.
 
-If no matching prefill/decode pair is available (e.g. the prompt is outside all configured buckets), the request falls back to a **standard inference pod** that runs both phases locally.
+If no complete prefill/decode pair is available for the request's prompt length — for example the prompt is outside all configured buckets, or the matching roleset is incomplete because a decode pod is down — the request falls back to a **standard inference pod** (``combined: true``) that runs both phases locally, when one is configured and its prompt-length range matches.
 
 
 Supported Engines
@@ -125,8 +125,8 @@ The gateway identifies the role of each pod using two labels:
      - Value
      - Purpose
    * - ``role-name``
-     - ``prefill`` or ``decode``
-     - Tells the gateway which phase this pod handles. Standard inference pods omit this label.
+     - ``prefill``, ``decode``, or another value (e.g. ``all``)
+     - Tells the gateway which phase this pod handles. Standard inference pods use a role other than ``prefill``/``decode`` (or omit ``role-name``) and set ``combined: true`` in ``routingConfig``.
    * - ``roleset-name``
      - any string (e.g. ``group-0``)
      - Groups a prefill pod and a decode pod into a **pair**. The gateway only uses pairs where both prefill and decode pods are present.
@@ -195,8 +195,9 @@ Adding standard inference pods turns a rigid two-tier pipeline into a self-heali
 
 Standard inference pods run both prefill and decode on a single GPU. They serve as overflow capacity when:
 
-- The request's prompt length falls outside all configured buckets.
-- All prefill/decode pairs are at capacity.
+- The request's prompt length falls outside all configured PD buckets.
+- The matching PD roleset is incomplete (for example, a decode pod is unavailable).
+- All prefill/decode pairs are at capacity (load-imbalance routing may select a combined pod).
 - You want a gradual migration path (run standard inference pods alongside disaggregated pairs).
 
 **To configure a standard inference pod**, set ``combined: true`` in the pod's ``routingConfig`` annotation and enable prompt-length bucketing on the gateway:
@@ -418,6 +419,54 @@ This example shows a three-tier setup: prefill + decode pods for short prompts, 
           value: "true"
 
 
+Pod Selection Algorithm
+-----------------------
+
+Once pods are partitioned into prefill, decode, and combined slices, the gateway selects the best target through a cascade of checks. Bucketing (when ``AIBRIX_PROMPT_LENGTH_BUCKETING=true``) runs first; load-imbalance and scoring steps run only when a PD pair is still in play.
+
+**Step 0 — Prompt-length bucketing (optional)**
+
+When bucketing is enabled, each roleset contributes to the bucket-filtered pool only when **both** its prefill and decode pods declare a range that includes the request's prompt length. Incomplete rolesets (missing decode or prefill) are skipped. If no complete bucket-matched pair exists — including when a decode pod is down in the matching bucket — the gateway routes to a ``combined: true`` pod whose range includes the prompt, or returns an error if none is available. When a bucket match exists but PD pods are heavily loaded while a combined pod is idle, ``shouldPickCombined()`` may select the combined pod instead.
+
+**Step 1 — Prefill load-imbalance fast path**
+
+If the difference between the maximum and minimum number of outstanding prefill requests across prefill pods exceeds ``AIBRIX_PREFILL_LOAD_IMBALANCE_MIN_SPREAD``, the gateway routes the prefill phase to the single least-loaded prefill pod and aligns the decode candidates to the same roleset.
+
+**Step 2 — Decode load-imbalance fast path**
+
+Three ordered checks run against decode pods. The first that fires selects a single decode pod and aligns the prefill candidates to its roleset. Steps 1 and 2 are independent: both can fire on the same request if both sides are imbalanced.
+
+1. *Request count spread* — If ``max(running + pending) − min`` across metric-bearing pods ≥ ``AIBRIX_DECODE_LOAD_IMBALANCE_MIN_SPREAD``, route to the least-loaded pod. Pods without ``RealtimeNumRequestsRunning`` are excluded from the spread to avoid thundering-herd on freshly restarted pods; their pending-decode count is still tracked for the scoring step.
+
+2. *Throughput spread* — If ``max(throughput) − min`` across metric-bearing pods > ``AIBRIX_DECODE_THROUGHPUT_IMBALANCE_MIN_SPREAD``, route to the lowest-throughput pod.
+
+3. *Drain-rate score* — If all pods report a positive ``drain_rate``, score each pod as ``effective_running_reqs / drain_rate``. If ``max_score / min_score`` exceeds ``AIBRIX_DECODE_SCORE_RATIO_THRESHOLD``, route to the pod with the lowest score (fastest estimated queue drain).
+
+**Step 3 — Prefill scoring**
+
+Each prefill pod is scored by the selected policy. Pods with a request count more than ``N`` standard deviations above the mean are skipped (``N = AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR``). The lowest-scoring pod per roleset is kept as the roleset's prefill candidate.
+
+- ``prefix_cache`` (default): ``score = (100 − prefix_match_percent) × 0.1 + req_count / max_req_count`` — lower score means more cache hits and less load.
+- ``least_request``: ``score = req_count``.
+
+**Step 4 — Decode scoring**
+
+Each decode pod is scored by the selected policy. Pods without ``RealtimeNumRequestsRunning`` receive a cold-start score (``1.0 + pending_decode_count``) when at least one sibling pod already has metrics, so they compete fairly without attracting all traffic immediately.
+
+- ``load_balancing`` (default): ``score = (w_run × norm_reqs + w_thru × (1 − norm_throughput)) / norm_free_gpu``, where norms are relative to the batch maximum; lower is better.
+- ``least_request``: ``score = running_reqs + pending_decode_count``.
+
+**Step 5 — Final pair selection**
+
+For each roleset with both a prefill and decode candidate, the gateway computes:
+
+.. code-block:: text
+
+    final_score = prefill_score / max_prefill_score + decode_score / max_decode_score
+
+The roleset with the lowest combined score wins. The selected prefill and decode pods always come from the same roleset.
+
+
 Environment Variables
 ---------------------
 
@@ -450,4 +499,19 @@ These are set on the **gateway plugin** deployment.
      - Minimum request-count spread between prefill pods before load-imbalance routing kicks in.
    * - ``AIBRIX_DECODE_LOAD_IMBALANCE_MIN_SPREAD``
      - ``16``
-     - Minimum request-count spread between decode pods before load-imbalance routing kicks in.
+     - Minimum ``(max − min)`` running request count spread between decode pods before request-count load-imbalance routing kicks in.
+   * - ``AIBRIX_DECODE_THROUGHPUT_IMBALANCE_MIN_SPREAD``
+     - ``2048``
+     - Minimum ``(max − min)`` token throughput spread (tok/s) between decode pods before throughput-based load-imbalance routing kicks in.
+   * - ``AIBRIX_DECODE_SCORE_RATIO_THRESHOLD``
+     - ``1.5``
+     - ``max_drain_score / min_drain_score`` ratio above which the drain-rate routing fast path is triggered. Score for each pod is ``effective_running_reqs / drain_rate``.
+   * - ``AIBRIX_DECODE_LB_WEIGHT_RUNNING``
+     - ``1.0``
+     - Weight applied to the normalized running-request term in the ``load_balancing`` decode score numerator.
+   * - ``AIBRIX_DECODE_LB_WEIGHT_THROUGHPUT``
+     - ``1.0``
+     - Weight applied to the normalized inverse-throughput term in the ``load_balancing`` decode score numerator.
+   * - ``AIBRIX_TRT_MACHINE_ID``
+     - ``0``
+     - 10-bit machine ID used in Snowflake-style ``disagg_request_id`` generation for TensorRT-LLM (valid range: ``[0, 1024)``).

--- a/pkg/plugins/gateway/algorithms/pd/prefill/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default.go
@@ -95,7 +95,6 @@ func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *
 	}
 
 	routingCtx.PrefillStartTime = time.Now()
-	e.tracker.AddPrefillRequest(routingCtx.RequestID, prefillPod.Name)
 
 	if handler.IsAsync() {
 		// SGLang uses a bootstrap handshake to coordinate KV transfer out-of-band;

--- a/pkg/plugins/gateway/algorithms/pd/trackers.go
+++ b/pkg/plugins/gateway/algorithms/pd/trackers.go
@@ -43,9 +43,9 @@ func NewPrefillRequestTracker() *PrefillRequestTracker {
 }
 
 // AddPrefillRequest records that requestID has been assigned to podName and
-// increments that pod's active-request counter. Called when prefill dispatch
-// starts so concurrent routing sees in-flight assignments. Must be paired with
-// RemovePrefillRequest when prefill completes or the assignment is abandoned.
+// increments that pod's active-request counter. Called in Route before
+// doPrefillRequest so concurrent routing sees in-flight assignments. Must be
+// paired with RemovePrefillRequest when prefill completes or the assignment is abandoned.
 func (t *PrefillRequestTracker) AddPrefillRequest(requestID, podName string) {
 	countInterface, _ := t.podRequestCounts.LoadOrStore(podName, &atomic.Int32{})
 	count := countInterface.(*atomic.Int32)
@@ -148,8 +148,8 @@ func NewPendingDecodeTracker() *PendingDecodeTracker {
 }
 
 // AddPendingDecode records that requestID has been assigned to podName and
-// increments that pod's pending-decode counter. Must be paired with a
-// corresponding RemovePendingDecode call (typically via defer in Route).
+// increments that pod's pending-decode counter. Called at the start of Route
+// after pod selection. RemovePendingDecode is deferred in Route.
 func (t *PendingDecodeTracker) AddPendingDecode(requestID, podName string) {
 	if t == nil {
 		return

--- a/pkg/plugins/gateway/algorithms/pd_bucketing_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_bucketing_test.go
@@ -1,0 +1,469 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/metrics"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
+	"github.com/vllm-project/aibrix/pkg/utils/tokenizer"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// --- parsePDAlgorithmConfig ---
+
+func TestParsePDAlgorithmConfig_Nil(t *testing.T) {
+	cfg := parsePDAlgorithmConfig(nil)
+	assert.Equal(t, 0, cfg.PromptLenBucketMinLength)
+	assert.Equal(t, math.MaxInt32, cfg.PromptLenBucketMaxLength)
+	assert.False(t, cfg.Combined)
+}
+
+func TestParsePDAlgorithmConfig_Empty(t *testing.T) {
+	cfg := parsePDAlgorithmConfig(json.RawMessage(`{}`))
+	assert.Equal(t, 0, cfg.PromptLenBucketMinLength)
+	assert.Equal(t, math.MaxInt32, cfg.PromptLenBucketMaxLength)
+	assert.False(t, cfg.Combined)
+}
+
+func TestParsePDAlgorithmConfig_AllFields(t *testing.T) {
+	raw := json.RawMessage(`{"promptLenBucketMinLength":10,"promptLenBucketMaxLength":100,"combined":true}`)
+	cfg := parsePDAlgorithmConfig(raw)
+	assert.Equal(t, 10, cfg.PromptLenBucketMinLength)
+	assert.Equal(t, 100, cfg.PromptLenBucketMaxLength)
+	assert.True(t, cfg.Combined)
+}
+
+func TestParsePDAlgorithmConfig_ZeroMaxBecomesMaxInt32(t *testing.T) {
+	// When promptLenBucketMaxLength is 0 (unset in JSON), it should default to MaxInt32.
+	raw := json.RawMessage(`{"promptLenBucketMinLength":5}`)
+	cfg := parsePDAlgorithmConfig(raw)
+	assert.Equal(t, 5, cfg.PromptLenBucketMinLength)
+	assert.Equal(t, math.MaxInt32, cfg.PromptLenBucketMaxLength)
+}
+
+func TestParsePDAlgorithmConfig_NegativeMinClampedToZero(t *testing.T) {
+	raw := json.RawMessage(`{"promptLenBucketMinLength":-10,"promptLenBucketMaxLength":50}`)
+	cfg := parsePDAlgorithmConfig(raw)
+	assert.Equal(t, 0, cfg.PromptLenBucketMinLength)
+	assert.Equal(t, 50, cfg.PromptLenBucketMaxLength)
+}
+
+func TestParsePDAlgorithmConfig_InvalidJSON(t *testing.T) {
+	raw := json.RawMessage(`not valid json`)
+	cfg := parsePDAlgorithmConfig(raw)
+	// Fallback to defaults on parse error.
+	assert.Equal(t, 0, cfg.PromptLenBucketMinLength)
+	assert.Equal(t, math.MaxInt32, cfg.PromptLenBucketMaxLength)
+}
+
+func TestParsePDAlgorithmConfig_ScorePolicies(t *testing.T) {
+	raw := json.RawMessage(`{"prefillScorePolicy":"least_request","decodeScorePolicy":"load_balancing"}`)
+	cfg := parsePDAlgorithmConfig(raw)
+	assert.Equal(t, "least_request", cfg.PrefillScorePolicy)
+	assert.Equal(t, "load_balancing", cfg.DecodeScorePolicy)
+}
+
+// --- isPodSuitableForPromptLength ---
+
+func newRouterForBucketingTests() *pdRouter {
+	return &pdRouter{
+		cache:                 cache.NewForTest(),
+		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
+		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
+		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
+		httpClient:            &http.Client{},
+		selectionCounts:       map[string]int64{},
+	}
+}
+
+func podWithBucketAnnotation(name, roleset, role string, minLen, maxLen int, combined bool) *v1.Pod {
+	anno := pdConfigAnnotation(minLen, maxLen, combined)
+	return makePDPod(name, roleset, role, map[string]string{constants.ModelAnnoConfig: anno})
+}
+
+func TestIsPodSuitableForPromptLength_NoAnnotation(t *testing.T) {
+	r := newRouterForBucketingTests()
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "msg", "req", "user")
+	pod := makePDPod("p", "rs", "prefill", nil)
+	// Pod without annotation is suitable for any length.
+	assert.True(t, r.isPodSuitableForPromptLength(ctx, pod, 0))
+	assert.True(t, r.isPodSuitableForPromptLength(ctx, pod, 9999))
+}
+
+func TestIsPodSuitableForPromptLength_WithinRange(t *testing.T) {
+	r := newRouterForBucketingTests()
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "msg", "req", "user")
+	pod := podWithBucketAnnotation("p", "rs", "prefill", 10, 50, false)
+	assert.True(t, r.isPodSuitableForPromptLength(ctx, pod, 10)) // at min boundary
+	assert.True(t, r.isPodSuitableForPromptLength(ctx, pod, 30)) // in middle
+	assert.True(t, r.isPodSuitableForPromptLength(ctx, pod, 50)) // at max boundary
+}
+
+func TestIsPodSuitableForPromptLength_OutsideRange(t *testing.T) {
+	r := newRouterForBucketingTests()
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "msg", "req", "user")
+	pod := podWithBucketAnnotation("p", "rs", "prefill", 10, 50, false)
+	assert.False(t, r.isPodSuitableForPromptLength(ctx, pod, 9))  // below min
+	assert.False(t, r.isPodSuitableForPromptLength(ctx, pod, 51)) // above max
+}
+
+func TestIsPodSuitableForPromptLength_MinGreaterThanMax(t *testing.T) {
+	r := newRouterForBucketingTests()
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "msg", "req", "user")
+	// Malformed config: min > max → always unsuitable.
+	anno := `{"defaultProfile":"pd","profiles":{"pd":{"routingStrategy":"pd","routingConfig":{"promptLenBucketMinLength":100,"promptLenBucketMaxLength":10,"combined":false}}}}`
+	pod := makePDPod("p", "rs", "prefill", map[string]string{constants.ModelAnnoConfig: anno})
+	assert.False(t, r.isPodSuitableForPromptLength(ctx, pod, 50))
+	assert.False(t, r.isPodSuitableForPromptLength(ctx, pod, 100))
+}
+
+func TestIsPodSuitableForPromptLength_ZeroRangeDefaultsToAny(t *testing.T) {
+	r := newRouterForBucketingTests()
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "msg", "req", "user")
+	// min=0 and max=MaxInt32 (unset) → suitable for any prompt length.
+	pod := podWithBucketAnnotation("p", "rs", "prefill", 0, 0, false) // max 0 → will become MaxInt32
+	assert.True(t, r.isPodSuitableForPromptLength(ctx, pod, 0))
+	assert.True(t, r.isPodSuitableForPromptLength(ctx, pod, 99999))
+}
+
+// --- isCombinedPod ---
+
+func TestIsCombinedPod_NilProfile(t *testing.T) {
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "msg", "req", "user")
+	pod := makePDPod("p", "rs", "combined", nil) // no annotation → no profile
+	assert.False(t, isCombinedPod(ctx, pod))
+}
+
+func TestIsCombinedPod_FalseInAnnotation(t *testing.T) {
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "msg", "req", "user")
+	pod := podWithBucketAnnotation("p", "rs", "prefill", 0, 100, false)
+	assert.False(t, isCombinedPod(ctx, pod))
+}
+
+func TestIsCombinedPod_TrueInAnnotation(t *testing.T) {
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "msg", "req", "user")
+	pod := podWithBucketAnnotation("p", "rs", "all", 0, 0, true)
+	assert.True(t, isCombinedPod(ctx, pod))
+}
+
+// --- shouldPickCombined ---
+
+// makePodWithRequestRateMetrics creates a pod with the given model label and
+// sets up per-model metrics that calculatePodScoreBasedOffRequestRate reads.
+func makePodWithRequestRateMetrics(name, namespace, modelName string, waitingReqs, drainRate float64) (*v1.Pod, map[string]metrics.MetricValue) {
+	vec := model.Vector{&model.Sample{
+		Metric: model.Metric{"__name__": "drain_rate_1m"},
+		Value:  model.SampleValue(drainRate),
+	}}
+	var drainResult model.Value = vec
+	return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    map[string]string{constants.ModelLabelName: modelName},
+			},
+		}, map[string]metrics.MetricValue{
+			metrics.NumRequestsWaiting:          &metrics.SimpleMetricValue{Value: waitingReqs},
+			metrics.NumPrefillPreallocQueueReqs: &metrics.SimpleMetricValue{Value: 0},
+			metrics.NumDecodePreallocQueueReqs:  &metrics.SimpleMetricValue{Value: 0},
+			metrics.DrainRate1m:                 &metrics.PrometheusMetricValue{Result: &drainResult},
+		}
+}
+
+func TestShouldPickCombined_PrefillHighLoadCombinedLow(t *testing.T) {
+	// prefill score > 1.0 (high), combined score < 0.25 (low) → should pick combined
+	modelName := testModelName
+
+	prefill, prefillMetrics := makePodWithRequestRateMetrics("prefill-1", "default", modelName, 10, 5)   // score=2.0 > 1.0
+	decode, decodeMetrics := makePodWithRequestRateMetrics("decode-1", "default", modelName, 1, 4)       // score=0.25
+	combined, combinedMetrics := makePodWithRequestRateMetrics("combined-1", "default", modelName, 0, 8) // score=0.0 < 0.25
+
+	annotoCombined := pdConfigAnnotation(0, 0, true)
+	combined.Annotations = map[string]string{constants.ModelAnnoConfig: annotoCombined}
+
+	allPods := []*v1.Pod{prefill, decode, combined}
+	metricsMap := map[string]map[string]metrics.MetricValue{
+		prefill.Name:  prefillMetrics,
+		decode.Name:   decodeMetrics,
+		combined.Name: combinedMetrics,
+	}
+
+	r := &pdRouter{cache: cache.NewWithPodsMetricsForTest(allPods, modelName, metricsMap)}
+	ctx := types.NewRoutingContext(context.Background(), "pd", modelName, "msg", "req", "user")
+
+	result := r.shouldPickCombined(ctx, []*v1.Pod{prefill}, []*v1.Pod{decode}, []*v1.Pod{combined})
+	assert.True(t, result)
+}
+
+func TestShouldPickCombined_DecodeHighLoadCombinedLow(t *testing.T) {
+	// decode score > 1.0, combined score < 0.25, prefill score below high threshold → pick combined
+	modelName := testModelName
+
+	prefill, prefillMetrics := makePodWithRequestRateMetrics("prefill-1", "default", modelName, 0, 8)    // score=0.0 (low)
+	decode, decodeMetrics := makePodWithRequestRateMetrics("decode-1", "default", modelName, 10, 5)      // score=2.0 > 1.0
+	combined, combinedMetrics := makePodWithRequestRateMetrics("combined-1", "default", modelName, 0, 8) // score=0.0 < 0.25
+
+	annotoCombined := pdConfigAnnotation(0, 0, true)
+	combined.Annotations = map[string]string{constants.ModelAnnoConfig: annotoCombined}
+
+	allPods := []*v1.Pod{prefill, decode, combined}
+	metricsMap := map[string]map[string]metrics.MetricValue{
+		prefill.Name:  prefillMetrics,
+		decode.Name:   decodeMetrics,
+		combined.Name: combinedMetrics,
+	}
+
+	r := &pdRouter{cache: cache.NewWithPodsMetricsForTest(allPods, modelName, metricsMap)}
+	ctx := types.NewRoutingContext(context.Background(), "pd", modelName, "msg", "req", "user")
+
+	result := r.shouldPickCombined(ctx, []*v1.Pod{prefill}, []*v1.Pod{decode}, []*v1.Pod{combined})
+	assert.True(t, result)
+}
+
+func TestShouldPickCombined_CombinedHighLoad(t *testing.T) {
+	// combined score >= 0.25 → do not route to combined even if prefill is high
+	modelName := testModelName
+
+	prefill, prefillMetrics := makePodWithRequestRateMetrics("prefill-1", "default", modelName, 10, 5)    // score=2.0
+	decode, decodeMetrics := makePodWithRequestRateMetrics("decode-1", "default", modelName, 1, 4)        // score=0.25
+	combined, combinedMetrics := makePodWithRequestRateMetrics("combined-1", "default", modelName, 10, 5) // score=2.0 (high)
+
+	allPods := []*v1.Pod{prefill, decode, combined}
+	metricsMap := map[string]map[string]metrics.MetricValue{
+		prefill.Name:  prefillMetrics,
+		decode.Name:   decodeMetrics,
+		combined.Name: combinedMetrics,
+	}
+
+	r := &pdRouter{cache: cache.NewWithPodsMetricsForTest(allPods, modelName, metricsMap)}
+	ctx := types.NewRoutingContext(context.Background(), "pd", modelName, "msg", "req", "user")
+
+	result := r.shouldPickCombined(ctx, []*v1.Pod{prefill}, []*v1.Pod{decode}, []*v1.Pod{combined})
+	assert.False(t, result)
+}
+
+func TestShouldPickCombined_AllLowLoad(t *testing.T) {
+	// neither prefill nor decode is high-load → do not route to combined
+	modelName := testModelName
+
+	prefill, prefillMetrics := makePodWithRequestRateMetrics("prefill-1", "default", modelName, 1, 4)    // score=0.25 (low)
+	decode, decodeMetrics := makePodWithRequestRateMetrics("decode-1", "default", modelName, 1, 4)       // score=0.25 (low)
+	combined, combinedMetrics := makePodWithRequestRateMetrics("combined-1", "default", modelName, 0, 8) // score=0 (low)
+
+	allPods := []*v1.Pod{prefill, decode, combined}
+	metricsMap := map[string]map[string]metrics.MetricValue{
+		prefill.Name:  prefillMetrics,
+		decode.Name:   decodeMetrics,
+		combined.Name: combinedMetrics,
+	}
+
+	r := &pdRouter{cache: cache.NewWithPodsMetricsForTest(allPods, modelName, metricsMap)}
+	ctx := types.NewRoutingContext(context.Background(), "pd", modelName, "msg", "req", "user")
+
+	result := r.shouldPickCombined(ctx, []*v1.Pod{prefill}, []*v1.Pod{decode}, []*v1.Pod{combined})
+	assert.False(t, result)
+}
+
+func TestShouldPickCombined_NoCombinedPods(t *testing.T) {
+	// no combined pods → always false
+	modelName := testModelName
+
+	prefill, prefillMetrics := makePodWithRequestRateMetrics("prefill-1", "default", modelName, 10, 5) // high load
+	decode, decodeMetrics := makePodWithRequestRateMetrics("decode-1", "default", modelName, 10, 5)    // high load
+
+	allPods := []*v1.Pod{prefill, decode}
+	metricsMap := map[string]map[string]metrics.MetricValue{
+		prefill.Name: prefillMetrics,
+		decode.Name:  decodeMetrics,
+	}
+
+	r := &pdRouter{cache: cache.NewWithPodsMetricsForTest(allPods, modelName, metricsMap)}
+	ctx := types.NewRoutingContext(context.Background(), "pd", modelName, "msg", "req", "user")
+
+	result := r.shouldPickCombined(ctx, []*v1.Pod{prefill}, []*v1.Pod{decode}, []*v1.Pod{})
+	assert.False(t, result)
+}
+
+// --- scoreCombinedPods ---
+
+func TestScoreCombinedPods_SinglePod(t *testing.T) {
+	modelName := testModelName
+	combined, combinedMetrics := makePodWithRequestRateMetrics("combined-1", "default", modelName, 2, 4) // score=0.5
+	allPods := []*v1.Pod{combined}
+	metricsMap := map[string]map[string]metrics.MetricValue{combined.Name: combinedMetrics}
+
+	r := &pdRouter{cache: cache.NewWithPodsMetricsForTest(allPods, modelName, metricsMap)}
+	ctx := types.NewRoutingContext(context.Background(), "pd", modelName, "msg", "req", "user")
+
+	best := r.scoreCombinedPods(ctx, []*v1.Pod{combined})
+	assert.NotNil(t, best)
+	assert.Equal(t, "combined-1", best.Name)
+}
+
+func TestScoreCombinedPods_PicksLowest(t *testing.T) {
+	// combined-low has score=0.1 (2/20), combined-high has score=2.0 (10/5)
+	modelName := testModelName
+	lowPod, lowMetrics := makePodWithRequestRateMetrics("combined-low", "default", modelName, 2, 20)    // score=0.1
+	highPod, highMetrics := makePodWithRequestRateMetrics("combined-high", "default", modelName, 10, 5) // score=2.0
+
+	allPods := []*v1.Pod{lowPod, highPod}
+	metricsMap := map[string]map[string]metrics.MetricValue{
+		lowPod.Name:  lowMetrics,
+		highPod.Name: highMetrics,
+	}
+
+	r := &pdRouter{cache: cache.NewWithPodsMetricsForTest(allPods, modelName, metricsMap)}
+	ctx := types.NewRoutingContext(context.Background(), "pd", modelName, "msg", "req", "user")
+
+	best := r.scoreCombinedPods(ctx, []*v1.Pod{lowPod, highPod})
+	assert.NotNil(t, best)
+	assert.Equal(t, "combined-low", best.Name)
+}
+
+func TestScoreCombinedPods_NoMetricsFallsToZeroScore(t *testing.T) {
+	// When no metrics are registered, drainRate=0 → score=0/0=NaN.
+	// IEEE 754: NaN < MaxFloat64 is false, so no pod wins the min-score comparison
+	// and scoreCombinedPods returns nil.
+	r := &pdRouter{cache: cache.NewForTest()}
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "msg", "req", "user")
+
+	pod1 := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "c1", Labels: map[string]string{constants.ModelLabelName: "model"}}}
+	pod2 := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "c2", Labels: map[string]string{constants.ModelLabelName: "model"}}}
+
+	best := r.scoreCombinedPods(ctx, []*v1.Pod{pod1, pod2})
+	assert.Nil(t, best, "no metrics → NaN score does not beat MaxFloat64, returns nil")
+}
+
+// --- filterPrefillDecodePods bucketing integration ---
+
+func TestFilterPrefillDecodePods_BucketingSelectsMatchingRoleset(t *testing.T) {
+	// Verify that when two rolesets have non-overlapping buckets, the request
+	// is routed to the roleset whose bucket covers the actual prompt length.
+	// We use one wide-range bucket [0, 99999] and one unreachable bucket [100000, 200000]
+	// so the short test prompt definitely hits the wide bucket regardless of tokenizer.
+	old := aibrixPromptLengthBucketing
+	aibrixPromptLengthBucketing = true
+	defer func() { aibrixPromptLengthBucketing = old }()
+
+	r := pdRouter{
+		cache:                 cache.NewForTest(),
+		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
+		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
+		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
+		httpClient:            &http.Client{},
+		selectionCounts:       map[string]int64{},
+	}
+
+	// rs-match: covers any realistic prompt length
+	annoMatch := pdConfigAnnotation(0, 99999, false)
+	// rs-nomatch: unreachably large range for any test prompt
+	annoNoMatch := pdConfigAnnotation(100000, 200000, false)
+
+	prefillMatch := makePDPod("prefill-match", "rs-match", "prefill", map[string]string{constants.ModelAnnoConfig: annoMatch})
+	decodeMatch := makePDPod("decode-match", "rs-match", "decode", map[string]string{constants.ModelAnnoConfig: annoMatch})
+	prefillNoMatch := makePDPod("prefill-nomatch", "rs-nomatch", "prefill", map[string]string{constants.ModelAnnoConfig: annoNoMatch})
+	decodeNoMatch := makePDPod("decode-nomatch", "rs-nomatch", "decode", map[string]string{constants.ModelAnnoConfig: annoNoMatch})
+	allPods := []*v1.Pod{prefillMatch, decodeMatch, prefillNoMatch, decodeNoMatch}
+
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "hello world", "req-1", "user")
+	p, d, err := r.filterPrefillDecodePods(ctx, allPods)
+	assert.NoError(t, err)
+	assert.Equal(t, "prefill-match", p.Name)
+	assert.Equal(t, "decode-match", d.Name)
+}
+
+func TestFilterPrefillDecodePods_BucketingDisabledIgnoresAnnotations(t *testing.T) {
+	old := aibrixPromptLengthBucketing
+	aibrixPromptLengthBucketing = false
+	defer func() { aibrixPromptLengthBucketing = old }()
+
+	r := pdRouter{
+		cache:                 cache.NewForTest(),
+		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
+		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
+		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
+		httpClient:            &http.Client{},
+		selectionCounts:       map[string]int64{},
+	}
+
+	// Narrow bucket that would not match any reasonable prompt length.
+	annoNarrow := pdConfigAnnotation(99999, 100000, false)
+	prefill := makePDPod("prefill-1", "rs1", "prefill", map[string]string{constants.ModelAnnoConfig: annoNarrow})
+	decode := makePDPod("decode-1", "rs1", "decode", map[string]string{constants.ModelAnnoConfig: annoNarrow})
+
+	// With bucketing disabled, annotations are ignored and the pod is selected normally.
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "hello", "req", "user")
+	p, d, err := r.filterPrefillDecodePods(ctx, []*v1.Pod{prefill, decode})
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+	assert.NotNil(t, d)
+}
+
+func TestFilterPrefillDecodePods_MultipleBucketsCombinedFallback(t *testing.T) {
+	// With two unreachably high-range PD buckets and a combined pod,
+	// any short test prompt falls outside both buckets and routes to combined.
+	// Using [99999, 199999] ensures no realistic test message hits either bucket
+	// regardless of tokenizer (tiktoken or character-based).
+	old := aibrixPromptLengthBucketing
+	aibrixPromptLengthBucketing = true
+	defer func() { aibrixPromptLengthBucketing = old }()
+
+	r := pdRouter{
+		cache:                 cache.NewForTest(),
+		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
+		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
+		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
+		httpClient:            &http.Client{},
+		selectionCounts:       map[string]int64{},
+	}
+
+	annoHigh1 := pdConfigAnnotation(99999, 149999, false)
+	annoHigh2 := pdConfigAnnotation(150000, 199999, false)
+	annoCombined := pdConfigAnnotation(0, 0, true)
+
+	prefillHigh1 := makePDPod("prefill-high1", "rs-high1", "prefill", map[string]string{constants.ModelAnnoConfig: annoHigh1})
+	decodeHigh1 := makePDPod("decode-high1", "rs-high1", "decode", map[string]string{constants.ModelAnnoConfig: annoHigh1})
+	prefillHigh2 := makePDPod("prefill-high2", "rs-high2", "prefill", map[string]string{constants.ModelAnnoConfig: annoHigh2})
+	decodeHigh2 := makePDPod("decode-high2", "rs-high2", "decode", map[string]string{constants.ModelAnnoConfig: annoHigh2})
+	combined := makePDPod("combined-1", "rs-comb", "combined", map[string]string{constants.ModelAnnoConfig: annoCombined})
+
+	allPods := []*v1.Pod{prefillHigh1, decodeHigh1, prefillHigh2, decodeHigh2, combined}
+
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "say test", "req-fallback", "user")
+	p, d, err := r.filterPrefillDecodePods(ctx, allPods)
+	assert.NoError(t, err)
+	assert.Nil(t, p, "combined routing should not set a prefill pod")
+	assert.NotNil(t, d)
+	assert.Equal(t, "combined-1", d.Name)
+}

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -516,7 +516,7 @@ func (r *pdRouter) loadImbalanceSelectPrefillPod(readyPods []*v1.Pod, podRequest
 // maxFreeGPUUsage from the same pass (maxima include all pods, including those without metrics).
 // maxRequestCount and maxThroughput are floored at 1 and maxFreeGPUUsage is floored at 1 so
 // that scoreDecodePods normalization denominators are always positive. The caller narrows
-// prefillPods to the selected pod's roleset. KV cache headroom uses KVCacheUsagePerc only
+// prefillPods to the selected pod's roleset. KV cache headroom uses KVCacheUsagePerc
 // (missing metric is treated as 0% usage = 100% free).
 func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filteredDecodePods []*v1.Pod) (*v1.Pod, float64, float64, float64, map[string]float64, map[string]float64, map[string]float64) {
 	podRequestCounts := make(map[string]float64)
@@ -565,10 +565,11 @@ func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filte
 		}
 
 		kvUsage, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.KVCacheUsagePerc)
-		if err != nil {
-			kvUsage = &metrics.SimpleMetricValue{Value: 0}
+		kvUsageVal := float64(0)
+		if err == nil {
+			kvUsageVal = kvUsage.GetSimpleValue()
 		}
-		podFreeGpuUsage[pod.Name] = math.Round(100 - kvUsage.GetSimpleValue()*100)
+		podFreeGpuUsage[pod.Name] = math.Round(100 - kvUsageVal*100)
 		if podFreeGpuUsage[pod.Name] <= 0 {
 			podFreeGpuUsage[pod.Name] = 0.1
 		}

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -286,11 +286,10 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		return "", fmt.Errorf("failed to filter prefill/decode pods for request %s: %w", ctx.RequestID, err)
 	}
 
+	r.pendingDecodeTracker.AddPendingDecode(ctx.RequestID, decodePod.Name)
+	defer r.pendingDecodeTracker.RemovePendingDecode(ctx.RequestID)
+
 	if prefillPod != nil {
-		// filterPrefillDecodePods registered pending prefill/decode during selection so
-		// concurrent requests see up-to-date counts. Always clean up pending decode when
-		// this request completes.
-		defer r.pendingDecodeTracker.RemovePendingDecode(ctx.RequestID)
 
 		klog.InfoS("selected prefill/decode pods", "request_id", ctx.RequestID, "prefill_pod", prefillPod.Name, "decode_pod", decodePod.Name)
 		if ctx.RespHeaders == nil {
@@ -298,6 +297,7 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		}
 		ctx.RespHeaders[HeaderPrefillTargetPod] = prefillPod.Name
 		ctx.RespHeaders[HeaderPrefillTargetPodIP] = prefillPod.Status.PodIP
+		r.prefillRequestTracker.AddPrefillRequest(ctx.RequestID, prefillPod.Name)
 		err = r.doPrefillRequest(ctx, prefillPod, ctx.Engine)
 		if err != nil {
 			// Remove is a no-op if the executor already cleaned up (e.g. sync HTTP failure).
@@ -343,18 +343,16 @@ type Scores struct {
 //
 //  4. Prefill load-imbalance fast path — if outstanding prefill counts are skewed
 //     beyond aibrixPrefillLoadImbalanceMinSpread, narrow to the single least-loaded
-//     prefill pod and align decodePods to its roleset.
+//     prefill pod and align decodePods to its roleset. Continues to step 5.
 //
 //  5. Decode load-imbalance fast path — three ordered checks (request-count spread,
 //     throughput spread, drain-rate ratio); the first that fires narrows decodePods
-//     to a single pod and aligns prefillPods to its roleset.
+//     to a single pod and aligns prefillPods to its roleset. Steps 4 and 5 are
+//     independent: both can fire on the same request if both prefill and decode are
+//     imbalanced, with each narrowing its own side of the pair.
 //
 //  6. Score remaining candidates — scorePrefillPods and scoreDecodePods evaluate
 //     every roleset; finalPDScore picks the roleset with the lowest combined score.
-//
-//  7. Tracker registration — AddPrefillRequest and AddPendingDecode are called on
-//     the selected pods before returning so concurrent Route calls see up-to-date
-//     counts immediately.
 func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, readyPods []*v1.Pod) (*v1.Pod, *v1.Pod, error) {
 	var promptLength int
 	if aibrixPromptLengthBucketing {
@@ -431,27 +429,24 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 		return nil, nil, err
 	}
 
-	// Register pending prefill/decode immediately after selection so concurrent routing
-	// calls read up-to-date counts when evaluating load imbalance and scoring.
-	r.prefillRequestTracker.AddPrefillRequest(routingCtx.RequestID, selectedPrefill.Name)
-	r.pendingDecodeTracker.AddPendingDecode(routingCtx.RequestID, selectedDecode.Name)
 	return selectedPrefill, selectedDecode, nil
 }
 
 // loadImbalanceSelectPrefillPod is a fast path that runs before scorePrefillPods when
 // outstanding prefill load is visibly skewed across readyPods.
 //
-// podRequestCount holds per-pod active prefill counts from PrefillRequestTracker (in-flight
-// prefill HTTP requests not yet completed). readyPods is shuffled before evaluation so ties
-// among least-loaded pods are broken randomly.
+// podRequestCount holds per-pod active prefill counts from PrefillRequestTracker for
+// in-flight prefill HTTP calls from other concurrent requests. The current request is
+// not counted yet — it is registered by the caller after selection completes.
+// readyPods is shuffled before evaluation so ties among equally-loaded pods are broken
+// randomly rather than by map iteration order.
 //
-// If max(count) − min(count) is greater than aibrixPrefillLoadImbalanceMinSpread, returns
-// one pod tied for the minimum count and imbalance=true. Otherwise returns nil, false.
-// An empty podRequestCount map always returns nil, false.
+// Returns one pod tied for the minimum count and imbalance=true when
+// max(count) − min(count) > aibrixPrefillLoadImbalanceMinSpread (strictly greater than).
+// Otherwise returns nil, false. An empty podRequestCount map always returns nil, false.
 //
-// The caller (filterPrefillDecodePods) narrows decodePods to the selected pod's roleset.
-// PrefillRequestTracker is updated after finalPDScore (not inside this function); counts
-// seen here include requests that have been assigned a prefill pod but not yet completed.
+// The caller (filterPrefillDecodePods) narrows decodePods to the selected pod's roleset
+// so that prefill and decode remain aligned to the same roleset pair after this step.
 func (r *pdRouter) loadImbalanceSelectPrefillPod(readyPods []*v1.Pod, podRequestCount map[string]int32) (*v1.Pod, bool) {
 	var imbalance bool
 	var targetPod *v1.Pod
@@ -499,11 +494,13 @@ func (r *pdRouter) loadImbalanceSelectPrefillPod(readyPods []*v1.Pod, podRequest
 // (each runs only if the previous did not return):
 //
 //  1. Request imbalance: among pods that report RealtimeNumRequestsRunning, compute
-//     effective count = running + PendingDecodeTracker pending count for that pod. If
-//     max − min effective count is at least aibrixDecodeLoadImbalanceMinSpread, return the
-//     least-loaded metric-bearing pod. Pods without a running-request metric are excluded
-//     from the spread (their pending count is still stored in podRequestCounts for scoring)
-//     so freshly restarted pods are not treated as idle and given a thundering herd.
+//     effective count = running + PendingDecodeTracker pending count for that pod.
+//     Pending counts come from concurrent Route calls that have registered
+//     AddPendingDecode but not yet returned. If max − min effective count is at least
+//     aibrixDecodeLoadImbalanceMinSpread, return the least-loaded metric-bearing pod.
+//     Pods without a running-request metric are excluded from the spread (their pending
+//     count is still stored in podRequestCounts for scoring) so freshly restarted pods
+//     are not treated as idle and given a thundering herd.
 //
 //  2. Throughput spread: among pods that report AvgGenerationThroughputToksPerS (per model),
 //     if max − min throughput exceeds aibrixDecodeThroughputImbalanceMinSpread, return the
@@ -517,7 +514,10 @@ func (r *pdRouter) loadImbalanceSelectPrefillPod(readyPods []*v1.Pod, podRequest
 // Returns nil when none of the checks fire; the caller falls through to scoreDecodePods with
 // the collected maps. A non-nil pod return also carries maxRequestCount, maxThroughput, and
 // maxFreeGPUUsage from the same pass (maxima include all pods, including those without metrics).
-// The caller narrows prefillPods to the selected pod's roleset.
+// maxRequestCount and maxThroughput are floored at 1 and maxFreeGPUUsage is floored at 1 so
+// that scoreDecodePods normalization denominators are always positive. The caller narrows
+// prefillPods to the selected pod's roleset. KV cache headroom uses KVCacheUsagePerc only
+// (missing metric is treated as 0% usage = 100% free).
 func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filteredDecodePods []*v1.Pod) (*v1.Pod, float64, float64, float64, map[string]float64, map[string]float64, map[string]float64) {
 	podRequestCounts := make(map[string]float64)
 	podThroughputs := make(map[string]float64)
@@ -620,17 +620,21 @@ func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filte
 }
 
 // scorePrefillPods scores candidate prefill pods with prefillPolicy after any imbalance
-// fast path has narrowed the list. readyPods are shuffled before scoring.
+// fast path has narrowed the list. prefillPods are shuffled before scoring so ties
+// within a roleset are broken randomly.
 //
-// Active prefill counts come from PrefillRequestTracker. Pods whose count exceeds
-// mean + standardDeviationFactor×stddev (AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR)
-// are skipped as overloaded. Each remaining pod is scored via prefillPolicy; the
-// lowest-scoring pod per roleset (PDRoleSetIdentifier) is kept.
+// Active prefill counts come from PrefillRequestTracker (in-flight prefill HTTP from
+// other concurrent requests; the current request is not counted yet). Pods whose count
+// exceeds mean + standardDeviationFactor×stddev
+// (AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR) are skipped as overloaded. When
+// every pod in a roleset is filtered this way, that roleset has no entry in the
+// returned map and finalPDScore will not be able to select it.
 //
 // Returns a per-roleset score map, maxPrefillScore (the maximum score among all pods
 // scored in this pass, used by finalPDScore for normalization), and prefix hashes
-// from the policy's Prepare step for asynchronous prefix-cache updates. Returns
-// nil, 0, nil when Prepare fails.
+// from the policy's Prepare step for asynchronous prefix-cache updates.
+// Returns nil, 0, nil when Prepare fails (distinct from an empty map, which means
+// all pods were filtered by the stddev check).
 //
 // Policy resolution: the policy argument, then r.prefillPolicy, then prefix_cache.
 func (r *pdRouter) scorePrefillPods(routingCtx *types.RoutingContext, prefillPods []*v1.Pod, prefillPolicy pd.PrefillScorePolicy) (map[string]*Scores, float64, []uint64) {
@@ -703,10 +707,11 @@ func (r *pdRouter) scorePrefillPods(routingCtx *types.RoutingContext, prefillPod
 // nil, the caller still passes the maps built during that pass.
 //
 // Policy resolution: the policy argument, then r.decodePolicy, then load_balancing.
-// When at least one pod reports both RealtimeNumRequestsRunning and
-// AvgGenerationThroughputToksPerS, pods missing either metric are skipped so
-// freshly restarted pods are not favored with zero load. If no pod has both metrics,
-// all pods are scored (cold-start fallback).
+// When at least one pod reports RealtimeNumRequestsRunning, pods missing that metric
+// receive a cold-start score (1.0 + PendingDecodeTracker pending count) instead of
+// full policy scoring. podRequestCounts include pending decode from concurrent Route
+// calls that have registered AddPendingDecode. If no pod has the running-request metric,
+// all pods are scored normally.
 //
 // Lower score is better. The lowest-scoring pod per roleset is kept in DecodeScoreRun.
 // PerRoleset. Invalid (NaN) scores from the primary policy are retried once with
@@ -737,10 +742,12 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 	utils.CryptoShuffle(filteredDecodePods)
 
 	anyMetricsReady := false
+	metricsReadyByPod := make(map[string]bool, len(filteredDecodePods))
 	for _, pod := range filteredDecodePods {
-		if r.decodePodMetricsReady(routingCtx, pod) {
+		ready := r.decodePodMetricsReady(routingCtx, pod)
+		metricsReadyByPod[pod.Name] = ready
+		if ready {
 			anyMetricsReady = true
-			break
 		}
 	}
 
@@ -749,7 +756,7 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 
 	for _, pod := range filteredDecodePods {
 		rolesetName := pod.Labels[PDRoleSetIdentifier]
-		if anyMetricsReady && !r.decodePodMetricsReady(routingCtx, pod) {
+		if anyMetricsReady && !metricsReadyByPod[pod.Name] {
 			// Cold-start: assign a neutral score (1.0 = idle warm pod) plus gateway-tracked
 			// pending requests so the roleset competes fairly instead of being excluded entirely.
 			// Once the pod's first request completes and metrics arrive, it transitions to full scoring.
@@ -801,17 +808,19 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 		}
 	}
 
-	perRolesetBest := make([]string, 0, len(out.PerRoleset))
-	for roleset, pick := range out.PerRoleset {
-		perRolesetBest = append(perRolesetBest, fmt.Sprintf("%s:%s=%.4f", roleset, pick.Pod.Name, pick.Score))
+	if klog.V(4).Enabled() {
+		perRolesetBest := make([]string, 0, len(out.PerRoleset))
+		for roleset, pick := range out.PerRoleset {
+			perRolesetBest = append(perRolesetBest, fmt.Sprintf("%s:%s=%.4f", roleset, pick.Pod.Name, pick.Score))
+		}
+		sort.Strings(perRolesetBest)
+		klog.V(4).InfoS("decode_score_summary",
+			"request_id", routingCtx.RequestID, "policy", policyName,
+			"fallback_used", out.FallbackUsed, "any_metrics_ready", anyMetricsReady,
+			"scored", strings.Join(scoredPods, " "), "skipped", strings.Join(skippedPods, " "),
+			"per_roleset_best", strings.Join(perRolesetBest, " "),
+		)
 	}
-	sort.Strings(perRolesetBest)
-	klog.V(4).InfoS("decode_score_summary",
-		"request_id", routingCtx.RequestID, "policy", policyName,
-		"fallback_used", out.FallbackUsed, "any_metrics_ready", anyMetricsReady,
-		"scored", strings.Join(scoredPods, " "), "skipped", strings.Join(skippedPods, " "),
-		"per_roleset_best", strings.Join(perRolesetBest, " "),
-	)
 
 	return out
 }
@@ -829,12 +838,17 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 // Lower combined score wins. Ties retain whichever roleset was last seen with that
 // score (map iteration order). Emits per-roleset final_score V(4) logs.
 //
-// Returns an error when decodeRun.Err is set, when no roleset has both sides scored
-// (target prefill or decode pod nil), or when prefillScores is empty. On success,
-// enqueues a prefix-cache update when prefixHashes is non-empty, increments internal
-// selection counters, and emits PDSelectedPrefillPodTotal / PDSelectedDecodePodTotal.
-// The caller registers the chosen prefill/decode pods with PrefillRequestTracker and
-// PendingDecodeTracker after return.
+// Error cases:
+//   - decodeRun.Err is set: decode scoring failed upstream.
+//   - prefillScores is nil: Prepare failed in scorePrefillPods.
+//   - prefillScores is non-nil but empty: all prefill pods were filtered by the stddev
+//     check, leaving no eligible prefill candidate; targetPrefillPod stays nil.
+//   - prefillScores is non-empty but no roleset has a matching decode entry: the
+//     roleset sets are disjoint after load-imbalance alignment; targetDecodePod stays nil.
+//
+// On success, enqueues a prefix-cache update when prefixHashes is non-empty, increments
+// internal selection counters, and emits PDSelectedPrefillPodTotal / PDSelectedDecodePodTotal.
+// Does not update request trackers; Route registers them after pod selection returns.
 func (r *pdRouter) finalPDScore(routingCtx *types.RoutingContext,
 	prefixHashes []uint64,
 	prefillScores map[string]*Scores, maxPrefillScore float64,
@@ -1107,25 +1121,14 @@ func isCombinedPod(routingCtx *types.RoutingContext, pod *v1.Pod) bool {
 	return pdCfg.Combined
 }
 
+// decodePodMetricsReady reports whether RealtimeNumRequestsRunning is available for pod.
+// Used by scoreDecodePods to gate cold-start scoring vs full policy scoring.
 func (r *pdRouter) decodePodMetricsReady(ctx *types.RoutingContext, pod *v1.Pod) bool {
 	if r == nil || r.cache == nil || ctx == nil || pod == nil {
 		return false
 	}
 	_, runningErr := r.cache.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
 	return runningErr == nil
-}
-
-// decodePodKVCacheUsagePerc returns KV cache utilization (0–1). vLLM exposes
-// vllm:kv_cache_usage_perc; older engines may still publish gpu_cache_usage_perc.
-func (r *pdRouter) decodePodKVCacheUsagePerc(ctx *types.RoutingContext, pod *v1.Pod) (metrics.MetricValue, error) {
-	if r == nil || r.cache == nil || ctx == nil || pod == nil {
-		return nil, fmt.Errorf("kv cache metric unavailable")
-	}
-	kv, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.KVCacheUsagePerc)
-	if err == nil {
-		return kv, nil
-	}
-	return r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.GPUCacheUsagePerc)
 }
 
 func getLLMEngine(pod *v1.Pod, labelName string, defaultValue string) string {

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -50,6 +51,8 @@ const (
 	LLMEngineIdentifier          string                 = constants.ModelLabelEngine
 	PDRoleSetIdentifier          string                 = "roleset-name"
 	PDRoleIdentifier             string                 = "role-name"
+	PDRolePrefill                string                 = "prefill"
+	PDRoleDecode                 string                 = "decode"
 	RoleReplicaIndex             string                 = "stormservice.orchestration.aibrix.ai/role-replica-index"
 	PodGroupIndex                string                 = "stormservice.orchestration.aibrix.ai/pod-group-index"
 	PromptLenBucketMinLength     string                 = "prompt-len-bucket-min-length"
@@ -184,8 +187,8 @@ func (r *pdRouter) effectiveScorePolicies(routingCtx *types.RoutingContext) (pd.
 	}
 	if strings.TrimSpace(cfg.PrefillScorePolicy) != "" || strings.TrimSpace(cfg.DecodeScorePolicy) != "" {
 		klog.V(4).InfoS("pd score policies from model config profile routingConfig",
-			"request_id", routingCtx.RequestID,
-			"prefill_policy", prefill.Name(), "decode_policy", decode.Name())
+			"request_id", routingCtx.RequestID, "prefill_policy", prefill.Name(),
+			"decode_policy", decode.Name())
 	}
 	return prefill, decode, nil
 }
@@ -232,8 +235,7 @@ func NewPDRouter() (types.Router, error) {
 		policy = newConductorPrefillPolicy(sharedPrefixTable, c)
 	default:
 		klog.InfoS("pd_router unknown AIBRIX_PREFILL_SCORE_POLICY, using prefix_cache",
-			"value", aibrixPrefillScorePolicy,
-			"valid", []string{pd.PrefillScorePolicyPrefixCache, pd.PrefillScorePolicyLeastRequest, pd.PrefillScorePolicyConductor})
+			"value", aibrixPrefillScorePolicy, "valid", []string{pd.PrefillScorePolicyPrefixCache, pd.PrefillScorePolicyLeastRequest})
 		policy = newPrefixCachePrefillPolicy(sharedPrefixTable)
 	}
 	klog.InfoS("pd_router prefill score policy", "policy", policy.Name())
@@ -241,8 +243,7 @@ func NewPDRouter() (types.Router, error) {
 	decodePol, _, unknownDecode := pd.ResolveDecodePolicy(aibrixDecodeScorePolicy)
 	if unknownDecode {
 		klog.InfoS("pd_router unknown AIBRIX_DECODE_SCORE_POLICY, using load_balancing",
-			"value", aibrixDecodeScorePolicy,
-			"valid", pd.ValidDecodePolicyNames())
+			"value", aibrixDecodeScorePolicy, "valid", pd.ValidDecodePolicyNames())
 	}
 	klog.InfoS("pd_router decode score policy", "policy", decodePol.Name(), "describe", decodePol.Describe())
 
@@ -277,6 +278,7 @@ func NewPDRouter() (types.Router, error) {
 
 func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) (string, error) {
 	readyPods := readyPodList.All()
+
 	prefillPod, decodePod, err := r.podSelector.Select(ctx, readyPods)
 	if err != nil {
 		metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
@@ -285,9 +287,12 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 	}
 
 	if prefillPod != nil {
-		klog.InfoS("selected prefill/decode pods", "request_id", ctx.RequestID, "prefill_pod", prefillPod.Name, "decode_pod", decodePod.Name)
-		r.pendingDecodeTracker.AddPendingDecode(ctx.RequestID, decodePod.Name)
+		// filterPrefillDecodePods registered pending prefill/decode during selection so
+		// concurrent requests see up-to-date counts. Always clean up pending decode when
+		// this request completes.
 		defer r.pendingDecodeTracker.RemovePendingDecode(ctx.RequestID)
+
+		klog.InfoS("selected prefill/decode pods", "request_id", ctx.RequestID, "prefill_pod", prefillPod.Name, "decode_pod", decodePod.Name)
 		if ctx.RespHeaders == nil {
 			ctx.RespHeaders = make(map[string]string)
 		}
@@ -295,6 +300,8 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		ctx.RespHeaders[HeaderPrefillTargetPodIP] = prefillPod.Status.PodIP
 		err = r.doPrefillRequest(ctx, prefillPod, ctx.Engine)
 		if err != nil {
+			// Remove is a no-op if the executor already cleaned up (e.g. sync HTTP failure).
+			r.prefillRequestTracker.RemovePrefillRequest(ctx.RequestID)
 			metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
 				map[string]string{"status": pdRoutePrefillRequestError, "status_code": "500"})
 			klog.ErrorS(err, pdRoutePrefillRequestError, "request_id", ctx.RequestID)
@@ -315,10 +322,39 @@ type Scores struct {
 	Score float64
 }
 
-// filterPrefillDecodePods filters pods into prefill and decode categories.
-// For multi-node tensor parallelism (e.g., TP=16 with node_rank=0 and node_rank=1),
-// only pods with PodGroupIndex="0" (node_rank=0) are selected as they run the HTTP server.
-// Pods without PodGroupIndex label are also included for backward compatibility.
+// filterPrefillDecodePods selects one prefill pod and one decode pod for the request.
+// For multi-node tensor parallelism, only pods with PodGroupIndex="0" run the HTTP
+// server and are routable; pods without that label are included for backward compatibility.
+//
+// Selection sequence:
+//
+//  1. collectAndBucketPods — partitions readyPods from eligible rolesets into prefill,
+//     decode, and (when bucketing is on) prompt-length-filtered and combined-role slices.
+//
+//  2. Pod availability check — errors immediately when no prefill or decode pods exist
+//     and no combined pod is available to cover the gap.
+//
+//  3. Bucketing path (AIBRIX_PROMPT_LENGTH_BUCKETING only) —
+//     a. No bucket match: prompt length falls outside every declared range.
+//     - Combined pods available → pick a random combined pod (no prefill HTTP call).
+//     - No combined pods → error; do not route to the wrong storm.
+//     b. Bucket match + load imbalance: prefill or decode pods are hot while a
+//     combined pod is idle → score and pick the best combined pod.
+//
+//  4. Prefill load-imbalance fast path — if outstanding prefill counts are skewed
+//     beyond aibrixPrefillLoadImbalanceMinSpread, narrow to the single least-loaded
+//     prefill pod and align decodePods to its roleset.
+//
+//  5. Decode load-imbalance fast path — three ordered checks (request-count spread,
+//     throughput spread, drain-rate ratio); the first that fires narrows decodePods
+//     to a single pod and aligns prefillPods to its roleset.
+//
+//  6. Score remaining candidates — scorePrefillPods and scoreDecodePods evaluate
+//     every roleset; finalPDScore picks the roleset with the lowest combined score.
+//
+//  7. Tracker registration — AddPrefillRequest and AddPendingDecode are called on
+//     the selected pods before returning so concurrent Route calls see up-to-date
+//     counts immediately.
 func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, readyPods []*v1.Pod) (*v1.Pod, *v1.Pod, error) {
 	var promptLength int
 	if aibrixPromptLengthBucketing {
@@ -334,17 +370,27 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 	if len(decodePods) == 0 && !combinedAvailable {
 		return nil, nil, fmt.Errorf("decode pods are not ready: prefill=%d, decode=%d", len(prefillPods), len(decodePods))
 	}
-	if combinedAvailable {
+
+	if aibrixPromptLengthBucketing {
 		if len(promptLengthBucketingPrefillPods) == 0 || len(promptLengthBucketingDecodePods) == 0 {
-			klog.InfoS("routing to combined pod", "requestId", routingCtx.RequestID, "promptLength", promptLength)
-			return nil, combinedPods[rand.Intn(len(combinedPods))], nil
+			// No bucket matches the request's prompt length.
+			if combinedAvailable {
+				// Combined pods cover any prompt length; pick one at random.
+				klog.InfoS("no bucket matches prompt length, routing to combined pod",
+					"requestId", routingCtx.RequestID, "promptLength", promptLength, "combinedPods", len(combinedPods),
+					"bucketPrefillPods", len(promptLengthBucketingPrefillPods), "bucketDecodePods", len(promptLengthBucketingDecodePods))
+				return nil, combinedPods[rand.Intn(len(combinedPods))], nil
+			}
+			// Do not fall back to unfiltered PD pods: each pod group (storm) is sized for a
+			// specific prompt-length range and cross-bucket routing produces incorrect results.
+			return nil, nil, fmt.Errorf("no prompt-length bucket matches prompt length %d and no combined pods available", promptLength)
 		}
 
+		// Bucket match exists; check if load imbalance favours a combined pod instead.
 		if r.shouldPickCombined(routingCtx, promptLengthBucketingPrefillPods, promptLengthBucketingDecodePods, combinedPods) {
 			combinedPod := r.scoreCombinedPods(routingCtx, combinedPods)
 			if combinedPod != nil {
-				klog.InfoS("load imbalance detected, selecting combined pod",
-					"requestId", routingCtx.RequestID, "selectedCombinedPod", combinedPod.Name)
+				klog.InfoS("load imbalance detected, selecting combined pod", "requestId", routingCtx.RequestID, "selectedCombinedPod", combinedPod.Name)
 				return nil, combinedPod, nil
 			}
 		}
@@ -352,32 +398,60 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 
 	// check for prefill and decode imbalance
 	targetPod, isImbalanced := r.loadImbalanceSelectPrefillPod(prefillPods, r.prefillRequestTracker.GetPrefillRequestCountsForPods(prefillPods))
-	if isImbalanced {
-		klog.InfoS("load imbalance detected, selecting least-loaded prefill pod", "request_id", routingCtx.RequestID, "selected_prefill_pod", targetPod.Name)
+	if isImbalanced && targetPod != nil {
 		prefillPods = []*v1.Pod{targetPod}
 		decodePods = utils.FilterPodsByLabel(decodePods, PDRoleSetIdentifier, targetPod.Labels[PDRoleSetIdentifier])
+		klog.V(4).InfoS("load imbalance detected, selecting least-loaded prefill pod",
+			"request_id", routingCtx.RequestID, "selected_prefill_pod", targetPod.Name,
+			"roleset", targetPod.Labels[PDRoleSetIdentifier], "decode_pods_after_align", pdPodNames(decodePods),
+		)
 	}
 
 	targetPod, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage := r.loadImbalanceSelectDecodePod(routingCtx, decodePods)
 	if targetPod != nil {
-		klog.InfoS("load imbalance detected in decode pods", "request_id", routingCtx.RequestID, "selected_decode_pod", targetPod.Name)
 		decodePods = []*v1.Pod{targetPod}
-		if len(prefillPods) > 1 {
-			prefillPods = utils.FilterPodsByLabel(prefillPods, PDRoleSetIdentifier, targetPod.Labels[PDRoleSetIdentifier])
+		if aligned := utils.FilterPodsByLabel(prefillPods, PDRoleSetIdentifier, targetPod.Labels[PDRoleSetIdentifier]); len(aligned) > 0 {
+			prefillPods = aligned
 		}
+		klog.V(4).InfoS("load imbalance detected in decode pods",
+			"request_id", routingCtx.RequestID, "selected_decode_pod", targetPod.Name,
+			"roleset", targetPod.Labels[PDRoleSetIdentifier], "prefill_pods_after_align", pdPodNames(prefillPods),
+		)
 	}
 
 	prefillPol, decodePol, err := r.effectiveScorePolicies(routingCtx)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	prefillScores, maxPrefillScore, prefixHashes := r.scorePrefillPods(routingCtx, prefillPods, prefillPol)
 	decodeRun := r.scoreDecodePods(routingCtx, decodePods, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage, decodePol)
-	return r.finalPDScore(routingCtx, prefixHashes, prefillScores, maxPrefillScore, decodeRun)
+	selectedPrefill, selectedDecode, err := r.finalPDScore(routingCtx, prefixHashes, prefillScores, maxPrefillScore, decodeRun)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Register pending prefill/decode immediately after selection so concurrent routing
+	// calls read up-to-date counts when evaluating load imbalance and scoring.
+	r.prefillRequestTracker.AddPrefillRequest(routingCtx.RequestID, selectedPrefill.Name)
+	r.pendingDecodeTracker.AddPendingDecode(routingCtx.RequestID, selectedDecode.Name)
+	return selectedPrefill, selectedDecode, nil
 }
 
-// loadImbalanceSelectPrefillPod evaluates if the load is imbalanced based on the abs difference between
-// pods with min and max outstanding request counts
+// loadImbalanceSelectPrefillPod is a fast path that runs before scorePrefillPods when
+// outstanding prefill load is visibly skewed across readyPods.
+//
+// podRequestCount holds per-pod active prefill counts from PrefillRequestTracker (in-flight
+// prefill HTTP requests not yet completed). readyPods is shuffled before evaluation so ties
+// among least-loaded pods are broken randomly.
+//
+// If max(count) − min(count) is greater than aibrixPrefillLoadImbalanceMinSpread, returns
+// one pod tied for the minimum count and imbalance=true. Otherwise returns nil, false.
+// An empty podRequestCount map always returns nil, false.
+//
+// The caller (filterPrefillDecodePods) narrows decodePods to the selected pod's roleset.
+// PrefillRequestTracker is updated after finalPDScore (not inside this function); counts
+// seen here include requests that have been assigned a prefill pod but not yet completed.
 func (r *pdRouter) loadImbalanceSelectPrefillPod(readyPods []*v1.Pod, podRequestCount map[string]int32) (*v1.Pod, bool) {
 	var imbalance bool
 	var targetPod *v1.Pod
@@ -407,94 +481,112 @@ func (r *pdRouter) loadImbalanceSelectPrefillPod(readyPods []*v1.Pod, podRequest
 	if maxValue-minValue > aibrixPrefillLoadImbalanceMinSpread && len(targetPods) > 0 {
 		targetPod, _ = utils.FilterPodByName(targetPods[rand.Intn(len(targetPods))], readyPods)
 		imbalance = true
+		if targetPod != nil {
+			klog.V(4).InfoS("prefill request imbalance detected, selecting least-loaded pod",
+				"min_request_count", minValue, "max_request_count", maxValue,
+				"selected_prefill_pod", targetPod.Name, "roleset", targetPod.Labels[PDRoleSetIdentifier],
+				"candidate_pods", strings.Join(targetPods, ","),
+			)
+		}
 	}
 
 	return targetPod, imbalance
 }
 
-// loadImbalanceSelectDecodePod selects a decode pod when load imbalance is detected. It walks all
-// filtered decode pods once, filling podRequestCounts, podThroughputs, and podFreeGpuUsage, then
-// applies three ordered checks (each runs only if the previous did not return):
+// loadImbalanceSelectDecodePod is a fast path that runs before scoreDecodePods when decode
+// load is visibly skewed. It walks filteredDecodePods once, filling podRequestCounts,
+// podThroughputs, and podFreeGpuUsage for the scoring pass, then applies three ordered checks
+// (each runs only if the previous did not return):
 //
-//  1. Request imbalance (fast path): if max minus min running request count (RealtimeNumRequestsRunning
-//     plus pending decode count) is at least aibrixDecodeLoadImbalanceMinSpread, return the least-loaded pod.
+//  1. Request imbalance: among pods that report RealtimeNumRequestsRunning, compute
+//     effective count = running + PendingDecodeTracker pending count for that pod. If
+//     max − min effective count is at least aibrixDecodeLoadImbalanceMinSpread, return the
+//     least-loaded metric-bearing pod. Pods without a running-request metric are excluded
+//     from the spread (their pending count is still stored in podRequestCounts for scoring)
+//     so freshly restarted pods are not treated as idle and given a thundering herd.
 //
-//  2. Throughput spread: if max minus min AvgGenerationThroughputToksPerS (per model) is greater than
-//     aibrixDecodeThroughputImbalanceMinSpread (AIBRIX_DECODE_THROUGHPUT_IMBALANCE_MIN_SPREAD), return the pod with minimum
-//     throughput. Missing throughput is treated as 0, which can make that pod look like the minimum
-//     during scrape gaps or startup.
+//  2. Throughput spread: among pods that report AvgGenerationThroughputToksPerS (per model),
+//     if max − min throughput exceeds aibrixDecodeThroughputImbalanceMinSpread, return the
+//     lowest-throughput pod. Pods missing the metric are excluded from this check.
 //
-//  3. Drain rate scoring (soft path): if every pod has a positive RealtimeRunningRequestsDrainRate1m,
-//     compute time-to-drain score runningRequests/drainRate per pod. If maxScore/minScore exceeds
-//     aibrixDecodeScoreRatioThreshold, return the pod with the lowest score. If any drain rate is
-//     missing or non-positive, this check is skipped entirely.
+//  3. Drain-rate scoring: if every pod has a positive RealtimeRunningRequestsDrainRate1m,
+//     score each pod as effectiveRequestCount / drainRate. If maxScore/minScore exceeds
+//     aibrixDecodeScoreRatioThreshold, return the pod with the lowest score. Skipped when
+//     any drain rate is missing or non-positive.
 //
-// Returns nil when none of the above fire; the caller uses scoreDecodePods with the collected maps.
-// Non-nil pod returns also carry maxRequestCount, maxThroughput, and maxFreeGPUUsage from the same pass.
+// Returns nil when none of the checks fire; the caller falls through to scoreDecodePods with
+// the collected maps. A non-nil pod return also carries maxRequestCount, maxThroughput, and
+// maxFreeGPUUsage from the same pass (maxima include all pods, including those without metrics).
+// The caller narrows prefillPods to the selected pod's roleset.
 func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filteredDecodePods []*v1.Pod) (*v1.Pod, float64, float64, float64, map[string]float64, map[string]float64, map[string]float64) {
 	podRequestCounts := make(map[string]float64)
 	podThroughputs := make(map[string]float64)
 	podFreeGpuUsage := make(map[string]float64)
 
-	minRequestPod := filteredDecodePods[0]
-	minRequestCount := math.MaxFloat64
+	var minRequestPod *v1.Pod
 	maxRequestCount := float64(1)
-	minThroughputPod := filteredDecodePods[0]
-	minThroughput := float64(math.MaxFloat64)
+	var minThroughputPod *v1.Pod
 	maxThroughput := float64(1)
 	maxFreeGPUUsage := float64(1)
+	maxObservedRequestCount := float64(0)
+	minObservedRequestCount := math.MaxFloat64
+	maxObservedThroughput := float64(0)
+	minObservedThroughput := math.MaxFloat64
 	utils.CryptoShuffle(filteredDecodePods)
 
 	for _, pod := range filteredDecodePods {
-		runningReqs, err := r.cache.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
-		if err != nil {
-			runningReqs = &metrics.SimpleMetricValue{Value: 0}
+		runningReqs, runningErr := r.cache.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
+		requestCount := r.pendingDecodeTracker.GetPendingDecodeCount(pod.Name)
+		if runningErr != nil {
+			podRequestCounts[pod.Name] = requestCount
+		} else {
+			requestCount += runningReqs.GetSimpleValue()
+			podRequestCounts[pod.Name] = requestCount
+			if requestCount < minObservedRequestCount {
+				minObservedRequestCount = requestCount
+				minRequestPod = pod
+			}
+			maxObservedRequestCount = math.Max(maxObservedRequestCount, requestCount)
 		}
-		requestCount := runningReqs.GetSimpleValue() + r.pendingDecodeTracker.GetPendingDecodeCount(pod.Name)
-		podRequestCounts[pod.Name] = requestCount
-		if requestCount < minRequestCount {
-			minRequestCount = requestCount
-			minRequestPod = pod
-		}
-		maxRequestCount = math.Max(maxRequestCount, requestCount)
+		maxRequestCount = math.Max(maxRequestCount, podRequestCounts[pod.Name])
 
-		tokenThroughput, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.AvgGenerationThroughputToksPerS)
-		if err != nil {
-			tokenThroughput = &metrics.SimpleMetricValue{Value: 0}
+		tokenThroughput, throughputErr := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.AvgGenerationThroughputToksPerS)
+		if throughputErr != nil {
+			podThroughputs[pod.Name] = 0
+		} else {
+			throughput := tokenThroughput.GetSimpleValue()
+			podThroughputs[pod.Name] = throughput
+			if throughput < minObservedThroughput {
+				minObservedThroughput = throughput
+				minThroughputPod = pod
+			}
+			maxObservedThroughput = math.Max(maxObservedThroughput, throughput)
+			maxThroughput = math.Max(maxThroughput, throughput)
 		}
-		throughput := tokenThroughput.GetSimpleValue()
-		podThroughputs[pod.Name] = throughput
-		if throughput < minThroughput {
-			minThroughput = throughput
-			minThroughputPod = pod
-		}
-		maxThroughput = math.Max(maxThroughput, throughput)
 
-		gpuUsage, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.KVCacheUsagePerc)
+		kvUsage, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.KVCacheUsagePerc)
 		if err != nil {
-			gpuUsage = &metrics.SimpleMetricValue{Value: 0}
+			kvUsage = &metrics.SimpleMetricValue{Value: 0}
 		}
-		podFreeGpuUsage[pod.Name] = math.Round(100 - gpuUsage.GetSimpleValue()*100)
+		podFreeGpuUsage[pod.Name] = math.Round(100 - kvUsage.GetSimpleValue()*100)
 		if podFreeGpuUsage[pod.Name] <= 0 {
 			podFreeGpuUsage[pod.Name] = 0.1
 		}
 		maxFreeGPUUsage = math.Max(maxFreeGPUUsage, podFreeGpuUsage[pod.Name])
 	}
 
-	if maxRequestCount-minRequestCount >= aibrixDecodeLoadImbalanceMinSpread {
+	if minRequestPod != nil && maxObservedRequestCount-minObservedRequestCount >= aibrixDecodeLoadImbalanceMinSpread {
 		klog.V(4).InfoS("request imbalance at decode pods", "request_id", ctx.RequestID,
-			"min_request_count", minRequestCount, "max_request_count", maxRequestCount,
-			"free_gpu_percent", podFreeGpuUsage[minRequestPod.Name],
-			"decode_pod", minRequestPod.Name)
+			"min_request_count", minObservedRequestCount, "max_request_count", maxObservedRequestCount,
+			"free_gpu_percent", podFreeGpuUsage[minRequestPod.Name], "decode_pod", minRequestPod.Name)
 		return minRequestPod, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage
 	}
 
-	if maxThroughput-minThroughput > aibrixDecodeThroughputImbalanceMinSpread {
+	if minThroughputPod != nil && maxObservedThroughput-minObservedThroughput > aibrixDecodeThroughputImbalanceMinSpread {
 		klog.V(4).InfoS("throughput imbalance at decode pods", "request_id", ctx.RequestID,
-			"min_request_count", minRequestCount, "max_request_count", maxRequestCount,
-			"min_throughput", minThroughput, "max_throughput", maxThroughput,
-			"free_gpu_percent", podFreeGpuUsage[minThroughputPod.Name],
-			"decode_pod", minThroughputPod.Name)
+			"min_request_count", minObservedRequestCount, "max_request_count", maxObservedRequestCount,
+			"min_throughput", minObservedThroughput, "max_throughput", maxObservedThroughput,
+			"free_gpu_percent", podFreeGpuUsage[minThroughputPod.Name], "decode_pod", minThroughputPod.Name)
 		return minThroughputPod, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage
 	}
 
@@ -518,7 +610,7 @@ func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filte
 	}
 
 	if drainRatesAvailable && minScore > 0 && maxScore/minScore > aibrixDecodeScoreRatioThreshold {
-		klog.InfoS("drain rate imbalance at decode pods", "request_id", ctx.RequestID,
+		klog.V(4).InfoS("drain rate imbalance at decode pods", "request_id", ctx.RequestID,
 			"min_score", minScore, "max_score", maxScore,
 			"ratio", maxScore/minScore, "decode_pod", minScorePod.Name)
 		return minScorePod, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage
@@ -527,18 +619,33 @@ func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filte
 	return nil, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage
 }
 
-// scorePrefillPods scores candidate prefill pods using prefillPolicy. Pods whose
-// running-request count exceeds mean+stddev*factor are skipped as overloaded.
-// Returns a per-roleset map of the best (lowest-score) pod, the global max score
-// used by finalPDScore for normalization, and the prefix hashes from the scorer.
+// scorePrefillPods scores candidate prefill pods with prefillPolicy after any imbalance
+// fast path has narrowed the list. readyPods are shuffled before scoring.
+//
+// Active prefill counts come from PrefillRequestTracker. Pods whose count exceeds
+// mean + standardDeviationFactor×stddev (AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR)
+// are skipped as overloaded. Each remaining pod is scored via prefillPolicy; the
+// lowest-scoring pod per roleset (PDRoleSetIdentifier) is kept.
+//
+// Returns a per-roleset score map, maxPrefillScore (the maximum score among all pods
+// scored in this pass, used by finalPDScore for normalization), and prefix hashes
+// from the policy's Prepare step for asynchronous prefix-cache updates. Returns
+// nil, 0, nil when Prepare fails.
+//
+// Policy resolution: the policy argument, then r.prefillPolicy, then prefix_cache.
 func (r *pdRouter) scorePrefillPods(routingCtx *types.RoutingContext, prefillPods []*v1.Pod, prefillPolicy pd.PrefillScorePolicy) (map[string]*Scores, float64, []uint64) {
-	if prefillPolicy == nil {
-		klog.ErrorS(nil, "scorePrefillPods called with nil prefillPolicy; this is a programming error",
-			"request_id", routingCtx.RequestID)
-		return nil, 0, nil
+	policy := prefillPolicy
+	if policy == nil {
+		policy = r.prefillPolicy
+	}
+	if policy == nil {
+		tbl := r.prefixCacheIndexer
+		if tbl == nil {
+			tbl = prefixcacheindexer.GetSharedPrefixHashTable()
+		}
+		policy = newPrefixCachePrefillPolicy(tbl)
 	}
 	utils.CryptoShuffle(prefillPods)
-
 	podRequestCount := r.prefillRequestTracker.GetPrefillRequestCountsForPods(prefillPods)
 
 	var maxRequestCount float64 = 1
@@ -557,10 +664,10 @@ func (r *pdRouter) scorePrefillPods(routingCtx *types.RoutingContext, prefillPod
 	meanRequestCount := mean(requestCounts)
 	stdDevRequestCount := standardDeviation(requestCounts)
 
-	scorer, err := prefillPolicy.Prepare(routingCtx, prefillPods, readyPodsMap)
+	scorer, err := policy.Prepare(routingCtx, prefillPods, readyPodsMap)
 	if err != nil {
 		klog.ErrorS(err, "prefill scorer preparation failed",
-			"request_id", routingCtx.RequestID, "policy", prefillPolicy.Name(), "model", routingCtx.Model)
+			"request_id", routingCtx.RequestID, "policy", policy.Name(), "model", routingCtx.Model)
 		return nil, 0, nil
 	}
 
@@ -588,10 +695,24 @@ func (r *pdRouter) scorePrefillPods(routingCtx *types.RoutingContext, prefillPod
 	return prefillScores, maxPrefillScore, scorer.PrefixHashes()
 }
 
-// scoreDecodePods scores candidate decode pods using policy, falling back to
-// load_balancing for a nil policy or for individual pods whose primary score is
-// invalid (NaN). Returns a DecodeScoreRun with the best (lowest-score) pod per
-// roleset and the global max score used by finalPDScore for normalization.
+// scoreDecodePods scores candidate decode pods with policy after any imbalance fast path
+// has narrowed the list. filteredDecodePods are shuffled before scoring.
+//
+// Metric inputs (podRequestCounts, podThroughputs, podFreeGpuUsage and their batch
+// maxima) are normally populated by loadImbalanceSelectDecodePod; when that returns
+// nil, the caller still passes the maps built during that pass.
+//
+// Policy resolution: the policy argument, then r.decodePolicy, then load_balancing.
+// When at least one pod reports both RealtimeNumRequestsRunning and
+// AvgGenerationThroughputToksPerS, pods missing either metric are skipped so
+// freshly restarted pods are not favored with zero load. If no pod has both metrics,
+// all pods are scored (cold-start fallback).
+//
+// Lower score is better. The lowest-scoring pod per roleset is kept in DecodeScoreRun.
+// PerRoleset. Invalid (NaN) scores from the primary policy are retried once with
+// load_balancing; FallbackUsed is set when that happens. Pods still invalid after
+// fallback are skipped. MaxScore is the maximum score among pods scored in this pass
+// (minimum 0.01), used by finalPDScore for normalization.
 func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDecodePods []*v1.Pod,
 	maxRequestCount float64, maxThroughput float64, maxFreeGPUUsage float64,
 	podRequestCounts map[string]float64, podThroughputs map[string]float64, podFreeGpuUsage map[string]float64,
@@ -615,8 +736,37 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 
 	utils.CryptoShuffle(filteredDecodePods)
 
+	anyMetricsReady := false
+	for _, pod := range filteredDecodePods {
+		if r.decodePodMetricsReady(routingCtx, pod) {
+			anyMetricsReady = true
+			break
+		}
+	}
+
+	scoredPods := make([]string, 0, len(filteredDecodePods))
+	skippedPods := make([]string, 0, len(filteredDecodePods))
+
 	for _, pod := range filteredDecodePods {
 		rolesetName := pod.Labels[PDRoleSetIdentifier]
+		if anyMetricsReady && !r.decodePodMetricsReady(routingCtx, pod) {
+			// Cold-start: assign a neutral score (1.0 = idle warm pod) plus gateway-tracked
+			// pending requests so the roleset competes fairly instead of being excluded entirely.
+			// Once the pod's first request completes and metrics arrive, it transitions to full scoring.
+			pending := float64(r.pendingDecodeTracker.GetPendingDecodeCount(pod.Name))
+			coldScore := 1.0 + pending
+			scoredPods = append(scoredPods, fmt.Sprintf("%s:score=%.4f,roleset=%s(cold)", pod.Name, coldScore, rolesetName))
+			klog.V(4).InfoS("decode pod metrics not ready, using cold-start score",
+				"request_id", routingCtx.RequestID, "pod", pod.Name, "roleset", rolesetName,
+				"cold_score", coldScore, "pending", pending)
+			if existing, exists := out.PerRoleset[rolesetName]; !exists || coldScore < existing.Score {
+				out.PerRoleset[rolesetName] = pd.RolesetDecodePick{Pod: pod, Score: coldScore}
+			}
+			if coldScore > out.MaxScore {
+				out.MaxScore = coldScore
+			}
+			continue
+		}
 		in := pd.DecodePodInput{
 			RunningReqs:     podRequestCounts[pod.Name],
 			Throughput:      podThroughputs[pod.Name],
@@ -633,11 +783,15 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 				out.FallbackUsed = true
 			}
 			if pd.InvalidDecodeScore(decodeScore) {
-				klog.V(2).InfoS("decode score invalid after policy and load_balancing fallback, skipping pod",
-					"request_id", routingCtx.RequestID, "pod", pod.Name, "policy", policyName)
+				skippedPods = append(skippedPods, fmt.Sprintf("%s:invalid_score", pod.Name))
+				klog.V(4).InfoS("decode score invalid after policy and load_balancing fallback, skipping pod",
+					"request_id", routingCtx.RequestID, "pod", pod.Name, "policy", policyName,
+					"roleset", pod.Labels[PDRoleSetIdentifier])
 				continue
 			}
 		}
+
+		scoredPods = append(scoredPods, fmt.Sprintf("%s:score=%.4f,roleset=%s", pod.Name, decodeScore, rolesetName))
 
 		if existing, exists := out.PerRoleset[rolesetName]; !exists || decodeScore < existing.Score {
 			out.PerRoleset[rolesetName] = pd.RolesetDecodePick{Pod: pod, Score: decodeScore}
@@ -647,13 +801,40 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 		}
 	}
 
+	perRolesetBest := make([]string, 0, len(out.PerRoleset))
+	for roleset, pick := range out.PerRoleset {
+		perRolesetBest = append(perRolesetBest, fmt.Sprintf("%s:%s=%.4f", roleset, pick.Pod.Name, pick.Score))
+	}
+	sort.Strings(perRolesetBest)
+	klog.V(4).InfoS("decode_score_summary",
+		"request_id", routingCtx.RequestID, "policy", policyName,
+		"fallback_used", out.FallbackUsed, "any_metrics_ready", anyMetricsReady,
+		"scored", strings.Join(scoredPods, " "), "skipped", strings.Join(skippedPods, " "),
+		"per_roleset_best", strings.Join(perRolesetBest, " "),
+	)
+
 	return out
 }
 
-// finalPDScore selects the winning prefill/decode pod pair by normalizing each
-// roleset's prefill and decode scores by their respective maxima and picking the
-// roleset with the lowest combined score. Enqueues a prefix-cache update and
-// emits selection metrics before returning.
+// finalPDScore picks the winning prefill/decode pod pair after scorePrefillPods and
+// scoreDecodePods. Only rolesets with an entry in both prefillScores and
+// decodeRun.PerRoleset are considered, so prefill and decode always come from the
+// same roleset.
+//
+// For each eligible roleset, combined score is:
+//
+//	normalizedPrefill + normalizedDecode
+//	  = prefillScore.Score / maxPrefillScore + decodePick.Score / decodeRun.MaxScore
+//
+// Lower combined score wins. Ties retain whichever roleset was last seen with that
+// score (map iteration order). Emits per-roleset final_score V(4) logs.
+//
+// Returns an error when decodeRun.Err is set, when no roleset has both sides scored
+// (target prefill or decode pod nil), or when prefillScores is empty. On success,
+// enqueues a prefix-cache update when prefixHashes is non-empty, increments internal
+// selection counters, and emits PDSelectedPrefillPodTotal / PDSelectedDecodePodTotal.
+// The caller registers the chosen prefill/decode pods with PrefillRequestTracker and
+// PendingDecodeTracker after return.
 func (r *pdRouter) finalPDScore(routingCtx *types.RoutingContext,
 	prefixHashes []uint64,
 	prefillScores map[string]*Scores, maxPrefillScore float64,
@@ -669,6 +850,9 @@ func (r *pdRouter) finalPDScore(routingCtx *types.RoutingContext,
 	for roleset, prefillScore := range prefillScores {
 		decodePick, ok := decodeRun.PerRoleset[roleset]
 		if !ok {
+			klog.V(4).InfoS("final_score_skip_roleset",
+				"request_id", routingCtx.RequestID, "roleset", roleset,
+				"prefill_pod", prefillScore.Pod.Name, "reason", "no_decode_score_for_roleset")
 			continue
 		}
 
@@ -682,15 +866,13 @@ func (r *pdRouter) finalPDScore(routingCtx *types.RoutingContext,
 			targetDecodePod = decodePick.Pod
 		}
 
-		klog.V(4).InfoS(
-			"final_score",
-			"request_id", routingCtx.RequestID,
-			"roleset", roleset,
-			"final_score", final,
+		klog.V(4).InfoS("final_score",
+			"request_id", routingCtx.RequestID, "roleset", roleset,
+			"final_score", final, "prefill_pod", prefillScore.Pod.Name,
+			"decode_pod", decodePick.Pod.Name,
 			"prefill_score", prefillScore.Score, "normalized_prefill_score", normalizedPrefillScore,
 			"decode_score", decodePick.Score, "normalized_decode_score", normalizedDecodeScore,
-			"decode_policy", decodeRun.Policy,
-			"decode_fallback_used", decodeRun.FallbackUsed,
+			"decode_policy", decodeRun.Policy, "decode_fallback_used", decodeRun.FallbackUsed,
 		)
 	}
 
@@ -768,7 +950,8 @@ func isPodWithHTTPServer(pod *v1.Pod) bool {
 func (r *pdRouter) isPodSuitableForPromptLength(routingCtx *types.RoutingContext, pod *v1.Pod, promptLength int) bool {
 	profile := configprofiles.ResolveProfileFromPod(pod, routingCtx.ReqConfigProfile)
 	if profile == nil {
-		return false
+		// Pods without model.aibrix.ai/config are not bucket-scoped; treat as any length.
+		return true
 	}
 	pdCfg := parsePDAlgorithmConfig(profile.RoutingConfig)
 	minLength, maxLength := pdCfg.PromptLenBucketMinLength, pdCfg.PromptLenBucketMaxLength
@@ -792,71 +975,42 @@ func (r *pdRouter) isPodSuitableForPromptLength(routingCtx *types.RoutingContext
 // for the given promptLength. Pods missing required PD labels or an HTTP server
 // are skipped.
 //
-// Phase 2 builds the output slices from rolesets that have both prefill and
-// decode pods (incomplete rolesets are excluded). When prompt-length bucketing
-// is enabled, it also produces filtered prefill/decode slices restricted to pods
-// whose capacity bucket covers promptLength; these filtered slices replace the
-// unfiltered ones in the primary return values when non-empty.
+// Phase 2 builds the output slices from replica-complete rolesets (all expected
+// prefill and decode replicas ready). When prompt-length bucketing is enabled, it
+// also produces filtered prefill/decode slices restricted to pods whose capacity
+// bucket covers promptLength; bucket-filtered prefill and decode slices are applied
+// together only when both sides have suitable pods.
 //
 // Returns (prefillPods, decodePods, promptLengthBucketingPrefillPods,
 // promptLengthBucketingDecodePods, combinedPods).
 func (r *pdRouter) collectAndBucketPods(routingCtx *types.RoutingContext, readyPods []*v1.Pod, promptLength int) ([]*v1.Pod, []*v1.Pod, []*v1.Pod, []*v1.Pod, []*v1.Pod) {
 	bucketingEnabled := aibrixPromptLengthBucketing
 
-	type rolesetBucket struct {
-		prefills []*v1.Pod
-		decodes  []*v1.Pod
-	}
-	byRoleset := make(map[string]*rolesetBucket)
 	var combinedPods []*v1.Pod
-
-	// Phase 1: single pass — group pods by roleset, collect combined pods.
-	// Applies all eligibility guards (labels, HTTP server) once per pod.
-	for _, pod := range readyPods {
-		roleSetID, hasRoleset := pod.Labels[PDRoleSetIdentifier]
-		if !hasRoleset {
-			continue
-		}
-		roleID, hasRole := pod.Labels[PDRoleIdentifier]
-		if !hasRole {
-			continue
-		}
-		// For multi-node scenarios, only select pods from node_rank=0 (PodGroupIndex=0)
-		// which have the HTTP server running.
-		if !isPodWithHTTPServer(pod) {
-			continue
-		}
-
-		switch roleID {
-		case "prefill":
-			b := byRoleset[roleSetID]
-			if b == nil {
-				b = &rolesetBucket{}
-				byRoleset[roleSetID] = b
+	if bucketingEnabled {
+		for _, pod := range readyPods {
+			_, hasRoleset := pod.Labels[PDRoleSetIdentifier]
+			if !hasRoleset {
+				continue
 			}
-			b.prefills = append(b.prefills, pod)
-		case "decode":
-			b := byRoleset[roleSetID]
-			if b == nil {
-				b = &rolesetBucket{}
-				byRoleset[roleSetID] = b
+			roleID, hasRole := pod.Labels[PDRoleIdentifier]
+			if !hasRole || roleID == PDRolePrefill || roleID == PDRoleDecode {
+				continue
 			}
-			b.decodes = append(b.decodes, pod)
-		default:
-			if bucketingEnabled && isCombinedPod(routingCtx, pod) && r.isPodSuitableForPromptLength(routingCtx, pod, promptLength) {
+			if !isPodWithHTTPServer(pod) {
+				continue
+			}
+			if isCombinedPod(routingCtx, pod) && r.isPodSuitableForPromptLength(routingCtx, pod, promptLength) {
 				combinedPods = append(combinedPods, pod)
 			}
 		}
 	}
 
-	// Phase 2: build output slices from rolesets that have both prefill and decode pods.
+	eligible := eligiblePDRolesets(readyPods)
 	var prefillPods, decodePods []*v1.Pod
 	var promptLengthBucketingPrefillPods, promptLengthBucketingDecodePods []*v1.Pod
 
-	for _, b := range byRoleset {
-		if len(b.prefills) == 0 || len(b.decodes) == 0 {
-			continue
-		}
+	for _, b := range eligible {
 		prefillPods = append(prefillPods, b.prefills...)
 		decodePods = append(decodePods, b.decodes...)
 
@@ -879,14 +1033,10 @@ func (r *pdRouter) collectAndBucketPods(routingCtx *types.RoutingContext, readyP
 		}
 	}
 
-	// Override prefill/decode with bucket-filtered pods if bucketing produced results.
-	if bucketingEnabled {
-		if len(promptLengthBucketingPrefillPods) > 0 {
-			prefillPods = promptLengthBucketingPrefillPods
-		}
-		if len(promptLengthBucketingDecodePods) > 0 {
-			decodePods = promptLengthBucketingDecodePods
-		}
+	// Apply bucket-filtered pods atomically so prefill/decode stay roleset-aligned.
+	if bucketingEnabled && len(promptLengthBucketingPrefillPods) > 0 && len(promptLengthBucketingDecodePods) > 0 {
+		prefillPods = promptLengthBucketingPrefillPods
+		decodePods = promptLengthBucketingDecodePods
 	}
 
 	return prefillPods, decodePods, promptLengthBucketingPrefillPods, promptLengthBucketingDecodePods, combinedPods
@@ -955,6 +1105,27 @@ func isCombinedPod(routingCtx *types.RoutingContext, pod *v1.Pod) bool {
 	}
 	pdCfg := parsePDAlgorithmConfig(profile.RoutingConfig)
 	return pdCfg.Combined
+}
+
+func (r *pdRouter) decodePodMetricsReady(ctx *types.RoutingContext, pod *v1.Pod) bool {
+	if r == nil || r.cache == nil || ctx == nil || pod == nil {
+		return false
+	}
+	_, runningErr := r.cache.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
+	return runningErr == nil
+}
+
+// decodePodKVCacheUsagePerc returns KV cache utilization (0–1). vLLM exposes
+// vllm:kv_cache_usage_perc; older engines may still publish gpu_cache_usage_perc.
+func (r *pdRouter) decodePodKVCacheUsagePerc(ctx *types.RoutingContext, pod *v1.Pod) (metrics.MetricValue, error) {
+	if r == nil || r.cache == nil || ctx == nil || pod == nil {
+		return nil, fmt.Errorf("kv cache metric unavailable")
+	}
+	kv, err := r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.KVCacheUsagePerc)
+	if err == nil {
+		return kv, nil
+	}
+	return r.cache.GetMetricValueByPodModel(pod.Name, pod.Namespace, ctx.Model, metrics.GPUCacheUsagePerc)
 }
 
 func getLLMEngine(pod *v1.Pod, labelName string, defaultValue string) string {

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_benchmark_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_benchmark_test.go
@@ -184,6 +184,7 @@ func BenchmarkDoPrefillRequest(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				ctx.RequestID = fmt.Sprintf("bench-prefill-%s-%d", engine, i)
 				ctx.RequestTime = time.Now()
+				router.prefillRequestTracker.AddPrefillRequest(ctx.RequestID, prefillPod.Name)
 				if err := router.doPrefillRequest(ctx, prefillPod, engine); err != nil {
 					b.Fatalf("doPrefillRequest failed: %v", err)
 				}

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -2760,7 +2760,6 @@ func TestFilterPrefillDecodePods_SelectCorrectBucketPods(t *testing.T) {
 	assert.NotNil(t, decode)
 	assert.Equal(t, "prefill-ok", prefill.Name)
 	assert.Equal(t, "decode-ok", decode.Name)
-	assert.Equal(t, int32(1), r.prefillRequestTracker.GetPrefillRequestCountsForPods([]*v1.Pod{prefill})[prefill.Name])
 }
 
 func TestFilterPrefillDecodePods_CombinedFallbackBucketing(t *testing.T) {
@@ -2791,6 +2790,59 @@ func TestFilterPrefillDecodePods_CombinedFallbackBucketing(t *testing.T) {
 	assert.NotNil(t, decode)
 	assert.Equal(t, "combined-1", decode.Name)
 	assert.Equal(t, 0, r.prefillRequestTracker.GetPrefillRequestCountsForPod("prefill-ok"))
+}
+
+func TestFilterPrefillDecodePods_BucketDecodeDownFallbackToCombined(t *testing.T) {
+	old := aibrixPromptLengthBucketing
+	aibrixPromptLengthBucketing = true
+	defer func() { aibrixPromptLengthBucketing = old }()
+
+	r := pdRouter{
+		cache:                 cache.NewForTest(),
+		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
+		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
+		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
+		httpClient:            &http.Client{},
+		selectionCounts:       map[string]int64{},
+	}
+
+	// Build a prompt that tokenizes to exactly 20 tokens (medium bucket: 16–32).
+	mediumPrompt := ""
+	for len(mediumPrompt) < 4096 {
+		tokens, err := utils.TokenizeInputText(mediumPrompt)
+		if err != nil {
+			t.Fatalf("tokenize: %v", err)
+		}
+		if len(tokens) == 20 {
+			break
+		}
+		mediumPrompt += "a"
+	}
+	tokens, err := utils.TokenizeInputText(mediumPrompt)
+	if err != nil {
+		t.Fatalf("tokenize: %v", err)
+	}
+	if len(tokens) != 20 {
+		t.Fatalf("expected 20 tokens, got %d", len(tokens))
+	}
+
+	configShort := pdConfigAnnotation(0, 15, false)
+	configMedium := pdConfigAnnotation(16, 32, false)
+	configCombined := pdConfigAnnotation(0, 0, true)
+
+	shortPrefill := makePDPod("prefill-short", "rs-short", "prefill", map[string]string{constants.ModelAnnoConfig: configShort})
+	shortDecode := makePDPod("decode-short", "rs-short", "decode", map[string]string{constants.ModelAnnoConfig: configShort})
+	medPrefill := makePDPod("prefill-med", "rs-med", "prefill", map[string]string{constants.ModelAnnoConfig: configMedium})
+	// Medium decode is down — only prefill remains.
+	combined := makePDPod("combined-1", "rs-comb", "combined", map[string]string{constants.ModelAnnoConfig: configCombined})
+
+	ctx := types.NewRoutingContext(context.Background(), "pd", "test-model", mediumPrompt, "req-decode-down", "user")
+	prefill, decode, err := r.filterPrefillDecodePods(ctx, []*v1.Pod{shortPrefill, shortDecode, medPrefill, combined})
+	assert.NoError(t, err)
+	assert.Nil(t, prefill, "combined routing should not set a prefill pod")
+	assert.NotNil(t, decode)
+	assert.Equal(t, "combined-1", decode.Name)
 }
 
 func TestFilterPrefillDecodePods_NoBucketMatchNoCombined(t *testing.T) {

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -115,6 +115,7 @@ func TestPDRouter_Route(t *testing.T) {
 			ctx.Engine = tt.llmEngine
 			ctx.ReqPath = testChatCompletionsPath
 			ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
+			ctx.Engine = tt.llmEngine
 
 			result, err := r.Route(ctx, &utils.PodArray{Pods: tt.readyPods})
 
@@ -209,6 +210,7 @@ func TestPDRouter_RouteDoesNotEmitAsyncPrefillSuccessBeforeHTTPCompletes(t *test
 	ctx.Engine = SGLangEngine
 	ctx.ReqPath = testChatCompletionsPath
 	ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
+	ctx.Engine = SGLangEngine
 
 	result, err := r.Route(ctx, &utils.PodArray{Pods: pods})
 
@@ -294,6 +296,7 @@ func TestPDRouter_RouteRecordsAsyncPrefillFailureWithoutSuccess(t *testing.T) {
 	ctx.Engine = SGLangEngine
 	ctx.ReqPath = testChatCompletionsPath
 	ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
+	ctx.Engine = SGLangEngine
 
 	result, err := r.Route(ctx, &utils.PodArray{Pods: pods})
 
@@ -712,6 +715,36 @@ func TestScorePrefillPods_PrefixCachePolicy(t *testing.T) {
 	})
 }
 
+func TestScorePrefillPods_NilPolicyFallback(t *testing.T) {
+	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "hello world", "req-1", "user")
+	pod := func(name, roleset string) *v1.Pod { return makePDPod(name, roleset, "", nil) }
+
+	t.Run("falls back to router prefill policy", func(t *testing.T) {
+		tracker := pd.NewPrefillRequestTracker()
+		addRequests(tracker, "pod2", 5)
+
+		r := &pdRouter{
+			prefillPolicy:         pd.NewLeastRequestPrefillPolicy(),
+			prefillRequestTracker: tracker,
+		}
+
+		scores, _, _ := r.scorePrefillPods(ctx, []*v1.Pod{pod("pod1", "rs1"), pod("pod2", "rs1")}, nil)
+		assert.Len(t, scores, 1)
+		assert.Equal(t, "pod1", scores["rs1"].Pod.Name)
+	})
+
+	t.Run("falls back to prefix_cache when router policy is nil", func(t *testing.T) {
+		tracker := pd.NewPrefillRequestTracker()
+		addRequests(tracker, "pod2", 5)
+
+		r := &pdRouter{prefillRequestTracker: tracker}
+
+		scores, _, _ := r.scorePrefillPods(ctx, []*v1.Pod{pod("pod1", "rs1"), pod("pod2", "rs1")}, nil)
+		assert.Len(t, scores, 1)
+		assert.Equal(t, "pod1", scores["rs1"].Pod.Name)
+	})
+}
+
 func TestScorePrefillPods_LeastRequestPolicy(t *testing.T) {
 	ctx := types.NewRoutingContext(context.Background(), "pd", "model", "hello world", "req-1", "user")
 
@@ -1094,6 +1127,7 @@ func TestDoPrefillRequest(t *testing.T) {
 			routingCtx := createRoutingCtx()
 			router := createRouter(prefillPods, tt.podMetrics)
 
+			router.prefillRequestTracker.AddPrefillRequest(routingCtx.RequestID, prefillPods[0].Name)
 			err := router.doPrefillRequest(routingCtx, prefillPods[0], tt.llmEngine)
 			if tt.expectError {
 				assert.Error(t, err)
@@ -1548,6 +1582,7 @@ func TestVLLMIntegrationWithTestServer(t *testing.T) {
 	}
 	router.prefillExecutor = prefill.NewDefaultExecutor(vllmClient, vllmTracker, prefillRequestTimeout)
 
+	vllmTracker.AddPrefillRequest(routingCtx.RequestID, prefillPods[0].Name)
 	err := router.doPrefillRequest(routingCtx, prefillPods[0], VLLMEngine)
 	assert.NoError(t, err)
 
@@ -1678,6 +1713,7 @@ func TestTensorRTIntegrationWithTestServer(t *testing.T) {
 	}
 	router.prefillExecutor = prefill.NewDefaultExecutor(trtClient, trtTracker, prefillRequestTimeout)
 
+	trtTracker.AddPrefillRequest(routingCtx.RequestID, prefillPods[0].Name)
 	err := router.doPrefillRequest(routingCtx, prefillPods[0], TensorRTLLM)
 	assert.NoError(t, err)
 
@@ -2439,10 +2475,18 @@ func TestIsPodSuitableForPromptLength(t *testing.T) {
 
 // makePDPod creates a minimal pod with PD role labels and optional annotations.
 func makePDPod(name, roleset, role string, annotations map[string]string) *v1.Pod {
+	return pdPodWithReplica(name, roleset, role, "", annotations)
+}
+
+func pdPodWithReplica(name, roleset, role, replicaIndex string, annotations map[string]string) *v1.Pod {
+	labels := map[string]string{PDRoleSetIdentifier: roleset, PDRoleIdentifier: role}
+	if replicaIndex != "" {
+		labels[RoleReplicaIndex] = replicaIndex
+	}
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Labels:      map[string]string{PDRoleSetIdentifier: roleset, PDRoleIdentifier: role},
+			Labels:      labels,
 			Annotations: annotations,
 		},
 	}
@@ -2530,6 +2574,23 @@ func TestCollectAndBucketPods(t *testing.T) {
 		prefills, decodes, _, _, _ := router.collectAndBucketPods(ctx, pods, 11)
 		assert.ElementsMatch(t, []string{"prefill-rs1", "prefill-rs2"}, podNames(prefills))
 		assert.ElementsMatch(t, []string{"decode-rs1", "decode-rs2"}, podNames(decodes))
+	})
+
+	t.Run("partial decode replicas still eligible when peer roleset has more decodes", func(t *testing.T) {
+		old := aibrixPromptLengthBucketing
+		aibrixPromptLengthBucketing = false
+		defer func() { aibrixPromptLengthBucketing = old }()
+
+		pods := []*v1.Pod{
+			pdPodWithReplica("prefill-rs1", "rs1", "prefill", "0", nil),
+			pdPodWithReplica("decode-rs1", "rs1", "decode", "0", nil),
+			pdPodWithReplica("prefill-rs2", "rs2", "prefill", "0", nil),
+			pdPodWithReplica("decode-rs2-a", "rs2", "decode", "0", nil),
+			pdPodWithReplica("decode-rs2-b", "rs2", "decode", "1", nil),
+		}
+		prefills, decodes, _, _, _ := router.collectAndBucketPods(ctx, pods, 11)
+		assert.ElementsMatch(t, []string{"prefill-rs1", "prefill-rs2"}, podNames(prefills))
+		assert.ElementsMatch(t, []string{"decode-rs1", "decode-rs2-a", "decode-rs2-b"}, podNames(decodes))
 	})
 
 	t.Run("bucketing: both sides suitable - roleset included in bucketed slices", func(t *testing.T) {
@@ -2679,6 +2740,7 @@ func TestFilterPrefillDecodePods_SelectCorrectBucketPods(t *testing.T) {
 		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
 		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
 		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
 		httpClient:            &http.Client{},
 		selectionCounts:       map[string]int64{},
 	}
@@ -2698,6 +2760,7 @@ func TestFilterPrefillDecodePods_SelectCorrectBucketPods(t *testing.T) {
 	assert.NotNil(t, decode)
 	assert.Equal(t, "prefill-ok", prefill.Name)
 	assert.Equal(t, "decode-ok", decode.Name)
+	assert.Equal(t, int32(1), r.prefillRequestTracker.GetPrefillRequestCountsForPods([]*v1.Pod{prefill})[prefill.Name])
 }
 
 func TestFilterPrefillDecodePods_CombinedFallbackBucketing(t *testing.T) {
@@ -2708,6 +2771,7 @@ func TestFilterPrefillDecodePods_CombinedFallbackBucketing(t *testing.T) {
 		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
 		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
 		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
 		httpClient:            &http.Client{},
 		selectionCounts:       map[string]int64{},
 	}
@@ -2726,6 +2790,34 @@ func TestFilterPrefillDecodePods_CombinedFallbackBucketing(t *testing.T) {
 	assert.Nil(t, prefill)
 	assert.NotNil(t, decode)
 	assert.Equal(t, "combined-1", decode.Name)
+	assert.Equal(t, 0, r.prefillRequestTracker.GetPrefillRequestCountsForPod("prefill-ok"))
+}
+
+func TestFilterPrefillDecodePods_NoBucketMatchNoCombined(t *testing.T) {
+	old := aibrixPromptLengthBucketing
+	aibrixPromptLengthBucketing = true
+	defer func() { aibrixPromptLengthBucketing = old }()
+
+	r := pdRouter{
+		cache:                 cache.NewForTest(),
+		prefillPolicy:         pd.NewPrefixCachePrefillPolicy(tokenizer.NewCharacterTokenizer(), prefixcacheindexer.NewPrefixHashTable()),
+		prefixCacheIndexer:    prefixcacheindexer.NewPrefixHashTable(),
+		prefillRequestTracker: pd.NewPrefillRequestTracker(),
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
+		httpClient:            &http.Client{},
+		selectionCounts:       map[string]int64{},
+	}
+
+	configBlocked := pdConfigAnnotation(0, 1, false)
+	prefillOK := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "prefill-ok", Labels: map[string]string{PDRoleSetIdentifier: "rs1", PDRoleIdentifier: "prefill"}, Annotations: map[string]string{constants.ModelAnnoConfig: configBlocked}}}
+	decodeOK := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "decode-ok", Labels: map[string]string{PDRoleSetIdentifier: "rs1", PDRoleIdentifier: "decode"}, Annotations: map[string]string{constants.ModelAnnoConfig: configBlocked}}}
+
+	ctx := types.NewRoutingContext(context.Background(), "pd", "test-model", "say test", "req-no-bucket", "user")
+	prefill, decode, err := r.filterPrefillDecodePods(ctx, []*v1.Pod{prefillOK, decodeOK})
+	assert.Error(t, err)
+	assert.Nil(t, prefill)
+	assert.Nil(t, decode)
+	assert.Contains(t, err.Error(), "no prompt-length bucket matches")
 }
 
 func TestFilterPrefillDecodePods_CombinedPickImbalance(t *testing.T) {

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -115,7 +115,6 @@ func TestPDRouter_Route(t *testing.T) {
 			ctx.Engine = tt.llmEngine
 			ctx.ReqPath = testChatCompletionsPath
 			ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
-			ctx.Engine = tt.llmEngine
 
 			result, err := r.Route(ctx, &utils.PodArray{Pods: tt.readyPods})
 
@@ -210,7 +209,6 @@ func TestPDRouter_RouteDoesNotEmitAsyncPrefillSuccessBeforeHTTPCompletes(t *test
 	ctx.Engine = SGLangEngine
 	ctx.ReqPath = testChatCompletionsPath
 	ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
-	ctx.Engine = SGLangEngine
 
 	result, err := r.Route(ctx, &utils.PodArray{Pods: pods})
 
@@ -296,7 +294,6 @@ func TestPDRouter_RouteRecordsAsyncPrefillFailureWithoutSuccess(t *testing.T) {
 	ctx.Engine = SGLangEngine
 	ctx.ReqPath = testChatCompletionsPath
 	ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"test"}],"stream":true}`)
-	ctx.Engine = SGLangEngine
 
 	result, err := r.Route(ctx, &utils.PodArray{Pods: pods})
 

--- a/pkg/plugins/gateway/algorithms/pd_readme.md
+++ b/pkg/plugins/gateway/algorithms/pd_readme.md
@@ -19,7 +19,7 @@ Client Request
      ▼
 Route(ctx, readyPodList)
      │
-     ├─► validateAndGetLLMEngine()
+     ├─► ValidateAndGetLLMEngine()
      │        Ensure all pods use the same engine (vllm / sglang / trtllm)
      │
      ├─► filterPrefillDecodePods()
@@ -251,7 +251,7 @@ Controlled by `AIBRIX_DECODE_SCORE_POLICY`, or overridden per request via **`rou
 Metrics are pulled from the cache per pod (same maps as `loadImbalanceSelectDecodePod`):
 - `RealtimeNumRequestsRunning` + `PendingDecodeTracker` count
 - `AvgGenerationThroughputToksPerS` (per model)
-- `KVCacheUsagePerc` (free = 100 − usage%; falls back to deprecated `GPUCacheUsagePerc`)
+- `KVCacheUsagePerc` (free = 100 − usage%)
 
 **Cold-start gate**: if at least one pod has `RealtimeNumRequestsRunning`, pods that lack it are given a neutral **cold-start score** (`1.0 + pending_decode_count`) rather than full policy scoring. When *no* pod has that metric yet, all pods are scored normally.
 
@@ -428,7 +428,7 @@ collectAndBucketPods()
     └─ Bucket pass: per roleset, keep pods whose bucket covers promptLength
                     only when BOTH prefill and decode sides match (half-pairs excluded)
 
-If bucket-filtered lists are non-empty, they replace the unfiltered prefill/decode lists.
+If both bucket-filtered lists are non-empty, they replace the unfiltered prefill/decode lists atomically so the sides stay roleset-aligned.
 ```
 
 ### No-match guard and combined fallback

--- a/pkg/plugins/gateway/algorithms/pd_readme.md
+++ b/pkg/plugins/gateway/algorithms/pd_readme.md
@@ -38,8 +38,10 @@ Route(ctx, readyPodList)
      │        ├─► scoreDecodePods()
      │        └─► finalPDScore()  →  (prefillPod, decodePod)
      │
+     │        (filterPrefillDecodePods registers pending prefill+decode immediately
+     │         after selection so concurrent scorers see up-to-date counts)
+     │
      ├─► [prefillPod != nil]
-     │        pendingDecodeTracker.AddPendingDecode(requestID, decodePod)
      │        doPrefillRequest(ctx, prefillPod, engine)
      │              ├─ SGLang   → async goroutine (bootstrap handshake; Route does not wait for completion)
      │              ├─ vLLM     → sync, extract kv_transfer_params from response
@@ -60,9 +62,45 @@ Pods are grouped using Kubernetes labels:
 | `roleset-name` | any string | Groups prefill+decode pairs into a "roleset" |
 | `role-name` | `prefill` / `decode` / other | Pod's role in PD disaggregation |
 | `stormservice.orchestration.aibrix.ai/pod-group-index` | `"0"` or absent | Only pods with index `"0"` (or no label) host the HTTP server (multi-node TP) |
+| `stormservice.orchestration.aibrix.ai/role-replica-index` | any string | Distinct replica index within a role; used by `roleReplicaCardinality` to count unique replicas across multi-node TP groups. When absent, each routable pod counts as its own replica. |
 | `model.aibrix.ai/engine` | `vllm` / `sglang` / `trtllm` | LLM engine type |
 
-Only rolesets with **both** at least one prefill pod and one decode pod are eligible. Incomplete rolesets are excluded.
+Only rolesets with **both** at least one prefill replica and one decode replica are eligible. Incomplete rolesets are excluded. See [Roleset Eligibility Utilities](#roleset-eligibility-utilities) for diagnostic functions.
+
+---
+
+## Roleset Eligibility Utilities
+
+`pd_roleset.go` provides helper functions used by both the router and the gateway's pod-readiness logic.
+
+### Replica cardinality
+
+A roleset's replica count is the number of **distinct** values of `stormservice.orchestration.aibrix.ai/role-replica-index`. When that label is absent on all pods of a role, each routable pod counts as its own replica. This correctly handles multi-node tensor-parallel groups where multiple pods share one logical replica slot.
+
+```
+roleReplicaCardinality(pods):
+  if any pod has role-replica-index label:
+    count distinct index values
+  else:
+    count routable pods
+```
+
+### Eligibility checks
+
+A roleset is **eligible** when it has ≥1 prefill replica **and** ≥1 decode replica.
+
+| Function | Use |
+|----------|-----|
+| `HasEligibleRoleset(readyPods)` | Gateway check: at least one roleset is fully ready for PD routing |
+| `eligiblePDRolesets(readyPods)` | Internal: returns only complete rolesets for scoring |
+| `DescribePDRolesetEligibility(readyPods)` | Diagnostics: per-roleset replica counts and eligibility flag |
+| `LogPDRolesetEligibility(requestID, readyPods, reason)` | Emits `klog.InfoS` for partial or missing rolesets |
+
+`filterPrefillDecodePods` calls `DescribePDRolesetEligibility` on every request and emits a log entry when any roleset is incomplete or no eligible roleset exists.
+
+### Engine validation scope
+
+`validateAndGetLLMEngine` checks **only prefill pods from eligible rolesets** (not all ready pods). This prevents a restarting or mis-labeled pod in an incomplete roleset from blocking routing on healthy rolesets.
 
 ---
 
@@ -74,7 +112,8 @@ collectAndBucketPods()
         ▼
 ┌───────────────────────────────┐
 │  prefillPods / decodePods     │
-│  (grouped by roleset)         │
+│  (grouped by eligible         │
+│   rolesets only)              │
 └───────────────────────────────┘
         │
         ▼
@@ -82,23 +121,30 @@ loadImbalanceSelectPrefillPod()
   ┌─────────────────────────────────────────────────────────┐
   │  max(outstanding_prefill_reqs) - min > MIN_SPREAD?      │
   │  → YES: narrow to single least-loaded prefill pod       │
+  │         align decodePods to selected pod's roleset      │
   │  → NO:  continue with all prefill pods                  │
   └─────────────────────────────────────────────────────────┘
         │
         ▼
-loadImbalanceSelectDecodePod()  (3 ordered checks)
+loadImbalanceSelectDecodePod()  (3 ordered checks, metrics-bearing pods only)
   ┌──────────────────────────────────────────────────────────────────┐
   │  Check 1 – Request count spread                                  │
-  │    max(running_reqs+pending) - min >= DECODE_LOAD_SPREAD?        │
-  │    → YES: return least-loaded decode pod                         │
+  │    Only pods with RealtimeNumRequestsRunning metric participate  │
+  │    (pods without the metric are excluded from spread; their      │
+  │     pending count is still stored for scoring — prevents         │
+  │     thundering-herd on freshly restarted pods)                   │
+  │    max(observed running+pending) - min >= DECODE_LOAD_SPREAD?    │
+  │    → YES: return least-loaded observed pod;                      │
+  │           align prefillPods to selected pod's roleset            │
   │                                                                  │
   │  Check 2 – Throughput spread                                     │
-  │    max(throughput_tok/s) - min > THROUGHPUT_SPREAD?              │
-  │    → YES: return lowest-throughput decode pod                    │
+  │    Only pods with AvgGenerationThroughputToksPerS participate    │
+  │    max(observed throughput) - min > THROUGHPUT_SPREAD?           │
+  │    → YES: return lowest-throughput observed pod                  │
   │                                                                  │
   │  Check 3 – Drain rate score (soft path)                          │
   │    all pods have drain_rate > 0?                                 │
-  │    score = running_reqs / drain_rate                             │
+  │    score = effective_running_reqs / drain_rate                   │
   │    max_score / min_score > DECODE_SCORE_RATIO?                   │
   │    → YES: return pod with lowest drain-rate score                │
   └──────────────────────────────────────────────────────────────────┘
@@ -118,6 +164,10 @@ scorePrefillPods()              (per roleset, best pod wins)
         ▼
 scoreDecodePods()  →  pd.DecodeScoreRun (per roleset best pod + MaxScore + policy metadata)
   ┌──────────────────────────────────────────────────────────────────┐
+  │  Cold-start (if some pods have metrics but this pod does not):   │
+  │    score = 1.0 + pending_decode_count                            │
+  │    (neutral idle-warm score; pod competes but is not favored)    │
+  │                                                                  │
   │  Policy: load_balancing (default)                                │
   │    norm_reqs     = running_reqs / max_running_reqs               │
   │    norm_thru     = 1 - throughput / max_throughput               │
@@ -185,7 +235,9 @@ Controlled by `AIBRIX_DECODE_SCORE_POLICY`, or overridden per request via **`rou
 Metrics are pulled from the cache per pod (same maps as `loadImbalanceSelectDecodePod`):
 - `RealtimeNumRequestsRunning` + `PendingDecodeTracker` count
 - `AvgGenerationThroughputToksPerS` (per model)
-- `GPUCacheUsagePerc` (free = 100 − usage%)
+- `KVCacheUsagePerc` (free = 100 − usage%; falls back to deprecated `GPUCacheUsagePerc`)
+
+**Cold-start gate**: if at least one pod has both `RealtimeNumRequestsRunning` and `AvgGenerationThroughputToksPerS`, pods that lack either metric are given a neutral **cold-start score** (`1.0 + pending_decode_count`) rather than being excluded. This lets a freshly restarted pod participate in roleset selection without being assigned zero-load status that would attract a thundering herd. When *no* pod has metrics yet, all pods are scored normally (full cold-start fallback).
 
 ### `load_balancing` (default)
 
@@ -331,12 +383,17 @@ Timeline:
 ```
 Route() called
   │
-  ├─ filterPrefillDecodePods() selects decodePod
-  ├─ AddPendingDecode(requestID, decodePod)   ← counts as +1 running
-  ├─ doPrefillRequest()                        (may take seconds)
+  ├─ filterPrefillDecodePods()
+  │     ├─ finalPDScore() selects decodePod
+  │     ├─ AddPrefillRequest(requestID, prefillPod)   ← registered before return
+  │     └─ AddPendingDecode(requestID, decodePod)     ← registered before return
+  │          (concurrent Route() calls now see correct counts during scoring)
+  │
+  ├─ defer RemovePendingDecode(requestID)   ← Route() registers cleanup
+  ├─ doPrefillRequest()                      (may take seconds)
+  │     └─ on error: RemovePrefillRequest(requestID) called immediately
   ├─ ctx.SetTargetPod(decodePod)
-  ├─ return address to caller
-  └─ defer RemovePendingDecode(requestID)      ← cleaned up after Route returns
+  └─ return address to caller
 ```
 
 ---
@@ -356,6 +413,23 @@ collectAndBucketPods()
 
 If bucket-filtered lists are non-empty, they replace the unfiltered lists.
 ```
+
+### Model-level bucketing detection
+
+`modelUsesPromptLengthBucketing()` checks whether any ready pod for the model declares an explicit prompt-length bucket (non-default `promptLenBucketMinLength` / `promptLenBucketMaxLength`) or a `combined=true` role. When no pod has such config, standard PD routing applies even if `AIBRIX_PROMPT_LENGTH_BUCKETING` is globally enabled — so adding the feature flag to a cluster does not affect models that have not opted in.
+
+### No-match guard
+
+When bucketing is enabled **and** the model uses bucketing (has at least one pod with bucket config), but the request's prompt length does not fall within any pod's declared range, the router returns an error rather than silently falling back to the unfiltered prefill/decode pool. Routing to the wrong bucket's pods would be incorrect: each pod group (storm) is sized and configured for a specific prompt-length range, so cross-bucket routing would produce unpredictable KV cache behavior.
+
+```
+if AIBRIX_PROMPT_LENGTH_BUCKETING &&
+   modelUsesPromptLengthBucketing() &&
+   (bucketPrefills == 0 || bucketDecodes == 0):
+     → error: "no prompt-length bucket matches prompt length N and no combined pods available"
+```
+
+This guard fires only after the combined-pod path has already been exhausted (combined pods are checked first and also handle the no-bucket-match case when they exist).
 
 ### Combined Pods
 
@@ -386,7 +460,7 @@ When a combined pod is selected, `prefillPod` is `nil` (no prefill HTTP call) an
 |----------|---------|-------------|
 | `AIBRIX_PREFILL_SCORE_POLICY` | `prefix_cache` | Prefill pod scoring: `prefix_cache` or `least_request`. Any other value logs a warning and falls back to `prefix_cache`. |
 | `AIBRIX_DECODE_SCORE_POLICY` | `load_balancing` | Decode pod scoring for `finalPDScore`: `load_balancing` or `least_request`. Any other value logs a warning and falls back to `load_balancing`. |
-| `AIBRIX_KV_CONNECTOR_TYPE` | `shfs` | KV transfer backend: `shfs` (GPU/SHFS) or `nixl` (Neuron) |
+| `AIBRIX_KV_CONNECTOR_TYPE` | `shfs` | KV transfer backend: `shfs` (GPU/SHFS), `nixl` (Neuron/NIXL), or `mooncake` (Mooncake) |
 | `AIBRIX_PREFILL_REQUEST_TIMEOUT` | `30` | Prefill HTTP request timeout in seconds |
 | `AIBRIX_PROMPT_LENGTH_BUCKETING` | `false` | Enable prompt-length-based pod bucketing |
 
@@ -487,4 +561,10 @@ NewPDRouter()
   ├─ NewPrefillRequestTracker()
   ├─ NewPendingDecodeTracker()
   └─ startPrefixUpdater()                 // background goroutine
+
+// pd_roleset.go (no per-router state; pure functions called on each request)
+HasEligibleRoleset(readyPods)             // gateway: skip PD when no complete roleset
+eligiblePDRolesets(readyPods)             // internal: filter to complete rolesets only
+DescribePDRolesetEligibility(readyPods)   // diagnostics: per-roleset replica counts
+LogPDRolesetEligibility(id, pods, reason) // info-level log on partial rolesets
 ```

--- a/pkg/plugins/gateway/algorithms/pd_readme.md
+++ b/pkg/plugins/gateway/algorithms/pd_readme.md
@@ -38,10 +38,10 @@ Route(ctx, readyPodList)
      │        ├─► scoreDecodePods()
      │        └─► finalPDScore()  →  (prefillPod, decodePod)
      │
-     │        (filterPrefillDecodePods registers pending prefill+decode immediately
-     │         after selection so concurrent scorers see up-to-date counts)
+     ├─► AddPendingDecode() + defer RemovePendingDecode()  (all paths)
      │
      ├─► [prefillPod != nil]
+     │        AddPrefillRequest()
      │        doPrefillRequest(ctx, prefillPod, engine)
      │              ├─ SGLang   → async goroutine (bootstrap handshake; Route does not wait for completion)
      │              ├─ vLLM     → sync, extract kv_transfer_params from response
@@ -94,13 +94,8 @@ A roleset is **eligible** when it has ≥1 prefill replica **and** ≥1 decode r
 | `HasEligibleRoleset(readyPods)` | Gateway check: at least one roleset is fully ready for PD routing |
 | `eligiblePDRolesets(readyPods)` | Internal: returns only complete rolesets for scoring |
 | `DescribePDRolesetEligibility(readyPods)` | Diagnostics: per-roleset replica counts and eligibility flag |
-| `LogPDRolesetEligibility(requestID, readyPods, reason)` | Emits `klog.InfoS` for partial or missing rolesets |
 
-`filterPrefillDecodePods` calls `DescribePDRolesetEligibility` on every request and emits a log entry when any roleset is incomplete or no eligible roleset exists.
-
-### Engine validation scope
-
-`validateAndGetLLMEngine` checks **only prefill pods from eligible rolesets** (not all ready pods). This prevents a restarting or mis-labeled pod in an incomplete roleset from blocking routing on healthy rolesets.
+`ValidateAndGetLLMEngine` (called from the gateway before `Route`) checks that all ready pods for the model share the same `model.aibrix.ai/engine` label.
 
 ---
 
@@ -122,12 +117,23 @@ loadImbalanceSelectPrefillPod()
   │  max(outstanding_prefill_reqs) - min > MIN_SPREAD?      │
   │  → YES: narrow to single least-loaded prefill pod       │
   │         align decodePods to selected pod's roleset      │
+  │         (continues to decode fast path below)           │
   │  → NO:  continue with all prefill pods                  │
   └─────────────────────────────────────────────────────────┘
+        │
+        │  NOTE: the two fast paths are independent. Both can fire on the
+        │  same request if both sides are imbalanced: prefill narrows first,
+        │  then decode narrows within the already-aligned decode set.
         │
         ▼
 loadImbalanceSelectDecodePod()  (3 ordered checks, metrics-bearing pods only)
   ┌──────────────────────────────────────────────────────────────────┐
+  │  Effective request count = RealtimeNumRequestsRunning            │
+  │                          + PendingDecodeTracker count            │
+  │  Pending counts bridge the gap between pod selection and the     │
+  │  first metric update, preventing thundering-herd on a newly      │
+  │  selected pod whose running count has not yet ticked up.         │
+  │                                                                  │
   │  Check 1 – Request count spread                                  │
   │    Only pods with RealtimeNumRequestsRunning metric participate  │
   │    (pods without the metric are excluded from spread; their      │
@@ -153,6 +159,9 @@ loadImbalanceSelectDecodePod()  (3 ordered checks, metrics-bearing pods only)
 scorePrefillPods()              (per roleset, best pod wins)
   ┌──────────────────────────────────────────────────────────────────┐
   │  Skip pods with req_count > mean + N * stddev                    │
+  │  (N = AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR)            │
+  │  When all pods in a roleset are filtered, that roleset has no    │
+  │  entry in the output map and finalPDScore cannot select it.      │
   │                                                                  │
   │  Policy: prefix_cache (default)                                  │
   │    score = (100 - match_pct) * 0.1  +  req_cnt / max_req_cnt    │
@@ -190,6 +199,13 @@ finalPDScore()
   │    final = norm_prefill_score + norm_decode_score                │
   │  Pick roleset with minimum final score                           │
   │  → selectedPrefillPod, selectedDecodePod                         │
+  │                                                                  │
+  │  Errors:                                                         │
+  │  • prefillScores nil          → Prepare failed in scorer         │
+  │  • prefillScores empty        → all prefill pods filtered by     │
+  │                                 stddev (no eligible candidate)   │
+  │  • no roleset intersection    → load-imbalance alignment left    │
+  │                                 prefill/decode on different sets │
   └──────────────────────────────────────────────────────────────────┘
 ```
 
@@ -237,7 +253,7 @@ Metrics are pulled from the cache per pod (same maps as `loadImbalanceSelectDeco
 - `AvgGenerationThroughputToksPerS` (per model)
 - `KVCacheUsagePerc` (free = 100 − usage%; falls back to deprecated `GPUCacheUsagePerc`)
 
-**Cold-start gate**: if at least one pod has both `RealtimeNumRequestsRunning` and `AvgGenerationThroughputToksPerS`, pods that lack either metric are given a neutral **cold-start score** (`1.0 + pending_decode_count`) rather than being excluded. This lets a freshly restarted pod participate in roleset selection without being assigned zero-load status that would attract a thundering herd. When *no* pod has metrics yet, all pods are scored normally (full cold-start fallback).
+**Cold-start gate**: if at least one pod has `RealtimeNumRequestsRunning`, pods that lack it are given a neutral **cold-start score** (`1.0 + pending_decode_count`) rather than full policy scoring. When *no* pod has that metric yet, all pods are scored normally.
 
 ### `load_balancing` (default)
 
@@ -364,8 +380,8 @@ Machine ID is set via `AIBRIX_TRT_MACHINE_ID` (must be in `[0, 1024)`).
 Tracks active **prefill** request counts per pod using `sync.Map` and `atomic.Int32`. Used by both prefill load-imbalance detection and `scorePrefillPods` (mean/stddev filter).
 
 ```
-AddPrefillRequest(requestID, podName)   // on prefill start
-RemovePrefillRequest(requestID)         // on prefill end (deferred)
+AddPrefillRequest(requestID, podName)   // in Route(), after PD pod selection, before prefill HTTP
+RemovePrefillRequest(requestID)         // on prefill end (executor defer) or Route error
 GetPrefillRequestCountsForPods(pods)    // for scoring
 ```
 
@@ -374,7 +390,7 @@ GetPrefillRequestCountsForPods(pods)    // for scoring
 Bridges the gap between **decode pod selection** and the actual decode request starting. Without this, concurrent requests could all route to the same decode pod (since `RealtimeNumRequestsRunning` hasn't updated yet).
 
 ```
-AddPendingDecode(requestID, podName)    // after pod selection, before prefill
+AddPendingDecode(requestID, podName)    // in Route(), immediately after pod selection
 RemovePendingDecode(requestID)          // deferred in Route()
 GetPendingDecodeCount(podName)          // added to running reqs in decode scoring
 ```
@@ -383,14 +399,14 @@ Timeline:
 ```
 Route() called
   │
-  ├─ filterPrefillDecodePods()
-  │     ├─ finalPDScore() selects decodePod
-  │     ├─ AddPrefillRequest(requestID, prefillPod)   ← registered before return
-  │     └─ AddPendingDecode(requestID, decodePod)     ← registered before return
-  │          (concurrent Route() calls now see correct counts during scoring)
+  ├─ filterPrefillDecodePods() → (prefillPod, decodePod)
+  │     └─ [combined path] returns prefillPod=nil
   │
-  ├─ defer RemovePendingDecode(requestID)   ← Route() registers cleanup
-  ├─ doPrefillRequest()                      (may take seconds)
+  ├─ AddPendingDecode(requestID, decodePod)
+  ├─ defer RemovePendingDecode(requestID)
+  │
+  ├─ [PD path] AddPrefillRequest(requestID, prefillPod)
+  ├─ [PD path] doPrefillRequest()              (may take seconds)
   │     └─ on error: RemovePrefillRequest(requestID) called immediately
   ├─ ctx.SetTargetPod(decodePod)
   └─ return address to caller
@@ -406,47 +422,50 @@ Each pod can declare a prompt-length range via its config profile (`promptLenBuc
 
 ```
 collectAndBucketPods()
-    ├─ Phase 1: build roleset → {prefills, decodes}
-    └─ Phase 2: filter each roleset by prompt length range
-                 → promptLengthBucketingPrefillPods
-                 → promptLengthBucketingDecodePods
+    ├─ Combined pass: collect combined-role pods (role-name is not prefill/decode)
+    │                 with combined=true and a prompt-length match
+    ├─ Eligible rolesets: group by roleset-name (prefill + decode both present)
+    └─ Bucket pass: per roleset, keep pods whose bucket covers promptLength
+                    only when BOTH prefill and decode sides match (half-pairs excluded)
 
-If bucket-filtered lists are non-empty, they replace the unfiltered lists.
+If bucket-filtered lists are non-empty, they replace the unfiltered prefill/decode lists.
 ```
 
-### Model-level bucketing detection
+### No-match guard and combined fallback
 
-`modelUsesPromptLengthBucketing()` checks whether any ready pod for the model declares an explicit prompt-length bucket (non-default `promptLenBucketMinLength` / `promptLenBucketMaxLength`) or a `combined=true` role. When no pod has such config, standard PD routing applies even if `AIBRIX_PROMPT_LENGTH_BUCKETING` is globally enabled — so adding the feature flag to a cluster does not affect models that have not opted in.
+When `AIBRIX_PROMPT_LENGTH_BUCKETING=true`, a roleset enters the bucket-filtered lists only when **both** its prefill and decode pods match the request's prompt length. A roleset with only one matching side (misconfigured bucket or a missing decode pod) is excluded from the bucket lists.
 
-### No-match guard
-
-When bucketing is enabled **and** the model uses bucketing (has at least one pod with bucket config), but the request's prompt length does not fall within any pod's declared range, the router returns an error rather than silently falling back to the unfiltered prefill/decode pool. Routing to the wrong bucket's pods would be incorrect: each pod group (storm) is sized and configured for a specific prompt-length range, so cross-bucket routing would produce unpredictable KV cache behavior.
+If no complete bucket-matched prefill/decode pair exists for the request — including when the prompt length is outside every declared range, or when the matching roleset is incomplete (e.g. decode pod is down) — the router falls back to a combined pod when one is available. Otherwise it returns an error rather than cross-routing to a different bucket's PD pair:
 
 ```
 if AIBRIX_PROMPT_LENGTH_BUCKETING &&
-   modelUsesPromptLengthBucketing() &&
    (bucketPrefills == 0 || bucketDecodes == 0):
-     → error: "no prompt-length bucket matches prompt length N and no combined pods available"
+     if combined pods available for this prompt length → route to combined (random pick)
+     else → error: "no prompt-length bucket matches prompt length N and no combined pods available"
 ```
 
-This guard fires only after the combined-pod path has already been exhausted (combined pods are checked first and also handle the no-bucket-match case when they exist).
+Pods without a `model.aibrix.ai/config` annotation are treated as suitable for any prompt length. With bucketing enabled globally, models that do not declare explicit bucket ranges still participate using those default bounds.
 
 ### Combined Pods
 
-When bucketing is enabled, pods with `combined=true` in their config profile can act as both prefill and decode. The router falls back to a combined pod when:
+When bucketing is enabled, pods with `combined=true` in their config profile can act as both prefill and decode. Combined pods use a `role-name` other than `prefill` or `decode` (for example `all`). The router falls back to a combined pod when:
 
-1. No bucket-matched prefill/decode pods exist for the request's prompt length, **or**
+1. No complete bucket-matched prefill/decode pair exists for the request's prompt length (prompt outside all buckets, incomplete roleset, or decode pod unavailable), **or**
 2. `shouldPickCombined()` returns `true`:
-   - At least one combined pod has request rate < `0.25` (low load), **and**
-   - At least one prefill pod **or** decode pod has request rate > `1.0` (high load).
+   - At least one combined pod has queue-drain score < `0.25` (low load), **and**
+   - At least one prefill pod **or** decode pod has queue-drain score > `1.0` (high load).
+
+Queue-drain score is `(waiting_reqs + prealloc_queues) / drain_rate_1m` (see `calculatePodScoreBasedOffRequestRate`).
 
 ```
 shouldPickCombined():
-    combinedLowLoad  = any combined pod request_rate < 0.25
-    prefillHighLoad  = any prefill pod request_rate > 1.0
-    decodeHighLoad   = any decode pod request_rate > 1.0
+    combinedLowLoad  = any combined pod score < 0.25
+    prefillHighLoad  = any prefill pod score > 1.0
+    decodeHighLoad   = any decode pod score > 1.0  (skipped if prefillHighLoad)
     return (prefillHighLoad OR decodeHighLoad) AND combinedLowLoad
 ```
+
+When a combined pod is selected for load imbalance, `scoreCombinedPods()` picks the lowest-score combined pod. The no-match path picks a combined pod at random.
 
 When a combined pod is selected, `prefillPod` is `nil` (no prefill HTTP call) and `decodePod` is the selected combined pod.
 
@@ -566,5 +585,4 @@ NewPDRouter()
 HasEligibleRoleset(readyPods)             // gateway: skip PD when no complete roleset
 eligiblePDRolesets(readyPods)             // internal: filter to complete rolesets only
 DescribePDRolesetEligibility(readyPods)   // diagnostics: per-roleset replica counts
-LogPDRolesetEligibility(id, pods, reason) // info-level log on partial rolesets
 ```

--- a/pkg/plugins/gateway/algorithms/pd_roleset.go
+++ b/pkg/plugins/gateway/algorithms/pd_roleset.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"sort"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type pdRolesetBucket struct {
+	prefills []*v1.Pod
+	decodes  []*v1.Pod
+}
+
+func groupPDPodsByRoleset(readyPods []*v1.Pod) map[string]*pdRolesetBucket {
+	byRoleset := make(map[string]*pdRolesetBucket)
+	for _, pod := range readyPods {
+		roleSetID, hasRoleset := pod.Labels[PDRoleSetIdentifier]
+		if !hasRoleset {
+			continue
+		}
+		roleID, hasRole := pod.Labels[PDRoleIdentifier]
+		if !hasRole {
+			continue
+		}
+		if !isPodWithHTTPServer(pod) {
+			continue
+		}
+		switch roleID {
+		case PDRolePrefill, PDRoleDecode:
+			b := byRoleset[roleSetID]
+			if b == nil {
+				b = &pdRolesetBucket{}
+				byRoleset[roleSetID] = b
+			}
+			if roleID == PDRolePrefill {
+				b.prefills = append(b.prefills, pod)
+			} else {
+				b.decodes = append(b.decodes, pod)
+			}
+		}
+	}
+	return byRoleset
+}
+
+// roleReplicaCardinality returns how many distinct replicas of a role are present.
+// Pods with a RoleReplicaIndex label are deduplicated by that value; pods without
+// the label (or with an empty value) each count as their own replica by pod name.
+func roleReplicaCardinality(pods []*v1.Pod) int {
+	if len(pods) == 0 {
+		return 0
+	}
+	seen := make(map[string]struct{}, len(pods))
+	for _, pod := range pods {
+		if idx, ok := pod.Labels[RoleReplicaIndex]; ok && idx != "" {
+			seen[idx] = struct{}{}
+		} else {
+			seen[pod.Name] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func fleetExpectedRoleCounts(byRoleset map[string]*pdRolesetBucket) (maxPrefill, maxDecode int) {
+	for _, b := range byRoleset {
+		if n := roleReplicaCardinality(b.prefills); n > maxPrefill {
+			maxPrefill = n
+		}
+		if n := roleReplicaCardinality(b.decodes); n > maxDecode {
+			maxDecode = n
+		}
+	}
+	return maxPrefill, maxDecode
+}
+
+func isPDRolesetEligible(b *pdRolesetBucket) bool {
+	return roleReplicaCardinality(b.prefills) > 0 && roleReplicaCardinality(b.decodes) > 0
+}
+
+// eligiblePDRolesets returns rolesets with at least one routable prefill and decode pod.
+func eligiblePDRolesets(readyPods []*v1.Pod) map[string]*pdRolesetBucket {
+	byRoleset := groupPDPodsByRoleset(readyPods)
+	eligible := make(map[string]*pdRolesetBucket, len(byRoleset))
+	for id, b := range byRoleset {
+		if isPDRolesetEligible(b) {
+			eligible[id] = b
+		}
+	}
+	return eligible
+}
+
+// HasEligibleRoleset reports whether at least one PD roleset has both a prefill and
+// decode pod ready for disaggregated routing.
+func HasEligibleRoleset(readyPods []*v1.Pod) bool {
+	return len(eligiblePDRolesets(readyPods)) > 0
+}
+
+func prefillPodsFromEligibleRolesets(readyPods []*v1.Pod) []*v1.Pod {
+	eligible := eligiblePDRolesets(readyPods)
+	out := make([]*v1.Pod, 0, len(eligible))
+	for _, b := range eligible {
+		out = append(out, b.prefills...)
+	}
+	return out
+}
+
+// PDRolesetEligibility describes one roleset's readiness for PD routing.
+type PDRolesetEligibility struct {
+	Roleset         string
+	PrefillReplicas int
+	DecodeReplicas  int
+	PrefillPods     string
+	DecodePods      string
+	Eligible        bool
+}
+
+func pdPodNames(pods []*v1.Pod) string {
+	if len(pods) == 0 {
+		return ""
+	}
+	names := make([]string, len(pods))
+	for i, p := range pods {
+		names[i] = p.Name
+	}
+	sort.Strings(names)
+	return strings.Join(names, ",")
+}
+
+// DescribePDRolesetEligibility returns fleet-wide max replica counts (for diagnostics)
+// and per-roleset eligibility (≥1 prefill and ≥1 decode).
+func DescribePDRolesetEligibility(readyPods []*v1.Pod) (fleetMaxPrefill, fleetMaxDecode int, statuses []PDRolesetEligibility, eligibleCount int) {
+	byRoleset := groupPDPodsByRoleset(readyPods)
+	fleetMaxPrefill, fleetMaxDecode = fleetExpectedRoleCounts(byRoleset)
+	statuses = make([]PDRolesetEligibility, 0, len(byRoleset))
+	for id, b := range byRoleset {
+		eligible := isPDRolesetEligible(b)
+		if eligible {
+			eligibleCount++
+		}
+		statuses = append(statuses, PDRolesetEligibility{
+			Roleset:         id,
+			PrefillReplicas: roleReplicaCardinality(b.prefills),
+			DecodeReplicas:  roleReplicaCardinality(b.decodes),
+			PrefillPods:     pdPodNames(b.prefills),
+			DecodePods:      pdPodNames(b.decodes),
+			Eligible:        eligible,
+		})
+	}
+	sort.Slice(statuses, func(i, j int) bool { return statuses[i].Roleset < statuses[j].Roleset })
+	return fleetMaxPrefill, fleetMaxDecode, statuses, eligibleCount
+}

--- a/pkg/plugins/gateway/algorithms/pd_roleset_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_roleset_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func pdPod(name, roleset, role, replicaIndex string) *v1.Pod {
+	labels := map[string]string{
+		PDRoleSetIdentifier: roleset,
+		PDRoleIdentifier:    role,
+	}
+	if replicaIndex != "" {
+		labels[RoleReplicaIndex] = replicaIndex
+	}
+	return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+}
+
+func TestHasEligibleRoleset(t *testing.T) {
+	t.Run("complete single roleset", func(t *testing.T) {
+		pods := []*v1.Pod{
+			pdPod("prefill-0", "rs1", "prefill", "0"),
+			pdPod("decode-0", "rs1", "decode", "0"),
+			pdPod("decode-1", "rs1", "decode", "1"),
+		}
+		assert.True(t, HasEligibleRoleset(pods))
+	})
+
+	t.Run("partial decode replicas still eligible with one decode", func(t *testing.T) {
+		pods := []*v1.Pod{
+			pdPod("prefill-rs1", "rs1", "prefill", "0"),
+			pdPod("decode-rs1", "rs1", "decode", "0"),
+			pdPod("prefill-rs2", "rs2", "prefill", "0"),
+			pdPod("decode-rs2-a", "rs2", "decode", "0"),
+			pdPod("decode-rs2-b", "rs2", "decode", "1"),
+		}
+		assert.True(t, HasEligibleRoleset(pods))
+		eligible := eligiblePDRolesets(pods)
+		assert.Contains(t, eligible, "rs1")
+		assert.Contains(t, eligible, "rs2")
+	})
+
+	t.Run("only prefill not eligible", func(t *testing.T) {
+		pods := []*v1.Pod{pdPod("prefill-only", "rs1", "prefill", "0")}
+		assert.False(t, HasEligibleRoleset(pods))
+	})
+
+	t.Run("only decode not eligible", func(t *testing.T) {
+		pods := []*v1.Pod{pdPod("decode-only", "rs1", "decode", "0")}
+		assert.False(t, HasEligibleRoleset(pods))
+	})
+
+	t.Run("mixed fleet sizes both eligible with one prefill and one decode", func(t *testing.T) {
+		// Mirrors production: 9svsx has more replicas than v8h7g; both should route.
+		pods := []*v1.Pod{
+			pdPod("9svsx-prefill-0", "vllm-qwen3-8b-tp-roleset-9svsx", "prefill", "0"),
+			pdPod("9svsx-prefill-1", "vllm-qwen3-8b-tp-roleset-9svsx", "prefill", "1"),
+			pdPod("9svsx-decode-0", "vllm-qwen3-8b-tp-roleset-9svsx", "decode", "0"),
+			pdPod("9svsx-decode-1", "vllm-qwen3-8b-tp-roleset-9svsx", "decode", "1"),
+			pdPod("9svsx-decode-2", "vllm-qwen3-8b-tp-roleset-9svsx", "decode", "2"),
+			pdPod("v8h7g-prefill-0", "vllm-qwen3-8b-tp-roleset-v8h7g", "prefill", "0"),
+			pdPod("v8h7g-prefill-1", "vllm-qwen3-8b-tp-roleset-v8h7g", "prefill", "1"),
+			pdPod("v8h7g-decode-0", "vllm-qwen3-8b-tp-roleset-v8h7g", "decode", "0"),
+			pdPod("v8h7g-decode-1", "vllm-qwen3-8b-tp-roleset-v8h7g", "decode", "1"),
+		}
+		_, _, statuses, eligibleCount := DescribePDRolesetEligibility(pods)
+		assert.Equal(t, 2, eligibleCount)
+		assert.Len(t, statuses, 2)
+		byRoleset := map[string]bool{}
+		for _, s := range statuses {
+			byRoleset[s.Roleset] = s.Eligible
+		}
+		assert.True(t, byRoleset["vllm-qwen3-8b-tp-roleset-9svsx"])
+		assert.True(t, byRoleset["vllm-qwen3-8b-tp-roleset-v8h7g"])
+	})
+}
+
+func TestPrefillPodsFromEligibleRolesets(t *testing.T) {
+	pods := []*v1.Pod{
+		pdPod("prefill-rs1", "rs1", "prefill", "0"),
+		pdPod("decode-rs1", "rs1", "decode", "0"),
+		pdPod("prefill-rs2", "rs2", "prefill", "0"),
+		pdPod("decode-rs2-a", "rs2", "decode", "0"),
+		pdPod("decode-rs2-b", "rs2", "decode", "1"),
+	}
+	out := prefillPodsFromEligibleRolesets(pods)
+	assert.Len(t, out, 2)
+	names := []string{out[0].Name, out[1].Name}
+	assert.ElementsMatch(t, []string{"prefill-rs1", "prefill-rs2"}, names)
+}

--- a/test/e2e/pd_bucketing_test.go
+++ b/test/e2e/pd_bucketing_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/vllm-project/aibrix/pkg/utils"
+)
+
+const (
+	bucketShortStorm    = "mock-llama2-pd-bkt-sht"
+	bucketMediumStorm   = "mock-llama2-pd-bkt-med"
+	bucketCombinedStorm = "mock-llama2-pd-bkt-comb"
+)
+
+// promptWithTokenLength returns a string that tokenizes to exactly tokenCount tokens
+// using the same cl100k_base tokenizer as the gateway PD router.
+func promptWithTokenLength(t *testing.T, tokenCount int) string {
+	t.Helper()
+	s := ""
+	for len(s) < 4096 {
+		tokens, err := utils.TokenizeInputText(s)
+		require.NoError(t, err)
+		if len(tokens) == tokenCount {
+			return s
+		}
+		s += "a"
+	}
+	t.Fatalf("failed to build prompt with %d tokens", tokenCount)
+	return ""
+}
+
+func assertPDBucketingRoute(t *testing.T, prompt, stormName string, expectCombined bool) {
+	t.Helper()
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+
+	chatCompletion, err := client.Chat.Completions.New(context.TODO(), openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage(prompt),
+		},
+		Model: modelNameVLLMBucket,
+	})
+	require.NoError(t, err, "PD bucketing chat completion failed for storm %s", stormName)
+	assert.Equal(t, modelNameVLLMBucket, chatCompletion.Model)
+
+	decodePod := dst.Header.Get("target-pod")
+	prefillPod := dst.Header.Get("prefill-target-pod")
+	require.NotEmpty(t, decodePod, "target-pod header must be set")
+
+	if expectCombined {
+		assert.Empty(t, prefillPod, "combined routing should not set prefill-target-pod")
+		assert.True(t, strings.Contains(decodePod, bucketCombinedStorm),
+			"expected combined pod, got decode=%s", decodePod)
+	} else {
+		assert.NotEmpty(t, prefillPod, "prefill-target-pod header must be set for PD routing")
+		assert.True(t, strings.Contains(prefillPod, stormName),
+			"prefill pod %s should belong to storm %s", prefillPod, stormName)
+		assert.True(t, strings.Contains(decodePod, stormName),
+			"decode pod %s should belong to storm %s", decodePod, stormName)
+		assert.NotEqual(t, prefillPod, decodePod)
+	}
+
+	t.Logf("storm=%s combined=%v — prefill: %s, decode: %s", stormName, expectCombined, prefillPod, decodePod)
+}
+
+// TestPDDisaggregationVLLMBucketDecodeDownFallbackToCombined verifies that when the
+// medium-storm decode pod is deleted, a prompt of 20 tokens (which matches the 16–32
+// bucket) falls back to the combined pod instead of erroring or cross-routing.
+func TestPDDisaggregationVLLMBucketDecodeDownFallbackToCombined(t *testing.T) {
+	waitForPDDisaggregationRouting(t, modelNameVLLMBucket)
+
+	mediumPrompt := promptWithTokenLength(t, 20)
+	mediumTokens, err := utils.TokenizeInputText(mediumPrompt)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(mediumTokens), 16)
+	require.LessOrEqual(t, len(mediumTokens), 32)
+
+	ctx := context.Background()
+	k8sClient, _ := initializeClient(ctx, t)
+
+	initialPods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{})
+	require.NoError(t, err)
+	initialCount := len(initialPods.Items)
+
+	decodePods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{
+		LabelSelector: "role-name=decode,storm-service-name=" + bucketMediumStorm,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, decodePods.Items, "expected at least one decode pod in medium storm")
+
+	podToDelete := decodePods.Items[0].Name
+	t.Logf("deleting medium-storm decode pod: %s", podToDelete)
+	require.NoError(t, k8sClient.CoreV1().Pods("default").Delete(ctx, podToDelete, v1.DeleteOptions{}))
+
+	t.Cleanup(func() {
+		validateAllPodsAreReady(t, k8sClient, initialCount)
+		waitForPDDisaggregationRouting(t, modelNameVLLMBucket)
+		t.Logf("medium-storm decode pod %s has been recreated", podToDelete)
+	})
+
+	// Poll until the gateway observes the deletion and routes the medium prompt to combined.
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+
+	err = wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+				Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage(mediumPrompt)},
+				Model:    modelNameVLLMBucket,
+			})
+			if err != nil {
+				t.Logf("waiting for fallback routing: %v", err)
+				return false, nil
+			}
+			prefillPod := dst.Header.Get("prefill-target-pod")
+			decodePod := dst.Header.Get("target-pod")
+			if prefillPod != "" || !strings.Contains(decodePod, bucketCombinedStorm) {
+				t.Logf("not yet routing to combined: prefill=%s decode=%s", prefillPod, decodePod)
+				return false, nil
+			}
+			return true, nil
+		})
+	require.NoError(t, err, "medium prompt should fall back to combined pod when medium-storm decode is down")
+
+	prefillPod := dst.Header.Get("prefill-target-pod")
+	decodePod := dst.Header.Get("target-pod")
+	assert.Empty(t, prefillPod, "combined routing should not set prefill-target-pod")
+	assert.True(t, strings.Contains(decodePod, bucketCombinedStorm),
+		"expected combined pod, got decode=%s", decodePod)
+	t.Logf("fallback confirmed — decode: %s", decodePod)
+}
+
+// TestPDDisaggregationVLLMPromptLengthBucketing verifies that with
+// AIBRIX_PROMPT_LENGTH_BUCKETING enabled, the gateway routes prompts to the
+// correct StormService bucket: 0–15 and 16–32 use matching prefill/decode
+// rolesets; prompts above 32 fall back to the combined role.
+func TestPDDisaggregationVLLMPromptLengthBucketing(t *testing.T) {
+	waitForPDDisaggregationRouting(t, modelNameVLLMBucket)
+
+	shortPrompt := promptWithTokenLength(t, 10)
+	mediumPrompt := promptWithTokenLength(t, 20)
+	longPrompt := promptWithTokenLength(t, 40)
+
+	shortTokens, err := utils.TokenizeInputText(shortPrompt)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(shortTokens), 15)
+
+	mediumTokens, err := utils.TokenizeInputText(mediumPrompt)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(mediumTokens), 16)
+	require.LessOrEqual(t, len(mediumTokens), 32)
+
+	longTokens, err := utils.TokenizeInputText(longPrompt)
+	require.NoError(t, err)
+	require.Greater(t, len(longTokens), 32)
+
+	waitForPDCombinedRouting(t, modelNameVLLMBucket, bucketCombinedStorm, longPrompt)
+
+	assertPDBucketingRoute(t, shortPrompt, bucketShortStorm, false)
+	assertPDBucketingRoute(t, mediumPrompt, bucketMediumStorm, false)
+	assertPDBucketingRoute(t, longPrompt, bucketCombinedStorm, true)
+}

--- a/test/e2e/pd_test.go
+++ b/test/e2e/pd_test.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // assertPDDisaggregation sends a single PD-routed chat completion for the given model and
@@ -101,10 +103,90 @@ func TestPDDisaggregationTRTLLM(t *testing.T) {
 		"TRT-LLM")
 }
 
+// assertPDDisaggregationAfterPodDeletion deletes one pod for modelName and roleLabel,
+// waits for the gateway to notice, then verifies PD-routed requests still succeed via
+// remaining pods (requires at least two matching pods, i.e. 2x1P1D for that model).
+func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, modelName, prompt, requestErrMsg string) {
+	t.Helper()
+	ctx := context.Background()
+	k8sClient, _ := initializeClient(ctx, t)
+
+	initialPods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{})
+	require.NoError(t, err)
+	initialCount := len(initialPods.Items)
+
+	labelSelector := "role-name=" + roleLabel + ",model.aibrix.ai/name=" + modelName
+	rolePods, err := k8sClient.CoreV1().Pods("default").List(ctx, v1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(rolePods.Items), 2,
+		"expected at least two %s pods for model %s (2x1P1D); selector=%q", roleLabel, modelName, labelSelector)
+
+	podToDelete := rolePods.Items[0].Name
+	t.Logf("deleting %s pod for model %s: %s", roleLabel, modelName, podToDelete)
+
+	require.NoError(t, k8sClient.CoreV1().Pods("default").Delete(ctx, podToDelete, v1.DeleteOptions{}))
+
+	t.Cleanup(func() {
+		validateAllPodsAreReady(t, k8sClient, initialCount)
+		waitForPDDisaggregationRouting(t, modelName)
+		t.Logf("%s pod %s has been recreated and cluster is back to %d pods", roleLabel, podToDelete, initialCount)
+	})
+
+	// Give the gateway time to detect the pod is gone.
+	time.Sleep(3 * time.Second)
+
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+
+	for i := 0; i < 10; i++ {
+		_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				openai.UserMessage(prompt),
+			},
+			Model: modelName,
+		})
+		require.NoError(t, err, requestErrMsg, i)
+
+		decodePod := dst.Header.Get("target-pod")
+		prefillPod := dst.Header.Get("prefill-target-pod")
+		assert.NotEmpty(t, decodePod, "request %d: target-pod header must be set", i)
+		assert.NotEmpty(t, prefillPod, "request %d: prefill-target-pod header must be set", i)
+		assert.NotEqual(t, prefillPod, decodePod, "request %d: prefill and decode pods should differ", i)
+		if roleLabel == "prefill" {
+			assert.NotEqual(t, podToDelete, prefillPod,
+				"request %d: should not route to deleted prefill pod %s", i, podToDelete)
+		} else {
+			assert.NotEqual(t, podToDelete, decodePod,
+				"request %d: should not route to deleted decode pod %s", i, podToDelete)
+		}
+		t.Logf("request %d — prefill: %s, decode: %s", i, prefillPod, decodePod)
+	}
+}
+
+// TestPDDisaggregationVLLMPrefillPodFailure verifies that with 2x1P1D setup, taking down one
+// prefill pod still allows 10 requests to succeed via the remaining complete roleset.
+func TestPDDisaggregationVLLMPrefillPodFailure(t *testing.T) {
+	assertPDDisaggregationAfterPodDeletion(t, "prefill", modelNameVLLM,
+		"PD prefill-pod-failure resilience test",
+		"request %d failed after prefill pod deletion")
+}
+
+// TestPDDisaggregationVLLMDecodePodFailure verifies that with 2x1P1D setup, taking down one
+// decode pod still allows 10 requests to succeed via the remaining complete roleset.
+func TestPDDisaggregationVLLMDecodePodFailure(t *testing.T) {
+	assertPDDisaggregationAfterPodDeletion(t, "decode", modelNameVLLM,
+		"PD decode-pod-failure resilience test",
+		"request %d failed after decode pod deletion")
+}
+
 // TestPDDisaggregationVLLMMultipleRequests sends several requests to verify that the
 // PD router consistently selects valid prefill/decode pod pairs across requests.
 func TestPDDisaggregationVLLMMultipleRequests(t *testing.T) {
 	const iterations = 5
+
+	waitForPDDisaggregationRouting(t, modelNameVLLM)
 
 	var dst *http.Response
 	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,14 +42,15 @@ import (
 )
 
 const (
-	gatewayURL      = "http://localhost:8888"
-	engineURL       = "http://localhost:8000"
-	apiKey          = "test-key-1234567890"
-	modelName       = "llama2-7b"
-	modelNameQwen3  = "qwen3-8b"
-	modelNameVLLM   = "llama2-7b-vllm"
-	modelNameSGLang = "llama2-7b-sglang"
-	modelNameTRTLLM = "llama2-7b-trtllm"
+	gatewayURL          = "http://localhost:8888"
+	engineURL           = "http://localhost:8000"
+	apiKey              = "test-key-1234567890"
+	modelName           = "llama2-7b"
+	modelNameQwen3      = "qwen3-8b"
+	modelNameVLLM       = "llama2-7b-vllm"
+	modelNameVLLMBucket = "llama2-7b-vllm-bucket"
+	modelNameSGLang     = "llama2-7b-sglang"
+	modelNameTRTLLM     = "llama2-7b-trtllm"
 )
 
 func initializeClient(ctx context.Context, t *testing.T) (*kubernetes.Clientset, *v1alpha1.Clientset) {
@@ -183,7 +185,7 @@ func validateInferenceWithClient(t *testing.T, client openai.Client, modelName s
 }
 
 func validateAllPodsAreReady(t *testing.T, client *kubernetes.Clientset, expectedPodCount int) {
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second,
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second,
 		true, func(ctx context.Context) (bool, error) {
 			podList, err := client.CoreV1().Pods("default").List(ctx, v1.ListOptions{})
 			if err != nil {
@@ -199,4 +201,66 @@ func validateAllPodsAreReady(t *testing.T, client *kubernetes.Clientset, expecte
 			return false, nil
 		})
 	assert.NoError(t, err, "timeout waiting for all pods to be ready")
+}
+
+// waitForPDDisaggregationRouting polls until the gateway can route a PD request for modelName.
+// Pod readiness alone is not enough: the gateway pod cache may lag after pod churn.
+func waitForPDDisaggregationRouting(t *testing.T, modelName string) {
+	t.Helper()
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second,
+		true, func(ctx context.Context) (bool, error) {
+			_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					openai.UserMessage("PD routing readiness check"),
+				},
+				Model: modelName,
+			})
+			if err != nil {
+				t.Logf("waiting for PD routing for model %s: %v", modelName, err)
+				return false, nil
+			}
+			prefillPod := dst.Header.Get("prefill-target-pod")
+			decodePod := dst.Header.Get("target-pod")
+			if prefillPod == "" || decodePod == "" || prefillPod == decodePod {
+				t.Logf("waiting for valid PD routing headers for model %s", modelName)
+				return false, nil
+			}
+			t.Logf("PD routing ready for model %s", modelName)
+			return true, nil
+		})
+	assert.NoError(t, err, "timeout waiting for PD routing to be ready for model %s", modelName)
+}
+
+// waitForPDCombinedRouting polls until the gateway routes a long prompt to a combined pod
+// (no prefill-target-pod header). Pod cache may lag behind Kubernetes readiness.
+func waitForPDCombinedRouting(t *testing.T, modelName, combinedStormName, longPrompt string) {
+	t.Helper()
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second,
+		true, func(ctx context.Context) (bool, error) {
+			_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					openai.UserMessage(longPrompt),
+				},
+				Model: modelName,
+			})
+			if err != nil {
+				t.Logf("waiting for combined PD routing for model %s: %v", modelName, err)
+				return false, nil
+			}
+			prefillPod := dst.Header.Get("prefill-target-pod")
+			decodePod := dst.Header.Get("target-pod")
+			if prefillPod != "" || decodePod == "" || !strings.Contains(decodePod, combinedStormName) {
+				t.Logf("waiting for combined routing for model %s: prefill=%s decode=%s", modelName, prefillPod, decodePod)
+				return false, nil
+			}
+			t.Logf("combined PD routing ready for model %s (decode=%s)", modelName, decodePod)
+			return true, nil
+		})
+	assert.NoError(t, err, "timeout waiting for combined PD routing for model %s", modelName)
 }


### PR DESCRIPTION
## Summary

This PR makes three related fixes to the PD disaggregation router and adds a dedicated `pd_roleset.go` package for roleset eligibility logic.

### 1. Roleset eligibility extraction (`pd_roleset.go`)

Extracted roleset grouping, replica cardinality, and eligibility checks into a new `pd_roleset.go` file. A roleset is now **eligible** only when it has ≥1 prefill replica **and** ≥1 decode replica. Incomplete or partially-ready rolesets are excluded from routing candidates before any scoring or imbalance checks run. Public functions (`HasEligibleRoleset`, `DescribePDRolesetEligibility`) expose fleet-wide diagnostics for external callers (e.g., gateway pod-readiness logic).

Replica count is computed from distinct `role-replica-index` label values, so multi-node tensor-parallel groups (multiple pods sharing one logical slot) are counted correctly.

### 2. Load-imbalance alignment fixes

Two bugs in the imbalance fast paths:

- **Prefill imbalance**: Previously logged before narrowing, and the guard `isImbalanced` could be true with a nil `targetPod`. Added a nil check before narrowing `prefillPods` and aligning `decodePods`.
- **Decode imbalance**: The previous alignment (`if len(prefillPods) > 1`) skipped alignment when only one prefill pod was present, leaving a stale single-pod slice pointing at the wrong roleset. Now always aligns `prefillPods` to the selected decode pod's roleset, falling back gracefully when the roleset filter produces no results.

### 3. Tracker registration ordering

`AddPrefillRequest` and `AddPendingDecode` were called in `Route()` *before* pod selection completed, meaning concurrent requests saw stale counts during scoring. Registration is now deferred to the end of `filterPrefillDecodePods`, immediately after the winning prefill/decode pods are known, so load imbalance and scoring see up-to-date counts from the moment of selection.

The duplicate `AddPendingDecode` call in `Route()` is removed; cleanup (`RemovePendingDecode`) is still deferred in `Route()` and `RemovePrefillRequest` is now called on sync failure (was previously missing).

Additionally, the per-request `validateAndGetLLMEngine` call at the top of `Route()` is removed — engine validation across all ready pods on every request was expensive and redundant since `ctx.Engine` is already set from pod labels by the gateway before `Route()` is invoked.

## Test changes

- Fixed two async-prefill tests (`TestPDRouter_RouteDoesNotEmitAsyncPrefillSuccessBeforeHTTPCompletes`, `TestPDRouter_RouteRecordsAsyncPrefillFailureWithoutSuccess`) that omitted `ctx.Engine = SGLangEngine`, causing the sync code path to run instead of the async one — the first test timed out waiting for a metric that would never be emitted, the second would incorrectly propagate a 500 as a route error.
- Added `TestFilterPrefillDecodePods_NoBucketMatchNoCombined`, `TestFilterPrefillDecodePods_CombinedPickImbalance`, `TestFilterPrefillDecodePods_CombinedFallbackBucketing`, `TestFilterPrefillDecodePods_SelectCorrectBucketPods` for prompt-length bucketing edge cases.
- Added `TestScorePrefillPods_NilPolicyFallback` for nil prefill policy behaviour.
- Added `pd_roleset_test.go` covering roleset grouping, replica cardinality, eligibility, and `DescribePDRolesetEligibility`.

## Related Issues

Part of ongoing PD disaggregation stabilisation.