### PR TITLE
fix(helm): start built-in Redis master with --requirepass when password is set (#2396)

### DIFF
--- a/dist/chart/templates/metadata-service/redis.yaml
+++ b/dist/chart/templates/metadata-service/redis.yaml
@@ -27,6 +27,13 @@ spec:
             - containerPort: 6379
           resources: {{ toYaml .Values.metadata.redis.container.resources | nindent 12 }}
           {{- if include "aibrix.redis.sharedHasPassword" . }}
+          # The official redis image ignores the REDIS_PASSWORD env var, so pass
+          # the password to redis-server explicitly. Without this the built-in
+          # master starts with no auth while clients send AUTH, producing
+          # "Client sent AUTH, but no password is set" errors (see #2396).
+          args:
+            - "--requirepass"
+            - "$(REDIS_PASSWORD)"
           env:
             - name: REDIS_PASSWORD
               valueFrom:

--- a/dist/chart/tests/redis_config_test.yaml
+++ b/dist/chart/tests/redis_config_test.yaml
@@ -88,3 +88,24 @@ tests:
           value: "ZGRkZA=="
         documentIndex: 2
 
+  - it: should require auth on the built-in redis master when password enabled
+    set:
+      metadata.redis.enabled: true
+      metadata.redis.enablePassword: true
+      metadata.redis.password: "dddd"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "--requirepass"
+            - "$(REDIS_PASSWORD)"
+        documentIndex: 0
+  - it: should not set redis master args when no password configured
+    set:
+      metadata.redis.enabled: true
+      metadata.redis.enablePassword: false
+      metadata.redis.password: ""
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].args
+        documentIndex: 0


### PR DESCRIPTION
## Summary

Fixes #2396.

When the built-in Redis is deployed with password auth enabled
(`metadata.redis.enablePassword=true` and `metadata.redis.password` set),
the `metadata-service` pod crashloops with a Redis `AuthenticationError`.

### Root cause

The Redis master `Deployment` injects the password into the container as the
`REDIS_PASSWORD` environment variable:

```yaml
env:
  - name: REDIS_PASSWORD
    valueFrom:
      secretKeyRef: ...
```

but the chart uses the **official** `redis` image (`redis:7.4`), which — unlike
the Bitnami image — does **not** read `REDIS_PASSWORD`. So the server starts
with no auth, while the clients (correctly configured from the Secret) send
`AUTH`, producing:

```
Client sent AUTH, but no password is set
```

and the dependent pods crashloop.

### Fix

Pass the password to `redis-server` explicitly so the master actually requires
it, using Kubernetes env-var substitution from the existing `REDIS_PASSWORD`:

```yaml
args:
  - "--requirepass"
  - "$(REDIS_PASSWORD)"
```

The `args` are emitted under the same `aibrix.redis.sharedHasPassword`
condition as the `REDIS_PASSWORD` env var, so the no-password path is
unchanged.

### Tests

Extended `dist/chart/tests/redis_config_test.yaml`:
- the built-in master gets `--requirepass $(REDIS_PASSWORD)` when a password is configured;
- no `args` are set when no password is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
