### PR TITLE
[Bug]Fixes batch job recovery issues around metadata-service restart.

### DIFF
--- a/python/aibrix/aibrix/batch/batch_manager.py
+++ b/python/aibrix/aibrix/batch/batch_manager.py
@@ -1016,6 +1016,9 @@ class BatchManager(RunningJobs, SchedulableJobs):
         Pending jobs finalize immediately into the done pool. In-progress jobs
         persist the expired condition and then signal their live driver like the
         cancellation flow, so execution stops before finalizing the expired job.
+        Jobs that have already entered FINALIZING are past the interruption
+        point; expiration is rejected so the in-flight terminalization can
+        complete consistently.
 
         Returns True if the job was expired. Called by the scheduler's cleanup
         loop, which makes the registry the single source of truth for expiry
@@ -1042,10 +1045,18 @@ class BatchManager(RunningJobs, SchedulableJobs):
         ):
             return True
 
+        if old_job.status.state == BatchJobState.FINALIZING:
+            logger.info(
+                "Job already finalizing, skipping expiration",
+                job_id=job_id,
+                state=old_job.status.state,
+            )  # type: ignore[call-arg]
+            return False
+
         old_job = self._normalize_recovered_in_progress_job_for_cleanup(job_id, old_job)
 
         job_expired = self._build_expired_job_update(old_job)
-        if old_job.status.state != BatchJobState.IN_PROGRESS:
+        if old_job.status.state in (BatchJobState.CREATED, BatchJobState.VALIDATING):
             expired_at = job_expired.status.expired_at
             assert expired_at is not None
             job_expired.status.finalized_at = expired_at

--- a/python/aibrix/aibrix/batch/batch_manager.py
+++ b/python/aibrix/aibrix/batch/batch_manager.py
@@ -195,6 +195,34 @@ class BatchManager(RunningJobs, SchedulableJobs):
         meta_job.status = job.status
         return meta_job
 
+    def _normalize_recovered_in_progress_job_for_cleanup(
+        self, job_id: str, job: BatchJob
+    ) -> JobMetaInfo | BatchJob:
+        """Move a recovered active job into the in-progress registry if needed.
+
+        Restart/bootstrap can temporarily stage a persisted ``IN_PROGRESS`` job
+        in ``_pending_jobs`` before scheduler admission rebuilds the runtime
+        state. Expire/cancel cleanup paths operate on the in-progress registry,
+        so normalize that recovered shape before persisting status updates or
+        clearing durable execution metadata.
+        """
+
+        if job.status.state != BatchJobState.IN_PROGRESS:
+            return job
+        if job_id in self._in_progress_jobs:
+            return self._in_progress_jobs[job_id]
+        if job_id not in self._pending_jobs:
+            return job
+
+        meta_data = self._as_job_meta(job)
+        del self._pending_jobs[job_id]
+        self._in_progress_jobs[job_id] = meta_data
+        logger.debug(
+            "Normalized recovered in-progress job for cleanup",
+            job_id=job_id,
+        )  # type: ignore[call-arg]
+        return meta_data
+
     async def set_job_entity_manager(
         self, job_entity_manager: JobEntityManager
     ) -> None:
@@ -903,7 +931,10 @@ class BatchManager(RunningJobs, SchedulableJobs):
             state=job.status.state,
         )  # type: ignore[call-arg]
 
-        job = meta_data.copy(job.status)
+        # Copy the target status snapshot so the live in-progress JobMetaInfo is
+        # not mutated to FINALIZED before job_updated_handler computes the old
+        # category transition.
+        job = meta_data.copy(job.status.model_copy(deep=True))
         finalized_at = datetime.now(timezone.utc)
         job.status.finalized_at = finalized_at
         # Do not override existing condition. Fill up locally for data integrity in case apply_job_changes does nothing
@@ -1010,6 +1041,8 @@ class BatchManager(RunningJobs, SchedulableJobs):
             and old_job.status.check_condition(ConditionType.EXPIRED)
         ):
             return True
+
+        old_job = self._normalize_recovered_in_progress_job_for_cleanup(job_id, old_job)
 
         job_expired = self._build_expired_job_update(old_job)
         if old_job.status.state != BatchJobState.IN_PROGRESS:

--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -1429,7 +1429,11 @@ class BaseJobDriver:
             logger.debug("Finalized job", job_id=job.job_id)  # type: ignore[call-arg]
             self._log_completed(synced)
         except Exception as e:
-            logger.error("Error finalizing job output data: %s", e)  # type: ignore[call-arg]
+            logger.error(
+                "Error finalizing job output data",
+                job_id=job.job_id,
+                error=str(e),
+            )  # type: ignore[call-arg]
             raise BatchJobError(
                 BatchJobErrorCode.FINALIZING_ERROR,
                 message=str(e),

--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -371,17 +371,31 @@ class BaseJobDriver:
 
         Expiration/cancellation can discover durable execution metadata even
         when the original in-memory driver instance no longer exists. Recreated
-        drivers use this hook to tear down any reachable runtime and then clear
-        the durable execution ref so later recovery does not keep retrying a
-        stale runtime attachment.
+        drivers use this hook to tear down any reachable runtime, clear the
+        durable execution ref, and then continue the normal stopped-job finish
+        path so recovery does not strand an expired/cancelled job in-progress.
         """
         await self._runtime.cleanup(job)
-        if job.job_id is None or job.status.execution is None:
+
+        current_job = job
+
+        if job.status.execution is not None:
+            cleared_status = job.status.model_copy(deep=True)
+            cleared_status.execution = None
+            current_job = await self._progress_manager.update_job_status(
+                job.job_id, cleared_status
+            )
+        else:
+            reloaded_job = await self._progress_manager.get_job(job.job_id)
+            if reloaded_job is not None:
+                current_job = reloaded_job
+
+        if current_job.status.finished:
+            return
+        if not self._should_stop_before_proceed(current_job):
             return
 
-        cleared_status = job.status.model_copy(deep=True)
-        cleared_status.execution = None
-        await self._progress_manager.update_job_status(job.job_id, cleared_status)
+        await self._finish_stopped_job(current_job)
 
     # ── overridable options ──────────────────────────────────────────
 

--- a/python/aibrix/aibrix/batch/state/job_entity_manager.py
+++ b/python/aibrix/aibrix/batch/state/job_entity_manager.py
@@ -310,6 +310,23 @@ class JobEntityManager(ABC):
             return
         self._monitored_job_snapshots[job.job_id] = job.model_copy(deep=True)
 
+    async def _publish_active_job_on_cache_miss(self, job: Optional[BatchJob]) -> None:
+        """Republish an active job discovered outside bootstrap/refresh.
+
+        A direct ``get_job()`` read can discover an unfinished job that was not
+        restored into the manager during startup recovery. In that case, publish
+        the same committed event the refresh/bootstrap path would have emitted.
+        """
+
+        if job is None or job.job_id is None or job.status.finished:
+            return
+        if (
+            job.job_id in self.active_jobs
+            or job.job_id in self._monitored_job_snapshots
+        ):
+            return
+        await self.job_committed(job.model_copy(deep=True))
+
     def _forget_job(self, job_id: Optional[str]) -> None:
         if job_id is None:
             return

--- a/python/aibrix/aibrix/batch/state/job_store.py
+++ b/python/aibrix/aibrix/batch/state/job_store.py
@@ -39,6 +39,7 @@ from aibrix.batch.storage.batch_metastore import (
     put_batch_job,
 )
 from aibrix.metadata.setting import settings
+from aibrix.storage.types import StorageListOrdering
 
 
 class JobStore(JobEntityManager):
@@ -81,7 +82,11 @@ class JobStore(JobEntityManager):
         )
 
     def _supports_created_at_desc_recovery_ordering(self) -> bool:
-        return batch_metastore.supports_created_at_desc_batch_job_listing()
+        return (
+            batch_metastore.p_metastore is not None
+            and batch_metastore.p_metastore.get_list_ordering()
+            == StorageListOrdering.CREATED_AT_DESC
+        )
 
     async def submit_job(
         self, session_id: str, job_spec: BatchJobSpec, request_count: int = 0

--- a/python/aibrix/aibrix/batch/state/job_store.py
+++ b/python/aibrix/aibrix/batch/state/job_store.py
@@ -59,8 +59,9 @@ class JobStore(JobEntityManager):
         if job_id in self.active_jobs and not force_reload:
             return self.active_jobs[job_id]
         job = await get_batch_job(job_id)
+        await self._publish_active_job_on_cache_miss(job)
         if job is not None and not job.status.finished:
-            self.active_jobs[job_id] = job
+            return self.active_jobs.get(job_id, job)
         return job
 
     async def list_jobs(

--- a/python/aibrix/aibrix/batch/storage/batch_metastore.py
+++ b/python/aibrix/aibrix/batch/storage/batch_metastore.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import os
+from dataclasses import replace
 from datetime import datetime
 from typing import Callable, Optional, Tuple
 
@@ -25,9 +26,10 @@ from aibrix.batch.job_entity import (
     aggregate_batch_job_status,
 )
 from aibrix.logger import init_logger
-from aibrix.storage import BaseStorage, StorageType, create_storage
+from aibrix.storage import BaseStorage, StorageConfig, StorageType, create_storage
 from aibrix.storage.base import PutObjectOptionsBuilder
 from aibrix.storage.local import LOCAL_STORAGE_PATH_VAR
+from aibrix.storage.types import StorageListOrdering
 
 logger = init_logger(__name__)
 
@@ -54,12 +56,6 @@ def initialize_batch_metastore(storage_type=StorageType.AUTO, params={}):
     if storage_type == StorageType.AUTO and envs.STORAGE_REDIS_AVAILABLE:
         storage_type = StorageType.REDIS
 
-    if not supports_created_at_desc_batch_job_listing(storage_type):
-        raise RuntimeError(
-            f"Metastore backend {storage_type.value} cannot list batch jobs "
-            "in descending created_at order."
-        )
-
     # The LOCAL metastore lives under the configured storage root, so a dev/test
     # run that isolates STORAGE_LOCAL_PATH isolates the metastore too (rather
     # than sharing one cwd-relative ``.metastore``). Other substrates (redis /
@@ -69,10 +65,45 @@ def initialize_batch_metastore(storage_type=StorageType.AUTO, params={}):
 
     # Create new storage instance and wrap with adapter
     try:
+        create_params = dict(params or {})
+        requested_config = create_params.pop("config", None)
+        if requested_config is None:
+            requested_config = StorageConfig()
+        elif not isinstance(requested_config, StorageConfig):
+            raise TypeError("params['config'] must be a StorageConfig instance")
+        if requested_config.list_ordering is None:
+            requested_config = replace(
+                requested_config,
+                list_ordering=StorageListOrdering.CREATED_AT_DESC,
+            )
+        elif requested_config.list_ordering != StorageListOrdering.CREATED_AT_DESC:
+            logger.warning(
+                "Metastore backend must use created_at-desc list ordering; overriding requested ordering.",
+                storage=storage_type.value,
+                old_ordering=requested_config.list_ordering.value,
+                new_ordering=StorageListOrdering.CREATED_AT_DESC.value,
+            )
+            requested_config = replace(
+                requested_config,
+                list_ordering=StorageListOrdering.CREATED_AT_DESC,
+            )
+
         logger.info(
-            "Initializing batch metastore", storage_type=storage_type, params=params
+            "Initializing batch metastore",
+            storage_type=storage_type,
+            config=requested_config,
+            params=create_params,
         )  # type: ignore[call-arg]
-        p_metastore = create_storage(storage_type, base_path=base_path, **params)
+        # Metastore scans require created_at-desc ordering. Backends that do not
+        # support that contract reject the selected StorageConfig during
+        # create_storage()/storage initialization.
+        storage = create_storage(
+            storage_type,
+            config=requested_config,
+            base_path=base_path,
+            **create_params,
+        )
+        p_metastore = storage
     except Exception as e:
         logger.error("Failed to initialize metastore", error=str(e))  # type: ignore[call-arg]
         raise
@@ -348,13 +379,6 @@ async def list_batch_jobs(
         for index, job in zip(uncached_indices, fetched_jobs):
             jobs[index] = job
     return [job for job in jobs if job is not None]
-
-
-def supports_created_at_desc_batch_job_listing(
-    storage_type: Optional[StorageType] = None,
-) -> bool:
-    metastore_type = storage_type or get_metastore_type()
-    return metastore_type in {StorageType.LOCAL, StorageType.REDIS}
 
 
 async def list_metastore_keys(

--- a/python/aibrix/aibrix/batch/storage/batch_metastore.py
+++ b/python/aibrix/aibrix/batch/storage/batch_metastore.py
@@ -37,9 +37,29 @@ p_metastore: Optional[BaseStorage] = None
 NUM_REQUESTS_PER_READ = 1024
 STATUS_REQUEST_LOCKING = "processing"
 METASTORE_LIST_PAGE_SIZE = 1000
-JOB_KEY_PREFIX = "batchjob:"
-JOB_STATUS_COPIES_PREFIX = "batchstatus_copies:"
+JOB_KEY_PREFIX = "batchjob"
+JOB_STATUS_COPIES_PREFIX = "batchstatus_copies:%s"
 OLDEST_UNFINISHED_JOB_CREATED_AT_KEY = "batchjob_meta:oldest_unfinished_created_at"
+
+
+def _job_key(batch_id: str) -> str:
+    return f"{JOB_KEY_PREFIX}/{batch_id}"
+
+
+def _job_list_prefix() -> str:
+    return f"{JOB_KEY_PREFIX}/"
+
+
+def _status_copies_parent_key(batch_id: str) -> str:
+    return JOB_STATUS_COPIES_PREFIX % batch_id
+
+
+def _status_copies_list_prefix(batch_id: str) -> str:
+    return f"{_status_copies_parent_key(batch_id)}/"
+
+
+def _status_copy_key(batch_id: str, worker_id: str) -> str:
+    return f"{_status_copies_list_prefix(batch_id)}{worker_id}"
 
 
 def initialize_batch_metastore(storage_type=StorageType.AUTO, params={}):
@@ -252,7 +272,7 @@ async def unlock_request(key: str, status: str) -> bool:
 
 
 async def put_batch_job(batch_id: str, job: BatchJob) -> None:
-    """Persist a BatchJob document under ``JOB_KEY_PREFIX<id>``.
+    """Persist a BatchJob document under ``JOB_KEY_PREFIX/<id>``.
 
     Last-writer-wins. When the metastore is Redis-backed this is a
     single SET; on file-backed metastores it is a small object write.
@@ -266,17 +286,15 @@ async def put_batch_job(batch_id: str, job: BatchJob) -> None:
             continue
 
         status_json = status_copy.model_dump_json(by_alias=True, exclude_none=True)
-        await set_metadata(
-            f"{JOB_STATUS_COPIES_PREFIX}{batch_id}:{worker_id}", status_json
-        )
+        await set_metadata(_status_copy_key(batch_id, worker_id), status_json)
     # Store the main status document
     payload = job_to_store.model_dump_json(by_alias=True, exclude_none=True)
-    await set_metadata(f"{JOB_KEY_PREFIX}{batch_id}", payload)
+    await set_metadata(_job_key(batch_id), payload)
 
 
 async def get_batch_job(batch_id: str) -> Optional[BatchJob]:
     """Fetch a BatchJob document or ``None`` if absent."""
-    raw, exists = await get_metadata(f"{JOB_KEY_PREFIX}{batch_id}")
+    raw, exists = await get_metadata(_job_key(batch_id))
     if not exists:
         return None
     job = BatchJob.model_validate_json(raw)
@@ -289,13 +307,15 @@ async def get_batch_job(batch_id: str) -> Optional[BatchJob]:
 
     # Load updated status copies
     status_copies = {}
-    prefix = f"{JOB_STATUS_COPIES_PREFIX}{batch_id}:"
-    keys = await list_metastore_all_keys(prefix)
-    storage_keys = [key if key.startswith(prefix) else f"{prefix}{key}" for key in keys]
+    prefix = _status_copies_list_prefix(batch_id)
+    # Keep the trailing "/" in the listing prefix so every backend treats this
+    # as "list children under this namespace". Redis normalizes either form,
+    # but local/object-style listings would otherwise collapse to a common prefix.
+    keys = await list_metastore_all_keys(prefix, delimiter="/")
     metadata_results = await asyncio.gather(
-        *(get_metadata(storage_key) for storage_key in storage_keys)
+        *(get_metadata(storage_key) for storage_key in keys)
     )
-    for storage_key, (status_json, exists) in zip(storage_keys, metadata_results):
+    for storage_key, (status_json, exists) in zip(keys, metadata_results):
         if exists:
             worker_id = storage_key[len(prefix) :]
             status_copies[worker_id] = BatchJobStatusCopy.model_validate_json(
@@ -312,15 +332,14 @@ async def get_batch_job(batch_id: str) -> Optional[BatchJob]:
 async def delete_batch_job(batch_id: str) -> None:
     """Remove the BatchJob document. Silent no-op if absent."""
     try:
-        prefix = f"{JOB_STATUS_COPIES_PREFIX}{batch_id}:"
-        for key in await list_metastore_all_keys(prefix):
+        prefix = _status_copies_list_prefix(batch_id)
+        for key in await list_metastore_all_keys(prefix, delimiter="/"):
             try:
-                storage_key = key if key.startswith(prefix) else f"{prefix}{key}"
-                await delete_metadata(storage_key)
+                await delete_metadata(key)
             except FileNotFoundError:
                 continue
 
-        await delete_metadata(f"{JOB_KEY_PREFIX}{batch_id}")
+        await delete_metadata(_job_key(batch_id))
     except FileNotFoundError:
         return
 
@@ -354,11 +373,12 @@ async def list_batch_jobs(
 ) -> list[BatchJob]:
     """List BatchJob documents using backend-native created-time ordering."""
     keys, _ = await list_metastore_keys(
-        JOB_KEY_PREFIX,
-        after_key=f"{JOB_KEY_PREFIX}{after}" if after is not None else None,
+        _job_list_prefix(),
+        delimiter="/",
+        after_key=_job_key(after) if after is not None else None,
         limit=limit,
     )
-    job_ids = [key.removeprefix(JOB_KEY_PREFIX) for key in keys]
+    job_ids = [key.removeprefix(_job_list_prefix()) for key in keys]
     jobs: list[Optional[BatchJob]] = [None] * len(job_ids)
     uncached_indices: list[int] = []
     uncached_job_ids: list[str] = []
@@ -383,6 +403,7 @@ async def list_batch_jobs(
 
 async def list_metastore_keys(
     prefix: str,
+    delimiter: Optional[str] = None,
     continuation_token: Optional[str] = None,
     limit: int = METASTORE_LIST_PAGE_SIZE,
     after_key: Optional[str] = None,
@@ -408,13 +429,16 @@ async def list_metastore_keys(
 
     return await p_metastore.list_objects(
         prefix=prefix,
+        delimiter=delimiter,
         continuation_token=continuation_token,
         limit=limit,
         after_key=after_key,
     )
 
 
-async def list_metastore_all_keys(prefix: str) -> list[str]:
+async def list_metastore_all_keys(
+    prefix: str, delimiter: Optional[str] = None
+) -> list[str]:
     """List all metastore keys matching the given prefix.
 
 
@@ -438,6 +462,7 @@ async def list_metastore_all_keys(prefix: str) -> list[str]:
     while True:
         batch_keys, continuation_token = await p_metastore.list_objects(
             prefix=prefix,
+            delimiter=delimiter,
             continuation_token=continuation_token,
             limit=METASTORE_LIST_PAGE_SIZE,  # Process in batches of 1000
         )

--- a/python/aibrix/aibrix/client/redis.py
+++ b/python/aibrix/aibrix/client/redis.py
@@ -155,6 +155,12 @@ class AsyncRedis(Protocol):
         value: bytes | bytearray | memoryview | str | int | float,
     ) -> Optional[int]: ...
 
+    async def zscore(
+        self,
+        name: bytes | str | memoryview,
+        value: bytes | bytearray | memoryview | str | int | float,
+    ) -> Optional[float]: ...
+
     async def zrem(
         self,
         name: bytes | str | memoryview,

--- a/python/aibrix/aibrix/metadata/api/v1/batch.py
+++ b/python/aibrix/aibrix/metadata/api/v1/batch.py
@@ -40,7 +40,6 @@ from aibrix.batch.job_entity import (
     RuntimeSpec,
 )
 from aibrix.batch.manifest import RenderError
-from aibrix.batch.storage.batch_metastore import get_batch_job
 from aibrix.batch.template import (
     BatchProfile,
     ModelDeploymentTemplate,
@@ -611,17 +610,13 @@ async def create_batch(request: Request, batch_spec: BatchSpec) -> BatchResponse
 
 
 async def _resolve_batch_job(request: Request, batch_id: str) -> Optional[BatchJob]:
-    """Resolve a BatchJob by id, metastore-first with BatchManager fallback.
+    """Resolve a BatchJob by id through the BatchDriver.
 
-    The batch metastore is the source of truth. The fallback to the driver's
-    in-memory pool covers the brief window after POST before the store write
-    is observable, since the metadata service seeds the BatchManager pool
-    synchronously on create.
+    Reads flow through the BatchDriver so an unfinished job that exists only in
+    the metastore can be republished into the manager's runtime pools if restart
+    recovery missed it. The driver still covers the brief POST -> store window
+    because freshly created jobs are seeded into the in-memory pools first.
     """
-    job = await get_batch_job(batch_id)
-    if job is not None:
-        return job
-
     batch_driver: BatchDriver = request.app.state.batch_driver
     return await batch_driver.get_job(batch_id)
 

--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -37,6 +37,7 @@ from aibrix.metadata.core import HTTPXClientWrapper
 from aibrix.metadata.setting import settings
 from aibrix.metadata.store import RedisMetadataStore
 from aibrix.storage import create_storage
+from aibrix.storage.redis_upgrade import maybe_upgrade_storage
 
 logger = init_logger(__name__)
 router = APIRouter()
@@ -116,6 +117,14 @@ async def liveness_check():
 async def readiness_check(request: Request):
     # Check if metadata store is ready
     try:
+        if getattr(request.app.state, "storage_upgrade_in_progress", False):
+            return JSONResponse(
+                content={
+                    "status": "not ready",
+                    "error": "storage upgrade in progress",
+                },
+                status_code=503,
+            )
         if hasattr(request.app.state, "metadata_store"):
             ping_ok = await request.app.state.metadata_store.ping()
             if not ping_ok:
@@ -160,6 +169,7 @@ async def status_check(request: Request):
 async def lifespan(app: FastAPI):
     # Code executed on startup
     logger.info("Initializing FastAPI app...")
+    app.state.storage_upgrade_in_progress = True
 
     # Initialize metadata store (abstraction over Redis) only if not already set
     # (e.g., tests may pre-configure a mock store before lifespan runs)
@@ -170,6 +180,12 @@ async def lifespan(app: FastAPI):
         # that haven't migrated to the MetadataStore interface yet
         app.state.redis_client = metadata_store.client
         logger.info("Metadata store initialized")
+
+    try:
+        for storage in _iter_upgrade_candidate_storages(app):
+            await maybe_upgrade_storage(storage)
+    finally:
+        app.state.storage_upgrade_in_progress = False
 
     if hasattr(app.state, "httpx_client_wrapper"):
         app.state.httpx_client_wrapper.start()
@@ -188,6 +204,31 @@ async def lifespan(app: FastAPI):
     elif hasattr(app.state, "redis_client"):
         await app.state.redis_client.aclose()  # type: ignore[attr-defined]
         logger.info("Redis client closed")
+
+
+def _iter_upgrade_candidate_storages(app: FastAPI):
+    seen_ids: set[int] = set()
+
+    def _yield_once(storage):
+        if storage is None:
+            return
+        storage_id = id(storage)
+        if storage_id in seen_ids:
+            return
+        seen_ids.add(storage_id)
+        yield storage
+
+    if hasattr(app.state, "storage"):
+        yield from _yield_once(app.state.storage)
+
+    try:
+        from aibrix.batch.storage import batch_metastore, batch_storage
+
+        if batch_storage.p_storage is not None:
+            yield from _yield_once(batch_storage.p_storage.storage)
+        yield from _yield_once(batch_metastore.p_metastore)
+    except Exception:
+        logger.exception("Failed to inspect batch storages for upgrade")  # type: ignore[call-arg]
 
 
 def build_app(args: argparse.Namespace, params={}):

--- a/python/aibrix/aibrix/storage/README.md
+++ b/python/aibrix/aibrix/storage/README.md
@@ -4,30 +4,43 @@
 
 - `v1`
   - Redis sorted-set timestamp indexes store positive Unix timestamps.
-  - Ascending `ZRANGE` pagination therefore returns oldest-first results.
+  - Only oldest-first listing is available from the stored score direction.
 - `v2`
   - Redis sorted-set timestamp indexes store negative Unix timestamps.
   - The existing `list_objects()` pagination and rank logic stays unchanged.
   - Ascending `ZRANGE` now returns newest-first results because newer objects
     have smaller scores.
+- `v3`
+  - Stores positive Unix timestamps as the canonical created_at score.
+  - Supports both `created_at_asc` and `created_at_desc` list ordering.
+  - Uses `ZRANGE` / `ZRANK` for ascending and `ZREVRANGE` / `ZREVRANK` for descending.
+  - Rekeys batch metastore jobs from `batchjob:<id>` to `batchjob/<id>`.
+  - Rekeys batch status copies from
+    `batchstatus_copies:<job_id>:<worker_id>` to
+    `batchstatus_copies:<job_id>/<worker_id>`.
+  - Rebuilds hierarchical Redis indexes from the migrated keys so
+    `list_objects()` can use `parent:index` and `timestamps:{parent}` for batch
+    metastore listings.
 
 ## Version Key
 
 - Redis key: `storage:version`
 - Missing key defaults to version `1`
-- Latest version is `2`
+- Latest version is `3`
 
 ## Upgrade Logic
 
 - Startup inspects every initialized Redis-backed storage instance before the
   metadata service reports readiness.
 - If `storage:version` is missing, startup treats the storage as `v1`.
-- The `v1 -> v2` upgrade rewrites:
-  - `timestamps:all`
-  - each hierarchical parent index `timestamps:{parent}`
-- Every score is normalized from `score` to `-abs(score)`.
+- The `v1/v2 -> v3` upgrade:
+  - normalizes every timestamp score to `abs(score)`
+  - migrates batch metastore keys to the new slash-delimited schema
+  - rebuilds `timestamps:all`
+  - rebuilds each affected `parent:index`
+  - rebuilds each affected `timestamps:{parent}`
 - After all index rewrites complete successfully, startup sets
-  `storage:version = 2`.
+  `storage:version = 3`.
 
 ## Startup Behavior
 
@@ -46,4 +59,9 @@ poetry run python scripts/upgrade_redis_storage.py
 ```
 
 - The script uses the normal Redis environment configuration and applies the
-  same `v1 -> v2` migration as startup initialization.
+  same direct `v1/v2 -> v3` migration as startup initialization.
+- For a batch-focused operator entrypoint, run:
+
+```bash
+poetry run python scripts/upgrade_redis_storage.py
+```

--- a/python/aibrix/aibrix/storage/README.md
+++ b/python/aibrix/aibrix/storage/README.md
@@ -1,0 +1,49 @@
+# Redis Storage Versioning
+
+## Versions
+
+- `v1`
+  - Redis sorted-set timestamp indexes store positive Unix timestamps.
+  - Ascending `ZRANGE` pagination therefore returns oldest-first results.
+- `v2`
+  - Redis sorted-set timestamp indexes store negative Unix timestamps.
+  - The existing `list_objects()` pagination and rank logic stays unchanged.
+  - Ascending `ZRANGE` now returns newest-first results because newer objects
+    have smaller scores.
+
+## Version Key
+
+- Redis key: `storage:version`
+- Missing key defaults to version `1`
+- Latest version is `2`
+
+## Upgrade Logic
+
+- Startup inspects every initialized Redis-backed storage instance before the
+  metadata service reports readiness.
+- If `storage:version` is missing, startup treats the storage as `v1`.
+- The `v1 -> v2` upgrade rewrites:
+  - `timestamps:all`
+  - each hierarchical parent index `timestamps:{parent}`
+- Every score is normalized from `score` to `-abs(score)`.
+- After all index rewrites complete successfully, startup sets
+  `storage:version = 2`.
+
+## Startup Behavior
+
+- `metadata/app.py` sets `app.state.storage_upgrade_in_progress = True` before
+  running Redis storage upgrades.
+- `/readyz` returns `503` while that flag is set.
+- The batch driver starts only after upgrades finish, so recovery never reads a
+  partially migrated Redis index.
+
+## Manual Upgrade Script
+
+- Run from `python/aibrix`:
+
+```bash
+poetry run python scripts/upgrade_redis_storage.py
+```
+
+- The script uses the normal Redis environment configuration and applies the
+  same `v1 -> v2` migration as startup initialization.

--- a/python/aibrix/aibrix/storage/__init__.py
+++ b/python/aibrix/aibrix/storage/__init__.py
@@ -20,7 +20,7 @@ from .local import LocalStorage
 from .reader import Reader, SizeExceededError
 from .s3 import S3Storage
 from .tos import TOSStorage
-from .types import StorageType
+from .types import StorageListOrdering, StorageType
 from .utils import ObjectMetadata, generate_filename
 
 if TYPE_CHECKING:
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 __all__ = [
     "BaseStorage",
     "StorageConfig",
+    "StorageListOrdering",
     "StorageType",
     "create_storage",
     "create_storage_from_env",

--- a/python/aibrix/aibrix/storage/base.py
+++ b/python/aibrix/aibrix/storage/base.py
@@ -20,7 +20,7 @@ from io import BytesIO, StringIO
 from typing import AsyncIterator, BinaryIO, Optional, TextIO, Union
 
 from aibrix.storage.reader import Reader
-from aibrix.storage.types import StorageType
+from aibrix.storage.types import StorageListOrdering, StorageType
 from aibrix.storage.utils import ObjectMetadata
 
 
@@ -48,6 +48,7 @@ class StorageConfig:
     # Read configuration
     range_chunksize: int = 1024 * 1024  # 1MB for range reads
     readline_buffer_size: int = 8192  # 8KB buffer for readline
+    list_ordering: Optional[StorageListOrdering] = None
 
 
 @dataclass
@@ -115,6 +116,15 @@ class BaseStorage(ABC):
 
     def __init__(self, config: Optional[StorageConfig] = None):
         self.config = config or StorageConfig()
+        selected_ordering = self.config.list_ordering
+        if selected_ordering is not None and (
+            selected_ordering not in self.get_supported_list_orderings()
+        ):
+            raise ValueError(
+                f"List ordering {selected_ordering.value} is not supported by "
+                f"{self.get_type().value} storage"
+            )
+        self._selected_list_ordering = selected_ordering
 
     @abstractmethod
     def get_type(self) -> StorageType:
@@ -148,6 +158,15 @@ class BaseStorage(ABC):
             True if SET IF EXISTS is supported, False otherwise
         """
         return False
+
+    @classmethod
+    def get_supported_list_orderings(cls) -> tuple[StorageListOrdering, ...]:
+        """Return the supported ordering contracts for ``list_objects`` results."""
+        return (StorageListOrdering.LEXICOGRAPHIC_ASC,)
+
+    def get_list_ordering(self) -> StorageListOrdering:
+        """Return the currently active ordering contract for ``list_objects``."""
+        return self._selected_list_ordering or self.get_supported_list_orderings()[0]
 
     @abstractmethod
     async def put_object(

--- a/python/aibrix/aibrix/storage/local.py
+++ b/python/aibrix/aibrix/storage/local.py
@@ -21,9 +21,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncIterator, BinaryIO, Optional, TextIO, Union
 
-from aibrix.storage.base import PutObjectOptions, StorageConfig, StorageType
+from aibrix.storage.base import (
+    PutObjectOptions,
+    StorageConfig,
+    StorageType,
+)
 from aibrix.storage.base2 import BaseStorage2
 from aibrix.storage.reader import Reader
+from aibrix.storage.types import StorageListOrdering
 from aibrix.storage.utils import ObjectMetadata, _sanitize_key, generate_filename
 
 LOCAL_STORAGE_PATH_VAR = "STORAGE_LOCAL_PATH"
@@ -91,6 +96,10 @@ class LocalStorage(BaseStorage2):
             Type of storage, set to StorageType.LOCAL
         """
         return StorageType.LOCAL
+
+    @classmethod
+    def get_supported_list_orderings(cls) -> tuple[StorageListOrdering, ...]:
+        return (StorageListOrdering.CREATED_AT_DESC,)
 
     async def put_object(
         self,

--- a/python/aibrix/aibrix/storage/local.py
+++ b/python/aibrix/aibrix/storage/local.py
@@ -299,7 +299,6 @@ class LocalStorage(BaseStorage2):
         for keys that were stored without an extension.
         """
         _METADATA_SUFFIX = ".metadata"
-        _BATCH_JOB_PREFIX = "batchjob:"
 
         def _list_files():
             # Parse continuation token as offset (default to 0)
@@ -316,10 +315,7 @@ class LocalStorage(BaseStorage2):
             # directory path — so flat keys like ``batchjob:<id>`` are found by
             # a partial prefix such as ``batchjob:`` (directory descent missed
             # them, returning nothing for any non-directory prefix).
-            entries: list[str] = []
-            batch_job_entries: list[tuple[str, Optional[datetime]]] = []
-            seen: set[str] = set()
-            batch_job_ordering = delimiter is None and prefix == _BATCH_JOB_PREFIX
+            entry_created_at: dict[str, Optional[datetime]] = {}
             for item in self.base_path.rglob("*" + _METADATA_SUFFIX):
                 if not item.is_file():
                     continue
@@ -338,27 +334,24 @@ class LocalStorage(BaseStorage2):
                     )
                 else:
                     entry = key
-                if entry not in seen:
-                    seen.add(entry)
-                    if batch_job_ordering:
-                        batch_job_entries.append(
-                            (entry, self._read_metadata_created_at(item))
-                        )
-                    else:
-                        entries.append(entry)
+                created_at = self._read_metadata_created_at(item)
+                previous_created_at = entry_created_at.get(entry)
+                if previous_created_at is None or (
+                    created_at is not None and created_at > previous_created_at
+                ):
+                    entry_created_at[entry] = created_at
 
-            if batch_job_ordering:
-                batch_job_entries.sort(key=lambda entry: entry[0])
-                batch_job_entries.sort(
-                    key=lambda entry: (
-                        entry[1].timestamp() if entry[1] is not None else float("-inf")
-                    ),
-                    reverse=True,
-                )
-                entries = [entry for entry, _ in batch_job_entries]
-            else:
-                # Sort for consistent pagination
-                entries.sort()
+            sorted_entries = sorted(
+                entry_created_at.items(),
+                key=lambda entry: entry[0],
+            )
+            sorted_entries.sort(
+                key=lambda entry: (
+                    entry[1].timestamp() if entry[1] is not None else float("-inf")
+                ),
+                reverse=True,
+            )
+            entries = [entry for entry, _ in sorted_entries]
 
             if continuation_token is None and after_key:
                 try:

--- a/python/aibrix/aibrix/storage/local.py
+++ b/python/aibrix/aibrix/storage/local.py
@@ -321,9 +321,8 @@ class LocalStorage(BaseStorage2):
             # Recover every stored key by enumerating the sidecar ``.metadata``
             # files anywhere under base_path. ``prefix`` is matched as an
             # S3-style string prefix (``key.startswith(prefix)``), NOT as a
-            # directory path — so flat keys like ``batchjob:<id>`` are found by
-            # a partial prefix such as ``batchjob:`` (directory descent missed
-            # them, returning nothing for any non-directory prefix).
+            # directory path, so both hierarchical keys like ``batchjob/<id>``
+            # and flat keys like ``flatkey:<id>`` are discovered correctly.
             entry_created_at: dict[str, Optional[datetime]] = {}
             for item in self.base_path.rglob("*" + _METADATA_SUFFIX):
                 if not item.is_file():

--- a/python/aibrix/aibrix/storage/redis.py
+++ b/python/aibrix/aibrix/storage/redis.py
@@ -37,15 +37,18 @@ class RedisStorage(BaseStorage2):
     - Hierarchical key support using Redis sets (e.g., "xxx/yyy" creates set "xxx:index")
     - Simple get/put/delete operations
     - List operations that work with Redis structures
-    - Timestamp-ordered listing: version 2 stores descending-order scores while
-      preserving the existing pagination and rank logic
+    - Timestamp-ordered listing for both created_at ascending and descending
 
     Timestamp Tracking:
     - All keys are tracked in "timestamps:all" sorted set with creation time as score
     - Hierarchical keys are also tracked in "timestamps:{parent}" sorted sets
     - Version 1 stored positive timestamps (oldest-first ordering)
-    - Version 2 stores negative timestamps so the existing ascending zset
-      pagination returns newest-first results
+    - Version 2 stored negative timestamps so the existing ascending zset
+      pagination returned newest-first results
+    - Version 3 stores positive timestamps and supports both created_at
+      ascending and descending order
+    - Listing chooses ZRANGE/ZRANK for ascending order and
+      ZREVRANGE/ZREVRANK for descending order
     - Timestamps are cleaned up automatically when objects are deleted
     """
 
@@ -68,7 +71,35 @@ class RedisStorage(BaseStorage2):
 
     @classmethod
     def get_supported_list_orderings(cls) -> tuple[StorageListOrdering, ...]:
-        return (StorageListOrdering.CREATED_AT_DESC,)
+        return (
+            StorageListOrdering.CREATED_AT_DESC,
+            StorageListOrdering.CREATED_AT_ASC,
+        )
+
+    def _is_created_at_desc_order(self) -> bool:
+        return self.get_list_ordering() == StorageListOrdering.CREATED_AT_DESC
+
+    async def _zrange_by_list_order(
+        self,
+        redis_client: redis.AsyncRedis,
+        key: str,
+        start: int,
+        end: int,
+        withscores: bool = False,
+    ):
+        if self._is_created_at_desc_order():
+            return await redis_client.zrevrange(key, start, end, withscores=withscores)
+        return await redis_client.zrange(key, start, end, withscores=withscores)
+
+    async def _zrank_by_list_order(
+        self,
+        redis_client: redis.AsyncRedis,
+        key: str,
+        member: str,
+    ) -> Optional[int]:
+        if self._is_created_at_desc_order():
+            return await redis_client.zrevrank(key, member)
+        return await redis_client.zrank(key, member)
 
     async def _get_redis(self) -> redis.AsyncRedis:
         """Get Redis connection, creating it if necessary."""
@@ -168,20 +199,32 @@ class RedisStorage(BaseStorage2):
             # Conditional SET failed (NX or XX condition not met)
             return False
 
-        # Version 2 stores negative timestamps so the existing ascending zset
-        # pagination yields descending created_at order without changing ranks.
-        existing_timestamp = await redis_client.zscore("timestamps:all", key)
-        if existing_timestamp is None:
-            # Preserve created_at ordering across overwrites. Batch jobs are
-            # updated in place many times, and rewriting the score here would
-            # silently turn "created_at desc" listing into "last_updated desc".
-            timestamp = -time.time()
-        else:
-            timestamp = float(existing_timestamp)
-        await redis_client.zadd("timestamps:all", {key: timestamp})
+        # Store canonical positive created_at timestamps. Listing direction is
+        # selected at read time via ZRANGE/ZREVRANGE based on StorageConfig.
+        # Use ZADD NX so first insert wins without a preceding ZSCORE, then
+        # fall back to reading the canonical global score only when a parent
+        # index needs to mirror it on overwrite.
+        timestamp = time.time()
+        global_timestamp_added = await redis_client.zadd(
+            "timestamps:all", {key: timestamp}, nx=True
+        )
 
         # If hierarchical, add to parent list and track timestamp
         if parent_key is not None:
+            if global_timestamp_added == 0:
+                # Always rewrite the parent timestamp entry on put. ``SADD`` only
+                # proves the membership set already contains ``item_key``; it
+                # does not guarantee ``timestamps:{parent}`` still has the member
+                # or that it still carries the canonical created-at score from
+                # ``timestamps:all``. Re-applying the parent ZADD keeps the
+                # hierarchical ordering index aligned and repairs partial drift
+                # from interrupted writes or manual Redis changes.
+                existing_timestamp = await redis_client.zscore("timestamps:all", key)
+                if existing_timestamp is None:
+                    raise RuntimeError(
+                        f"Redis timestamps:all lost score for existing key {key!r}"
+                    )
+                timestamp = float(existing_timestamp)
             # Add item to parent list (only if not already present)
             await redis_client.sadd(f"{parent_key}:index", item_key)
             # Also track timestamp for hierarchical objects
@@ -285,40 +328,50 @@ class RedisStorage(BaseStorage2):
             except (ValueError, TypeError):
                 offset = 0
 
+        # Allow callers to pass either the parent prefix ("batchjob") or the
+        # slash-qualified listing prefix ("batchjob/") for hierarchical keys.
+        hierarchical_prefix = prefix
+        parent_prefix = prefix
+        if delimiter and prefix.endswith(delimiter):
+            parent_prefix = prefix[: -len(delimiter)]
+        elif delimiter and prefix:
+            hierarchical_prefix = f"{prefix}{delimiter}"
+
         # Check if this prefix corresponds to a list index
-        list_key = f"{prefix}:index"
+        list_key = f"{parent_prefix}:index"
         if await redis_client.exists(list_key):
             # Get members ordered by timestamp from the sorted set
-            timestamp_key = f"timestamps:{prefix}"
+            timestamp_key = f"timestamps:{parent_prefix}"
             members: list[str]
             if await redis_client.exists(timestamp_key):
                 if continuation_token is None and after_key:
-                    if delimiter and after_key.startswith(f"{prefix}{delimiter}"):
-                        after_member = after_key[len(f"{prefix}{delimiter}") :]
+                    if delimiter and after_key.startswith(hierarchical_prefix):
+                        after_member = after_key[len(hierarchical_prefix) :]
                     else:
                         after_member = after_key
-                    rank = await redis_client.zrank(timestamp_key, after_member)
+                    rank = await self._zrank_by_list_order(
+                        redis_client, timestamp_key, after_member
+                    )
                     if rank is None:
                         return [], None
                     offset = rank + 1
-                # Calculate pagination bounds
+                # Calculate pagination bounds. When paginating, read one extra
+                # member so ``has_more`` can be derived without a second Redis
+                # round trip, then trim the page back to ``limit`` below.
                 start = offset
-                end = offset + limit - 1 if limit is not None else -1
+                end = offset + limit if limit is not None else -1
 
-                # Version 2 stores descending-order scores, so ascending zrange
-                # now returns newest-first without altering pagination logic.
-                members_with_scores = await redis_client.zrange(
-                    timestamp_key, start, end, withscores=False
+                # Read the zset in the configured created_at direction while
+                # keeping pagination based on logical rank offsets.
+                members_with_scores = await self._zrange_by_list_order(
+                    redis_client, timestamp_key, start, end, withscores=False
                 )
                 members = [member.decode("utf-8") for member in members_with_scores]
 
-                # Check if there are more items for next page
-                has_more = False
-                if limit is not None and len(members) == limit:
-                    next_item = await redis_client.zrange(
-                        timestamp_key, start + limit, start + limit, withscores=False
-                    )
-                    has_more = len(next_item) > 0
+                # Trim the extra member after probing for ``has_more``.
+                has_more = limit is not None and len(members) > limit
+                if has_more:
+                    members = members[:limit]
             else:
                 # Fallback to unordered members if no timestamps
                 members_raw = await redis_client.smembers(list_key)
@@ -326,8 +379,8 @@ class RedisStorage(BaseStorage2):
                     member.decode("utf-8") for member in members_raw
                 ]
                 if continuation_token is None and after_key:
-                    if delimiter and after_key.startswith(f"{prefix}{delimiter}"):
-                        after_member = after_key[len(f"{prefix}{delimiter}") :]
+                    if delimiter and after_key.startswith(hierarchical_prefix):
+                        after_member = after_key[len(hierarchical_prefix) :]
                     else:
                         after_member = after_key
                     try:
@@ -344,7 +397,7 @@ class RedisStorage(BaseStorage2):
 
             if delimiter:
                 # Return hierarchical format with delimiter
-                result_keys = [f"{prefix}{delimiter}{member}" for member in members]
+                result_keys = [f"{hierarchical_prefix}{member}" for member in members]
             else:
                 # Return just the member names
                 result_keys = members
@@ -356,8 +409,8 @@ class RedisStorage(BaseStorage2):
         # Fallback to key scanning with timestamp ordering
         if prefix:
             # For prefix searches, get all keys from timestamp sorted set and filter
-            all_keys_with_timestamps = await redis_client.zrange(
-                "timestamps:all", 0, -1, withscores=False
+            all_keys_with_timestamps = await self._zrange_by_list_order(
+                redis_client, "timestamps:all", 0, -1, withscores=False
             )
 
             filtered_keys = []
@@ -386,8 +439,8 @@ class RedisStorage(BaseStorage2):
         else:
             # For no prefix, get all keys first, then filter and paginate
             # This ensures consistent pagination even when internal keys are present
-            all_keys_with_timestamps = await redis_client.zrange(
-                "timestamps:all", 0, -1, withscores=False
+            all_keys_with_timestamps = await self._zrange_by_list_order(
+                redis_client, "timestamps:all", 0, -1, withscores=False
             )
             all_user_keys = []
             for key_bytes in all_keys_with_timestamps:

--- a/python/aibrix/aibrix/storage/redis.py
+++ b/python/aibrix/aibrix/storage/redis.py
@@ -32,12 +32,15 @@ class RedisStorage(BaseStorage2):
     - Hierarchical key support using Redis sets (e.g., "xxx/yyy" creates set "xxx:index")
     - Simple get/put/delete operations
     - List operations that work with Redis structures
-    - Timestamp-ordered listing: list_objects returns keys ordered by creation timestamp
+    - Timestamp-ordered listing: version 2 stores descending-order scores while
+      preserving the existing pagination and rank logic
 
     Timestamp Tracking:
     - All keys are tracked in "timestamps:all" sorted set with creation time as score
     - Hierarchical keys are also tracked in "timestamps:{parent}" sorted sets
-    - list_objects returns keys in chronological order (oldest first)
+    - Version 1 stored positive timestamps (oldest-first ordering)
+    - Version 2 stores negative timestamps so the existing ascending zset
+      pagination returns newest-first results
     - Timestamps are cleaned up automatically when objects are deleted
     """
 
@@ -156,8 +159,16 @@ class RedisStorage(BaseStorage2):
             # Conditional SET failed (NX or XX condition not met)
             return False
 
-        # Store creation timestamp for ordering (only if SET succeeded)
-        timestamp = time.time()
+        # Version 2 stores negative timestamps so the existing ascending zset
+        # pagination yields descending created_at order without changing ranks.
+        existing_timestamp = await redis_client.zscore("timestamps:all", key)
+        if existing_timestamp is None:
+            # Preserve created_at ordering across overwrites. Batch jobs are
+            # updated in place many times, and rewriting the score here would
+            # silently turn "created_at desc" listing into "last_updated desc".
+            timestamp = -time.time()
+        else:
+            timestamp = float(existing_timestamp)
         await redis_client.zadd("timestamps:all", {key: timestamp})
 
         # If hierarchical, add to parent list and track timestamp
@@ -252,7 +263,7 @@ class RedisStorage(BaseStorage2):
 
         Returns:
             Tuple of (object_keys, next_continuation_token)
-            - object_keys: List of object keys ordered by creation timestamp (oldest first)
+            - object_keys: List of object keys ordered by created_at descending.
             - next_continuation_token: String offset for next page (None if no more pages)
         """
         redis_client = await self._get_redis()
@@ -285,7 +296,8 @@ class RedisStorage(BaseStorage2):
                 start = offset
                 end = offset + limit - 1 if limit is not None else -1
 
-                # Get members ordered by timestamp (oldest first) with pagination
+                # Version 2 stores descending-order scores, so ascending zrange
+                # now returns newest-first without altering pagination logic.
                 members_with_scores = await redis_client.zrange(
                     timestamp_key, start, end, withscores=False
                 )
@@ -294,7 +306,6 @@ class RedisStorage(BaseStorage2):
                 # Check if there are more items for next page
                 has_more = False
                 if limit is not None and len(members) == limit:
-                    # Check if there's at least one more item after this page
                     next_item = await redis_client.zrange(
                         timestamp_key, start + limit, start + limit, withscores=False
                     )
@@ -305,7 +316,6 @@ class RedisStorage(BaseStorage2):
                 all_members: list[str] = [
                     member.decode("utf-8") for member in members_raw
                 ]
-
                 if continuation_token is None and after_key:
                     if delimiter and after_key.startswith(f"{prefix}{delimiter}"):
                         after_member = after_key[len(f"{prefix}{delimiter}") :]

--- a/python/aibrix/aibrix/storage/redis.py
+++ b/python/aibrix/aibrix/storage/redis.py
@@ -17,9 +17,14 @@ import time
 from typing import BinaryIO, Optional, TextIO, Union
 
 import aibrix.client.redis as redis
-from aibrix.storage.base import PutObjectOptions, StorageConfig, StorageType
+from aibrix.storage.base import (
+    PutObjectOptions,
+    StorageConfig,
+    StorageType,
+)
 from aibrix.storage.base2 import BaseStorage2
 from aibrix.storage.reader import Reader
+from aibrix.storage.types import StorageListOrdering
 from aibrix.storage.utils import ObjectMetadata
 
 
@@ -60,6 +65,10 @@ class RedisStorage(BaseStorage2):
             Type of storage, set to StorageType.REDIS
         """
         return StorageType.REDIS
+
+    @classmethod
+    def get_supported_list_orderings(cls) -> tuple[StorageListOrdering, ...]:
+        return (StorageListOrdering.CREATED_AT_DESC,)
 
     async def _get_redis(self) -> redis.AsyncRedis:
         """Get Redis connection, creating it if necessary."""

--- a/python/aibrix/aibrix/storage/redis_upgrade.py
+++ b/python/aibrix/aibrix/storage/redis_upgrade.py
@@ -1,0 +1,111 @@
+import math
+from typing import Any, Iterable, Optional
+
+from aibrix.logger import init_logger
+from aibrix.storage.redis import RedisStorage
+
+logger = init_logger(__name__)
+
+REDIS_STORAGE_VERSION_KEY = "storage:version"
+REDIS_STORAGE_VERSION_V1 = 1
+REDIS_STORAGE_VERSION_V2 = 2
+REDIS_STORAGE_LATEST_VERSION = REDIS_STORAGE_VERSION_V2
+_ZADD_CHUNK_SIZE = 1000
+
+
+def _decode_redis_value(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)
+
+
+def _normalize_desc_score(score: float) -> float:
+    if math.isnan(score):
+        raise ValueError("Redis storage index contains NaN score")
+    return -abs(float(score))
+
+
+def _chunk_mapping(
+    mapping: dict[str, float], chunk_size: int
+) -> Iterable[dict[str, float]]:
+    items = list(mapping.items())
+    for start in range(0, len(items), chunk_size):
+        yield dict(items[start : start + chunk_size])
+
+
+async def get_redis_storage_version(redis_client: Any) -> int:
+    raw_version = _decode_redis_value(await redis_client.get(REDIS_STORAGE_VERSION_KEY))
+    if raw_version is None:
+        return REDIS_STORAGE_VERSION_V1
+    try:
+        return int(raw_version)
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid Redis storage version value: {raw_version!r}"
+        ) from exc
+
+
+async def ensure_redis_storage_version(storage: RedisStorage) -> int:
+    redis_client = await storage._get_redis()
+    current_version = await get_redis_storage_version(redis_client)
+    if current_version >= REDIS_STORAGE_LATEST_VERSION:
+        return current_version
+
+    logger.info(
+        "Upgrading Redis storage indexes",
+        from_version=current_version,
+        to_version=REDIS_STORAGE_LATEST_VERSION,
+    )  # type: ignore[call-arg]
+
+    if current_version == REDIS_STORAGE_VERSION_V1:
+        await upgrade_redis_storage_v1_to_v2(redis_client)
+    else:
+        raise RuntimeError(f"Unsupported Redis storage version: {current_version}")
+
+    await redis_client.set(
+        REDIS_STORAGE_VERSION_KEY, str(REDIS_STORAGE_LATEST_VERSION).encode("utf-8")
+    )
+    logger.info(
+        "Redis storage indexes upgraded",
+        to_version=REDIS_STORAGE_LATEST_VERSION,
+    )  # type: ignore[call-arg]
+    return REDIS_STORAGE_LATEST_VERSION
+
+
+async def maybe_upgrade_storage(storage: Any) -> Optional[int]:
+    if not isinstance(storage, RedisStorage):
+        return None
+    return await ensure_redis_storage_version(storage)
+
+
+async def upgrade_redis_storage_v1_to_v2(redis_client: Any) -> None:
+    # Rewrite the global key index from positive timestamps (oldest first) to
+    # negative timestamps so the existing ascending pagination yields newest first.
+    timestamp_entries = await redis_client.zrange(
+        "timestamps:all", 0, -1, withscores=True
+    )
+
+    global_mapping: dict[str, float] = {}
+    parent_mappings: dict[str, dict[str, float]] = {}
+
+    for member, score in timestamp_entries:
+        key = _decode_redis_value(member)
+        if key is None:
+            continue
+        normalized_score = _normalize_desc_score(float(score))
+        global_mapping[key] = normalized_score
+
+        if "/" not in key:
+            continue
+        parent_key, item_key = key.split("/", 1)
+        parent_mappings.setdefault(parent_key, {})[item_key] = normalized_score
+
+    for mapping in _chunk_mapping(global_mapping, _ZADD_CHUNK_SIZE):
+        await redis_client.zadd("timestamps:all", mapping)
+
+    for parent_key, mapping in parent_mappings.items():
+        timestamp_key = f"timestamps:{parent_key}"
+        for chunk in _chunk_mapping(mapping, _ZADD_CHUNK_SIZE):
+            await redis_client.zadd(timestamp_key, chunk)

--- a/python/aibrix/aibrix/storage/redis_upgrade.py
+++ b/python/aibrix/aibrix/storage/redis_upgrade.py
@@ -9,8 +9,14 @@ logger = init_logger(__name__)
 REDIS_STORAGE_VERSION_KEY = "storage:version"
 REDIS_STORAGE_VERSION_V1 = 1
 REDIS_STORAGE_VERSION_V2 = 2
-REDIS_STORAGE_LATEST_VERSION = REDIS_STORAGE_VERSION_V2
+REDIS_STORAGE_VERSION_V3 = 3
+REDIS_STORAGE_LATEST_VERSION = REDIS_STORAGE_VERSION_V3
 _ZADD_CHUNK_SIZE = 1000
+_SADD_CHUNK_SIZE = 1000
+_VERIFY_ZRANGE_CHUNK_SIZE = 1000
+_OLD_BATCH_JOB_PREFIX = "batchjob:"
+_NEW_BATCH_JOB_PREFIX = "batchjob/"
+_OLD_BATCH_STATUS_COPIES_PREFIX = "batchstatus_copies:"
 
 
 def _decode_redis_value(value: Any) -> Optional[str]:
@@ -21,10 +27,10 @@ def _decode_redis_value(value: Any) -> Optional[str]:
     return str(value)
 
 
-def _normalize_desc_score(score: float) -> float:
+def _normalize_created_at_score(score: float) -> float:
     if math.isnan(score):
         raise ValueError("Redis storage index contains NaN score")
-    return -abs(float(score))
+    return abs(float(score))
 
 
 def _chunk_mapping(
@@ -33,6 +39,121 @@ def _chunk_mapping(
     items = list(mapping.items())
     for start in range(0, len(items), chunk_size):
         yield dict(items[start : start + chunk_size])
+
+
+def _chunk_items(items: Iterable[str], chunk_size: int) -> Iterable[list[str]]:
+    buffered: list[str] = []
+    for item in items:
+        buffered.append(item)
+        if len(buffered) == chunk_size:
+            yield buffered
+            buffered = []
+    if buffered:
+        yield buffered
+
+
+async def _iter_zrange_withscores(
+    redis_client: Any,
+    key: str,
+    chunk_size: int = _VERIFY_ZRANGE_CHUNK_SIZE,
+):
+    offset = 0
+    while True:
+        entries = await redis_client.zrange(
+            key,
+            offset,
+            offset + chunk_size - 1,
+            withscores=True,
+        )
+        if not entries:
+            break
+        for entry in entries:
+            yield entry
+        if len(entries) < chunk_size:
+            break
+        offset += len(entries)
+
+
+def _remap_batch_metastore_key_to_v3(key: str) -> str:
+    if key.startswith(_OLD_BATCH_JOB_PREFIX):
+        return f"{_NEW_BATCH_JOB_PREFIX}{key.removeprefix(_OLD_BATCH_JOB_PREFIX)}"
+
+    if key.startswith(_OLD_BATCH_STATUS_COPIES_PREFIX):
+        remainder = key.removeprefix(_OLD_BATCH_STATUS_COPIES_PREFIX)
+        batch_id, separator, worker_id = remainder.rpartition(":")
+        if separator and batch_id and worker_id:
+            return f"{_OLD_BATCH_STATUS_COPIES_PREFIX}{batch_id}/{worker_id}"
+
+    return key
+
+
+async def verify_redis_storage_v3(redis_client: Any) -> None:
+    """Validate that Redis storage indexes match the v3 invariants.
+
+    Raises:
+        RuntimeError: If any migrated key, score, or parent index is inconsistent
+    """
+    expected_parent_scores: dict[str, dict[str, float]] = {}
+    expected_parent_members: dict[str, set[str]] = {}
+
+    async for member, score in _iter_zrange_withscores(redis_client, "timestamps:all"):
+        key = _decode_redis_value(member)
+        if key is None:
+            continue
+
+        normalized_score = _normalize_created_at_score(float(score))
+        if float(score) != normalized_score:
+            raise RuntimeError(
+                f"Redis storage v3 verification failed: negative timestamp score for {key!r}"
+            )
+
+        migrated_key = _remap_batch_metastore_key_to_v3(key)
+        if migrated_key != key:
+            raise RuntimeError(
+                f"Redis storage v3 verification failed: legacy key still present {key!r}"
+            )
+
+        if "/" not in key:
+            continue
+
+        parent_key, item_key = key.split("/", 1)
+        expected_parent_scores.setdefault(parent_key, {})[item_key] = normalized_score
+        expected_parent_members.setdefault(parent_key, set()).add(item_key)
+
+    for parent_key, expected_members in expected_parent_members.items():
+        actual_members_raw = await redis_client.smembers(f"{parent_key}:index")
+        actual_members = {
+            value
+            for member in actual_members_raw
+            if (value := _decode_redis_value(member)) is not None
+        }
+        if actual_members != expected_members:
+            raise RuntimeError(
+                "Redis storage v3 verification failed: parent index mismatch for "
+                f"{parent_key!r}, expected {sorted(expected_members)!r}, got {sorted(actual_members)!r}"
+            )
+
+        actual_scores: dict[str, float] = {}
+        async for member, score in _iter_zrange_withscores(
+            redis_client, f"timestamps:{parent_key}"
+        ):
+            decoded_item_key = _decode_redis_value(member)
+            if decoded_item_key is None:
+                continue
+            normalized_score = _normalize_created_at_score(float(score))
+            if float(score) != normalized_score:
+                raise RuntimeError(
+                    "Redis storage v3 verification failed: negative parent timestamp "
+                    f"score for {parent_key!r}/{decoded_item_key!r}"
+                )
+            actual_scores[decoded_item_key] = normalized_score
+
+        expected_scores = expected_parent_scores[parent_key]
+        if actual_scores != expected_scores:
+            raise RuntimeError(
+                "Redis storage v3 verification failed: parent timestamp mismatch for "
+                f"{parent_key!r}, expected {expected_scores!r}, got {actual_scores!r}"
+            )
 
 
 async def get_redis_storage_version(redis_client: Any) -> int:
@@ -59,8 +180,9 @@ async def ensure_redis_storage_version(storage: RedisStorage) -> int:
         to_version=REDIS_STORAGE_LATEST_VERSION,
     )  # type: ignore[call-arg]
 
-    if current_version == REDIS_STORAGE_VERSION_V1:
-        await upgrade_redis_storage_v1_to_v2(redis_client)
+    if current_version in (REDIS_STORAGE_VERSION_V1, REDIS_STORAGE_VERSION_V2):
+        await upgrade_redis_storage_to_v3(redis_client)
+        current_version = REDIS_STORAGE_VERSION_V3
     else:
         raise RuntimeError(f"Unsupported Redis storage version: {current_version}")
 
@@ -80,32 +202,57 @@ async def maybe_upgrade_storage(storage: Any) -> Optional[int]:
     return await ensure_redis_storage_version(storage)
 
 
-async def upgrade_redis_storage_v1_to_v2(redis_client: Any) -> None:
-    # Rewrite the global key index from positive timestamps (oldest first) to
-    # negative timestamps so the existing ascending pagination yields newest first.
+async def upgrade_redis_storage_to_v3(redis_client: Any) -> None:
+    # Normalize all Redis timestamp indexes to positive created_at scores,
+    # rekey batch metastore entries to slash-delimited hierarchy, and rebuild
+    # hierarchical parent indexes from the canonical global timestamp set.
     timestamp_entries = await redis_client.zrange(
         "timestamps:all", 0, -1, withscores=True
     )
 
     global_mapping: dict[str, float] = {}
     parent_mappings: dict[str, dict[str, float]] = {}
+    parent_members: dict[str, set[str]] = {}
 
     for member, score in timestamp_entries:
         key = _decode_redis_value(member)
         if key is None:
             continue
-        normalized_score = _normalize_desc_score(float(score))
-        global_mapping[key] = normalized_score
+        migrated_key = _remap_batch_metastore_key_to_v3(key)
+        normalized_score = _normalize_created_at_score(float(score))
 
-        if "/" not in key:
+        if migrated_key != key:
+            payload = await redis_client.get(key)
+            if payload is not None:
+                await redis_client.set(migrated_key, payload)
+                await redis_client.delete(key)
+            elif not await redis_client.exists(migrated_key):
+                logger.warning(
+                    "Skipping missing batch metastore key during Redis v3 upgrade",
+                    key=key,
+                    migrated_key=migrated_key,
+                )  # type: ignore[call-arg]
+
+        global_mapping[migrated_key] = normalized_score
+
+        if "/" not in migrated_key:
             continue
-        parent_key, item_key = key.split("/", 1)
-        parent_mappings.setdefault(parent_key, {})[item_key] = normalized_score
 
-    for mapping in _chunk_mapping(global_mapping, _ZADD_CHUNK_SIZE):
-        await redis_client.zadd("timestamps:all", mapping)
+        parent_key, item_key = migrated_key.split("/", 1)
+        parent_mappings.setdefault(parent_key, {})[item_key] = normalized_score
+        parent_members.setdefault(parent_key, set()).add(item_key)
+
+    await redis_client.delete("timestamps:all")
+    for score_chunk in _chunk_mapping(global_mapping, _ZADD_CHUNK_SIZE):
+        await redis_client.zadd("timestamps:all", score_chunk)
 
     for parent_key, mapping in parent_mappings.items():
-        timestamp_key = f"timestamps:{parent_key}"
-        for chunk in _chunk_mapping(mapping, _ZADD_CHUNK_SIZE):
-            await redis_client.zadd(timestamp_key, chunk)
+        await redis_client.delete(f"{parent_key}:index", f"timestamps:{parent_key}")
+        for member_chunk in _chunk_items(
+            sorted(parent_members[parent_key]), _SADD_CHUNK_SIZE
+        ):
+            await redis_client.sadd(f"{parent_key}:index", *member_chunk)
+        for score_chunk in _chunk_mapping(mapping, _ZADD_CHUNK_SIZE):
+            await redis_client.zadd(f"timestamps:{parent_key}", score_chunk)
+
+    await verify_redis_storage_v3(redis_client)

--- a/python/aibrix/aibrix/storage/types.py
+++ b/python/aibrix/aibrix/storage/types.py
@@ -23,3 +23,10 @@ class StorageType(Enum):
     TOS = "tos"
     REDIS = "redis"
     AUTO = "auto"
+
+
+class StorageListOrdering(str, Enum):
+    """Ordering contract for ``list_objects`` results."""
+
+    LEXICOGRAPHIC_ASC = "lexicographic_asc"
+    CREATED_AT_DESC = "created_at_desc"

--- a/python/aibrix/aibrix/storage/types.py
+++ b/python/aibrix/aibrix/storage/types.py
@@ -29,4 +29,5 @@ class StorageListOrdering(str, Enum):
     """Ordering contract for ``list_objects`` results."""
 
     LEXICOGRAPHIC_ASC = "lexicographic_asc"
+    CREATED_AT_ASC = "created_at_asc"
     CREATED_AT_DESC = "created_at_desc"

--- a/python/aibrix/scripts/upgrade_redis_storage.py
+++ b/python/aibrix/scripts/upgrade_redis_storage.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import asyncio
+
+from aibrix.logger import init_logger
+from aibrix.storage import RedisStorage, StorageType, create_storage
+from aibrix.storage.redis_upgrade import (
+    REDIS_STORAGE_LATEST_VERSION,
+    ensure_redis_storage_version,
+)
+
+logger = init_logger(__name__)
+
+
+async def _main() -> int:
+    storage = create_storage(StorageType.REDIS)
+    if not isinstance(storage, RedisStorage):
+        raise RuntimeError(
+            "create_storage(StorageType.REDIS) did not return RedisStorage"
+        )
+
+    try:
+        version = await ensure_redis_storage_version(storage)
+        logger.info(
+            "Redis storage upgrade completed",
+            version=version,
+            latest=REDIS_STORAGE_LATEST_VERSION,
+        )  # type: ignore[call-arg]
+        return 0
+    finally:
+        await storage.close()
+
+
+def main() -> int:
+    return asyncio.run(_main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/aibrix/tests/batch/test_batch_api_read_flip.py
+++ b/python/aibrix/tests/batch/test_batch_api_read_flip.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for the metadata API read-flip helper.
+"""Unit tests for the metadata API batch resolve helper.
 
 Exercises ``aibrix.metadata.api.v1.batch._resolve_batch_job`` directly
 with stubbed app state, so the test does not need a running FastAPI
-TestClient or a real ``BatchDriver``. The point is to pin down the
-metastore-first-with-BatchManager-fallback contract that closes the
-submit -> kopf ADDED window.
+TestClient or a real ``BatchDriver``. The helper now resolves through
+``BatchDriver`` so GET can trigger on-demand republishing of unfinished
+jobs that were missed during restart recovery.
 """
 
 import os
@@ -26,7 +26,6 @@ import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Optional
-from unittest.mock import patch
 
 # Set required environment variable before importing
 os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing")
@@ -104,34 +103,24 @@ def _make_request(*, manager_jobs: Optional[dict] = None):
 
 
 @pytest.mark.asyncio
-async def test_metastore_hit_returns_metastore_document():
-    job = _make_job("batch-store-hit")
+async def test_driver_hit_returns_driver_document():
+    job = _make_job("batch-driver-hit")
+    request = _make_request(manager_jobs={"batch-driver-hit": job})
 
-    # BatchManager has nothing — proves we did not fall through.
-    request = _make_request(manager_jobs={})
+    result = await _resolve_batch_job(request, "batch-driver-hit")
 
-    async def fake_get(batch_id: str) -> Optional[BatchJob]:
-        return job if batch_id == "batch-store-hit" else None
-
-    with patch("aibrix.metadata.api.v1.batch.get_batch_job", side_effect=fake_get):
-        result = await _resolve_batch_job(request, "batch-store-hit")
     assert result is not None
-    assert result.status.job_id == "batch-store-hit"
+    assert result.status.job_id == "batch-driver-hit"
 
 
 @pytest.mark.asyncio
 async def test_metastore_miss_falls_back_to_job_manager():
-    """Covers the K8s submit -> kopf ADDED gap where the metastore has
-    not yet observed the new job but the metadata service already
-    seeded its BatchManager pool synchronously on POST."""
+    """Covers the K8s submit -> kopf ADDED gap where the metadata service
+    has already seeded its BatchManager pool synchronously on POST."""
     job = _make_job("batch-gap")
     request = _make_request(manager_jobs={"batch-gap": job})
 
-    async def fake_get(batch_id: str) -> Optional[BatchJob]:
-        return None
-
-    with patch("aibrix.metadata.api.v1.batch.get_batch_job", side_effect=fake_get):
-        result = await _resolve_batch_job(request, "batch-gap")
+    result = await _resolve_batch_job(request, "batch-gap")
     assert result is not None
     assert result.status.job_id == "batch-gap"
 
@@ -140,33 +129,5 @@ async def test_metastore_miss_falls_back_to_job_manager():
 async def test_both_miss_returns_none():
     request = _make_request(manager_jobs={})
 
-    async def fake_get(batch_id: str) -> Optional[BatchJob]:
-        return None
-
-    with patch("aibrix.metadata.api.v1.batch.get_batch_job", side_effect=fake_get):
-        result = await _resolve_batch_job(request, "batch-missing")
+    result = await _resolve_batch_job(request, "batch-missing")
     assert result is None
-
-
-@pytest.mark.asyncio
-async def test_metastore_takes_precedence_over_job_manager():
-    """If the metastore has an updated copy and BatchManager has stale
-    state, the read returns the metastore's view — that is the whole
-    point of the read flip."""
-    fresh = _make_job("batch-fresh")
-    fresh.status.state = BatchJobState.FINALIZED
-    fresh.status.request_counts.completed = 10
-
-    stale = _make_job("batch-fresh")
-    stale.status.state = BatchJobState.IN_PROGRESS
-    stale.status.request_counts.completed = 5
-    request = _make_request(manager_jobs={"batch-fresh": stale})
-
-    async def fake_get(batch_id: str) -> Optional[BatchJob]:
-        return fresh if batch_id == "batch-fresh" else None
-
-    with patch("aibrix.metadata.api.v1.batch.get_batch_job", side_effect=fake_get):
-        result = await _resolve_batch_job(request, "batch-fresh")
-    assert result is not None
-    assert result.status.state == BatchJobState.FINALIZED
-    assert result.status.request_counts.completed == 10

--- a/python/aibrix/tests/batch/test_batch_manager.py
+++ b/python/aibrix/tests/batch/test_batch_manager.py
@@ -23,7 +23,7 @@ import pytest
 os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing")
 
 from aibrix.batch.batch_manager import BatchManager
-from aibrix.batch.job_driver import TerminateResult
+from aibrix.batch.job_driver import BaseJobDriver, TerminateResult
 from aibrix.batch.job_entity import (
     BatchJob,
     BatchJobEndpoint,
@@ -42,6 +42,7 @@ from aibrix.batch.job_entity import (
 )
 from aibrix.batch.state import JobEntityManager, JobMetaInfo
 from aibrix.context import InfrastructureContext
+from tests.fake.batch_runtime import FakeRuntime
 
 
 def _job_manager() -> BatchManager:
@@ -577,15 +578,31 @@ async def test_expire_job_terminates_live_driver_for_admitted_job():
 
 
 @pytest.mark.asyncio
-async def test_expire_job_cleans_orphaned_execution_when_driver_missing(monkeypatch):
+@pytest.mark.parametrize(
+    ("job_id", "owner_ref", "initial_bucket"),
+    [
+        ("test-job-id-expire-orphaned", "owner-2", "in_progress"),
+        ("test-job-id-expire-recovered-pending", "owner-3", "pending"),
+    ],
+)
+async def test_expired_job_cleans_up_during_recovery(
+    monkeypatch,
+    job_id: str,
+    owner_ref: str,
+    initial_bucket: str,
+):
     job_manager = _job_manager()
-    meta_job = _in_progress_meta_job("test-job-id-expire-orphaned", total_requests=1)
-    meta_job.status.set_runtime_ref(
+    recovered_job = _in_progress_meta_job(job_id, total_requests=1)
+    recovered_job.status.set_runtime_ref(
         "fake",
-        JobRuntimeRef(driverType="fake", ownerRef="owner-2", attempt=1),
+        JobRuntimeRef(driverType="fake", ownerRef=owner_ref, attempt=1),
     )
-    job_manager._in_progress_jobs[meta_job.job_id] = meta_job
-    cleanup_driver = _FakeJobDriver()
+    if initial_bucket == "pending":
+        job_manager._pending_jobs[recovered_job.job_id] = recovered_job
+    else:
+        job_manager._in_progress_jobs[recovered_job.job_id] = recovered_job
+    cleanup_runtime = FakeRuntime()
+    cleanup_driver = BaseJobDriver(job_manager, cleanup_runtime, recovered_job)
 
     monkeypatch.setattr(
         "aibrix.batch.batch_manager.create_job_driver",
@@ -594,12 +611,23 @@ async def test_expire_job_cleans_orphaned_execution_when_driver_missing(monkeypa
         ),
     )
 
-    result = await job_manager.expire_job(meta_job.job_id)
+    result = await job_manager.expire_job(recovered_job.job_id)
 
     assert result is True
-    assert cleanup_driver.cleanup_calls == [meta_job.job_id]
-    assert meta_job.status.condition == ConditionType.EXPIRED
-    assert meta_job.status.state == BatchJobState.IN_PROGRESS
+    assert cleanup_runtime.cleanup_job_ids == [recovered_job.job_id]
+    assert cleanup_runtime.teardown_handles == ["fake-handle"]
+    assert recovered_job.job_id not in job_manager._pending_jobs
+    assert recovered_job.job_id not in job_manager._in_progress_jobs
+    assert recovered_job.job_id in job_manager._done_jobs
+    assert job_manager._done_jobs[recovered_job.job_id].status.execution is None
+    assert (
+        job_manager._done_jobs[recovered_job.job_id].status.condition
+        == ConditionType.EXPIRED
+    )
+    assert (
+        job_manager._done_jobs[recovered_job.job_id].status.state
+        == BatchJobState.FINALIZED
+    )
 
 
 @pytest.mark.asyncio
@@ -844,7 +872,13 @@ class MockJobEntityManager(JobEntityManager):
         self, job_id: str, force_reload: bool = False
     ) -> Optional[BatchJob]:
         """Mock get_job implementation."""
-        return self.jobs.get(job_id)
+        if job_id in self.active_jobs and not force_reload:
+            return self.active_jobs[job_id]
+        job = self.jobs.get(job_id)
+        await self._publish_active_job_on_cache_miss(job)
+        if job is not None and not job.status.finished:
+            return self.active_jobs.get(job_id, job)
+        return job
 
     async def update_job_ready(self, job: BatchJob) -> None:
         """Mock update_job_ready implementation."""
@@ -954,6 +988,44 @@ async def test_async_create_job():
 
     # Verify the future was cleaned up
     assert session_id not in job_manager._bridge._creating_jobs
+
+
+@pytest.mark.asyncio
+async def test_get_job_republishes_untracked_entity_manager_job():
+    _set_current_loop_name("test_get_job_republishes")
+    entity_manager = MockJobEntityManager(delay=0.0)
+    job_manager = _job_manager()
+    await job_manager.set_job_entity_manager(entity_manager)
+    scheduler = _CapturingScheduler()
+    job_manager.set_scheduler(scheduler)
+
+    batch_job = BatchJob(
+        typeMeta=TypeMeta(apiVersion="batch/v1", kind="Job"),
+        metadata=ObjectMeta(
+            name="recovery-job",
+            namespace="default",
+            uid="recovery-uid",
+            creationTimestamp=datetime.now(),
+        ),
+        spec=BatchJobSpec(
+            input_file_id="f-recovery",
+            endpoint=BatchJobEndpoint.CHAT_COMPLETIONS.value,
+            completion_window=CompletionWindow.TWENTY_FOUR_HOURS.expires_at(),
+        ),
+        status=BatchJobStatus(
+            jobID="recovery-job-id",
+            state=BatchJobState.IN_PROGRESS,
+            createdAt=datetime.now(),
+        ),
+    )
+    entity_manager.jobs[batch_job.job_id] = batch_job
+
+    resolved_job = await job_manager.get_job(batch_job.job_id)
+
+    assert resolved_job is not None
+    assert resolved_job.job_id == batch_job.job_id
+    assert batch_job.job_id in scheduler.appended_job_ids
+    assert batch_job.job_id in job_manager._pending_jobs
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/batch/test_batch_manager.py
+++ b/python/aibrix/tests/batch/test_batch_manager.py
@@ -578,6 +578,26 @@ async def test_expire_job_terminates_live_driver_for_admitted_job():
 
 
 @pytest.mark.asyncio
+async def test_expire_job_skips_already_finalizing_job():
+    job_manager = _job_manager()
+    meta_job = _in_progress_meta_job("test-job-id-expire-finalizing", total_requests=1)
+    meta_job.status.state = BatchJobState.FINALIZING
+    meta_job.status.finalizing_at = datetime.now()
+    driver = _FakeJobDriver(meta_job=meta_job)
+    meta_job._job_driver = driver
+    job_manager._in_progress_jobs[meta_job.job_id] = meta_job
+
+    result = await job_manager.expire_job(meta_job.job_id)
+
+    assert result is False
+    assert driver.terminate_calls == []
+    assert meta_job.job_id in job_manager._in_progress_jobs
+    assert meta_job.job_id not in job_manager._done_jobs
+    assert meta_job.status.state == BatchJobState.FINALIZING
+    assert meta_job.status.condition is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("job_id", "owner_ref", "initial_bucket"),
     [

--- a/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
+++ b/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
@@ -2048,8 +2048,8 @@ async def test_job_cancellation_in_finalizing(e2e_test_app, test_backend):
 
 @pytest.mark.asyncio
 async def test_job_expiration_in_finalizing(e2e_test_app, test_backend):
-    """Batch completion-window expiry after entering FINALIZING should end as
-    expired, not completed."""
+    """Batch completion-window expiry after entering FINALIZING should not
+    interrupt terminalization; the job still completes."""
     print("Test 6b: Job expiration during finalizing scenario")
 
     with create_test_client(e2e_test_app) as client:
@@ -2083,7 +2083,7 @@ async def test_job_expiration_in_finalizing(e2e_test_app, test_backend):
                 assert status_during_finalizing["status"] == "finalizing"
 
                 final_status = await wait_for_status(
-                    client, batch_id, "expired", max_polls=40, poll_interval=0.5
+                    client, batch_id, "completed", max_polls=40, poll_interval=0.5
                 )
 
                 validate_batch_response_with_runtime_teardown(
@@ -2095,14 +2095,14 @@ async def test_job_expiration_in_finalizing(e2e_test_app, test_backend):
                     expect_runtime_teardown=backend_expect_runtime_teardown(
                         test_backend
                     ),
-                    expected_status="expired",
+                    expected_status="completed",
                     expected_completion_window="0h",
                     expected_endpoint="/v1/chat/completions",
                     expected_in_progress_at=True,
                     expected_finalizing_at=True,
-                    expected_completed_at=False,
+                    expected_completed_at=True,
                     expected_failed_at=False,
-                    expected_expired_at=True,
+                    expected_expired_at=False,
                     expected_cancelled_at=False,
                     expected_cancelling_at=False,
                     expected_output_file_id=True,

--- a/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
+++ b/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
@@ -2032,6 +2032,7 @@ async def test_job_cancellation_in_finalizing(e2e_test_app, test_backend):
                     expected_finalizing_at=True,  # Should have reached finalizing
                     expected_cancelling_at=False,
                     expected_cancelled_at=False,
+                    expected_errors="cancel_rejected",
                     expected_output_file_id=True,  # Should have output file
                     expected_error_file_id=False,  # No failures -> no error file
                     expected_request_counts=True,  # Should have request counts

--- a/python/aibrix/tests/batch/test_job_store.py
+++ b/python/aibrix/tests/batch/test_job_store.py
@@ -98,7 +98,7 @@ class FakeMetastore:
 @pytest.fixture
 def fake_metastore(monkeypatch):
     """In-memory stand-in for the metastore — the single document store the
-    JobStore delegates to (keyed ``batchjob:<id>`` like the real one)."""
+    JobStore delegates to (keyed ``batchjob/<id>`` like the real one)."""
     store = FakeMetastore()
     calls = []
 
@@ -319,18 +319,18 @@ async def test_batch_metastore_list_metastore_keys_supports_pagination(fake_meta
     JobStore(storage_type=StorageType.LOCAL)
 
     for suffix in ("001", "002", "003"):
-        await store.put_object(f"batchjob:{suffix}", "{}")
+        await store.put_object(f"batchjob/{suffix}", "{}")
 
     first_page, next_token = await batch_metastore.list_metastore_keys(
-        "batchjob:", limit=2
+        "batchjob/", delimiter="/", limit=2
     )
     second_page, final_token = await batch_metastore.list_metastore_keys(
-        "batchjob:", limit=2, continuation_token=next_token
+        "batchjob/", delimiter="/", limit=2, continuation_token=next_token
     )
 
-    assert first_page == ["batchjob:001", "batchjob:002"]
+    assert first_page == ["batchjob/001", "batchjob/002"]
     assert next_token == "2"
-    assert second_page == ["batchjob:003"]
+    assert second_page == ["batchjob/003"]
     assert final_token is None
 
 

--- a/python/aibrix/tests/batch/test_job_store.py
+++ b/python/aibrix/tests/batch/test_job_store.py
@@ -33,7 +33,8 @@ from aibrix.batch.job_entity import (
 )
 from aibrix.batch.state import JobEntityManager, JobStore
 from aibrix.batch.storage import batch_metastore
-from aibrix.storage import StorageType
+from aibrix.storage import StorageConfig, StorageType
+from aibrix.storage.types import StorageListOrdering
 
 
 class FakeMetastore:
@@ -89,6 +90,9 @@ class FakeMetastore:
 
     def get_type(self) -> StorageType:
         return self.storage_type
+
+    def get_list_ordering(self) -> StorageListOrdering:
+        return StorageListOrdering.CREATED_AT_DESC
 
 
 @pytest.fixture
@@ -562,15 +566,46 @@ async def test_job_store_recovery_does_not_stop_early_without_time_ordering(
 
 def test_batch_metastore_initialize_errors_for_unsupported_ordering_backend():
     with pytest.raises(
-        RuntimeError,
-        match="cannot list batch jobs in descending created_at order",
+        ValueError,
+        match="List ordering created_at_desc is not supported by s3 storage",
     ):
-        batch_metastore.initialize_batch_metastore(StorageType.S3)
+        batch_metastore.initialize_batch_metastore(
+            StorageType.S3,
+            {"bucket_name": "test-bucket"},
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="List ordering created_at_desc is not supported by tos storage",
+    ):
+        batch_metastore.initialize_batch_metastore(
+            StorageType.TOS,
+            {
+                "bucket_name": "test-bucket",
+                "access_key": "key",
+                "secret_key": "secret",
+                "endpoint": "http://example.com",
+                "region": "cn-beijing",
+            },
+        )
 
 
-def test_batch_metastore_supports_desc_listing_for_local_and_redis():
-    assert batch_metastore.supports_created_at_desc_batch_job_listing(StorageType.LOCAL)
-    assert batch_metastore.supports_created_at_desc_batch_job_listing(StorageType.REDIS)
-    assert not batch_metastore.supports_created_at_desc_batch_job_listing(
-        StorageType.S3
+def test_batch_metastore_initialize_merges_config_and_defaults_ordering(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("STORAGE_LOCAL_PATH", str(tmp_path))
+    monkeypatch.setattr(batch_metastore, "p_metastore", None)
+
+    config = StorageConfig(max_retries=11)
+    batch_metastore.initialize_batch_metastore(
+        StorageType.LOCAL,
+        {"config": config},
     )
+
+    assert batch_metastore.p_metastore is not None
+    assert batch_metastore.p_metastore.config.max_retries == 11
+    assert (
+        batch_metastore.p_metastore.get_list_ordering()
+        == StorageListOrdering.CREATED_AT_DESC
+    )
+    assert config.list_ordering is None

--- a/python/aibrix/tests/fake/__init__.py
+++ b/python/aibrix/tests/fake/__init__.py
@@ -1,0 +1,1 @@
+# Shared test fakes package.

--- a/python/aibrix/tests/fake/batch_runtime.py
+++ b/python/aibrix/tests/fake/batch_runtime.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from aibrix.batch.job_driver.runtime.base import RuntimeBase
+from aibrix.batch.job_entity import BatchJob, JobRuntimeRef
+from aibrix.context import InfrastructureContext
+
+
+class FakeRuntime(RuntimeBase):
+    """Shared fake provisioning runtime for batch job-driver tests."""
+
+    provisions = True
+
+    def __init__(
+        self,
+        *,
+        runtime_key: str = "fake",
+        reconnect_handle: Any = "fake-handle",
+        reconnect_job_id: Optional[str] = None,
+    ) -> None:
+        super().__init__(InfrastructureContext())
+        self.runtime_key = runtime_key
+        self.reconnect_handle = reconnect_handle
+        self.reconnect_job_id = reconnect_job_id
+        self.cleanup_job_ids: list[str] = []
+        self.reconnect_calls: list[tuple[str, JobRuntimeRef]] = []
+        self.wait_ready_handles: list[Any] = []
+        self.teardown_handles: list[Any] = []
+
+    def _get_runtime_key(self, job: BatchJob) -> str:
+        del job
+        return self.runtime_key
+
+    async def _reconnect(
+        self, job: BatchJob, job_id: str, runtimeRef: JobRuntimeRef
+    ) -> Any | None:
+        del job
+        self.cleanup_job_ids.append(job_id)
+        self.reconnect_calls.append((job_id, runtimeRef))
+        if self.reconnect_job_id is not None and job_id != self.reconnect_job_id:
+            return None
+        return self.reconnect_handle
+
+    async def _wait_ready(self, handle: Any) -> None:
+        self.wait_ready_handles.append(handle)
+
+    async def _teardown(self, handle: Any) -> None:
+        self.teardown_handles.append(handle)

--- a/python/aibrix/tests/metadata/test_app_integration.py
+++ b/python/aibrix/tests/metadata/test_app_integration.py
@@ -207,3 +207,22 @@ def test_ready_endpoint():
 
     data = response.json()
     assert data["status"] == "ready"
+
+
+def test_ready_endpoint_reports_storage_upgrade_in_progress():
+    args = _args(
+        enable_k8s_support=False,
+        disable_batch_api=True,
+        disable_file_api=True,
+    )
+
+    app = build_app(args)
+    app.state.storage_upgrade_in_progress = True
+    test_client = TestClient(app)
+
+    response = test_client.get("/readyz")
+    assert response.status_code == 503
+
+    data = response.json()
+    assert data["status"] == "not ready"
+    assert data["error"] == "storage upgrade in progress"

--- a/python/aibrix/tests/metadata/test_batches_api.py
+++ b/python/aibrix/tests/metadata/test_batches_api.py
@@ -314,7 +314,7 @@ class TestCancelBatch:
             }
             if body["status"] in {"finalizing", "completed"}:
                 assert body["errors"] is not None
-                assert body["errors"]["data"][-1]["code"] == "cancel_rejected_error"
+                assert body["errors"]["data"][-1]["code"] == "cancel_rejected"
                 assert "cannot be cancelled" in body["errors"]["data"][-1]["message"]
 
 

--- a/python/aibrix/tests/storage/test_factory.py
+++ b/python/aibrix/tests/storage/test_factory.py
@@ -26,6 +26,7 @@ import pytest
 from aibrix.storage import (
     LocalStorage,
     StorageConfig,
+    StorageListOrdering,
     StorageType,
     create_storage,
 )
@@ -71,6 +72,18 @@ class TestStorageFactory:
             assert storage.config.max_session_concurrency == 5
             assert storage.config.multi_object_delete_limit == 123
             assert storage.config.range_chunksize == 512 * 1024
+
+    def test_create_storage_with_list_ordering_in_config(self):
+        """Test selecting the active list ordering through StorageConfig."""
+        config = StorageConfig(list_ordering=StorageListOrdering.CREATED_AT_DESC)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            storage = create_storage(
+                StorageType.LOCAL, config=config, base_path=tmp_dir
+            )
+
+            assert isinstance(storage, LocalStorage)
+            assert storage.get_list_ordering() == StorageListOrdering.CREATED_AT_DESC
 
     def test_create_s3_storage_missing_bucket(self):
         """Test that S3 storage creation fails without bucket name."""

--- a/python/aibrix/tests/storage/test_local_storage.py
+++ b/python/aibrix/tests/storage/test_local_storage.py
@@ -158,8 +158,8 @@ class TestLocalStorage:
             after_key=first_page[-1],
         )
 
-        assert first_page == ["after/file1.txt", "after/file2.txt"]
-        assert second_page == ["after/file3.txt"]
+        assert first_page == ["after/file3.txt", "after/file2.txt"]
+        assert second_page == ["after/file1.txt"]
 
         for key in test_files:
             await local_storage.delete_object(key)
@@ -178,17 +178,17 @@ class TestLocalStorage:
         await local_storage.put_object("other:zzz", b"c")
 
         keys, _ = await local_storage.list_objects(prefix="batchjob:")
-        assert sorted(keys) == ["batchjob:abc", "batchjob:def"]
+        assert keys == ["batchjob:def", "batchjob:abc"]
 
         # A delimiter must not break flat-prefix matching.
         keys2, _ = await local_storage.list_objects(prefix="batchjob:", delimiter=":")
-        assert sorted(keys2) == ["batchjob:abc", "batchjob:def"]
+        assert keys2 == ["batchjob:def", "batchjob:abc"]
 
         for key in ("batchjob:abc", "batchjob:def", "other:zzz"):
             await local_storage.delete_object(key)
 
     @pytest.mark.asyncio
-    async def test_list_batchjob_prefix_orders_by_created_at_desc(
+    async def test_list_prefix_orders_by_created_at_desc(
         self, local_storage: LocalStorage
     ):
         keys = ["batchjob:job-b", "batchjob:job-a", "batchjob:job-c"]

--- a/python/aibrix/tests/storage/test_local_storage.py
+++ b/python/aibrix/tests/storage/test_local_storage.py
@@ -168,23 +168,22 @@ class TestLocalStorage:
     async def test_list_with_flat_string_prefix(self, local_storage: LocalStorage):
         """list_objects matches a STRING prefix, not just a directory path.
 
-        Flat root-level keys like ``batchjob:<id>`` (no '/') must be found by a
-        partial prefix such as ``batchjob:`` — this is the JobStore.list_jobs
-        recovery contract on a LOCAL metastore. The old directory-descent
+        Flat root-level keys like ``flatkey:<id>`` (no '/') must be found by a
+        partial prefix such as ``flatkey:``. The old directory-descent
         implementation returned nothing for any non-directory prefix.
         """
-        await local_storage.put_object("batchjob:abc", b"a")
-        await local_storage.put_object("batchjob:def", b"b")
+        await local_storage.put_object("flatkey:abc", b"a")
+        await local_storage.put_object("flatkey:def", b"b")
         await local_storage.put_object("other:zzz", b"c")
 
-        keys, _ = await local_storage.list_objects(prefix="batchjob:")
-        assert keys == ["batchjob:def", "batchjob:abc"]
+        keys, _ = await local_storage.list_objects(prefix="flatkey:")
+        assert keys == ["flatkey:def", "flatkey:abc"]
 
         # A delimiter must not break flat-prefix matching.
-        keys2, _ = await local_storage.list_objects(prefix="batchjob:", delimiter=":")
-        assert keys2 == ["batchjob:def", "batchjob:abc"]
+        keys2, _ = await local_storage.list_objects(prefix="flatkey:", delimiter=":")
+        assert keys2 == ["flatkey:def", "flatkey:abc"]
 
-        for key in ("batchjob:abc", "batchjob:def", "other:zzz"):
+        for key in ("flatkey:abc", "flatkey:def", "other:zzz"):
             await local_storage.delete_object(key)
 
     @pytest.mark.asyncio

--- a/python/aibrix/tests/storage/test_redis_storage.py
+++ b/python/aibrix/tests/storage/test_redis_storage.py
@@ -20,6 +20,12 @@ import pytest
 
 import aibrix.client.redis as redis_client
 from aibrix.storage import RedisStorage, StorageType, create_storage
+from aibrix.storage.redis_upgrade import (
+    REDIS_STORAGE_LATEST_VERSION,
+    REDIS_STORAGE_VERSION_KEY,
+    ensure_redis_storage_version,
+    get_redis_storage_version,
+)
 
 
 def _test_redis_connectivity():
@@ -66,6 +72,89 @@ requires_redis = pytest.mark.skipif(
 def get_redis_storage(**kwargs):
     """Helper to create Redis storage with environment-based configuration."""
     return create_storage(StorageType.REDIS, **kwargs)
+
+
+class _FakeRedisForListObjects:
+    def __init__(self, keys_in_timestamp_order: list[str]):
+        self._keys = [key.encode("utf-8") for key in keys_in_timestamp_order]
+
+    async def exists(self, _key: str) -> bool:
+        return False
+
+    async def zrange(
+        self,
+        key: str,
+        start: int,
+        end: int,
+        withscores: bool = False,
+    ):
+        assert withscores is False
+        assert key == "timestamps:all"
+        if end == -1:
+            return self._keys[start:]
+        return self._keys[start : end + 1]
+
+
+class _FakeRedisForUpgrade:
+    def __init__(self):
+        self.objects: dict[str, bytes] = {}
+        self.values: dict[str, bytes] = {}
+        self.zsets: dict[str, dict[str, float]] = {
+            "timestamps:all": {
+                "batch/job_001": 10.0,
+                "batch/job_002": 30.0,
+                "flat-key": 20.0,
+            },
+            "timestamps:batch": {
+                "job_001": 10.0,
+                "job_002": 30.0,
+            },
+        }
+
+    async def get(self, key: str):
+        return self.values.get(key)
+
+    async def set(
+        self,
+        key: str,
+        value,
+        ex=None,
+        px=None,
+        nx: bool = False,
+        xx: bool = False,
+    ):
+        if nx and key in self.objects:
+            return None
+        if xx and key not in self.objects:
+            return None
+        if isinstance(value, str):
+            value = value.encode("utf-8")
+        self.objects[key] = value
+        self.values[key] = value
+        return True
+
+    async def zscore(self, key: str, member: str):
+        return self.zsets.get(key, {}).get(member)
+
+    async def zrange(self, key: str, start: int, end: int, withscores: bool = False):
+        members = sorted(self.zsets.get(key, {}).items(), key=lambda item: item[1])
+        if end == -1:
+            sliced = members[start:]
+        else:
+            sliced = members[start : end + 1]
+        if withscores:
+            return [(member.encode("utf-8"), score) for member, score in sliced]
+        return [member.encode("utf-8") for member, _ in sliced]
+
+    async def zadd(self, key: str, mapping: dict[str, float]):
+        self.zsets.setdefault(key, {}).update(mapping)
+        return len(mapping)
+
+    async def exists(self, key: str) -> bool:
+        return key in self.objects or key in self.values or key in self.zsets
+
+    async def sadd(self, key: str, member: str):
+        return 1
 
 
 @pytest.mark.asyncio
@@ -140,6 +229,110 @@ def test_pagination_parameters():
     assert sig.parameters["continuation_token"].default is None
 
 
+@pytest.mark.asyncio
+async def test_list_objects_returns_created_at_desc_order(monkeypatch):
+    storage = RedisStorage()
+    fake_redis = _FakeRedisForListObjects(
+        [
+            "batchjob:job-c",
+            "batchjob:job-a",
+            "other:key",
+            "batchjob:job-b",
+        ]
+    )
+
+    async def fake_get_redis():
+        return fake_redis
+
+    monkeypatch.setattr(storage, "_get_redis", fake_get_redis)
+
+    all_keys, _ = await storage.list_objects()
+    first_page, _ = await storage.list_objects(prefix="batchjob:", limit=2)
+    second_page, _ = await storage.list_objects(
+        prefix="batchjob:",
+        limit=2,
+        after_key=first_page[-1],
+    )
+    delimited_keys, _ = await storage.list_objects(prefix="batchjob:", delimiter=":")
+
+    assert all_keys == [
+        "batchjob:job-c",
+        "batchjob:job-a",
+        "other:key",
+        "batchjob:job-b",
+    ]
+    assert first_page == ["batchjob:job-c", "batchjob:job-a"]
+    assert second_page == ["batchjob:job-b"]
+    assert delimited_keys == ["batchjob:job-c", "batchjob:job-a", "batchjob:job-b"]
+
+    await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_storage_version_defaults_to_v1_without_version_key():
+    fake_redis = _FakeRedisForUpgrade()
+
+    version = await get_redis_storage_version(fake_redis)
+
+    assert version == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_redis_storage_version_upgrades_v1_indexes(monkeypatch):
+    storage = RedisStorage()
+    fake_redis = _FakeRedisForUpgrade()
+
+    async def fake_get_redis():
+        return fake_redis
+
+    monkeypatch.setattr(storage, "_get_redis", fake_get_redis)
+
+    version = await ensure_redis_storage_version(storage)
+
+    assert version == REDIS_STORAGE_LATEST_VERSION
+    assert fake_redis.values[REDIS_STORAGE_VERSION_KEY] == b"2"
+    assert fake_redis.zsets["timestamps:all"] == {
+        "batch/job_001": -10.0,
+        "batch/job_002": -30.0,
+        "flat-key": -20.0,
+    }
+    assert fake_redis.zsets["timestamps:batch"] == {
+        "job_001": -10.0,
+        "job_002": -30.0,
+    }
+
+    await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_put_object_preserves_created_at_order_on_overwrite(monkeypatch):
+    storage = RedisStorage()
+    fake_redis = _FakeRedisForUpgrade()
+    fake_redis.zsets = {"timestamps:all": {}}
+
+    async def fake_get_redis():
+        return fake_redis
+
+    times = iter([100.0, 200.0, 300.0])
+
+    monkeypatch.setattr(storage, "_get_redis", fake_get_redis)
+    monkeypatch.setattr("aibrix.storage.redis.time.time", lambda: next(times))
+
+    await storage.put_object("batchjob:job-a", b"v1")
+    await storage.put_object("batchjob:job-b", b"v1")
+    await storage.put_object("batchjob:job-a", b"v2")
+
+    keys, _ = await storage.list_objects(prefix="batchjob:")
+
+    assert fake_redis.zsets["timestamps:all"] == {
+        "batchjob:job-a": -100.0,
+        "batchjob:job-b": -200.0,
+    }
+    assert keys == ["batchjob:job-b", "batchjob:job-a"]
+
+    await storage.close()
+
+
 # Integration tests - enabled when Redis is available
 @requires_redis
 @pytest.mark.asyncio
@@ -200,23 +393,19 @@ async def test_redis_hierarchical_operations():
 
 @requires_redis
 @pytest.mark.asyncio
-async def test_redis_timestamp_ordering():
-    """Test that list_objects returns keys ordered by creation timestamp (requires Redis running)."""
+async def test_redis_default_ordering_is_created_at_desc():
+    """Test that default Redis listing order is newest-first."""
     storage = get_redis_storage()
     try:
-        # Put objects with slight delays to ensure different timestamps
         await storage.put_object("test_key_3", b"third")
         await asyncio.sleep(0.01)  # Small delay
         await storage.put_object("test_key_1", b"first")
         await asyncio.sleep(0.01)
         await storage.put_object("test_key_2", b"second")
 
-        # List all objects - should be ordered by creation time
         objects, _ = await storage.list_objects()
 
-        # Should be ordered by creation timestamp: test_key_3, test_key_1, test_key_2
-        assert objects.index("test_key_3") < objects.index("test_key_1")
-        assert objects.index("test_key_1") < objects.index("test_key_2")
+        assert objects == ["test_key_2", "test_key_1", "test_key_3"]
 
         # Clean up
         await storage.delete_object("test_key_1")
@@ -229,8 +418,8 @@ async def test_redis_timestamp_ordering():
 
 @requires_redis
 @pytest.mark.asyncio
-async def test_redis_hierarchical_timestamp_ordering():
-    """Test hierarchical key timestamp ordering (requires Redis running)."""
+async def test_redis_hierarchical_ordering_is_created_at_desc():
+    """Test hierarchical Redis listing order is newest-first."""
     storage = get_redis_storage()
     try:
         # Put hierarchical objects with delays
@@ -243,13 +432,10 @@ async def test_redis_hierarchical_timestamp_ordering():
         await asyncio.sleep(0.01)
         await storage.put_object("batch2/job_001", b"job data 1")
 
-        # List batch objects - should be ordered by creation time
         objects, _ = await storage.list_objects("batch", "/")
 
-        # Should be ordered by creation timestamp
         assert len(objects) == 3
-        assert objects.index("batch/job_003") < objects.index("batch/job_001")
-        assert objects.index("batch/job_001") < objects.index("batch/job_002")
+        assert objects == ["batch/job_002", "batch/job_001", "batch/job_003"]
 
         # Clean up
         await storage.delete_object("batch/job_001")
@@ -279,7 +465,7 @@ async def test_redis_token_pagination():
         # Test token-based pagination
         page1, token1 = await storage.list_objects(limit=3)
         page2, token2 = await storage.list_objects(limit=3, continuation_token=token1)
-        page3, token3 = await storage.list_objects(limit=3, continuation_token=token2)
+        page3, _ = await storage.list_objects(limit=3, continuation_token=token2)
 
         # Should have 3 items each (except maybe last page)
         assert len(page1) == 3
@@ -291,7 +477,7 @@ async def test_redis_token_pagination():
         assert token2 is not None
         # Last page might have more items or not
 
-        # Should be in timestamp order and not overlap
+        # Should preserve the same created_at-desc order as a full listing
         all_paginated = page1 + page2 + page3
         all_objects, _ = await storage.list_objects()
         assert all_paginated[:9] == all_objects[:9]  # First 9 should match
@@ -330,7 +516,7 @@ async def test_redis_hierarchical_token_pagination():
 
         # Test token-based pagination on hierarchical objects
         page1, token1 = await storage.list_objects("batch", "/", limit=4)
-        page2, token2 = await storage.list_objects(
+        page2, _ = await storage.list_objects(
             "batch", "/", limit=4, continuation_token=token1
         )
 
@@ -358,7 +544,7 @@ async def test_redis_hierarchical_token_pagination():
 @requires_redis
 @pytest.mark.asyncio
 async def test_redis_hierarchical_after_key_pagination():
-    """Test hierarchical after_key pagination uses timestamp ordering."""
+    """Test hierarchical after_key pagination follows created_at-desc ordering."""
     storage = get_redis_storage()
     try:
         test_keys = [f"batch/after_job_{i:03d}" for i in range(4)]

--- a/python/aibrix/tests/storage/test_redis_storage.py
+++ b/python/aibrix/tests/storage/test_redis_storage.py
@@ -20,12 +20,16 @@ import pytest
 
 import aibrix.client.redis as redis_client
 from aibrix.storage import RedisStorage, StorageType, create_storage
+from aibrix.storage.base import StorageConfig
 from aibrix.storage.redis_upgrade import (
     REDIS_STORAGE_LATEST_VERSION,
     REDIS_STORAGE_VERSION_KEY,
+    REDIS_STORAGE_VERSION_V2,
     ensure_redis_storage_version,
     get_redis_storage_version,
+    verify_redis_storage_v3,
 )
+from aibrix.storage.types import StorageListOrdering
 
 
 def _test_redis_connectivity():
@@ -75,11 +79,23 @@ def get_redis_storage(**kwargs):
 
 
 class _FakeRedisForListObjects:
-    def __init__(self, keys_in_timestamp_order: list[str]):
-        self._keys = [key.encode("utf-8") for key in keys_in_timestamp_order]
+    def __init__(self, keys_in_created_at_asc: list[str]):
+        self._keys_asc = [key.encode("utf-8") for key in keys_in_created_at_asc]
+        self._hierarchical_zsets: dict[str, list[bytes]] = {}
+        self._existing_keys: set[str] = set()
 
-    async def exists(self, _key: str) -> bool:
-        return False
+    def with_hierarchical_index(
+        self, prefix: str, members_in_created_at_asc: list[str]
+    ):
+        self._existing_keys.add(f"{prefix}:index")
+        self._existing_keys.add(f"timestamps:{prefix}")
+        self._hierarchical_zsets[f"timestamps:{prefix}"] = [
+            member.encode("utf-8") for member in members_in_created_at_asc
+        ]
+        return self
+
+    async def exists(self, key: str) -> bool:
+        return key in self._existing_keys
 
     async def zrange(
         self,
@@ -89,16 +105,62 @@ class _FakeRedisForListObjects:
         withscores: bool = False,
     ):
         assert withscores is False
-        assert key == "timestamps:all"
+        if key == "timestamps:all":
+            if end == -1:
+                return self._keys_asc[start:]
+            return self._keys_asc[start : end + 1]
+
+        members = self._hierarchical_zsets[key]
         if end == -1:
-            return self._keys[start:]
-        return self._keys[start : end + 1]
+            return members[start:]
+        return members[start : end + 1]
+
+    async def zrevrange(
+        self,
+        key: str,
+        start: int,
+        end: int,
+        withscores: bool = False,
+        score_cast_func=float,
+    ):
+        assert withscores is False
+        if key == "timestamps:all":
+            members = list(reversed(self._keys_asc))
+            if end == -1:
+                return members[start:]
+            return members[start : end + 1]
+
+        members = list(reversed(self._hierarchical_zsets[key]))
+        if end == -1:
+            return members[start:]
+        return members[start : end + 1]
+
+    async def zrank(self, key: str, member: str):
+        members = [item.decode("utf-8") for item in self._hierarchical_zsets[key]]
+        try:
+            return members.index(member)
+        except ValueError:
+            return None
+
+    async def zrevrank(self, key: str, member: str):
+        if key == "timestamps:all":
+            members = [item.decode("utf-8") for item in reversed(self._keys_asc)]
+        else:
+            members = [
+                item.decode("utf-8") for item in reversed(self._hierarchical_zsets[key])
+            ]
+        try:
+            return members.index(member)
+        except ValueError:
+            return None
 
 
 class _FakeRedisForUpgrade:
     def __init__(self):
         self.objects: dict[str, bytes] = {}
         self.values: dict[str, bytes] = {}
+        self.sets: dict[str, set[str]] = {}
+        self.zscore_calls = 0
         self.zsets: dict[str, dict[str, float]] = {
             "timestamps:all": {
                 "batch/job_001": 10.0,
@@ -134,7 +196,18 @@ class _FakeRedisForUpgrade:
         return True
 
     async def zscore(self, key: str, member: str):
+        self.zscore_calls += 1
         return self.zsets.get(key, {}).get(member)
+
+    async def zrevrank(self, key: str, member: str):
+        members = sorted(
+            self.zsets.get(key, {}).items(), key=lambda item: item[1], reverse=True
+        )
+        names = [name for name, _ in members]
+        try:
+            return names.index(member)
+        except ValueError:
+            return None
 
     async def zrange(self, key: str, start: int, end: int, withscores: bool = False):
         members = sorted(self.zsets.get(key, {}).items(), key=lambda item: item[1])
@@ -146,15 +219,77 @@ class _FakeRedisForUpgrade:
             return [(member.encode("utf-8"), score) for member, score in sliced]
         return [member.encode("utf-8") for member, _ in sliced]
 
-    async def zadd(self, key: str, mapping: dict[str, float]):
-        self.zsets.setdefault(key, {}).update(mapping)
-        return len(mapping)
+    async def zrevrange(
+        self,
+        key: str,
+        start: int,
+        end: int,
+        withscores: bool = False,
+        score_cast_func=float,
+    ):
+        members = sorted(
+            self.zsets.get(key, {}).items(), key=lambda item: item[1], reverse=True
+        )
+        if end == -1:
+            sliced = members[start:]
+        else:
+            sliced = members[start : end + 1]
+        if withscores:
+            return [(member.encode("utf-8"), score) for member, score in sliced]
+        return [member.encode("utf-8") for member, _ in sliced]
+
+    async def zadd(
+        self, key: str, mapping: dict[str, float], nx: bool = False, **_kwargs
+    ):
+        zset = self.zsets.setdefault(key, {})
+        added = 0
+        for member, score in mapping.items():
+            if nx and member in zset:
+                continue
+            if member not in zset:
+                added += 1
+            zset[member] = float(score)
+        return added
 
     async def exists(self, key: str) -> bool:
-        return key in self.objects or key in self.values or key in self.zsets
+        return (
+            key in self.objects
+            or key in self.values
+            or key in self.zsets
+            or key in self.sets
+        )
 
-    async def sadd(self, key: str, member: str):
-        return 1
+    async def sadd(self, key: str, *members: str):
+        self.sets.setdefault(key, set()).update(members)
+        return len(members)
+
+    async def smembers(self, key: str):
+        return {member.encode("utf-8") for member in self.sets.get(key, set())}
+
+    async def delete(self, *names: str):
+        removed = 0
+        for name in names:
+            removed += int(self.objects.pop(name, None) is not None)
+            self.values.pop(name, None)
+            self.zsets.pop(name, None)
+            self.sets.pop(name, None)
+        return removed
+
+    async def zrem(self, key: str, *values: str):
+        zset = self.zsets.get(key, {})
+        removed = 0
+        for value in values:
+            removed += int(zset.pop(value, None) is not None)
+        return removed
+
+    async def srem(self, key: str, *values: str):
+        members = self.sets.get(key, set())
+        removed = 0
+        for value in values:
+            if value in members:
+                members.remove(value)
+                removed += 1
+        return removed
 
 
 @pytest.mark.asyncio
@@ -234,10 +369,10 @@ async def test_list_objects_returns_created_at_desc_order(monkeypatch):
     storage = RedisStorage()
     fake_redis = _FakeRedisForListObjects(
         [
-            "batchjob:job-c",
-            "batchjob:job-a",
-            "other:key",
             "batchjob:job-b",
+            "other:key",
+            "batchjob:job-a",
+            "batchjob:job-c",
         ]
     )
 
@@ -269,6 +404,78 @@ async def test_list_objects_returns_created_at_desc_order(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_objects_supports_trailing_delimiter_prefix(monkeypatch):
+    storage = RedisStorage()
+    fake_redis = _FakeRedisForListObjects([]).with_hierarchical_index(
+        "batchjob",
+        ["job-b", "job-a", "job-c"],
+    )
+
+    async def fake_get_redis():
+        return fake_redis
+
+    monkeypatch.setattr(storage, "_get_redis", fake_get_redis)
+
+    first_page, next_token = await storage.list_objects(
+        prefix="batchjob/",
+        delimiter="/",
+        limit=2,
+    )
+    second_page, final_token = await storage.list_objects(
+        prefix="batchjob/",
+        delimiter="/",
+        limit=2,
+        continuation_token=next_token,
+    )
+
+    assert first_page == ["batchjob/job-c", "batchjob/job-a"]
+    assert next_token == "2"
+    assert second_page == ["batchjob/job-b"]
+    assert final_token is None
+
+    await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_list_objects_supports_created_at_asc_order(monkeypatch):
+    storage = RedisStorage(
+        config=StorageConfig(list_ordering=StorageListOrdering.CREATED_AT_ASC)
+    )
+    fake_redis = _FakeRedisForListObjects(
+        [
+            "batchjob:job-b",
+            "other:key",
+            "batchjob:job-a",
+            "batchjob:job-c",
+        ]
+    )
+
+    async def fake_get_redis():
+        return fake_redis
+
+    monkeypatch.setattr(storage, "_get_redis", fake_get_redis)
+
+    all_keys, _ = await storage.list_objects()
+    first_page, _ = await storage.list_objects(prefix="batchjob:", limit=2)
+    second_page, _ = await storage.list_objects(
+        prefix="batchjob:",
+        limit=2,
+        after_key=first_page[-1],
+    )
+
+    assert all_keys == [
+        "batchjob:job-b",
+        "other:key",
+        "batchjob:job-a",
+        "batchjob:job-c",
+    ]
+    assert first_page == ["batchjob:job-b", "batchjob:job-a"]
+    assert second_page == ["batchjob:job-c"]
+
+    await storage.close()
+
+
+@pytest.mark.asyncio
 async def test_storage_version_defaults_to_v1_without_version_key():
     fake_redis = _FakeRedisForUpgrade()
 
@@ -290,18 +497,144 @@ async def test_ensure_redis_storage_version_upgrades_v1_indexes(monkeypatch):
     version = await ensure_redis_storage_version(storage)
 
     assert version == REDIS_STORAGE_LATEST_VERSION
-    assert fake_redis.values[REDIS_STORAGE_VERSION_KEY] == b"2"
+    assert fake_redis.values[REDIS_STORAGE_VERSION_KEY] == b"3"
     assert fake_redis.zsets["timestamps:all"] == {
-        "batch/job_001": -10.0,
-        "batch/job_002": -30.0,
-        "flat-key": -20.0,
+        "batch/job_001": 10.0,
+        "batch/job_002": 30.0,
+        "flat-key": 20.0,
     }
     assert fake_redis.zsets["timestamps:batch"] == {
-        "job_001": -10.0,
-        "job_002": -30.0,
+        "job_001": 10.0,
+        "job_002": 30.0,
     }
 
     await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_ensure_redis_storage_version_upgrades_v1_directly_to_v3(monkeypatch):
+    storage = RedisStorage()
+    fake_redis = _FakeRedisForUpgrade()
+
+    async def fake_get_redis():
+        return fake_redis
+
+    async def fail_if_called(_redis_client):
+        raise AssertionError("v1 -> v2 upgrade should be skipped when upgrading to v3")
+
+    monkeypatch.setattr(storage, "_get_redis", fake_get_redis)
+    monkeypatch.setattr(
+        "aibrix.storage.redis_upgrade.upgrade_redis_storage_v1_to_v2",
+        fail_if_called,
+        raising=False,
+    )
+
+    version = await ensure_redis_storage_version(storage)
+
+    assert version == REDIS_STORAGE_LATEST_VERSION
+    assert fake_redis.values[REDIS_STORAGE_VERSION_KEY] == b"3"
+
+    await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_ensure_redis_storage_version_upgrades_v2_batch_keys_to_v3(monkeypatch):
+    storage = RedisStorage()
+    fake_redis = _FakeRedisForUpgrade()
+    fake_redis.values[REDIS_STORAGE_VERSION_KEY] = str(REDIS_STORAGE_VERSION_V2).encode(
+        "utf-8"
+    )
+    fake_redis.objects.update(
+        {
+            "batchjob:job-a": b'{"job_id":"job-a"}',
+            "batchstatus_copies:job-a:worker-1": b'{"state":"running"}',
+            "other:key": b"other",
+        }
+    )
+    fake_redis.values.update(fake_redis.objects)
+    fake_redis.zsets = {
+        "timestamps:all": {
+            "batchjob:job-a": -100.0,
+            "batchstatus_copies:job-a:worker-1": -90.0,
+            "other:key": -50.0,
+        }
+    }
+
+    async def fake_get_redis():
+        return fake_redis
+
+    monkeypatch.setattr(storage, "_get_redis", fake_get_redis)
+
+    version = await ensure_redis_storage_version(storage)
+
+    assert version == REDIS_STORAGE_LATEST_VERSION
+    assert fake_redis.values[REDIS_STORAGE_VERSION_KEY] == b"3"
+    assert "batchjob:job-a" not in fake_redis.objects
+    assert (
+        fake_redis.objects["batchjob/job-a"]
+        == fake_redis.values["batchjob/job-a"]
+        == b'{"job_id":"job-a"}'
+    )
+    assert "batchstatus_copies:job-a:worker-1" not in fake_redis.objects
+    assert (
+        fake_redis.objects["batchstatus_copies:job-a/worker-1"]
+        == fake_redis.values["batchstatus_copies:job-a/worker-1"]
+        == b'{"state":"running"}'
+    )
+    assert fake_redis.zsets["timestamps:all"] == {
+        "batchjob/job-a": 100.0,
+        "batchstatus_copies:job-a/worker-1": 90.0,
+        "other:key": 50.0,
+    }
+    assert fake_redis.sets["batchjob:index"] == {"job-a"}
+    assert fake_redis.zsets["timestamps:batchjob"] == {"job-a": 100.0}
+    assert fake_redis.sets["batchstatus_copies:job-a:index"] == {"worker-1"}
+    assert fake_redis.zsets["timestamps:batchstatus_copies:job-a"] == {"worker-1": 90.0}
+
+    await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_verify_redis_storage_v3_accepts_consistent_indexes():
+    fake_redis = _FakeRedisForUpgrade()
+    fake_redis.zsets = {
+        "timestamps:all": {
+            "batchjob/job-a": 100.0,
+            "batchstatus_copies:job-a/worker-1": 90.0,
+            "other:key": 50.0,
+        },
+        "timestamps:batchjob": {
+            "job-a": 100.0,
+        },
+        "timestamps:batchstatus_copies:job-a": {
+            "worker-1": 90.0,
+        },
+    }
+    fake_redis.sets = {
+        "batchjob:index": {"job-a"},
+        "batchstatus_copies:job-a:index": {"worker-1"},
+    }
+
+    await verify_redis_storage_v3(fake_redis)
+
+
+@pytest.mark.asyncio
+async def test_verify_redis_storage_v3_rejects_parent_index_mismatch():
+    fake_redis = _FakeRedisForUpgrade()
+    fake_redis.zsets = {
+        "timestamps:all": {
+            "batchjob/job-a": 100.0,
+        },
+        "timestamps:batchjob": {
+            "job-a": 100.0,
+        },
+    }
+    fake_redis.sets = {
+        "batchjob:index": set(),
+    }
+
+    with pytest.raises(RuntimeError, match="parent index mismatch"):
+        await verify_redis_storage_v3(fake_redis)
 
 
 @pytest.mark.asyncio
@@ -325,10 +658,60 @@ async def test_put_object_preserves_created_at_order_on_overwrite(monkeypatch):
     keys, _ = await storage.list_objects(prefix="batchjob:")
 
     assert fake_redis.zsets["timestamps:all"] == {
-        "batchjob:job-a": -100.0,
-        "batchjob:job-b": -200.0,
+        "batchjob:job-a": 100.0,
+        "batchjob:job-b": 200.0,
     }
+    assert fake_redis.zscore_calls == 0
     assert keys == ["batchjob:job-b", "batchjob:job-a"]
+
+    await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_put_object_preserves_parent_timestamp_order_on_hierarchical_overwrite(
+    monkeypatch,
+):
+    storage = RedisStorage()
+    fake_redis = _FakeRedisForUpgrade()
+    fake_redis.zsets = {"timestamps:all": {}}
+
+    async def fake_get_redis():
+        return fake_redis
+
+    times = iter([100.0, 200.0])
+
+    monkeypatch.setattr(storage, "_get_redis", fake_get_redis)
+    monkeypatch.setattr("aibrix.storage.redis.time.time", lambda: next(times))
+
+    await storage.put_object("batchjob/job-a", b"v1")
+    await storage.put_object("batchjob/job-a", b"v2")
+
+    assert fake_redis.zscore_calls == 1
+    assert fake_redis.zsets["timestamps:all"] == {"batchjob/job-a": 100.0}
+    assert fake_redis.sets["batchjob:index"] == {"job-a"}
+    assert fake_redis.zsets["timestamps:batchjob"] == {"job-a": 100.0}
+
+    await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_put_object_skips_zscore_on_first_insert(monkeypatch):
+    storage = RedisStorage()
+    fake_redis = _FakeRedisForUpgrade()
+    fake_redis.zsets = {"timestamps:all": {}}
+
+    async def fake_get_redis():
+        return fake_redis
+
+    monkeypatch.setattr(storage, "_get_redis", fake_get_redis)
+    monkeypatch.setattr("aibrix.storage.redis.time.time", lambda: 123.0)
+
+    await storage.put_object("batchjob/job-a", b"v1")
+
+    assert fake_redis.zscore_calls == 0
+    assert fake_redis.zsets["timestamps:all"] == {"batchjob/job-a": 123.0}
+    assert fake_redis.sets["batchjob:index"] == {"job-a"}
+    assert fake_redis.zsets["timestamps:batchjob"] == {"job-a": 123.0}
 
     await storage.close()
 

--- a/python/aibrix/tests/storage/test_storage.py
+++ b/python/aibrix/tests/storage/test_storage.py
@@ -28,6 +28,13 @@ from typing import List, Union
 import pytest
 
 from aibrix.storage.base import BaseStorage
+from aibrix.storage.types import StorageListOrdering
+
+
+def _ordered_keys_for_backend(storage: BaseStorage, keys: list[str]) -> list[str]:
+    if storage.get_list_ordering() == StorageListOrdering.CREATED_AT_DESC:
+        return list(reversed(keys))
+    return sorted(keys)
 
 
 class TestStorageFunctionality:
@@ -230,9 +237,10 @@ class TestStorageFunctionality:
             continuation_token=continuation_token,
         )
 
-        assert first_page == test_objects[:2]
+        expected_order = _ordered_keys_for_backend(storage, test_objects)
+        assert first_page == expected_order[:2]
         assert continuation_token is not None
-        assert second_page == test_objects[2:]
+        assert second_page == expected_order[2:]
         assert next_token is None
 
         for key in test_objects:
@@ -258,8 +266,9 @@ class TestStorageFunctionality:
             after_key=first_page[-1],
         )
 
-        assert first_page == test_objects[:2]
-        assert second_page == test_objects[2:]
+        expected_order = _ordered_keys_for_backend(storage, test_objects)
+        assert first_page == expected_order[:2]
+        assert second_page == expected_order[2:]
         assert next_token is None
 
         for key in test_objects:


### PR DESCRIPTION
## Pull Request Description
- Switch Redis metastore listing to created_at descending order. Previously, jobs were stored in created_at ascending order, which prevented newly running jobs from being recovered during restart.
- Add Redis storage version upgrade (v1 -> v3) and startup/manual upgrade paths: review job key formulation (from batchjob:job_id to batchjob/job_id) to leverage Redis native zset for list_objects.
- Remove batch-job-specific ordering logic from local storage and make prefix listing generic.
- Route batch GET reads through BatchDriver so missed active jobs can be republished.
- Fix expired job cleanup for recovered/orphaned in-progress executions.
- Formalizes storage list-ordering capabilities and metastore initialization around CREATED_AT_DESC , updates shared/local tests to rely on backend feature detection instead of forcing local behavior, and fixes the affected batch recovery test doubles to match the new storage interface.

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>