### PR TITLE
fix(gateway): keep request stats bound to original pod

### DIFF
--- a/pkg/cache/cache_impl.go
+++ b/pkg/cache/cache_impl.go
@@ -213,7 +213,7 @@ func (c *Store) AddRequestCount(ctx *types.RoutingContext, requestID string, mod
 		return atomic.LoadInt64(&ctx.TraceTerm)
 	} else {
 		traceTerm = atomic.LoadInt64(&ctx.TraceTerm)
-		c.addPodStats(ctx, requestID)
+		c.addPodStats(ctx, requestID, modelName)
 	}
 	return traceTerm
 }
@@ -232,8 +232,8 @@ func (c *Store) DoneRequestCount(ctx *types.RoutingContext, requestID string, mo
 		// ignore traceTerm
 		tracker.DoneRequestCount(ctx, requestID, modelName, traceTerm)
 	}
-	if ctx != nil && ctx.CanDoneStats() {
-		c.donePodStats(ctx, requestID)
+	if ctx == nil || ctx.CanDoneStats() {
+		c.donePodStats(ctx, requestID, modelName)
 	}
 
 	meta, ok := c.metaModels.Load(modelName)
@@ -262,8 +262,8 @@ func (c *Store) DoneRequestTrace(ctx *types.RoutingContext, requestID string, mo
 		tracker.DoneRequestTrace(ctx, requestID, modelName, inputTokens, outputTokens, traceTerm)
 	}
 
-	if ctx != nil && ctx.CanDoneStats() {
-		c.donePodStats(ctx, requestID)
+	if ctx == nil || ctx.CanDoneStats() {
+		c.donePodStats(ctx, requestID, modelName)
 	}
 
 	meta, ok := c.metaModels.Load(modelName)

--- a/pkg/cache/cache_init.go
+++ b/pkg/cache/cache_init.go
@@ -84,8 +84,9 @@ type Store struct {
 	engineMetricsFetcher *metrics.EngineMetricsFetcher // Centralized typed metrics fetcher
 
 	// Request trace fields
-	enableTracing bool                                  // Default to load from enableGPUOptimizerTracing, can be configured.
-	requestTrace  *utils.SyncMap[string, *RequestTrace] // Request trace data (model_name -> *RequestTrace)
+	enableTracing bool                                   // Default to load from enableGPUOptimizerTracing, can be configured.
+	requestTrace  *utils.SyncMap[string, *RequestTrace]  // Request trace data (model_name -> *RequestTrace)
+	podStats      utils.SyncMap[string, *podStatsRecord] // Request stats data bound to request completion, not pod lifetime.
 
 	// Pod related storage
 	metaPods utils.SyncMap[string, *Pod] // pod_namespace/pod_name -> *Pod

--- a/pkg/cache/cache_request_tracker_test.go
+++ b/pkg/cache/cache_request_tracker_test.go
@@ -18,10 +18,13 @@ package cache
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // mockRequestTracker implements RequestTracker for testing
@@ -30,6 +33,27 @@ type mockRequestTracker struct {
 	doneCalled      bool
 	doneTraceCalled bool
 	lastCtx         *types.RoutingContext
+}
+
+func requestTrackerTestPod(name, namespace, model, ip string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				modelIdentifier: model,
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP: ip,
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodReady,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
 }
 
 func (m *mockRequestTracker) AddRequestCount(ctx *types.RoutingContext, requestID string, modelName string) int64 {
@@ -176,4 +200,116 @@ func TestContextCancellation_RealWorldScenario(t *testing.T) {
 			cache.DoneRequestCount(nil, "test-request", "test-model", 0)
 		}, "should handle nil context gracefully")
 	})
+}
+
+func TestDoneRequestCountAfterSameNamePodRecreationDoesNotDecrementNewPod(t *testing.T) {
+	const (
+		modelName = "test-model"
+		namespace = "default"
+		podName   = "decode-0"
+		requestID = "request-before-recreate"
+	)
+
+	cache := NewForTest()
+	oldPod := requestTrackerTestPod(podName, namespace, modelName, "10.0.0.1")
+	cache.addPod(oldPod)
+	oldMetaPod, ok := cache.metaPods.Load(namespace + "/" + podName)
+	assert.True(t, ok)
+
+	routingCtx := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+	routingCtx.SetTargetPod(oldPod)
+
+	traceTerm := cache.AddRequestCount(routingCtx, requestID, modelName)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&oldMetaPod.runningRequests))
+
+	cache.deletePod(oldPod)
+	newPod := requestTrackerTestPod(podName, namespace, modelName, "10.0.0.2")
+	cache.addPod(newPod)
+	newMetaPod, ok := cache.metaPods.Load(namespace + "/" + podName)
+	assert.True(t, ok)
+	assert.NotSame(t, oldMetaPod, newMetaPod)
+
+	cache.DoneRequestCount(routingCtx, requestID, modelName, traceTerm)
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&oldMetaPod.runningRequests))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&newMetaPod.runningRequests))
+}
+
+func TestDoneRequestWithNilContextCleansPreviouslyAddedPodStats(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		done func(cache *Store, requestID, modelName string, traceTerm int64)
+	}{
+		{
+			name: "DoneRequestCount",
+			done: func(cache *Store, requestID, modelName string, traceTerm int64) {
+				cache.DoneRequestCount(nil, requestID, modelName, traceTerm)
+			},
+		},
+		{
+			name: "DoneRequestTrace",
+			done: func(cache *Store, requestID, modelName string, traceTerm int64) {
+				cache.DoneRequestTrace(nil, requestID, modelName, 10, 20, traceTerm)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			const (
+				modelName = "test-model"
+				namespace = "default"
+				podName   = "decode-0"
+				requestID = "request-with-nil-done-context"
+			)
+
+			cache := NewForTest()
+			pod := requestTrackerTestPod(podName, namespace, modelName, "10.0.0.1")
+			cache.addPod(pod)
+			metaPod, ok := cache.metaPods.Load(namespace + "/" + podName)
+			assert.True(t, ok)
+
+			routingCtx := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+			routingCtx.SetTargetPod(pod)
+
+			traceTerm := cache.AddRequestCount(routingCtx, requestID, modelName)
+			assert.Equal(t, int32(1), atomic.LoadInt32(&metaPod.runningRequests))
+			assert.Equal(t, 1, cache.podStats.Len())
+
+			tt.done(cache, requestID, modelName, traceTerm)
+
+			assert.Equal(t, int32(0), atomic.LoadInt32(&metaPod.runningRequests))
+			assert.Equal(t, 0, cache.podStats.Len())
+		})
+	}
+}
+
+func TestDoubleCleanupOnlyDecrementsPodStatsOnce(t *testing.T) {
+	const (
+		modelName = "test-model"
+		namespace = "default"
+		podName   = "decode-0"
+		requestID = "request-with-double-cleanup"
+	)
+
+	cache := NewForTest()
+	pod := requestTrackerTestPod(podName, namespace, modelName, "10.0.0.1")
+	cache.addPod(pod)
+	metaPod, ok := cache.metaPods.Load(namespace + "/" + podName)
+	assert.True(t, ok)
+
+	routingCtx := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+	routingCtx.SetTargetPod(pod)
+
+	traceTerm := cache.AddRequestCount(routingCtx, requestID, modelName)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&metaPod.runningRequests))
+	assert.Equal(t, 1, cache.podStats.Len())
+
+	cache.DoneRequestTrace(routingCtx, requestID, modelName, 10, 20, traceTerm)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&metaPod.runningRequests))
+	assert.Equal(t, 0, cache.podStats.Len())
+
+	assert.NotPanics(t, func() {
+		cache.DoneRequestCount(routingCtx, requestID, modelName, traceTerm)
+	})
+	assert.Equal(t, int32(0), atomic.LoadInt32(&metaPod.runningRequests))
+	assert.Equal(t, 0, cache.podStats.Len())
 }

--- a/pkg/cache/cache_trace.go
+++ b/pkg/cache/cache_trace.go
@@ -34,6 +34,16 @@ const (
 	traceLogInterval                      = 1 * time.Second
 )
 
+type podStatsRecord struct {
+	pod         *Pod
+	port        int
+	pendingLoad float64
+}
+
+func podStatsKey(modelName, requestID string) string {
+	return modelName + "\x00" + requestID
+}
+
 func (c *Store) getRequestTrace(modelName string) *RequestTrace {
 	trace := NewRequestTrace(time.Now().UnixNano())
 	newer, loaded := c.requestTrace.LoadOrStore(modelName, trace)
@@ -45,7 +55,7 @@ func (c *Store) getRequestTrace(modelName string) *RequestTrace {
 	return newer
 }
 
-func (c *Store) addPodStats(ctx *types.RoutingContext, requestID string) {
+func (c *Store) addPodStats(ctx *types.RoutingContext, requestID string, modelName string) {
 	if !ctx.HasRouted() {
 		return
 	}
@@ -57,6 +67,7 @@ func (c *Store) addPodStats(ctx *types.RoutingContext, requestID string) {
 		klog.Warningf("can't find routing pod: %s, requestID: %s", pod.Name, requestID)
 		return
 	}
+	podStats := &podStatsRecord{pod: metaPod, port: port}
 
 	// Update running requests
 	requests := atomic.AddInt32(&metaPod.runningRequests, 1)
@@ -74,6 +85,7 @@ func (c *Store) addPodStats(ctx *types.RoutingContext, requestID string) {
 		var err error
 		ctx.PendingLoad, err = c.pendingLoadProvider.GetConsumption(ctx, pod)
 		if err == nil {
+			podStats.pendingLoad = ctx.PendingLoad
 			utilization = metaPod.pendingLoadUtilization.Add(ctx.PendingLoad)
 			if c.updatePodRecord(metaPod, "", metrics.RealtimeNormalizedPendings, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: utilization}) != nil {
 				klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s, err: %v", metrics.RealtimeNormalizedPendings, metaPod.Name, requestID, err)
@@ -82,25 +94,26 @@ func (c *Store) addPodStats(ctx *types.RoutingContext, requestID string) {
 			klog.Errorf("error on track request load consumption: %v", err)
 		}
 	}
+	c.podStats.Store(podStatsKey(modelName, requestID), podStats)
 
 	if metaPod.CanLogPodTrace(5) {
 		klog.V(4).InfoS("pod stats updated (addPodStats).", "pod", metaPod.Name, "requestID", ctx.RequestID, "running_requests", requests, "pending_util", utilization, "pending_load", ctx.PendingLoad)
 	}
 }
 
-func (c *Store) donePodStats(ctx *types.RoutingContext, requestID string) {
-	if !ctx.HasRouted() {
-		return
-	}
-	pod := ctx.TargetPod()
-	port := ctx.TargetPort()
-
-	// Now that pendingLoadProvider must be set.
-	metaPod, ok := c.metaPods.Load(utils.GeneratePodKey(pod.Namespace, pod.Name))
+func (c *Store) donePodStats(ctx *types.RoutingContext, requestID string, modelName string) {
+	podStats, ok := c.podStats.LoadAndDelete(podStatsKey(modelName, requestID))
 	if !ok {
-		klog.Warningf("can't find routing pod: %s, requestID: %s", pod.Name, requestID)
+		if ctx != nil {
+			pod := ctx.TargetPod()
+			if pod != nil {
+				klog.Warningf("can't find routing pod stats: %s, requestID: %s", pod.Name, requestID)
+			}
+		}
 		return
 	}
+	metaPod := podStats.pod
+	port := podStats.port
 
 	// Update running requests
 	requests := atomic.AddInt32(&metaPod.runningRequests, -1)
@@ -109,20 +122,20 @@ func (c *Store) donePodStats(ctx *types.RoutingContext, requestID string) {
 	if port > 0 {
 		metricName = metricName + "/" + strconv.Itoa(port)
 	}
-	if err := c.updatePodRecord(metaPod, ctx.Model, metricName, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: float64(requests)}); err != nil {
-		klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s", metrics.RealtimeNumRequestsRunning, pod.Name, requestID)
+	if err := c.updatePodRecord(metaPod, modelName, metricName, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: float64(requests)}); err != nil {
+		klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s", metrics.RealtimeNumRequestsRunning, metaPod.Name, requestID)
 	}
 
 	// Update pending load
 	var utilization float64
-	if ctx.PendingLoad != 0.0 {
-		utilization = metaPod.pendingLoadUtilization.Add(-ctx.PendingLoad)
-		if c.updatePodRecord(metaPod, ctx.Model, metrics.RealtimeNormalizedPendings, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: utilization}) != nil {
-			klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s", metrics.RealtimeNormalizedPendings, pod.Name, requestID)
+	if podStats.pendingLoad != 0.0 && c.pendingLoadProvider != nil {
+		utilization = metaPod.pendingLoadUtilization.Add(-podStats.pendingLoad)
+		if c.updatePodRecord(metaPod, modelName, metrics.RealtimeNormalizedPendings, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: utilization}) != nil {
+			klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s", metrics.RealtimeNormalizedPendings, metaPod.Name, requestID)
 		}
 		if utilization < c.pendingLoadProvider.Cap() {
 			// Notify queue router to try route with pending requests.
-			if metaModel, ok := c.metaModels.Load(ctx.Model); ok && metaModel.QueueRouter != nil {
+			if metaModel, ok := c.metaModels.Load(modelName); ok && metaModel.QueueRouter != nil {
 				// nolint: errcheck
 				metaModel.QueueRouter.Route(nil, metaModel.Pods.Array())
 			}
@@ -130,7 +143,7 @@ func (c *Store) donePodStats(ctx *types.RoutingContext, requestID string) {
 	}
 
 	if metaPod.CanLogPodTrace(5) {
-		klog.V(4).InfoS("pod stats updated (donePodStats).", "pod", metaPod.Name, "requestID", ctx.RequestID, "running_requests", requests, "pending_util", utilization, "pending_load", ctx.PendingLoad)
+		klog.V(4).InfoS("pod stats updated (donePodStats).", "pod", metaPod.Name, "requestID", requestID, "running_requests", requests, "pending_util", utilization, "pending_load", podStats.pendingLoad)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Bind gateway request stats to the original cache metaPod selected at AddRequestCount time.
- Use that saved metaPod when DoneRequestCount/DoneRequestTrace decrements running requests and pending load.
- Add a regression test for same-name pod recreation so new pods are not decremented by old in-flight requests.

Fixes #2421

## Test Plan
- go test -count=1 ./pkg/cache ./pkg/plugins/gateway ./pkg/plugins/gateway/algorithms
- git diff --check