### PR TITLE
[Misc]Harden batch status-copy key encoding across storages

### DIFF
--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -493,9 +493,12 @@ class BaseJobDriver:
         return job_id
 
     def _assign_worker_id(self, runtime_key: Optional[str]) -> str:
+        normalized_runtime_key = (
+            runtime_key.replace("/", "-") if runtime_key is not None else None
+        )
         self._worker_id = (
-            f"{runtime_key}-{self._worker_token}"
-            if runtime_key is not None
+            f"{normalized_runtime_key}-{self._worker_token}"
+            if normalized_runtime_key is not None
             else self._worker_token
         )
         return self._worker_id

--- a/python/aibrix/aibrix/batch/job_driver/runtime/k8s_deployment.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/k8s_deployment.py
@@ -107,7 +107,7 @@ class DeploymentRuntime(RuntimeBase):
         del job
         if self._active_handle is None:
             return None
-        return f"{self._active_handle.namespace}/{self._active_handle.deployment_name}"
+        return f"{self._active_handle.namespace}:{self._active_handle.deployment_name}"
 
     def _get_runtime_reconnect_payload(
         self,

--- a/python/aibrix/aibrix/batch/job_driver/runtime/k8s_job.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/k8s_job.py
@@ -118,7 +118,7 @@ class K8sJobRuntime(RuntimeBase):
         del job
         if self._active_handle is None:
             return None
-        return f"{self._active_handle.namespace}/{self._active_handle.job_name}"
+        return f"{self._active_handle.namespace}:{self._active_handle.job_name}"
 
     def _get_runtime_reconnect_payload(
         self,

--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -234,12 +234,24 @@ class BatchStorageAdapter:
             request_index: Index of the request being processed
             output_data: Single result dictionary
         """
-        assert (
+        has_required_files = (
             job.status.output_file_id
             and job.status.error_file_id
             and job.status.temp_output_file_id
             and job.status.temp_error_file_id
         )
+        if not has_required_files:
+            logger.error(
+                "Missing batch output file metadata before writing request result",
+                job_id=job.job_id,
+                request_index=request_index,
+                output_file_id=job.status.output_file_id,
+                error_file_id=job.status.error_file_id,
+                temp_output_file_id=job.status.temp_output_file_id,
+                temp_error_file_id=job.status.temp_error_file_id,
+                state=job.status.state.value,
+            )  # type: ignore[call-arg]
+        assert has_required_files
 
         # output_data["error"] may be a BatchJobError when inference
         # fails (see job_driver.create_response_record). The class

--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -234,24 +234,12 @@ class BatchStorageAdapter:
             request_index: Index of the request being processed
             output_data: Single result dictionary
         """
-        has_required_files = (
+        assert (
             job.status.output_file_id
             and job.status.error_file_id
             and job.status.temp_output_file_id
             and job.status.temp_error_file_id
         )
-        if not has_required_files:
-            logger.error(
-                "Missing batch output file metadata before writing request result",
-                job_id=job.job_id,
-                request_index=request_index,
-                output_file_id=job.status.output_file_id,
-                error_file_id=job.status.error_file_id,
-                temp_output_file_id=job.status.temp_output_file_id,
-                temp_error_file_id=job.status.temp_error_file_id,
-                state=job.status.state.value,
-            )  # type: ignore[call-arg]
-        assert has_required_files
 
         # output_data["error"] may be a BatchJobError when inference
         # fails (see job_driver.create_response_record). The class

--- a/python/aibrix/aibrix/batch/storage/batch_metastore.py
+++ b/python/aibrix/aibrix/batch/storage/batch_metastore.py
@@ -17,6 +17,7 @@ import os
 from dataclasses import replace
 from datetime import datetime
 from typing import Callable, Optional, Tuple
+from urllib.parse import quote, unquote
 
 from aibrix import envs
 from aibrix.batch.job_entity import (
@@ -58,8 +59,17 @@ def _status_copies_list_prefix(batch_id: str) -> str:
     return f"{_status_copies_parent_key(batch_id)}/"
 
 
+def _normalize_status_copy_worker_id(worker_id: str) -> str:
+    return quote(worker_id, safe="._-@+()[]{}~")
+
+
+def _decode_status_copy_worker_id(storage_worker_id: str) -> str:
+    return unquote(storage_worker_id)
+
+
 def _status_copy_key(batch_id: str, worker_id: str) -> str:
-    return f"{_status_copies_list_prefix(batch_id)}{worker_id}"
+    encoded_worker_id = _normalize_status_copy_worker_id(worker_id)
+    return f"{_status_copies_list_prefix(batch_id)}{encoded_worker_id}"
 
 
 def initialize_batch_metastore(storage_type=StorageType.AUTO, params={}):
@@ -341,7 +351,7 @@ async def get_batch_job(batch_id: str) -> Optional[BatchJob]:
     )
     for storage_key, (status_json, exists) in zip(keys, metadata_results):
         if exists:
-            worker_id = storage_key[len(prefix) :]
+            worker_id = _decode_status_copy_worker_id(storage_key[len(prefix) :])
             status_copies[worker_id] = BatchJobStatusCopy.model_validate_json(
                 status_json
             )

--- a/python/aibrix/aibrix/storage/local.py
+++ b/python/aibrix/aibrix/storage/local.py
@@ -20,6 +20,7 @@ import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncIterator, BinaryIO, Optional, TextIO, Union
+from urllib.parse import unquote
 
 from aibrix.storage.base import (
     PutObjectOptions,
@@ -327,9 +328,10 @@ class LocalStorage(BaseStorage2):
             for item in self.base_path.rglob("*" + _METADATA_SUFFIX):
                 if not item.is_file():
                     continue
-                key = item.relative_to(self.base_path).as_posix()[
+                encoded_key = item.relative_to(self.base_path).as_posix()[
                     : -len(_METADATA_SUFFIX)
                 ]
+                key = "/".join(unquote(part) for part in encoded_key.split("/"))
                 if not key.startswith(prefix):
                     continue
                 if delimiter:

--- a/python/aibrix/aibrix/storage/redis.py
+++ b/python/aibrix/aibrix/storage/redis.py
@@ -17,6 +17,7 @@ import time
 from typing import BinaryIO, Optional, TextIO, Union
 
 import aibrix.client.redis as redis
+from aibrix import envs
 from aibrix.storage.base import (
     PutObjectOptions,
     StorageConfig,
@@ -60,6 +61,20 @@ class RedisStorage(BaseStorage2):
         super().__init__(config)
         self._redis_clients: dict[int, redis.AsyncRedis] = {}
         self._kwargs = kwargs
+        self._global_prefix = (envs.DB_REDIS_PREFIX or "").strip()
+
+    def _prefixed_key(self, key: str) -> str:
+        if not self._global_prefix:
+            return key
+        return f"{self._global_prefix}:{key}"
+
+    def _strip_prefixed_key(self, key: str) -> str:
+        if not self._global_prefix:
+            return key
+        prefix = f"{self._global_prefix}:"
+        if key.startswith(prefix):
+            return key[len(prefix) :]
+        return key
 
     def get_type(self) -> StorageType:
         """Get the type of storage.
@@ -173,6 +188,10 @@ class RedisStorage(BaseStorage2):
 
         # Parse hierarchical key
         parent_key, item_key = self._parse_hierarchical_key(key)
+        storage_key = self._prefixed_key(key)
+        storage_parent_key = (
+            self._prefixed_key(parent_key) if parent_key is not None else None
+        )
 
         # Prepare Redis SET options from PutObjectOptions
         redis_ex = None
@@ -191,7 +210,12 @@ class RedisStorage(BaseStorage2):
 
         # Store the actual data with options
         result = await redis_client.set(
-            key, data_bytes, ex=redis_ex, px=redis_px, nx=redis_nx, xx=redis_xx
+            storage_key,
+            data_bytes,
+            ex=redis_ex,
+            px=redis_px,
+            nx=redis_nx,
+            xx=redis_xx,
         )
 
         # Check if the SET operation succeeded
@@ -206,7 +230,7 @@ class RedisStorage(BaseStorage2):
         # index needs to mirror it on overwrite.
         timestamp = time.time()
         global_timestamp_added = await redis_client.zadd(
-            "timestamps:all", {key: timestamp}, nx=True
+            self._prefixed_key("timestamps:all"), {storage_key: timestamp}, nx=True
         )
 
         # If hierarchical, add to parent list and track timestamp
@@ -219,16 +243,22 @@ class RedisStorage(BaseStorage2):
                 # ``timestamps:all``. Re-applying the parent ZADD keeps the
                 # hierarchical ordering index aligned and repairs partial drift
                 # from interrupted writes or manual Redis changes.
-                existing_timestamp = await redis_client.zscore("timestamps:all", key)
+                existing_timestamp = await redis_client.zscore(
+                    self._prefixed_key("timestamps:all"), storage_key
+                )
                 if existing_timestamp is None:
                     raise RuntimeError(
-                        f"Redis timestamps:all lost score for existing key {key!r}"
+                        f"Redis timestamps:all lost score for existing key {storage_key!r}"
                     )
                 timestamp = float(existing_timestamp)
             # Add item to parent list (only if not already present)
-            await redis_client.sadd(f"{parent_key}:index", item_key)
+            assert storage_parent_key is not None
+            await redis_client.sadd(f"{storage_parent_key}:index", item_key)
             # Also track timestamp for hierarchical objects
-            await redis_client.zadd(f"timestamps:{parent_key}", {item_key: timestamp})
+            await redis_client.zadd(
+                self._prefixed_key(f"timestamps:{parent_key}"),
+                {item_key: timestamp},
+            )
 
         return True
 
@@ -253,7 +283,7 @@ class RedisStorage(BaseStorage2):
         """
         redis_client = await self._get_redis()
 
-        data = await redis_client.get(key)
+        data = await redis_client.get(self._prefixed_key(key))
         if data is None:
             raise FileNotFoundError(f"Object not found: {key}")
         if isinstance(data, str):
@@ -280,17 +310,24 @@ class RedisStorage(BaseStorage2):
 
         # Parse hierarchical key
         parent_key, item_key = self._parse_hierarchical_key(key)
+        storage_key = self._prefixed_key(key)
+        storage_parent_key = (
+            self._prefixed_key(parent_key) if parent_key is not None else None
+        )
 
         # Delete the actual data
-        await redis_client.delete(key)
+        await redis_client.delete(storage_key)
 
         # Clean up timestamp tracking
-        await redis_client.zrem("timestamps:all", key)
+        await redis_client.zrem(self._prefixed_key("timestamps:all"), storage_key)
 
         # If hierarchical, remove from parent list and timestamps
         if parent_key is not None:
-            await redis_client.srem(f"{parent_key}:index", item_key)
-            await redis_client.zrem(f"timestamps:{parent_key}", item_key)
+            assert storage_parent_key is not None
+            await redis_client.srem(f"{storage_parent_key}:index", item_key)
+            await redis_client.zrem(
+                self._prefixed_key(f"timestamps:{parent_key}"), item_key
+            )
 
     async def list_objects(
         self,
@@ -338,10 +375,10 @@ class RedisStorage(BaseStorage2):
             hierarchical_prefix = f"{prefix}{delimiter}"
 
         # Check if this prefix corresponds to a list index
-        list_key = f"{parent_prefix}:index"
+        list_key = self._prefixed_key(f"{parent_prefix}:index")
         if await redis_client.exists(list_key):
             # Get members ordered by timestamp from the sorted set
-            timestamp_key = f"timestamps:{parent_prefix}"
+            timestamp_key = self._prefixed_key(f"timestamps:{parent_prefix}")
             members: list[str]
             if await redis_client.exists(timestamp_key):
                 if continuation_token is None and after_key:
@@ -410,12 +447,16 @@ class RedisStorage(BaseStorage2):
         if prefix:
             # For prefix searches, get all keys from timestamp sorted set and filter
             all_keys_with_timestamps = await self._zrange_by_list_order(
-                redis_client, "timestamps:all", 0, -1, withscores=False
+                redis_client,
+                self._prefixed_key("timestamps:all"),
+                0,
+                -1,
+                withscores=False,
             )
 
             filtered_keys = []
             for key_bytes in all_keys_with_timestamps:
-                key_str = key_bytes.decode("utf-8")
+                key_str = self._strip_prefixed_key(key_bytes.decode("utf-8"))
                 # Filter by prefix and exclude internal keys
                 if (
                     key_str.startswith(prefix)
@@ -440,11 +481,15 @@ class RedisStorage(BaseStorage2):
             # For no prefix, get all keys first, then filter and paginate
             # This ensures consistent pagination even when internal keys are present
             all_keys_with_timestamps = await self._zrange_by_list_order(
-                redis_client, "timestamps:all", 0, -1, withscores=False
+                redis_client,
+                self._prefixed_key("timestamps:all"),
+                0,
+                -1,
+                withscores=False,
             )
             all_user_keys = []
             for key_bytes in all_keys_with_timestamps:
-                key_str = key_bytes.decode("utf-8")
+                key_str = self._strip_prefixed_key(key_bytes.decode("utf-8"))
                 # Exclude internal keys
                 if not key_str.endswith(":index") and not key_str.startswith(
                     "timestamps:"
@@ -497,7 +542,7 @@ class RedisStorage(BaseStorage2):
             True if object exists, False otherwise
         """
         redis_client = await self._get_redis()
-        return bool(await redis_client.exists(key))
+        return bool(await redis_client.exists(self._prefixed_key(key)))
 
     async def get_object_size(self, key: str) -> int:
         """Get object size in bytes.
@@ -513,10 +558,11 @@ class RedisStorage(BaseStorage2):
         """
         redis_client = await self._get_redis()
 
-        size = await redis_client.strlen(key)
+        storage_key = self._prefixed_key(key)
+        size = await redis_client.strlen(storage_key)
         if size == 0:
             # Check if key actually exists
-            if not await redis_client.exists(key):
+            if not await redis_client.exists(storage_key):
                 raise FileNotFoundError(f"Object not found: {key}")
 
         return size

--- a/python/aibrix/aibrix/storage/redis_upgrade.py
+++ b/python/aibrix/aibrix/storage/redis_upgrade.py
@@ -87,6 +87,18 @@ def _remap_batch_metastore_key_to_v3(key: str) -> str:
     return key
 
 
+def _status_copy_parent_keys_for_cleanup(*keys: str) -> set[str]:
+    parent_keys: set[str] = set()
+    for key in keys:
+        if not key.startswith(_OLD_BATCH_STATUS_COPIES_PREFIX):
+            continue
+        slash_index = key.find("/")
+        while slash_index != -1:
+            parent_keys.add(key[:slash_index])
+            slash_index = key.find("/", slash_index + 1)
+    return parent_keys
+
+
 async def verify_redis_storage_v3(redis_client: Any) -> None:
     """Validate that Redis storage indexes match the v3 invariants.
 
@@ -111,6 +123,12 @@ async def verify_redis_storage_v3(redis_client: Any) -> None:
         if migrated_key != key:
             raise RuntimeError(
                 f"Redis storage v3 verification failed: legacy key still present {key!r}"
+            )
+
+        if key.startswith(_OLD_BATCH_STATUS_COPIES_PREFIX):
+            raise RuntimeError(
+                "Redis storage v3 verification failed: batch status copy entries "
+                f"must be removed during upgrade, found {key!r}"
             )
 
         if "/" not in key:
@@ -213,6 +231,7 @@ async def upgrade_redis_storage_to_v3(redis_client: Any) -> None:
     global_mapping: dict[str, float] = {}
     parent_mappings: dict[str, dict[str, float]] = {}
     parent_members: dict[str, set[str]] = {}
+    status_copy_parent_keys: set[str] = set()
 
     for member, score in timestamp_entries:
         key = _decode_redis_value(member)
@@ -220,6 +239,15 @@ async def upgrade_redis_storage_to_v3(redis_client: Any) -> None:
             continue
         migrated_key = _remap_batch_metastore_key_to_v3(key)
         normalized_score = _normalize_created_at_score(float(score))
+        if migrated_key.startswith(_OLD_BATCH_STATUS_COPIES_PREFIX):
+            status_copy_parent_keys.update(
+                _status_copy_parent_keys_for_cleanup(key, migrated_key)
+            )
+            if key != migrated_key:
+                await redis_client.delete(key, migrated_key)
+            else:
+                await redis_client.delete(key)
+            continue
 
         if migrated_key != key:
             payload = await redis_client.get(key)
@@ -245,6 +273,9 @@ async def upgrade_redis_storage_to_v3(redis_client: Any) -> None:
     await redis_client.delete("timestamps:all")
     for score_chunk in _chunk_mapping(global_mapping, _ZADD_CHUNK_SIZE):
         await redis_client.zadd("timestamps:all", score_chunk)
+
+    for parent_key in status_copy_parent_keys:
+        await redis_client.delete(f"{parent_key}:index", f"timestamps:{parent_key}")
 
     for parent_key, mapping in parent_mappings.items():
         await redis_client.delete(f"{parent_key}:index", f"timestamps:{parent_key}")

--- a/python/aibrix/aibrix/storage/utils.py
+++ b/python/aibrix/aibrix/storage/utils.py
@@ -16,6 +16,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
+from urllib.parse import quote
 
 from aibrix.metadata.core import AsyncLoopThread
 
@@ -135,8 +136,9 @@ def _sanitize_key(key: str) -> str:
         ):
             parts.append(part)
 
-    # Join with forward slashes (will be handled properly by pathlib)
-    sanitized = "/".join(parts)
+    # Percent-encode each path segment so hierarchical keys still map to
+    # subfolders while filesystem-hostile characters like ":" remain portable.
+    sanitized = "/".join(quote(part, safe="._-@+()[]{}~") for part in parts)
 
     # If the original key was empty or only contained dangerous patterns, use a safe default
     if not sanitized:

--- a/python/aibrix/tests/batch/conftest.py
+++ b/python/aibrix/tests/batch/conftest.py
@@ -13,9 +13,14 @@
 # limitations under the License.
 
 import argparse
+import asyncio
 import copy
 import json
 import os
+import re
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
@@ -28,6 +33,8 @@ from kubernetes import client, config
 
 import aibrix.batch.job_driver.runtime.k8s_deployment as deployment_runtime_module
 import aibrix.batch.job_driver.runtime.k8s_job as k8s_job_runtime_module
+import aibrix.client.redis as redis_client
+from aibrix import envs
 from aibrix.batch.client.sources import NoopEndpointSource
 from aibrix.batch.job_driver.base import BaseJobDriver
 from aibrix.batch.job_driver.runtime import ExternalRuntime
@@ -119,27 +126,75 @@ def s3_config_available():
 
 
 @pytest.fixture(scope="session")
-def redis_config_available():
-    """Check if S3 configuration is available locally."""
-    # Check for AWS credentials
-    if os.getenv("REDIS_HOST") is None:
-        pytest.skip("Redis configuration not available")
-
-    import redis
-
+def redis_available():
+    """Test whether Redis connectivity is available for batch tests."""
     try:
-        client = redis.Redis(
-            host=os.environ.get("REDIS_HOST", "localhost"),
-            port=int(os.environ.get("REDIS_PORT", "6379")),
-            db=int(os.environ.get("REDIS_DB", "0")),
-            password=os.environ.get("REDIS_PASSWORD"),
-            socket_connect_timeout=2,
-            socket_timeout=2,
-            decode_responses=True,
-        )
-        client.ping()
-    except Exception as e:
-        pytest.skip(f"Redis access not available: {e}")
+
+        def verify_connection():
+            async def ping():
+                client = redis_client.get_redis_client(test=True)
+                try:
+                    return await client.ping()
+                finally:
+                    await client.aclose()
+
+            return asyncio.run(ping())
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(verify_connection)
+            try:
+                ping_result = future.result(timeout=10)
+                if not ping_result:
+                    raise RuntimeError(
+                        f"Redis ping returned unexpected falsy result: {ping_result!r}"
+                    )
+            except FutureTimeoutError as ex:
+                pytest.skip(
+                    "Redis access not available: Redis connectivity check timed out after 10 seconds "
+                    f"({type(ex).__name__})"
+                )
+            except Exception as ex:  # noqa: BLE001
+                pytest.skip(f"Redis access not available: {ex}")
+    except ImportError as ex:
+        pytest.skip(f"Redis access not available: {ex}")
+    except Exception as ex:  # noqa: BLE001
+        pytest.skip(f"Redis access not available: {ex}")
+
+
+async def _delete_prefixed_redis_keys(redis_prefix: str) -> int:
+    client = redis_client.get_redis_client(test=True)
+    try:
+        timestamps_all_key = f"{redis_prefix}:timestamps:all"
+        timestamp_members = await client.zrange(timestamps_all_key, 0, -1)
+        object_keys = [
+            member.decode("utf-8") if isinstance(member, bytes) else str(member)
+            for member in timestamp_members
+        ]
+
+        cleanup_keys = {timestamps_all_key}
+        for object_key in object_keys:
+            cleanup_keys.add(object_key)
+            relative_key = object_key.removeprefix(f"{redis_prefix}:")
+            if "/" not in relative_key:
+                continue
+            parent_key, _ = relative_key.rsplit("/", 1)
+            cleanup_keys.add(f"{redis_prefix}:{parent_key}:index")
+            cleanup_keys.add(f"{redis_prefix}:timestamps:{parent_key}")
+
+        if cleanup_keys:
+            await client.delete(*sorted(cleanup_keys))
+        return len(cleanup_keys)
+    finally:
+        await client.aclose()
+
+
+def cleanup_test_redis_prefix(redis_prefix: str) -> None:
+    deleted = asyncio.run(_delete_prefixed_redis_keys(redis_prefix))
+    logger.info(  # type: ignore[call-arg]
+        "Cleaned test Redis prefix",
+        redis_prefix=redis_prefix,
+        deleted_keys=deleted,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -698,6 +753,8 @@ class E2ETestBackend(str):
     features: frozenset[str]
     runtime_debug_config: Optional[dict[str, str]]
     max_concurrency: int
+    storage_type: StorageType
+    metastore_type: StorageType
 
     def __new__(
         cls,
@@ -707,6 +764,8 @@ class E2ETestBackend(str):
         features: tuple[str, ...] = (),
         runtime_debug_config: Optional[dict[str, str]] = None,
         max_concurrency: int = 1,
+        storage_type: StorageType = StorageType.LOCAL,
+        metastore_type: StorageType = StorageType.LOCAL,
     ):
         backend = str.__new__(cls, name)
         backend.request_kwargs = dict(request_kwargs or {})
@@ -715,10 +774,25 @@ class E2ETestBackend(str):
             dict(runtime_debug_config) if runtime_debug_config is not None else None
         )
         backend.max_concurrency = max_concurrency
+        backend.storage_type = storage_type
+        backend.metastore_type = metastore_type
         return backend
 
     def has_feature(self, feature: str) -> bool:
         return feature in self.features
+
+    def with_metastore(self, metastore_type: StorageType) -> "E2ETestBackend":
+        if self.metastore_type == metastore_type:
+            return self
+        return type(self)(
+            str(self),
+            request_kwargs=self.request_kwargs,
+            features=tuple(self.features),
+            runtime_debug_config=self.runtime_debug_config,
+            max_concurrency=self.max_concurrency,
+            storage_type=self.storage_type,
+            metastore_type=metastore_type,
+        )
 
     @property
     def support_runtime(self) -> bool:
@@ -728,9 +802,41 @@ class E2ETestBackend(str):
     def fake_runtime(self) -> bool:
         return self.has_feature("fake_runtime")
 
+    @property
+    def uses_runtime(self) -> bool:
+        return "_using_" in str(self)
+
+    @property
+    def runtime_name(self) -> Optional[str]:
+        if not self.uses_runtime:
+            return None
+        return str(self).split("_using_", 1)[1]
+
+    @property
+    def dry_run(self) -> bool:
+        return not self.uses_runtime
+
+    @property
+    def requires_fake_runtime(self) -> bool:
+        return self.uses_runtime and (
+            self.storage_type == StorageType.LOCAL
+            or self.metastore_type == StorageType.LOCAL
+        )
+
+    @property
+    def pytest_id(self) -> str:
+        parts = [str(self)]
+        if self.storage_type != StorageType.LOCAL:
+            parts.append(f"{self.storage_type.value}_storage")
+        if self.metastore_type != StorageType.LOCAL:
+            parts.append(f"{self.metastore_type.value}_metastore")
+        return "_".join(parts)
+
 
 E2E_BACKENDS: dict[str, E2ETestBackend] = {
-    "local_metastore_job": E2ETestBackend("local_metastore_job"),
+    "local_metastore_job": E2ETestBackend(
+        "local_metastore_job",
+    ),
     "local_metastore_job_parallel": E2ETestBackend(
         "local_metastore_job_parallel",
         max_concurrency=5,
@@ -763,6 +869,25 @@ E2E_BACKENDS: dict[str, E2ETestBackend] = {
         },
         features=("support_runtime", "fake_runtime", "fake_provisioning_runtime"),
     ),
+    # Example backend configuration for implementing e2e Kubernetes Job tests.
+    # This documents the intended shape of a real k8s-job backend:
+    # TOS-backed storage with a Redis-backed metastore.
+    # NOTE: runtime_debug_config is intentionally omitted here. The deployment
+    # debug keys above are not correct for K8s Job. A developer should add a
+    # real fake/debug K8s Job backend first (for example, wiring BatchV1Api
+    # create/delete handles plus job-specific teardown/endpoint-source state
+    # into batch_driver._context.values), then set runtime_debug_config to
+    # those K8s Job-specific keys.
+    # "job_using_k8s_job": E2ETestBackend(
+    #     "job_using_k8s_job",
+    #     request_kwargs={
+    #         "aibrix_template": "mock-template",
+    #         "provider": "k8s_job",
+    #     },
+    #     features=("support_runtime"),
+    #     storage_type=StorageType.TOS,
+    #     metastore_type=StorageType.REDIS,
+    # ),
 }
 
 
@@ -774,6 +899,16 @@ def get_e2e_backend(test_backend: str | E2ETestBackend) -> E2ETestBackend:
 
 def backend_has_feature(test_backend: str | E2ETestBackend, feature: str) -> bool:
     return get_e2e_backend(test_backend).has_feature(feature)
+
+
+def apply_e2e_backend_keyword_overrides(
+    test_backend: E2ETestBackend, keyword: str
+) -> E2ETestBackend:
+    # Keyword modifiers are applied after base backend selection so they
+    # override whatever defaults the E2ETestBackend entry started with.
+    if "redis_metastore" in keyword:
+        test_backend = test_backend.with_metastore(StorageType.REDIS)
+    return test_backend
 
 
 def select_e2e_backends(
@@ -791,9 +926,11 @@ def select_e2e_backends(
             selected_backend = get_e2e_backend(backend)
             break
 
+    selected_backend = apply_e2e_backend_keyword_overrides(selected_backend, keyword)
+
     metafunc.parametrize(
         "test_backend",
-        [pytest.param(selected_backend, id=selected_backend)],
+        [pytest.param(selected_backend, id=selected_backend.pytest_id)],
     )
 
 
@@ -1002,53 +1139,64 @@ def build_e2e_test_app(
     test_backend: str | E2ETestBackend,
     tmp_path,
     monkeypatch,
-    *,
-    preserve_redis_prefix: bool = False,
 ):
     test_backend = get_e2e_backend(test_backend)
     monkeypatch.chdir(tmp_path)
-    del request, preserve_redis_prefix
-
-    if test_backend in {"local_metastore_job", "local_metastore_job_parallel"}:
-        app = create_test_app(
-            storage_type=StorageType.LOCAL,
-            metastore_type=StorageType.LOCAL,
-            dry_run=True,
-        )
-        app.state.metadata_store = MockMetadataStore()
-        app.state.redis_client = None
-        if test_backend == "local_metastore_job_parallel":
-            endpoint_source = ParallelNoopEndpointSource(
-                app.state.batch_driver._context,
-                capacity=test_backend.max_concurrency,
+    if (
+        test_backend.storage_type == StorageType.REDIS
+        or test_backend.metastore_type == StorageType.REDIS
+    ):
+        request.getfixturevalue("redis_available")
+        redis_prefix = getattr(request.node, "_aibrix_test_redis_prefix", None)
+        if redis_prefix is None:
+            node_id = re.sub(r"[^A-Za-z0-9_]+", "_", request.node.nodeid).strip("_")
+            redis_prefix = f"pytest_{node_id}_{uuid.uuid4().hex[:8]}"
+            setattr(request.node, "_aibrix_test_redis_prefix", redis_prefix)
+        if not getattr(request.node, "_aibrix_test_redis_cleanup_registered", False):
+            request.addfinalizer(
+                lambda prefix=redis_prefix: cleanup_test_redis_prefix(prefix)
             )
-            app.state.batch_driver._endpoint_source = endpoint_source
-            app.state.batch_driver.job_manager.set_endpoint_source(endpoint_source)
-        return app
+            setattr(request.node, "_aibrix_test_redis_cleanup_registered", True)
+        monkeypatch.setenv("DB_REDIS_PREFIX", redis_prefix)
+        monkeypatch.setattr(envs, "DB_REDIS_PREFIX", redis_prefix)
+    app = create_test_app(
+        storage_type=test_backend.storage_type,
+        metastore_type=test_backend.metastore_type,
+        dry_run=test_backend.dry_run,
+    )
+    app.state.metadata_store = MockMetadataStore()
+    app.state.redis_client = None
 
-    if test_backend == "local_job_using_deployment":
-        app = create_test_app(
-            storage_type=StorageType.LOCAL,
-            metastore_type=StorageType.LOCAL,
-            dry_run=False,
+    if test_backend == "local_metastore_job_parallel":
+        endpoint_source = ParallelNoopEndpointSource(
+            app.state.batch_driver._context,
+            capacity=test_backend.max_concurrency,
         )
-        app.state.metadata_store = MockMetadataStore()
-        app.state.redis_client = None
-        configure_local_metastore_deployment_backend(app, monkeypatch)
+        app.state.batch_driver._endpoint_source = endpoint_source
+        app.state.batch_driver.job_manager.set_endpoint_source(endpoint_source)
         return app
 
-    if test_backend == "local_job_using_k8s_job":
-        app = create_test_app(
-            storage_type=StorageType.LOCAL,
-            metastore_type=StorageType.LOCAL,
-            dry_run=False,
+    if not test_backend.uses_runtime:
+        return app
+
+    if test_backend.requires_fake_runtime:
+        if not test_backend.fake_runtime:
+            raise ValueError(
+                f"Backend {test_backend} must declare fake_runtime for local storage/metastore tests"
+            )
+
+        if test_backend.runtime_name == "deployment":
+            configure_local_metastore_deployment_backend(app, monkeypatch)
+            return app
+        elif test_backend.runtime_name == "k8s_job":
+            configure_local_metastore_k8s_job_backend(app, monkeypatch)
+            return app
+
+        raise ValueError(
+            f"Unsupported fake runtime backend: {test_backend.runtime_name}"
         )
-        app.state.metadata_store = MockMetadataStore()
-        app.state.redis_client = None
-        configure_local_metastore_k8s_job_backend(app, monkeypatch)
-        return app
 
-    raise ValueError(f"Unsupported e2e backend: {test_backend}")
+    return app
 
 
 @pytest.fixture(scope="function")

--- a/python/aibrix/tests/batch/test_base_job_driver.py
+++ b/python/aibrix/tests/batch/test_base_job_driver.py
@@ -51,6 +51,15 @@ def _make_driver(job: BatchJob) -> BaseJobDriver:
     return BaseJobDriver(SingleJobRunner(job), ExternalRuntime(None))
 
 
+def test_assign_worker_id_normalizes_runtime_owner_ref_slashes():
+    driver = BaseJobDriver(progress_manager=None)
+    driver._worker_token = "token1234"
+
+    worker_id = driver._assign_worker_id("cluster-a/default/workload-1")
+
+    assert worker_id == "cluster-a-default-workload-1-token1234"
+
+
 class _DeadlineStopRuntime:
     provisions = True
 

--- a/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
+++ b/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
@@ -97,6 +97,28 @@ def backend_expect_runtime_teardown(test_backend) -> bool:
     return _backend(test_backend).fake_runtime
 
 
+def backend_uses_redis_metastore(test_backend) -> bool:
+    return _backend(test_backend).metastore_type.value == "redis"
+
+
+def backend_status_wait_kwargs(
+    test_backend, *, expected_status: str
+) -> dict[str, float | int]:
+    if not backend_uses_redis_metastore(test_backend):
+        return {}
+    if expected_status == "in_progress":
+        return {"max_polls": 60, "poll_interval": 0.5}
+    if expected_status in {"completed", "cancelled"}:
+        return {"max_polls": 240, "poll_interval": 0.5}
+    return {}
+
+
+def backend_prepare_entry_timeout_seconds(test_backend) -> float:
+    if backend_uses_redis_metastore(test_backend):
+        return 20.0
+    return 5.0
+
+
 def backend_expect_exact_request_counts(test_backend) -> bool:
     return _backend(test_backend).max_concurrency == 1
 
@@ -1017,10 +1039,24 @@ async def run_follow_up_success_with_same_input(
 
     try:
         await wait_for_status(
-            client, batch_id, "in_progress", max_polls=30, poll_interval=0.5
+            client,
+            batch_id,
+            "in_progress",
+            **(
+                {"max_polls": 30, "poll_interval": 0.5}
+                | backend_status_wait_kwargs(
+                    test_backend, expected_status="in_progress"
+                )
+            ),
         )
         final_status = await wait_for_status(
-            client, batch_id, "completed", max_polls=60, poll_interval=0.5
+            client,
+            batch_id,
+            "completed",
+            **(
+                {"max_polls": 60, "poll_interval": 0.5}
+                | backend_status_wait_kwargs(test_backend, expected_status="completed")
+            ),
         )
 
         validate_batch_response_with_runtime_teardown(
@@ -1083,7 +1119,6 @@ async def complete_job_after_restart(
         test_backend,
         tmp_path,
         monkeypatch,
-        preserve_redis_prefix=True,
     )
     restarted_debug_state = capture_runtime_debug_state(restarted_app, test_backend)
     try:
@@ -1234,8 +1269,20 @@ async def test_job_success_baseline(e2e_test_app, test_backend):
         batch_id = create_batch_job(client, input_file_id, test_backend=test_backend)
 
         try:
-            await wait_for_status(client, batch_id, "in_progress")
-            final_status = await wait_for_status(client, batch_id, "completed")
+            await wait_for_status(
+                client,
+                batch_id,
+                "in_progress",
+                **backend_status_wait_kwargs(
+                    test_backend, expected_status="in_progress"
+                ),
+            )
+            final_status = await wait_for_status(
+                client,
+                batch_id,
+                "completed",
+                **backend_status_wait_kwargs(test_backend, expected_status="completed"),
+            )
 
             validate_batch_response_with_runtime_teardown(
                 final_status,
@@ -1661,7 +1708,10 @@ async def test_job_cancellation_in_progress_before_preparation(
 
             try:
                 # Step 3: Wait until the job is pinned inside prepare_job
-                await asyncio.wait_for(entered_preparation.wait(), timeout=5)
+                await asyncio.wait_for(
+                    entered_preparation.wait(),
+                    timeout=backend_prepare_entry_timeout_seconds(test_backend),
+                )
 
                 # Step 4: Verify the job is pending in progress before preparation completes
                 status_during_prepare = client.get(f"/v1/batches/{batch_id}")
@@ -1676,7 +1726,15 @@ async def test_job_cancellation_in_progress_before_preparation(
                 release_preparation.set()
 
                 final_status = await wait_for_status(
-                    client, batch_id, "cancelled", max_polls=40, poll_interval=0.5
+                    client,
+                    batch_id,
+                    "cancelled",
+                    **(
+                        {"max_polls": 40, "poll_interval": 0.5}
+                        | backend_status_wait_kwargs(
+                            test_backend, expected_status="cancelled"
+                        )
+                    ),
                 )
 
                 # Step 7: Verify cancelled status using comprehensive validation

--- a/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
+++ b/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
@@ -581,6 +581,7 @@ async def wait_for_status(
     client: TestClient,
     batch_id: str,
     expected_status: str,
+    *,
     extra_expected_fields: Optional[Union[str, List[str]]] = None,
     max_polls: int = 20,
     poll_interval: float = 0.5,
@@ -1036,27 +1037,31 @@ async def run_follow_up_success_with_same_input(
 ) -> None:
     debug_state = capture_runtime_debug_state(e2e_test_app, test_backend)
     batch_id = create_batch_job(client, input_file_id, test_backend=test_backend)
+    in_progress_wait_kwargs = {
+        "max_polls": 30,
+        "poll_interval": 0.5,
+        **backend_status_wait_kwargs(test_backend, expected_status="in_progress"),
+    }
+    completed_wait_kwargs = {
+        "max_polls": 60,
+        "poll_interval": 0.5,
+        **backend_status_wait_kwargs(test_backend, expected_status="completed"),
+    }
 
     try:
         await wait_for_status(
             client,
             batch_id,
             "in_progress",
-            **(
-                {"max_polls": 30, "poll_interval": 0.5}
-                | backend_status_wait_kwargs(
-                    test_backend, expected_status="in_progress"
-                )
-            ),
+            max_polls=int(in_progress_wait_kwargs["max_polls"]),
+            poll_interval=float(in_progress_wait_kwargs["poll_interval"]),
         )
         final_status = await wait_for_status(
             client,
             batch_id,
             "completed",
-            **(
-                {"max_polls": 60, "poll_interval": 0.5}
-                | backend_status_wait_kwargs(test_backend, expected_status="completed")
-            ),
+            max_polls=int(completed_wait_kwargs["max_polls"]),
+            poll_interval=float(completed_wait_kwargs["poll_interval"]),
         )
 
         validate_batch_response_with_runtime_teardown(

--- a/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
+++ b/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
@@ -201,7 +201,7 @@ def pytest_generate_tests(metafunc):
         [
             "local_metastore_job_parallel",
             "local_job_using_deployment",
-            "k8s_job",
+            "local_job_using_k8s_job",
         ],
         default_backend="local_metastore_job",
     )

--- a/python/aibrix/tests/batch/test_job_store.py
+++ b/python/aibrix/tests/batch/test_job_store.py
@@ -26,6 +26,7 @@ from aibrix.batch.job_entity import (
     BatchJobEndpoint,
     BatchJobSpec,
     BatchJobState,
+    BatchJobStatusCopy,
     CompletionWindow,
     Condition,
     ConditionStatus,
@@ -165,6 +166,49 @@ async def test_job_store_submit_persists_to_metastore_and_fires_committed(
     assert persisted_job is not None
     assert persisted_job.job_id == committed_job.job_id
     assert [job.job_id for job in listed_jobs] == [committed_job.job_id]
+
+
+@pytest.mark.asyncio
+async def test_status_copy_worker_id_encoding_is_reversible(monkeypatch):
+    store = FakeMetastore()
+    monkeypatch.setattr(batch_metastore, "p_metastore", store)
+
+    job = BatchJob.new_local(spec=_spec(), request_count=1)
+    assert job.job_id is not None
+    job.status.state = BatchJobState.IN_PROGRESS
+    job.status.status_copies = {
+        "cluster-a/default/workload-1": BatchJobStatusCopy(
+            state=BatchJobState.IN_PROGRESS,
+            updated=True,
+        )
+    }
+
+    await batch_metastore.put_batch_job(job.job_id, job)
+
+    status_copy_keys = [
+        key
+        for key in store.objects
+        if key.startswith(f"batchstatus_copies:{job.job_id}/")
+    ]
+    assert status_copy_keys == [
+        f"batchstatus_copies:{job.job_id}/cluster-a%2Fdefault%2Fworkload-1"
+    ]
+
+    loaded = await batch_metastore.get_batch_job(job.job_id)
+
+    assert loaded is not None
+    assert loaded.status.status_copies is not None
+    assert list(loaded.status.status_copies) == ["cluster-a/default/workload-1"]
+    assert (
+        batch_metastore._normalize_status_copy_worker_id("cluster-a/default/workload-1")
+        == "cluster-a%2Fdefault%2Fworkload-1"
+    )
+    assert (
+        batch_metastore._decode_status_copy_worker_id(
+            "cluster-a%2Fdefault%2Fworkload-1"
+        )
+        == "cluster-a/default/workload-1"
+    )
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/batch/test_k8s_deployment_runtime.py
+++ b/python/aibrix/tests/batch/test_k8s_deployment_runtime.py
@@ -285,7 +285,7 @@ async def test_k8s_deployment_runtime_builds_execution_ref_with_current_payload_
 
     assert execution is not None
     assert execution.driver_type == "k8s-deployment"
-    assert execution.owner_ref == "default/rendered-deployment"
+    assert execution.owner_ref == "default:rendered-deployment"
     assert execution.reconnect_payload == {
         "namespace": "default",
         "deploymentName": "rendered-deployment",
@@ -307,7 +307,7 @@ async def test_k8s_deployment_runtime_reconnect_accepts_current_payload_keys():
         job.job_id,
         JobRuntimeRef(
             driverType="k8s-deployment",
-            ownerRef="default/rendered-deployment",
+            ownerRef="default:rendered-deployment",
             reconnectPayload={
                 "namespace": "default",
                 "deploymentName": "rendered-deployment",

--- a/python/aibrix/tests/batch/test_k8s_job_runtime.py
+++ b/python/aibrix/tests/batch/test_k8s_job_runtime.py
@@ -96,7 +96,7 @@ async def test_build_runtime_ref_uses_job_handle_metadata():
 
     assert runtime_ref is not None
     assert runtime_ref.driver_type == "k8s-job"
-    assert runtime_ref.owner_ref == "ns-x/batch-job-1"
+    assert runtime_ref.owner_ref == "ns-x:batch-job-1"
     assert runtime_ref.reconnect_payload == {
         "namespace": "ns-x",
         "jobName": "batch-job-1",

--- a/python/aibrix/tests/storage/test_local_storage.py
+++ b/python/aibrix/tests/storage/test_local_storage.py
@@ -218,6 +218,50 @@ class TestLocalStorage:
             await local_storage.delete_object(key)
 
     @pytest.mark.asyncio
+    async def test_hierarchical_keys_with_colon_parent_are_supported(
+        self, local_storage: LocalStorage
+    ):
+        key = "batchstatus_copies:job-1/cluster-a"
+
+        await local_storage.put_object(key, b"payload")
+
+        objects, _ = await local_storage.list_objects(
+            prefix="batchstatus_copies:job-1/",
+            delimiter="/",
+        )
+        assert objects == [key]
+        assert await local_storage.object_exists(key)
+
+        await local_storage.delete_object(key)
+
+    @pytest.mark.asyncio
+    async def test_recursive_list_preserves_nested_subfolders(
+        self, local_storage: LocalStorage
+    ):
+        key = "batchstatus_copies:job-1/cluster-a/default/workload-1"
+
+        await local_storage.put_object(key, b"payload")
+
+        objects, _ = await local_storage.list_objects(
+            prefix="batchstatus_copies:job-1/",
+        )
+        assert objects == [key]
+
+        objects, _ = await local_storage.list_objects(
+            prefix="batchstatus_copies:job-1/cluster-a/",
+        )
+        assert objects == [key]
+
+        objects, _ = await local_storage.list_objects(
+            prefix="batchstatus_copies:job-1/cluster-a/default/",
+        )
+        assert objects == [key]
+
+        assert await local_storage.object_exists(key)
+
+        await local_storage.delete_object(key)
+
+    @pytest.mark.asyncio
     async def test_concurrent_operations(self, local_storage: LocalStorage):
         """Test concurrent read/write operations."""
         import asyncio

--- a/python/aibrix/tests/storage/test_redis_storage.py
+++ b/python/aibrix/tests/storage/test_redis_storage.py
@@ -27,6 +27,7 @@ from aibrix.storage.redis_upgrade import (
     REDIS_STORAGE_VERSION_V2,
     ensure_redis_storage_version,
     get_redis_storage_version,
+    upgrade_redis_storage_to_v3,
     verify_redis_storage_v3,
 )
 from aibrix.storage.types import StorageListOrdering
@@ -576,22 +577,60 @@ async def test_ensure_redis_storage_version_upgrades_v2_batch_keys_to_v3(monkeyp
         == b'{"job_id":"job-a"}'
     )
     assert "batchstatus_copies:job-a:worker-1" not in fake_redis.objects
-    assert (
-        fake_redis.objects["batchstatus_copies:job-a/worker-1"]
-        == fake_redis.values["batchstatus_copies:job-a/worker-1"]
-        == b'{"state":"running"}'
-    )
     assert fake_redis.zsets["timestamps:all"] == {
         "batchjob/job-a": 100.0,
-        "batchstatus_copies:job-a/worker-1": 90.0,
         "other:key": 50.0,
     }
     assert fake_redis.sets["batchjob:index"] == {"job-a"}
     assert fake_redis.zsets["timestamps:batchjob"] == {"job-a": 100.0}
-    assert fake_redis.sets["batchstatus_copies:job-a:index"] == {"worker-1"}
-    assert fake_redis.zsets["timestamps:batchstatus_copies:job-a"] == {"worker-1": 90.0}
+    assert "batchstatus_copies:job-a/worker-1" not in fake_redis.objects
+    assert "batchstatus_copies:job-a:index" not in fake_redis.sets
+    assert "timestamps:batchstatus_copies:job-a" not in fake_redis.zsets
 
     await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_upgrade_redis_storage_to_v3_removes_slash_worker_id_indexes():
+    fake_redis = _FakeRedisForUpgrade()
+    fake_redis.objects = {
+        "batchstatus_copies:job-a/cluster-a/default/workload-1": b'{"state":"running"}'
+    }
+    fake_redis.values.update(fake_redis.objects)
+    fake_redis.zsets = {
+        "timestamps:all": {
+            "batchstatus_copies:job-a/cluster-a/default/workload-1": -90.0,
+        },
+        "timestamps:batchstatus_copies:job-a": {
+            "cluster-a/default/workload-1": -90.0,
+        },
+        "timestamps:batchstatus_copies:job-a/cluster-a": {
+            "default/workload-1": -90.0,
+        },
+    }
+    fake_redis.sets = {
+        "batchstatus_copies:job-a:index": {"cluster-a/default/workload-1"},
+        "batchstatus_copies:job-a/cluster-a:index": {"default/workload-1"},
+    }
+
+    await upgrade_redis_storage_to_v3(fake_redis)
+
+    assert (
+        "batchstatus_copies:job-a/cluster-a/default/workload-1"
+        not in fake_redis.objects
+    )
+    assert (
+        "batchstatus_copies:job-a/cluster-a-default-workload-1"
+        not in fake_redis.objects
+    )
+    assert (
+        "timestamps:all" not in fake_redis.zsets
+        or fake_redis.zsets["timestamps:all"] == {}
+    )
+    assert "batchstatus_copies:job-a:index" not in fake_redis.sets
+    assert "batchstatus_copies:job-a/cluster-a:index" not in fake_redis.sets
+    assert "timestamps:batchstatus_copies:job-a" not in fake_redis.zsets
+    assert "timestamps:batchstatus_copies:job-a/cluster-a" not in fake_redis.zsets
 
 
 @pytest.mark.asyncio
@@ -600,19 +639,14 @@ async def test_verify_redis_storage_v3_accepts_consistent_indexes():
     fake_redis.zsets = {
         "timestamps:all": {
             "batchjob/job-a": 100.0,
-            "batchstatus_copies:job-a/worker-1": 90.0,
             "other:key": 50.0,
         },
         "timestamps:batchjob": {
             "job-a": 100.0,
         },
-        "timestamps:batchstatus_copies:job-a": {
-            "worker-1": 90.0,
-        },
     }
     fake_redis.sets = {
         "batchjob:index": {"job-a"},
-        "batchstatus_copies:job-a:index": {"worker-1"},
     }
 
     await verify_redis_storage_v3(fake_redis)
@@ -634,6 +668,19 @@ async def test_verify_redis_storage_v3_rejects_parent_index_mismatch():
     }
 
     with pytest.raises(RuntimeError, match="parent index mismatch"):
+        await verify_redis_storage_v3(fake_redis)
+
+
+@pytest.mark.asyncio
+async def test_verify_redis_storage_v3_rejects_status_copy_entries():
+    fake_redis = _FakeRedisForUpgrade()
+    fake_redis.zsets = {
+        "timestamps:all": {
+            "batchstatus_copies:job-a/cluster-a/default/workload-1": 90.0,
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="must be removed during upgrade"):
         await verify_redis_storage_v3(fake_redis)
 
 

--- a/python/aibrix/tests/storage/test_utils.py
+++ b/python/aibrix/tests/storage/test_utils.py
@@ -259,6 +259,10 @@ class TestSanitizeKey:
                 f"Expected {expected} but got {result} for {input_key}"
             )
 
+    def test_colons_are_percent_encoded_per_path_segment(self):
+        result = _sanitize_key("batchstatus_copies:job-1/cluster-a")
+        assert result == "batchstatus_copies%3Ajob-1/cluster-a"
+
     def test_tilde_handling(self):
         """Test handling of tilde characters in paths."""
         test_cases = [


### PR DESCRIPTION
## Pull Request Description
This PR improves batch status-copy keys for Redis-backed flows and aligns tests with the updated key model.

## Motivation

Worker IDs and status-copy keys can contain `/`, which collides with hierarchical storage semantics in both local and Redis-backed backends. Redis-backed tests also need stronger isolation and more tolerant polling to reflect asynchronous status propagation. This PR standardizes key encoding/normalization and adds the fixture/test support needed to validate it.

### What changed

- normalize runtime-derived worker IDs to avoid `/` leaking into storage keys
- switch Kubernetes runtime owner refs from `namespace/name` to `namespace:name`
- add Redis global-prefix support across object operations, indexes, and listing paths
- harden Redis v3 upgrade logic to remove legacy `batchstatus_copies` artifacts and their stale indexes
- add Redis-aware E2E backend setup, connectivity checks, per-test prefixes, and cleanup
- extend E2E wait/poll behavior for Redis-metastore runs to reduce timing-related flakes
- expand unit/integration coverage for encoded keys, owner refs, upgrade cleanup, and Redis-specific execution paths

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>