### PR TITLE
fix(gateway): wait for concurrent request stats update

### DIFF
--- a/pkg/cache/cache_impl.go
+++ b/pkg/cache/cache_impl.go
@@ -181,8 +181,11 @@ func (c *Store) AddRequestCount(ctx *types.RoutingContext, requestID string, mod
 		// ignore traceTerm
 		tracker.AddRequestCount(ctx, requestID, modelName)
 	}
-	// Current implementation assumes AddRequestCount() will not be called concurrently.
-	// TODO: Implment "wait for trace term" logic if AddRequestCount() is called concurrently.
+	// Queue-based routers call AddRequestCount once before enqueueing a request.
+	// That initializes trace/model-level counters before queueRouter.serve can see
+	// the RoutingContext. Later calls for the same routed request may happen from
+	// Route() and serve() concurrently, but CanAddTrace keeps this block
+	// idempotent and the trace term is already stored on the context.
 	if ctx == nil || ctx.CanAddTrace() {
 		if c.enableTracing {
 			success := false
@@ -205,8 +208,11 @@ func (c *Store) AddRequestCount(ctx *types.RoutingContext, requestID string, mod
 		}
 	}
 
-	// Current implementation assumes AddRequestCount() will not be called concurrently.
-	// TODO: Implment "wait for trace term" logic if AddRequestCount() is called concurrently.
+	// After a queue-based router assigns a target pod, queueRouter.serve records
+	// pod-level realtime stats. Route() also calls AddRequestCount after waiting
+	// for TargetPod() so those stats are visible before Route() returns. Either
+	// goroutine may win CanAddStats; concurrent callers wait for that in-flight
+	// stats update to complete and then return the trace term from the context.
 	if ctx == nil {
 		return traceTerm
 	} else if !ctx.HasRouted() {

--- a/pkg/cache/cache_impl.go
+++ b/pkg/cache/cache_impl.go
@@ -209,9 +209,13 @@ func (c *Store) AddRequestCount(ctx *types.RoutingContext, requestID string, mod
 	// TODO: Implment "wait for trace term" logic if AddRequestCount() is called concurrently.
 	if ctx == nil {
 		return traceTerm
-	} else if !ctx.HasRouted() || !ctx.CanAddStats() {
+	} else if !ctx.HasRouted() {
+		return atomic.LoadInt64(&ctx.TraceTerm)
+	} else if !ctx.CanAddStats() {
+		ctx.WaitStatsAdded()
 		return atomic.LoadInt64(&ctx.TraceTerm)
 	} else {
+		defer ctx.MarkStatsAdded()
 		traceTerm = atomic.LoadInt64(&ctx.TraceTerm)
 		c.addPodStats(ctx, requestID)
 	}

--- a/pkg/cache/cache_request_tracker_test.go
+++ b/pkg/cache/cache_request_tracker_test.go
@@ -18,10 +18,16 @@ package cache
 
 import (
 	"context"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // mockRequestTracker implements RequestTracker for testing
@@ -77,6 +83,108 @@ func TestDoneRequestCount_NilContext(t *testing.T) {
 		assert.NotNil(t, tracker.lastCtx, "tracker should receive valid context")
 		assert.Equal(t, "test-model", tracker.lastCtx.Model)
 	})
+}
+
+type blockingPendingLoadProvider struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingPendingLoadProvider() *blockingPendingLoadProvider {
+	return &blockingPendingLoadProvider{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (p *blockingPendingLoadProvider) Cap() float64 {
+	return 1.0
+}
+
+func (p *blockingPendingLoadProvider) GetUtilization(_ *types.RoutingContext, _ *v1.Pod) (float64, error) {
+	return 0, nil
+}
+
+func (p *blockingPendingLoadProvider) GetConsumption(_ *types.RoutingContext, _ *v1.Pod) (float64, error) {
+	p.once.Do(func() {
+		close(p.entered)
+	})
+	<-p.release
+	return 0.25, nil
+}
+
+func TestAddRequestCount_WaitsForConcurrentStatsUpdate(t *testing.T) {
+	const model = "test-model"
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+		},
+		Status: v1.PodStatus{PodIP: "1.0.0.1"},
+	}
+
+	store := InitWithPods(NewForTest(), []*v1.Pod{pod}, model)
+	provider := newBlockingPendingLoadProvider()
+	store.pendingLoadProvider = provider
+
+	ctx := types.NewRoutingContext(context.Background(), "test-algorithm", model, "message", "request-id", "")
+	ctx.SetTargetPod(pod)
+
+	firstDone := make(chan struct{})
+	go func() {
+		store.AddRequestCount(ctx, ctx.RequestID, model)
+		close(firstDone)
+	}()
+
+	select {
+	case <-provider.entered:
+	case <-time.After(time.Second):
+		t.Fatal("first AddRequestCount did not start stats update")
+	}
+
+	secondStarted := make(chan struct{})
+	secondDone := make(chan struct{})
+	go func() {
+		close(secondStarted)
+		store.AddRequestCount(ctx, ctx.RequestID, model)
+		close(secondDone)
+	}()
+
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second AddRequestCount goroutine did not start")
+	}
+
+	returnedBeforeStatsUpdate := false
+	deadline := time.After(100 * time.Millisecond)
+pollEarlyReturn:
+	for {
+		select {
+		case <-secondDone:
+			returnedBeforeStatsUpdate = true
+			break pollEarlyReturn
+		case <-deadline:
+			break pollEarlyReturn
+		default:
+			runtime.Gosched()
+		}
+	}
+
+	close(provider.release)
+	<-firstDone
+	if !returnedBeforeStatsUpdate {
+		<-secondDone
+	}
+
+	if returnedBeforeStatsUpdate {
+		t.Fatal("concurrent AddRequestCount returned before in-flight stats update completed")
+	}
+
+	pendingLoad, err := store.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNormalizedPendings)
+	assert.NoError(t, err)
+	assert.Equal(t, 0.25, pendingLoad.GetSimpleValue())
 }
 
 // TestDoneRequestTrace_NilContext verifies that DoneRequestTrace handles nil context

--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -36,8 +36,9 @@ var (
 
 const (
 	statusInitial = iota // 0: initial state
-	statusAdded          // 1: added
-	statusDone           // 2: done
+	statusAdding         // 1: update in progress
+	statusAdded          // 2: added
+	statusDone           // 3: done
 )
 
 type RequestFeatures []float64
@@ -118,6 +119,7 @@ type RoutingContext struct {
 	tokens       []int           // Cache of tokenized prompts
 	predictor    OutputPredictor // OutputPredictor gained from cache
 	statsUpdated int32           // Use to flag if in-memory realtime statistics has been updated for the request.
+	statsAdded   chan struct{}   // Closed once in-memory realtime statistics has been updated for the request.
 	traceAdded   int32           // Use to flag if trace has been added to cache
 
 	// Fields for unit tests
@@ -289,12 +291,27 @@ func (r *RoutingContext) HasError() bool {
 	return pod == nil && r.getError() != nil
 }
 
-// CanAddStats returns true if the first time trying update in-memory realtime statistics.
+// CanAddStats returns true if the caller won the right to update in-memory realtime statistics.
 func (r *RoutingContext) CanAddStats() bool {
-	return atomic.CompareAndSwapInt32(&r.statsUpdated, statusInitial, statusAdded)
+	return atomic.CompareAndSwapInt32(&r.statsUpdated, statusInitial, statusAdding)
+}
+
+// MarkStatsAdded marks that the in-memory realtime statistics update has completed.
+func (r *RoutingContext) MarkStatsAdded() {
+	atomic.StoreInt32(&r.statsUpdated, statusAdded)
+	close(r.statsAdded)
+}
+
+// WaitStatsAdded waits for an in-flight stats update to complete.
+func (r *RoutingContext) WaitStatsAdded() {
+	statsAdded := r.statsAdded
+	if atomic.LoadInt32(&r.statsUpdated) == statusAdding {
+		<-statsAdded
+	}
 }
 
 func (r *RoutingContext) CanDoneStats() bool {
+	r.WaitStatsAdded()
 	return atomic.CompareAndSwapInt32(&r.statsUpdated, statusAdded, statusDone)
 }
 
@@ -364,6 +381,7 @@ func (r *RoutingContext) reset(ctx context.Context, algorithms RoutingAlgorithm,
 	r.tokens = nil
 	r.predictor = nil
 	r.statsUpdated = statusInitial
+	r.statsAdded = make(chan struct{})
 }
 
 func (r *RoutingContext) debugWait() {


### PR DESCRIPTION
## Summary
- Split RoutingContext stats state into in-progress and completed states.
- Make concurrent AddRequestCount callers wait for an in-flight pod stats update before returning.
- Add a regression test for the stale realtime pending-load metric window that can make the SLO queue router test flaky.

## Root Cause
queueRouter.Route waits for TargetPod and then calls AddRequestCount to ensure realtime pod stats are visible before returning. However, the background serve goroutine can win the stats CAS first. In that case, the foreground AddRequestCount observes stats as already claimed and returns immediately while the background goroutine is still inside addPodStats. A test can then read the previous RealtimeNormalizedPendings value, send one extra fill request, and block until its context deadline expires.

## Test Plan
- go test ./pkg/cache -run TestAddRequestCount_WaitsForConcurrentStatsUpdate -count=1
- go test -race ./pkg/cache ./pkg/types ./pkg/plugins/gateway/algorithms -count=1
- go test ./pkg/cache ./pkg/types ./pkg/plugins/gateway/algorithms -count=1
- git diff --check

Note: make test-race-condition was attempted locally but failed before tests while building controller-gen v0.16.1 with local go1.25.1: golang.org/x/tools/internal/tokeninternal invalid array length. The failing CI job uses Go 1.22.12, so the targeted package-level race tests above were used for local verification.