### PR TITLE
fix(autoscaler): reject HPA role subtargets

### DIFF
--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -422,6 +422,12 @@ func (r *PodAutoscalerReconciler) validateScalingStrategy(pa *autoscalingv1alpha
 	if !checkValidAutoscalingStrategy(pa.Spec.ScalingStrategy) {
 		return invalid(ReasonInvalidScalingStrategy, "Unsupported scalingStrategy; must be one of HPA/KPA/APA.")
 	}
+	if pa.Spec.ScalingStrategy == autoscalingv1alpha1.HPA &&
+		pa.Spec.SubTargetSelector != nil &&
+		pa.Spec.SubTargetSelector.RoleName != "" {
+		return invalid(ReasonInvalidScalingStrategy,
+			"subTargetSelector.roleName is not supported with scalingStrategy=HPA; use APA or KPA for StormService role-level autoscaling.")
+	}
 	return validOK()
 }
 

--- a/pkg/controller/podautoscaler/podautoscaler_controller_test.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller_test.go
@@ -136,6 +136,43 @@ func TestValidateMetricsSourcesRequiresTargetMetricForK8sExternalMetrics(t *test
 	}
 }
 
+func TestValidateSpecRejectsHPARoleSubtarget(t *testing.T) {
+	r := &PodAutoscalerReconciler{}
+	pa := &autoscalingv1alpha1.PodAutoscaler{
+		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+			ScaleTargetRef: corev1.ObjectReference{
+				Name: "test-stormservice",
+				Kind: "StormService",
+			},
+			SubTargetSelector: &autoscalingv1alpha1.SubTargetSelector{
+				RoleName: "decode",
+			},
+			MinReplicas:     ptr.To(int32(1)),
+			MaxReplicas:     5,
+			ScalingStrategy: autoscalingv1alpha1.HPA,
+			MetricsSources: []autoscalingv1alpha1.MetricSource{
+				{
+					MetricSourceType: autoscalingv1alpha1.RESOURCE,
+					TargetMetric:     "cpu",
+					TargetValue:      "50",
+				},
+			},
+		},
+	}
+
+	result := r.validateSpec(pa)
+
+	if result.Valid {
+		t.Fatal("expected HPA with subTargetSelector.roleName to be invalid")
+	}
+	if result.Reason != ReasonInvalidScalingStrategy {
+		t.Fatalf("expected reason=%s, got %s", ReasonInvalidScalingStrategy, result.Reason)
+	}
+	if result.Message != "subTargetSelector.roleName is not supported with scalingStrategy=HPA; use APA or KPA for StormService role-level autoscaling." {
+		t.Fatalf("unexpected message: %s", result.Message)
+	}
+}
+
 // ---- helpers ----
 
 func buildPod(ns, name string, lbls map[string]string) *corev1.Pod {

--- a/pkg/webhook/podautoscaler_webhook.go
+++ b/pkg/webhook/podautoscaler_webhook.go
@@ -155,6 +155,9 @@ func (v *PodAutoscalerCustomValidator) validatePodAutoscaler(pa *autoscalingv1al
 			string(autoscalingv1alpha1.APA),
 		}))
 	}
+	if err := validateHPARoleSubtarget(pa, specPath); err != nil {
+		allErrs = append(allErrs, err)
+	}
 
 	// 4. Validate MetricsSources
 	metricsPath := specPath.Child("metricsSources")
@@ -249,5 +252,18 @@ func (v *PodAutoscalerCustomValidator) validatePodAutoscaler(pa *autoscalingv1al
 		schema.GroupKind{Group: autoscalingv1alpha1.GroupVersion.Group, Kind: "PodAutoscaler"},
 		pa.Name,
 		allErrs,
+	)
+}
+
+func validateHPARoleSubtarget(pa *autoscalingv1alpha1.PodAutoscaler, specPath *field.Path) *field.Error {
+	if pa.Spec.ScalingStrategy != autoscalingv1alpha1.HPA ||
+		pa.Spec.SubTargetSelector == nil ||
+		pa.Spec.SubTargetSelector.RoleName == "" {
+		return nil
+	}
+
+	return field.Forbidden(
+		specPath.Child("subTargetSelector").Child("roleName"),
+		"not supported with scalingStrategy=HPA; use APA or KPA for StormService role-level autoscaling",
 	)
 }

--- a/pkg/webhook/podautoscaler_webhook_test.go
+++ b/pkg/webhook/podautoscaler_webhook_test.go
@@ -169,6 +169,29 @@ func TestPodAutoscalerCustomValidator_validatePodAutoscaler(t *testing.T) {
 			expectError: true,
 			errorMsg:    "must be a valid number",
 		},
+		"HPA Does Not Support Role Subtarget": {
+			pa: &autoscalingv1alpha1.PodAutoscaler{
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					ScaleTargetRef: corev1.ObjectReference{
+						Name: "test-stormservice",
+						Kind: "StormService",
+					},
+					SubTargetSelector: &autoscalingv1alpha1.SubTargetSelector{
+						RoleName: "decode",
+					},
+					ScalingStrategy: autoscalingv1alpha1.HPA,
+					MetricsSources: []autoscalingv1alpha1.MetricSource{
+						{
+							MetricSourceType: autoscalingv1alpha1.RESOURCE,
+							TargetMetric:     "cpu",
+							TargetValue:      "50",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "subTargetSelector",
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Reject `scalingStrategy: HPA` when `subTargetSelector.roleName` is set in controller fallback validation.
- Add the same admission webhook validation to prevent ineffective role-level HPA configs.
- Cover both validation paths with unit tests.

## Test Plan
- go test ./pkg/webhook ./pkg/controller/podautoscaler -count=1