### PR TITLE
fix(batch): run jobs concurrently regardless of endpoint count

### DIFF
--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -953,10 +953,10 @@ class BaseJobDriver:
 
         Sending requests is delegated to the dispatch engine: the engine owns
         endpoint resolution, failover, and concurrency. Jobs with a known total
-        use the concurrent engine loop only when the engine advertises parallel
-        capacity and there is no serial-only compatibility option enabled.
-        Unknown-total jobs keep the serial cursor because input EOF discovery is
-        part of that protocol.
+        use the concurrent engine loop so client concurrency settings are
+        honored even when the source currently advertises one endpoint.
+        Unknown-total jobs keep the serial cursor because input EOF discovery
+        is part of that protocol.
         """
         if self._engine is None:
             raise RuntimeError(
@@ -971,10 +971,7 @@ class BaseJobDriver:
         if stopped:
             return await self._finish_stopped_job(job)
 
-        if (
-            job.status.request_counts.total > 0
-            and (await self._engine.capacity()).count > 1
-        ):
+        if job.status.request_counts.total > 0:
             return await self._execute_worker_concurrent(job)
 
         return await self._execute_worker_serial(job)

--- a/python/aibrix/tests/batch/test_base_job_driver_concurrent.py
+++ b/python/aibrix/tests/batch/test_base_job_driver_concurrent.py
@@ -76,7 +76,8 @@ class _SlowChannel:
         self.peak = max(self.peak, self.inflight)
         await asyncio.sleep(0.01)
         self.inflight -= 1
-        if request.ref[0] in self._fail_indices:
+        request_id = request.ref[0] if isinstance(request.ref, tuple) else request.ref
+        if request_id in self._fail_indices:
             raise InferenceError(
                 InferenceErrorCode.TRANSPORT_ERROR,
                 "injected failure",
@@ -275,6 +276,29 @@ async def test_execute_worker_uses_concurrent_dispatch_for_known_total(monkeypat
     assert result.status.usage.input_tokens == 4
     assert result.status.usage.output_tokens == 8
     assert result.status.usage.total_tokens == 12
+
+
+@pytest.mark.asyncio
+async def test_execute_worker_honors_client_concurrency_for_single_endpoint(
+    monkeypatch,
+):
+    job = _make_job(total=4)
+    job.spec.aibrix = AibrixMetadata(
+        client={"max_concurrency": 4, "adaptive_concurrency": False}
+    )
+    driver, channel = _driver(job, capacity=1)
+    requests = [
+        {"_request_index": i, "custom_id": f"req-{i}", "body": {"i": i}}
+        for i in range(4)
+    ]
+    outputs, _ = _patch_storage(monkeypatch, requests)
+
+    result = await driver.execute_worker(job.job_id)
+
+    assert result.status.state == BatchJobState.IN_PROGRESS
+    assert result.status.request_counts.completed == 4
+    assert set(outputs) == {0, 1, 2, 3}
+    assert channel.peak > 1
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
+++ b/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
@@ -65,7 +65,7 @@ TEST_OPTS_DELAY_BEFORE_FINALIZE_SHUTDOWN_SECONDS = (
 TEST_OPTS_DELAY_AFTER_FINALIZE_SHUTDOWN_SECONDS = (
     "delay_after_finalize_shutdown_seconds"
 )
-_ORIGINAL_RUNTIME_DELAY_SEND_ONE: Any = None
+_ORIGINAL_RUNTIME_DELAY_SEND: Any = None
 _PATCHED_RUNTIME_DELAY_SECONDS = 0.0
 
 
@@ -517,6 +517,44 @@ def install_pending_after_n_requests_barrier(
     return entered_pending, release_pending
 
 
+def pin_job_concurrency_to_serial(
+    monkeypatch, test_backend, *, per_request_delay: float = 0.0
+) -> None:
+    """Make request-persistence barriers deterministic for timing tests."""
+    target_driver = backend_runtime_driver_class(test_backend)
+
+    async def serial_execute_worker(self, job_id):
+        if self._engine is None:
+            raise RuntimeError(
+                "JobDriver was constructed without an engine; execute_worker "
+                "requires one."
+            )
+
+        job, stopped = await self._is_job_stopped(job_id)
+        if stopped:
+            return await self._finish_stopped_job(job)
+        return await self._execute_worker_serial(job)
+
+    monkeypatch.setattr(
+        target_driver,
+        "execute_worker",
+        serial_execute_worker,
+    )
+
+    if per_request_delay <= 0:
+        return
+
+    from aibrix.batch.client.engine import DispatchEngine
+
+    original_send = DispatchEngine._send_with_failover
+
+    async def delayed_send(self, request):
+        await asyncio.sleep(per_request_delay)
+        return await original_send(self, request)
+
+    monkeypatch.setattr(DispatchEngine, "_send_with_failover", delayed_send)
+
+
 async def wait_for_status(
     client: TestClient,
     batch_id: str,
@@ -924,7 +962,7 @@ def verify_runtime_restart_completion_teardown(
 def set_runtime_inference_delay(
     e2e_test_app, test_backend: str, delay_seconds: float
 ) -> Optional[float]:
-    global _ORIGINAL_RUNTIME_DELAY_SEND_ONE, _PATCHED_RUNTIME_DELAY_SECONDS
+    global _ORIGINAL_RUNTIME_DELAY_SEND, _PATCHED_RUNTIME_DELAY_SECONDS
 
     from aibrix.batch.client.engine import DispatchEngine
 
@@ -932,23 +970,23 @@ def set_runtime_inference_delay(
     original_delay = values.get("endpoint_source_delay_seconds", 0.0)
     values["endpoint_source_delay_seconds"] = delay_seconds
 
-    original_send_one = _ORIGINAL_RUNTIME_DELAY_SEND_ONE
-    if original_send_one is None:
-        _ORIGINAL_RUNTIME_DELAY_SEND_ONE = DispatchEngine.send_one
-        original_send_one = _ORIGINAL_RUNTIME_DELAY_SEND_ONE
+    original_send = _ORIGINAL_RUNTIME_DELAY_SEND
+    if original_send is None:
+        _ORIGINAL_RUNTIME_DELAY_SEND = DispatchEngine._send_with_failover
+        original_send = _ORIGINAL_RUNTIME_DELAY_SEND
 
     if delay_seconds > 0:
         _PATCHED_RUNTIME_DELAY_SECONDS = delay_seconds
-        if DispatchEngine.send_one is original_send_one:
+        if DispatchEngine._send_with_failover is original_send:
 
-            async def delayed_send_one(self, request):
+            async def delayed_send(self, request):
                 await asyncio.sleep(_PATCHED_RUNTIME_DELAY_SECONDS)
-                return await original_send_one(self, request)
+                return await original_send(self, request)
 
-            cast(Any, DispatchEngine).send_one = delayed_send_one
+            cast(Any, DispatchEngine)._send_with_failover = delayed_send
     else:
         _PATCHED_RUNTIME_DELAY_SECONDS = 0.0
-        cast(Any, DispatchEngine).send_one = original_send_one
+        cast(Any, DispatchEngine)._send_with_failover = original_send
 
     # Dry-run local/redis backends reuse a singleton NoopEndpointSource that
     # captures EchoChannel(delay=...) at app construction time. Update the live
@@ -1843,6 +1881,7 @@ async def test_job_cancellation_in_progress_during_service_discovery(
 async def test_job_cancellation_in_progress(e2e_test_app, test_backend, monkeypatch):
     """Test case 5: Create job, cancel during in progress, finalizing, validate finalized result."""
     print("Test 5: Job cancellation during processing scenario")
+    pin_job_concurrency_to_serial(monkeypatch, test_backend, per_request_delay=0.3)
     entered_pending, release_pending = install_pending_after_n_requests_barrier(
         monkeypatch,
         e2e_test_app,
@@ -2150,9 +2189,12 @@ async def test_job_expiration_during_validation(e2e_test_app, test_backend):
 
 
 @pytest.mark.asyncio
-async def test_job_expiration_during_processing(e2e_test_app, test_backend):
+async def test_job_expiration_during_processing(
+    e2e_test_app, test_backend, monkeypatch
+):
     """Test case 8: Create job, set expire to 1min, expired during in progress, finalizing, validate result."""
     print("Test 8: Job expiration during processing scenario")
+    pin_job_concurrency_to_serial(monkeypatch, test_backend)
 
     with create_test_client(e2e_test_app) as client:
         input_file_id = upload_batch_input_file(client, 3)
@@ -2293,6 +2335,7 @@ async def test_job_restart_during_in_progress(
         pytest.skip("Restart phase recovery is not covered for this backend")
 
     # Test setup
+    pin_job_concurrency_to_serial(monkeypatch, test_backend)
     force_batch_driver_crash_on_shutdown(monkeypatch, e2e_test_app)
     entered_pending, _ = install_pending_after_n_requests_barrier(
         monkeypatch,


### PR DESCRIPTION
## Pull Request Description
A single-endpoint source (capacity.count==1) was forced onto the serial path, silently dropping client concurrency config. Known-total jobs now always use the concurrent dispatch loop; serial is kept only for unknown-total EOF probing.

single job takes longer than expected.

https://github.com/vllm-project/aibrix/blob/adfe6f8373afe5a90a2e93687474f07a0d4aed26/python/aibrix/aibrix/batch/job_driver/base.py#L975-L980

problem here.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>