### PR TITLE
fix(batch): probe request-locking support once to avoid per-request warning spam (#2332)

### DIFF
--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -114,10 +114,10 @@ class BatchStorageAdapter:
             # Try to lock this request before processing.
             lock_key = self._get_request_meta_output_key(job, idx)
             if not locking_supported:
-                # Locking is unavailable, but a previous (interrupted) run may
-                # have already completed this request. Skip those so job
-                # recovery/resumption does not reprocess them from the start.
-                locked = not await is_request_done(lock_key)
+                # Locking is unavailable on this backend; process every request
+                # without dedup, preserving the previous behavior (minus the
+                # per-request warning, which we already logged once above).
+                locked = True
             else:
                 try:
                     # Try to acquire lock with configurable expiration

--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -25,6 +25,7 @@ from aibrix.batch.storage.batch_metastore import (
     delete_metadata,
     get_metadata,
     is_request_done,
+    is_request_locking_supported,
     list_metastore_keys,
     lock_request,
     unlock_request,
@@ -91,6 +92,17 @@ class BatchStorageAdapter:
         """
         idx = start_index
         done = 0  # Track done requests so far
+        # Locking relies on TTL + set-if-not-exists, which some metastore
+        # backends (e.g. the LOCAL dev/test metastore) do not support. Probe
+        # once up front so we don't emit an identical "locking not supported"
+        # warning for every request in the job.
+        locking_supported = is_request_locking_supported()
+        if not locking_supported:
+            logger.info(
+                "Metastore does not support request locking; "
+                "processing all requests without dedup",
+                job_id=job.job_id,
+            )  # type:ignore[call-arg]
         # Use 'async for' to iterate and 'yield' each item.
         async for line in self.storage.readline_iter(
             job.spec.input_file_id, start_index
@@ -101,19 +113,22 @@ class BatchStorageAdapter:
 
             # Try to lock this request before processing.
             lock_key = self._get_request_meta_output_key(job, idx)
-            try:
-                # Try to acquire lock with configurable expiration
-                locked = await lock_request(
-                    lock_key, expiration_seconds=envs.INFERENCE_TASK_TIMEOUT
-                )
-            except Exception as e:
-                logger.warning(
-                    "Error on locking request in the job, assuming locking not supported",
-                    job_id=job.job_id,
-                    line_no=idx,
-                    error=e,
-                )  # type:ignore[call-arg]
+            if not locking_supported:
                 locked = True
+            else:
+                try:
+                    # Try to acquire lock with configurable expiration
+                    locked = await lock_request(
+                        lock_key, expiration_seconds=envs.INFERENCE_TASK_TIMEOUT
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Error on locking request in the job, assuming locking not supported",
+                        job_id=job.job_id,
+                        line_no=idx,
+                        error=e,
+                    )  # type:ignore[call-arg]
+                    locked = True
 
             if locked:
                 request_data = json.loads(line)

--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -114,7 +114,10 @@ class BatchStorageAdapter:
             # Try to lock this request before processing.
             lock_key = self._get_request_meta_output_key(job, idx)
             if not locking_supported:
-                locked = True
+                # Locking is unavailable, but a previous (interrupted) run may
+                # have already completed this request. Skip those so job
+                # recovery/resumption does not reprocess them from the start.
+                locked = not await is_request_done(lock_key)
             else:
                 try:
                     # Try to acquire lock with configurable expiration

--- a/python/aibrix/aibrix/batch/storage/batch_metastore.py
+++ b/python/aibrix/aibrix/batch/storage/batch_metastore.py
@@ -194,6 +194,30 @@ async def lock_request(key: str, expiration_seconds: int = 3600) -> bool:
     )
 
 
+def is_request_locking_supported() -> bool:
+    """Whether the active metastore can lock requests.
+
+    Request locking relies on both TTL (to auto-expire stale locks) and
+    set-if-not-exists (NX) semantics. Backends that lack either -- notably the
+    LOCAL filesystem metastore used for dev/test runs -- cannot lock requests,
+    so callers should process every request without dedup instead of attempting
+    a lock per request (which would raise ``ValueError`` every time).
+
+    Returns:
+        True if the metastore supports request locking, False otherwise
+
+    Raises:
+        RuntimeError: If metastore has not been initialized
+    """
+    if p_metastore is None:
+        raise RuntimeError(
+            "Batch metastore not initialized. Call initialize_batch_metastore() first."
+        )
+    return (
+        p_metastore.is_ttl_supported() and p_metastore.is_set_if_not_exists_supported()
+    )
+
+
 async def is_request_done(key: str) -> bool:
     """Check if a request is done.
 

--- a/python/aibrix/tests/batch/test_batch_storage_adapter.py
+++ b/python/aibrix/tests/batch/test_batch_storage_adapter.py
@@ -102,10 +102,21 @@ async def test_read_job_next_input_data_keeps_locking_behavior(mock_storage):
         ]
     )
 
-    with patch(
-        "aibrix.batch.storage.adapter.lock_request",
-        AsyncMock(return_value=True),
-    ) as mock_lock:
+    # read_job_next_input_data probes is_request_locking_supported() once up
+    # front; force it True here so we exercise the per-request locking path and
+    # confirm the probe optimization doesn't skip lock_request when locking is
+    # available. (The probe reads the process metastore, which isn't initialized
+    # in unit tests, so it must be patched.)
+    with (
+        patch(
+            "aibrix.batch.storage.adapter.is_request_locking_supported",
+            return_value=True,
+        ),
+        patch(
+            "aibrix.batch.storage.adapter.lock_request",
+            AsyncMock(return_value=True),
+        ) as mock_lock,
+    ):
         requests = [
             item async for item in adapter.read_job_next_input_data(job, start_index=0)
         ]


### PR DESCRIPTION
## Summary

Fixes #2332.

When the batch API runs against the **LOCAL** filesystem metastore (dev/test, e.g. `npm run dev` + `poetry run python -m aibrix.metadata.app`), every request in a job produces an identical warning:

```
Error on locking request in the job, assuming locking not supported
```

`read_job_next_input_data` locks each request via `lock_request`, which needs both **TTL** and **set-if-not-exists (NX)** semantics. The LOCAL metastore supports neither, so `_validate_put_options` raises `ValueError` ("TTL not supported by local storage") on *every* request. That exception was caught and logged as a WARNING per request — a 500-request job emits 500 identical warnings.

## Fix

- Add `is_request_locking_supported()` to `batch_metastore` — returns whether the active metastore supports both TTL and set-if-not-exists.
- In `read_job_next_input_data`, probe it **once** before the read loop. When locking is unsupported, log a single info line and process every request without dedup — which is exactly the pre-existing fallback behaviour (`locked = True`), just without the per-request `ValueError`/warning.

The per-request `try/except` is retained for the locking-supported path, so genuine transient errors on Redis are still surfaced.

## Behaviour

- **Redis metastore:** unchanged — locking is probed as supported, per-request locking proceeds as before.
- **LOCAL metastore:** one info line instead of N warnings; all requests still processed (no dedup, same as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
