### PR TITLE
[Bug]Modify model of output payload to keep consistent with input

### DIFF
--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -55,6 +55,7 @@ from aibrix.batch.job_entity import (
     BatchJob,
     BatchJobError,
     BatchJobErrorCode,
+    BatchJobSpec,
     BatchJobState,
     BatchUsage,
     ConditionType,
@@ -643,7 +644,7 @@ class BaseJobDriver:
                         )
 
                 response = self._build_response(
-                    custom_id, job_id, line_no, request_output, last_error
+                    custom_id, job_id, line_no, job.spec, request_output, last_error
                 )
                 await storage.write_job_output_data(job, line_no, response)
 
@@ -734,7 +735,7 @@ class BaseJobDriver:
                     self._accumulate_usage(job_id, custom_id, response.get("usage"))
 
             record = self._build_response(
-                custom_id, job_id, request_id, response, error
+                custom_id, job_id, request_id, job.spec, response, error
             )
             await storage.write_job_output_data(job, request_id, record)
             latest_job = await self._progress_manager.complete_job_request(
@@ -935,6 +936,19 @@ class BaseJobDriver:
         shaped["model"] = self._active_model_name
         return shaped
 
+    def _shape_output_payload(
+        self, payload: Dict[str, Any], jobSpec: BatchJobSpec
+    ) -> Dict[str, Any]:
+        """Adjust a request body before dispatch. Pins the request to the
+        runtime's served model when one is known (single-model backends like a
+        provisioned Deployment), so the input's ``model`` field can't misroute;
+        identity otherwise."""
+        if jobSpec.model is None:
+            return payload
+        shaped = dict(payload)
+        shaped["model"] = jobSpec.model
+        return shaped
+
     async def finalize_job(self, job: BatchJob) -> BatchJob:
         """Aggregate outputs (when this driver owns aggregation) and mark done."""
         assert job.status.state == BatchJobState.FINALIZING
@@ -954,6 +968,7 @@ class BaseJobDriver:
         custom_id: str,
         job_id: str,
         request_id: int,
+        job_spec: BatchJobSpec,
         request_output: Any = None,
         error: Optional[Exception] = None,
     ) -> dict[str, Any]:
@@ -974,6 +989,8 @@ class BaseJobDriver:
                 code=BatchJobErrorCode.INFERENCE_FAILED, message=str(error)
             )
         else:
+            if isinstance(request_output, dict):
+                request_output = self._shape_output_payload(request_output, job_spec)
             response["response"] = {
                 "status_code": 200,
                 "request_id": f"{job_id}-{request_id}",

--- a/python/aibrix/tests/batch/test_base_job_driver_concurrent.py
+++ b/python/aibrix/tests/batch/test_base_job_driver_concurrent.py
@@ -203,6 +203,24 @@ def test_dispatch_kwargs_use_fixed_max_concurrency_when_adaptive_disabled():
     }
 
 
+def test_build_response_shapes_output_payload_model():
+    job = _make_job(total=1)
+    job.spec.aibrix = AibrixMetadata(model="requested-model")
+    driver = BaseJobDriver(SingleJobRunner(job), ExternalRuntime(None))
+    driver._active_model_name = "served-model"
+
+    response = driver._build_response(
+        "req-0",
+        "job-1",
+        0,
+        job.spec,
+        {"id": "resp-1", "model": "served-model"},
+        None,
+    )
+
+    assert response["response"]["body"]["model"] == "requested-model"
+
+
 def _patch_storage(monkeypatch, requests, done: Optional[set[int]] = None):
     done = done or set()
     outputs = {}


### PR DESCRIPTION
## Pull Request Description
In the current version, BaseJobDriver::_shape_payload() will override the input model for internal use. The model field in the output payload may inherit the overridden value, resulting in an inconsistency with the input. This MR fixed the inconsistency.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/aibrix/pr/2398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785010306&installation_id=142609222&pr_number=2398&repository=vllm-project%2Faibrix&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Faibrix%2Fpull%2F2398&signature=c4580a07634fdcddbf92a48e098153ae47ad029529df2f7206d932e925f0fa4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->