### PR TITLE
[Bug] Reflect KubernetesJob worker counts and usage on finalize

### DIFF
--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -904,7 +904,7 @@ class BaseJobDriver:
         * self-hosting (``endpoint.source is None`` and the runtime provisions):
           the worker dispatches inside its own compute (a k8s Job), so the
           control plane sends nothing and instead awaits the runtime to finish,
-          then moves to FINALIZING for output aggregation.
+          then finalizes to aggregate the output the worker wrote.
         """
         if endpoint.source is None and self._runtime.provisions:
             return await self._await_self_hosted_run(job_id)
@@ -925,8 +925,12 @@ class BaseJobDriver:
                 or completion.reason
                 or "self-hosted job failed",
             )
-        job.status.state = BatchJobState.FINALIZING
-        return job
+        # The worker ran in worker_mode: it wrote its output parts and the
+        # per-request done markers but did not finalize. This driver owns
+        # aggregation, so finalize assembles the output/error files from the
+        # surviving markers and records the real request_counts / usage before
+        # marking the job done.
+        return await self.finalize_job(job)
 
     # ── shared phases ────────────────────────────────────────────────────
 

--- a/python/aibrix/aibrix/batch/worker.py
+++ b/python/aibrix/aibrix/batch/worker.py
@@ -366,7 +366,8 @@ class BatchWorker:
             # the driver the per-job RunningJobs surface it needs, and the worker
             # dispatches against its own pod-local engine. execute runs
             # prepare(skipped — the metadata service already prepared the output
-            # files) -> run_job -> finalize, and re-raises on failure
+            # files) -> run_job; finalize is skipped in worker_mode and left to
+            # the metadata service. It re-raises on failure
             # (BaseJobDriver._reraise_on_failure=True).
             job_id = batch_job.job_id
             if job_id is None:
@@ -375,9 +376,16 @@ class BatchWorker:
             runner = SingleJobRunner(batch_job)
             if self.llm_engine_base_url is None:
                 raise RuntimeError("engine base url not resolved")
+            # worker_mode keeps this pod out of finalization: it dispatches
+            # requests and writes its output parts and per-request done markers,
+            # but leaves aggregation to the metadata service. Finalizing here
+            # would consume the markers and complete the multipart upload inside
+            # the Job, so the coordinator would then aggregate against emptied
+            # markers and overwrite the output with zero counts (#2263).
             driver = BaseJobDriver(
                 runner,
                 ExternalRuntime(GatewayEndpointSource(self.llm_engine_base_url)),
+                worker_mode=True,
             )
             logger.info("Executing batch job", job_id=job_id)  # type: ignore[call-arg]
             await driver.execute(job_id)

--- a/python/aibrix/tests/batch/conftest.py
+++ b/python/aibrix/tests/batch/conftest.py
@@ -27,7 +27,13 @@ from fastapi.testclient import TestClient
 from kubernetes import client, config
 
 import aibrix.batch.job_driver.runtime.k8s_deployment as deployment_runtime_module
+import aibrix.batch.job_driver.runtime.k8s_job as k8s_job_runtime_module
 from aibrix.batch.client.sources import NoopEndpointSource
+from aibrix.batch.job_driver.base import BaseJobDriver
+from aibrix.batch.job_driver.runtime import ExternalRuntime
+from aibrix.batch.job_entity import BatchJob
+from aibrix.batch.manifest import JobManifestRenderer
+from aibrix.batch.worker import SingleJobRunner
 from aibrix.logger import init_logger
 from aibrix.metadata.app import build_app
 from aibrix.metadata.setting import settings
@@ -481,6 +487,47 @@ class FakeDeploymentRenderer:
         }
 
 
+class FakeBatchV1Api:
+    """In-process stand-in for ``kubernetes.client.BatchV1Api`` used by the
+    local ``KubernetesJob`` backend. A Job stays without a terminal condition
+    until ``mark_complete`` flips it to ``Complete``; the fake worker run does
+    that once it has written the job's output, so the runtime's poll loop
+    observes completion exactly as it would against a real cluster."""
+
+    def __init__(self):
+        self.created: list[tuple[str, dict[str, Any]]] = []
+        self.deleted: list[tuple[str, str]] = []
+        self._conditions: dict[tuple[str, str], list[Any]] = {}
+
+    def create_namespaced_job(self, namespace: str, body: dict[str, Any]):
+        name = body["metadata"]["name"]
+        self.created.append((namespace, body))
+        self._conditions[(namespace, name)] = []
+
+    def patch_namespaced_job(self, name: str, namespace: str, body: dict[str, Any]):
+        if (namespace, name) not in self._conditions:
+            raise client.ApiException(status=404)
+
+    def read_namespaced_job_status(self, name: str, namespace: str):
+        conditions = self._conditions.get((namespace, name))
+        if conditions is None:
+            raise client.ApiException(status=404)
+        return SimpleNamespace(status=SimpleNamespace(conditions=conditions))
+
+    def delete_namespaced_job(
+        self, name: str, namespace: str, propagation_policy: str | None = None
+    ):
+        if (namespace, name) not in self._conditions:
+            raise client.ApiException(status=404)
+        self.deleted.append((namespace, name))
+        self._conditions.pop((namespace, name))
+
+    def mark_complete(self, namespace: str, name: str):
+        self._conditions[(namespace, name)] = [
+            SimpleNamespace(type="Complete", status="True", reason="", message="")
+        ]
+
+
 def configure_local_metastore_deployment_backend(app, monkeypatch) -> None:
     context = app.state.batch_driver._context
     shared_state = getattr(monkeypatch, "_aibrix_fake_deployment_backend_state", None)
@@ -535,6 +582,83 @@ def configure_local_metastore_deployment_backend(app, monkeypatch) -> None:
     monkeypatch.setattr(
         deployment_runtime_module.DeploymentRuntime,
         "_teardown_runtime",
+        _recording_teardown,
+    )
+
+
+def configure_local_metastore_k8s_job_backend(app, monkeypatch) -> None:
+    context = app.state.batch_driver._context
+    fake_api = FakeBatchV1Api()
+    context.values["k8s_job_batch_v1_api"] = fake_api
+    context.values["k8s_job_teardown_calls"] = []
+
+    # K8sJobRuntime reads batch_v1_api off the context, but the slotted
+    # InfrastructureContext has no such field, so the runtime falls back to
+    # constructing a real BatchV1Api(). Patch the constructor to hand every
+    # runtime the fake instead — no cluster is reachable in the local backend.
+    monkeypatch.setattr(
+        k8s_job_runtime_module.k8s_client,
+        "BatchV1Api",
+        lambda *args, **kwargs: fake_api,
+    )
+
+    # A real render resolves template/profile ConfigMaps that the local
+    # backend never applies, so return a minimal suspended-Job manifest.
+    def _render(self, session_id, spec, prepared_job=None, **kwargs):
+        job_id = getattr(prepared_job, "job_id", None) or session_id
+        job_name = f"batch-{job_id[:8]}-worker"
+        return {
+            "metadata": {"name": job_name, "namespace": "default"},
+            "spec": {"suspend": True},
+        }
+
+    monkeypatch.setattr(JobManifestRenderer, "render", _render)
+
+    original_on_prepared = k8s_job_runtime_module.K8sJobRuntime.on_prepared
+
+    async def _run_self_hosted_worker(self):
+        # Un-suspend first (the real hook), then stand in for the Job's pod:
+        # run the worker in worker_mode so it writes the output parts and
+        # per-request done markers but leaves finalization to the coordinator,
+        # exactly as the real KubernetesJob worker does. The coordinator then
+        # aggregates the surviving markers in finalize_job.
+        await original_on_prepared(self)
+        job_id = self._active_job_id
+        job = await self._progress_manager.get_job(job_id)
+        worker_job = BatchJob(
+            sessionID=job.session_id,
+            typeMeta=job.type_meta,
+            metadata=job.metadata,
+            spec=job.spec,
+            status=job.status.model_copy(deep=True),
+        )
+        worker = BaseJobDriver(
+            SingleJobRunner(worker_job),
+            ExternalRuntime(FastNoopEndpointSource(context)),
+            worker_mode=True,
+        )
+        await worker.execute(job_id)
+        handle = self.active_handle
+        fake_api.mark_complete(handle.namespace, handle.job_name)
+
+    monkeypatch.setattr(
+        k8s_job_runtime_module.K8sJobRuntime,
+        "on_prepared",
+        _run_self_hosted_worker,
+    )
+
+    original_teardown = k8s_job_runtime_module.K8sJobRuntime._teardown
+
+    async def _recording_teardown(self, handle):
+        if handle is not None:
+            context.values["k8s_job_teardown_calls"].append(
+                {"job_id": self._active_job_id, "job_name": handle.job_name}
+            )
+        return await original_teardown(self, handle)
+
+    monkeypatch.setattr(
+        k8s_job_runtime_module.K8sJobRuntime,
+        "_teardown",
         _recording_teardown,
     )
 
@@ -627,6 +751,18 @@ E2E_BACKENDS: dict[str, E2ETestBackend] = {
             "runtime_delete_attr": "deleted",
         },
     ),
+    # Self-hosting KubernetesJob backend on local storage/metastore, backed by
+    # a fake BatchV1Api. The worker runs in-process in worker_mode, so this
+    # exercises the coordinator-side finalize path the deployment backend does
+    # not reach (the deployment fake dispatches from the control plane).
+    "local_job_using_k8s_job": E2ETestBackend(
+        "local_job_using_k8s_job",
+        request_kwargs={
+            "aibrix_template": "mock-template",
+            "provider": "k8s_job",
+        },
+        features=("support_runtime", "fake_runtime", "fake_provisioning_runtime"),
+    ),
 }
 
 
@@ -706,6 +842,7 @@ def build_batch_request(
     if provider:
         runtime_targets = {
             "deployment": "Kubernetes",
+            "k8s_job": "KubernetesJob",
         }
         runtime_target = runtime_targets.get(provider)
         if runtime_target is not None:
@@ -898,6 +1035,17 @@ def build_e2e_test_app(
         app.state.metadata_store = MockMetadataStore()
         app.state.redis_client = None
         configure_local_metastore_deployment_backend(app, monkeypatch)
+        return app
+
+    if test_backend == "local_job_using_k8s_job":
+        app = create_test_app(
+            storage_type=StorageType.LOCAL,
+            metastore_type=StorageType.LOCAL,
+            dry_run=False,
+        )
+        app.state.metadata_store = MockMetadataStore()
+        app.state.redis_client = None
+        configure_local_metastore_k8s_job_backend(app, monkeypatch)
         return app
 
     raise ValueError(f"Unsupported e2e backend: {test_backend}")

--- a/python/aibrix/tests/batch/test_e2e_openai_batch_api.py
+++ b/python/aibrix/tests/batch/test_e2e_openai_batch_api.py
@@ -88,6 +88,7 @@ def pytest_generate_tests(metafunc):
         metafunc,
         [
             "local_job_using_deployment",
+            "local_job_using_k8s_job",
         ],
     )
 
@@ -123,11 +124,11 @@ def backend_batch_request(
 
 
 def backend_request_count(test_backend: str) -> int:
-    return 10 if test_backend == "k8s_job" else 3
+    return 10 if test_backend == "local_job_using_k8s_job" else 3
 
 
 def backend_max_polls(test_backend: str) -> int:
-    return 120 if test_backend == "k8s_job" else 20
+    return 120 if test_backend == "local_job_using_k8s_job" else 20
 
 
 async def wait_for_completed_batch(
@@ -278,7 +279,7 @@ async def test_openai_batch_api_success_workflow(e2e_test_app, test_backend):
             output_file_id = assert_completed_batch(completed_batch, expected_requests)
             await download_and_verify_output(client, output_file_id, expected_requests)
 
-            if test_backend == "k8s_job":
+            if test_backend == "local_job_using_k8s_job":
                 assert isinstance(completed_batch["in_progress_at"], int)
                 assert isinstance(completed_batch["finalizing_at"], int)
                 assert isinstance(completed_batch["completed_at"], int)

--- a/python/aibrix/tests/batch/test_k8s_job_driver.py
+++ b/python/aibrix/tests/batch/test_k8s_job_driver.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 """KubernetesJob backend: a self-hosting Runtime under the converged
 BaseJobDriver. The base execute phase awaits the provisioned Job to completion
-(source=None + provisions) then moves to FINALIZING; on_prepared un-suspends."""
+(source=None + provisions) then finalizes to aggregate the worker's output;
+on_prepared un-suspends."""
 
 from types import SimpleNamespace
 
@@ -52,6 +53,14 @@ class _FakePM:
     async def get_job(self, job_id):
         return self._job
 
+    async def mark_job_finalizing(self, job_id):
+        self._job.status.state = BatchJobState.FINALIZING
+        return self._job
+
+    async def mark_job_done(self, job):
+        job.status.state = BatchJobState.FINALIZED
+        return job
+
 
 def _job():
     return SimpleNamespace(
@@ -60,12 +69,31 @@ def _job():
 
 
 @pytest.mark.asyncio
-async def test_execute_waits_then_moves_to_finalizing_on_success():
+async def test_self_hosted_run_finalizes_on_success(monkeypatch):
+    """A successful self-hosted run aggregates the worker's output through
+    finalize_job, so the persisted job records the real request_counts / usage
+    instead of only flipping to FINALIZING with the stale in-memory copy (#2263).
+    The worker ran in worker_mode and left the per-request done markers intact
+    for this aggregation."""
     job = _job()
     rt = _FakeRuntime(Completion(succeeded=True))
     driver = BaseJobDriver(_FakePM(job), rt)
+
+    aggregated = []
+
+    async def _record_finalize(j):
+        aggregated.append(j)
+
+    monkeypatch.setattr(
+        "aibrix.batch.job_driver.base.storage.finalize_job_output_data",
+        _record_finalize,
+        raising=False,
+    )
+
     result = await driver.run_job("jid", Endpoint(source=None))
-    assert result.status.state == BatchJobState.FINALIZING
+
+    assert aggregated == [job]
+    assert result.status.state == BatchJobState.FINALIZED
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/batch/test_worker.py
+++ b/python/aibrix/tests/batch/test_worker.py
@@ -114,13 +114,50 @@ async def test_run_returns_failure_when_execution_fails(monkeypatch):
     monkeypatch.setattr(worker_module, "GatewayEndpointSource", lambda url: object())
     monkeypatch.setattr(worker_module, "ExternalRuntime", lambda src: object())
     monkeypatch.setattr(
-        worker_module, "BaseJobDriver", lambda runner, runtime: failing_driver
+        worker_module,
+        "BaseJobDriver",
+        lambda runner, runtime, **kwargs: failing_driver,
     )
 
     result = await worker.run()
 
     assert result == 1
     failing_driver.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_constructs_driver_in_worker_mode(monkeypatch):
+    """The worker pod builds its driver in worker_mode: it dispatches and writes
+    output parts and per-request done markers, but does not finalize. Aggregating
+    the markers is the metadata service's job; finalizing here would consume them
+    and the coordinator would then overwrite the output with zero counts (#2263)."""
+    worker = BatchWorker()
+    worker.llm_engine_base_url = "http://localhost:8000"
+    batch_job = _make_job(BatchJobState.IN_PROGRESS)
+
+    monkeypatch.setattr(worker, "load_job_from_env", lambda: batch_job)
+    monkeypatch.setattr(
+        worker, "wait_for_in_progress", AsyncMock(return_value=batch_job)
+    )
+    worker.health_checker = SimpleNamespace(wait_for_ready=AsyncMock(return_value=True))
+
+    from aibrix.batch import worker as worker_module
+
+    captured: dict = {}
+
+    def _capture_driver(runner, runtime, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(execute=AsyncMock(return_value=None))
+
+    monkeypatch.setattr(worker_module, "SingleJobRunner", lambda job: object())
+    monkeypatch.setattr(worker_module, "GatewayEndpointSource", lambda url: object())
+    monkeypatch.setattr(worker_module, "ExternalRuntime", lambda src: object())
+    monkeypatch.setattr(worker_module, "BaseJobDriver", _capture_driver)
+
+    result = await worker.run()
+
+    assert result == 0
+    assert captured.get("worker_mode") is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Pull Request Description
In `KubernetesJob` (self-hosting) mode the worker pod ran its `BaseJobDriver` without `worker_mode`, so `_should_finalize()` was True and the worker ran `finalize_job`. Since #2360 that calls `finalize_job_output_data` unconditionally, which aggregates the per-request `batch:<job_id>:done/*` markers, completes the multipart upload, and consumes the markers, all inside the Job pod. `_await_self_hosted_run` on the metadata service then only flipped the job to `FINALIZING` with its stale in-memory copy; when it aggregated it found the markers already consumed, recomputed `completed`/`failed` as 0 and `usage` as null, and committed an empty multipart over the worker's output. A completed `KubernetesJob` batch therefore persisted `completed = 0` and `usage = null` while the correct records had been assembled and then overwritten.

The worker's `BaseJobDriver` is now built with `worker_mode=True`, so it dispatches requests and writes its output parts and per-request done markers but does not finalize. `SingleJobRunner.mark_job_done` is pod-local, so this only affects the worker's own status. `_await_self_hosted_run` now calls `finalize_job` on the metadata service, which aggregates from the surviving markers, assembles the output/error files, and records the real `request_counts` / `usage` before marking the job done. The `Deployment` path keeps its endpoint and aggregates in the metadata process, so it is unchanged.

`test_self_hosted_run_finalizes_on_success` asserts the self-hosted run aggregates through `finalize_job`; it fails on the current code, where the run only sets `FINALIZING`, and passes with this change. `test_run_constructs_driver_in_worker_mode` asserts the worker builds its driver with `worker_mode=True`.

```
pytest tests/batch/test_k8s_job_driver.py::test_self_hosted_run_finalizes_on_success tests/batch/test_worker.py::test_run_constructs_driver_in_worker_mode -v
tests/batch/test_k8s_job_driver.py::test_self_hosted_run_finalizes_on_success PASSED
tests/batch/test_worker.py::test_run_constructs_driver_in_worker_mode PASSED
2 passed
```

Both affected files pass with no regressions (`9 passed`).

## Related Issues
Resolves #2263

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>