### PR TITLE
Fix StormService scale-in ordering for not-ready RoleSets

### DIFF
--- a/pkg/controller/stormservice/utils.go
+++ b/pkg/controller/stormservice/utils.go
@@ -223,17 +223,76 @@ func sortRoleSetByReadiness(roleSets []*orchestrationv1alpha1.RoleSet) {
 	})
 }
 
-// Sorts role sets: old revisions before new, and within the same revision, not-ready before ready.
-func sortRoleSetByRevision(roleSets []*orchestrationv1alpha1.RoleSet, updatedRevision string) {
-	sort.Slice(roleSets, func(i, j int) bool {
-		if isRoleSetMatchRevision(roleSets[i], updatedRevision) {
-			return false
-		} else if isRoleSetMatchRevision(roleSets[j], updatedRevision) {
-			return true
-		} else {
-			return !utils.IsRoleSetReady(roleSets[i])
+type roleSetOrderRule func(a, b *orchestrationv1alpha1.RoleSet) int
+
+const (
+	roleSetOrderBefore = -1
+	roleSetOrderSame   = 0
+	roleSetOrderAfter  = 1
+)
+
+func sortRoleSetsByRules(roleSets []*orchestrationv1alpha1.RoleSet, rules ...roleSetOrderRule) {
+	sort.SliceStable(roleSets, func(i, j int) bool {
+		for _, rule := range rules {
+			switch rule(roleSets[i], roleSets[j]) {
+			case roleSetOrderBefore:
+				return true
+			case roleSetOrderAfter:
+				return false
+			}
 		}
+		return false
 	})
+}
+
+func orderNilBeforeNonNil(a, b *orchestrationv1alpha1.RoleSet) int {
+	if a == nil && b == nil {
+		return roleSetOrderSame
+	}
+	if a == nil {
+		return roleSetOrderBefore
+	}
+	if b == nil {
+		return roleSetOrderAfter
+	}
+	return roleSetOrderSame
+}
+
+func orderOldRevisionBeforeUpdated(updatedRevision string) roleSetOrderRule {
+	return func(a, b *orchestrationv1alpha1.RoleSet) int {
+		aUpdated := isRoleSetMatchRevision(a, updatedRevision)
+		bUpdated := isRoleSetMatchRevision(b, updatedRevision)
+		if aUpdated == bUpdated {
+			return roleSetOrderSame
+		}
+		if !aUpdated && bUpdated {
+			return roleSetOrderBefore
+		}
+		return roleSetOrderAfter
+	}
+}
+
+func orderNotReadyBeforeReady(a, b *orchestrationv1alpha1.RoleSet) int {
+	aReady := utils.IsRoleSetReady(a)
+	bReady := utils.IsRoleSetReady(b)
+	if aReady == bReady {
+		return roleSetOrderSame
+	}
+	if !aReady && bReady {
+		return roleSetOrderBefore
+	}
+	return roleSetOrderAfter
+}
+
+// Sorts role sets: old revisions before new, and within the same revision class,
+// not-ready before ready. Equivalent items keep their existing relative order.
+func sortRoleSetByRevision(roleSets []*orchestrationv1alpha1.RoleSet, updatedRevision string) {
+	sortRoleSetsByRules(
+		roleSets,
+		orderNilBeforeNonNil,
+		orderOldRevisionBeforeUpdated(updatedRevision),
+		orderNotReadyBeforeReady,
+	)
 }
 
 // isServiceEqual compares two Kubernetes Service objects for equality

--- a/pkg/controller/stormservice/utils_test.go
+++ b/pkg/controller/stormservice/utils_test.go
@@ -150,6 +150,55 @@ func TestSortRoleSetByRevision(t *testing.T) {
 			updatedRevision: "rev2",
 			expectedOrder:   []string{"rs1", "rs2"},
 		},
+		{
+			name: "updated revision should delete not-ready before ready when input is ready first",
+			roleSets: []*orchestrationv1alpha1.RoleSet{
+				createRoleSet("updated-ready", "rev2", true),
+				createRoleSet("updated-not-ready", "rev2", false),
+			},
+			updatedRevision: "rev2",
+			expectedOrder:   []string{"updated-not-ready", "updated-ready"},
+		},
+		{
+			name: "old revision should delete not-ready before ready when input is ready first",
+			roleSets: []*orchestrationv1alpha1.RoleSet{
+				createRoleSet("old-ready", "rev1", true),
+				createRoleSet("old-not-ready", "rev1", false),
+				createRoleSet("updated-ready", "rev2", true),
+			},
+			updatedRevision: "rev2",
+			expectedOrder:   []string{"old-not-ready", "old-ready", "updated-ready"},
+		},
+		{
+			name: "old revision priority beats updated not-ready",
+			roleSets: []*orchestrationv1alpha1.RoleSet{
+				createRoleSet("updated-not-ready", "rev2", false),
+				createRoleSet("old-ready", "rev1", true),
+			},
+			updatedRevision: "rev2",
+			expectedOrder:   []string{"old-ready", "updated-not-ready"},
+		},
+		{
+			name: "equivalent rolesets keep original relative order",
+			roleSets: []*orchestrationv1alpha1.RoleSet{
+				createRoleSet("old-ready-1", "rev1", true),
+				createRoleSet("old-ready-2", "rev1", true),
+				createRoleSet("updated-ready-1", "rev2", true),
+				createRoleSet("updated-ready-2", "rev2", true),
+			},
+			updatedRevision: "rev2",
+			expectedOrder:   []string{"old-ready-1", "old-ready-2", "updated-ready-1", "updated-ready-2"},
+		},
+		{
+			name: "nil rolesets sort before non-nil rolesets",
+			roleSets: []*orchestrationv1alpha1.RoleSet{
+				createRoleSet("updated-ready", "rev2", true),
+				nil,
+				createRoleSet("old-ready", "rev1", true),
+			},
+			updatedRevision: "rev2",
+			expectedOrder:   []string{"<nil>", "old-ready", "updated-ready"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -163,6 +212,10 @@ func TestSortRoleSetByRevision(t *testing.T) {
 			// Extract names in the sorted order
 			actualOrder := make([]string, len(roleSetsCopy))
 			for i, rs := range roleSetsCopy {
+				if rs == nil {
+					actualOrder[i] = "<nil>"
+					continue
+				}
 				actualOrder[i] = rs.Name
 			}
 

--- a/test/integration/controller/stormservice_test.go
+++ b/test/integration/controller/stormservice_test.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -189,6 +191,147 @@ var _ = ginkgo.Describe("StormService controller test", func() {
 				},
 			},
 		),
+		ginkgo.Entry("scale-in deletes not-ready RoleSet before ready RoleSet in same revision",
+			func() *testValidatingCase {
+				var readyRoleSetName string
+				return &testValidatingCase{
+					makeStormService: func() *orchestrationapi.StormService {
+						matchLabel := map[string]string{"app": "scale-in-order"}
+						podTemplate := validation.MakePodTemplate("scale-in-order:test")
+						roleSetSpec := &orchestrationapi.RoleSetSpec{
+							Roles: []orchestrationapi.RoleSpec{
+								{
+									Name:     "worker",
+									Replicas: ptr.To(int32(1)),
+									Template: podTemplate,
+								},
+							},
+						}
+						return wrapper.MakeStormService("stormservice-scalein-order").
+							Namespace(ns.Name).
+							Replicas(ptr.To(int32(2))).
+							Selector(metav1.SetAsLabelSelector(matchLabel)).
+							UpdateStrategyType(orchestrationapi.RollingUpdateStormServiceStrategyType).
+							RoleSetTemplateMeta(metav1.ObjectMeta{Labels: matchLabel}, roleSetSpec).
+							Obj()
+					},
+					updates: []*update{
+						{
+							updateFunc: func(ss *orchestrationapi.StormService) {
+								gomega.Expect(k8sClient.Create(ctx, ss)).To(gomega.Succeed())
+								validation.WaitForRoleSetsCreated(ctx, k8sClient, ns.Name, ss.Name, 2)
+								validation.WaitForPodsCreated(ctx, k8sClient, ns.Name, constants.StormServiceNameLabelKey, ss.Name, 2)
+
+								roleSets := listStormServiceRoleSets(ctx, k8sClient, ns.Name, ss.Name)
+								gomega.Expect(roleSets).To(gomega.HaveLen(2))
+								readyRoleSetName = roleSets[0].Name
+								markRoleSetPodsReady(ctx, k8sClient, ns.Name, readyRoleSetName)
+								waitForRoleSetReady(ctx, k8sClient, ns.Name, readyRoleSetName)
+							},
+							checkFunc: func(ctx context.Context, k8sClient client.Client, ss *orchestrationapi.StormService) {
+								waitForStormServiceReplicaStatus(ctx, k8sClient, ss, 2, 1, 1, 2, 2, 1)
+							},
+						},
+						{
+							updateFunc: func(ss *orchestrationapi.StormService) {
+								validation.UpdateStormServiceReplicas(ctx, k8sClient, ss, 1)
+							},
+							checkFunc: func(ctx context.Context, k8sClient client.Client, ss *orchestrationapi.StormService) {
+								gomega.Eventually(func() ([]string, error) {
+									roleSets := listStormServiceRoleSets(ctx, k8sClient, ns.Name, ss.Name)
+									if len(roleSets) != 1 {
+										return nil, fmt.Errorf("expected 1 RoleSet, got %d", len(roleSets))
+									}
+									return []string{roleSets[0].Name}, nil
+								}, time.Second*10, time.Millisecond*250).Should(gomega.Equal([]string{readyRoleSetName}))
+							},
+						},
+					},
+				}
+			}(),
+		),
 		// TODO: add more test cases for different update strategies, stateful services, etc.
 	)
 })
+
+func listStormServiceRoleSets(ctx context.Context, k8sClient client.Client,
+	ns, ssName string,
+) []orchestrationapi.RoleSet {
+	roleSetList := &orchestrationapi.RoleSetList{}
+	gomega.Expect(k8sClient.List(ctx, roleSetList,
+		client.InNamespace(ns),
+		client.MatchingLabels{constants.StormServiceNameLabelKey: ssName},
+	)).To(gomega.Succeed())
+	sort.Slice(roleSetList.Items, func(i, j int) bool {
+		return roleSetList.Items[i].Name < roleSetList.Items[j].Name
+	})
+	return roleSetList.Items
+}
+
+func markRoleSetPodsReady(ctx context.Context, k8sClient client.Client, ns, roleSetName string) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		podList := &corev1.PodList{}
+		g.Expect(k8sClient.List(ctx, podList,
+			client.InNamespace(ns),
+			client.MatchingLabels{constants.RoleSetNameLabelKey: roleSetName},
+		)).To(gomega.Succeed())
+		g.Expect(podList.Items).NotTo(gomega.BeEmpty())
+
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			if pod.DeletionTimestamp != nil {
+				continue
+			}
+			validation.MakePodReady(pod)
+			g.Expect(k8sClient.Status().Update(ctx, pod)).To(gomega.Succeed())
+		}
+	}, time.Second*5, time.Millisecond*250).Should(gomega.Succeed())
+}
+
+func waitForRoleSetReady(ctx context.Context, k8sClient client.Client, ns, roleSetName string) {
+	gomega.Eventually(func() error {
+		roleSet := &orchestrationapi.RoleSet{}
+		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: roleSetName}, roleSet); err != nil {
+			return err
+		}
+		condition := validation.FindCondition(string(orchestrationapi.RoleSetReady), roleSet.Status.Conditions)
+		if condition == nil {
+			return fmt.Errorf("RoleSetReady condition not found")
+		}
+		if condition.Status != corev1.ConditionTrue {
+			return fmt.Errorf("expected RoleSetReady=True, got %s", condition.Status)
+		}
+		return nil
+	}, time.Second*10, time.Millisecond*250).Should(gomega.Succeed())
+}
+
+func waitForStormServiceReplicaStatus(ctx context.Context, k8sClient client.Client,
+	stormService *orchestrationapi.StormService,
+	replicas, ready, notReady, current, updated, updatedReady int32) {
+	gomega.Eventually(func() error {
+		latest := &orchestrationapi.StormService{}
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(stormService), latest); err != nil {
+			return err
+		}
+		if latest.Status.Replicas != replicas {
+			return fmt.Errorf("expected status.replicas=%d, got %d", replicas, latest.Status.Replicas)
+		}
+		if latest.Status.ReadyReplicas != ready {
+			return fmt.Errorf("expected status.readyReplicas=%d, got %d", ready, latest.Status.ReadyReplicas)
+		}
+		if latest.Status.NotReadyReplicas != notReady {
+			return fmt.Errorf("expected status.notReadyReplicas=%d, got %d", notReady, latest.Status.NotReadyReplicas)
+		}
+		if latest.Status.CurrentReplicas != current {
+			return fmt.Errorf("expected status.currentReplicas=%d, got %d", current, latest.Status.CurrentReplicas)
+		}
+		if latest.Status.UpdatedReplicas != updated {
+			return fmt.Errorf("expected status.updatedReplicas=%d, got %d", updated, latest.Status.UpdatedReplicas)
+		}
+		if latest.Status.UpdatedReadyReplicas != updatedReady {
+			return fmt.Errorf("expected status.updatedReadyReplicas=%d, got %d",
+				updatedReady, latest.Status.UpdatedReadyReplicas)
+		}
+		return nil
+	}, time.Second*30, time.Millisecond*250).Should(gomega.Succeed())
+}


### PR DESCRIPTION
## Summary
- Prioritize NotReady RoleSets before Ready RoleSets within the same revision during StormService scale-in.
- Refactor RoleSet ordering into an internal stable rule-chain sorter for future ordering extensions.
- Add unit regression coverage and a controller integration case for scale-in preserving the Ready RoleSet.

Fixes #2082

## Test Plan
- go test ./pkg/controller/stormservice -run TestSortRoleSetByRevision -count=1
- go test ./pkg/controller/stormservice -run "TestSortRoleSetByRevision|TestFilterReadyRoleSets|TestCalculateReplicas" -count=1
- go test ./test/integration/controller -run TestAPIs -count=1 -args -ginkgo.focus="scale-in deletes not-ready RoleSet before ready RoleSet in same revision"
- KUBEBUILDER_ASSETS=/private/tmp/aibrix-worktrees/fix-stormservice-scalein-notready/bin/k8s/1.30.0-darwin-arm64 go test ./pkg/controller/stormservice -count=1
- git diff --check