### PR TITLE
Fix RayClusterReplicaSet scale-down ordering

### DIFF
--- a/pkg/controller/rayclusterreplicaset/rayclusterreplicaset_controller.go
+++ b/pkg/controller/rayclusterreplicaset/rayclusterreplicaset_controller.go
@@ -181,6 +181,7 @@ func (r *RayClusterReplicaSetReconciler) scaleDown(ctx context.Context, replicas
 	const maxConcurrency = 10
 	semaphore := make(chan struct{}, maxConcurrency)
 
+	sortRayClustersForScaleDown(clusters)
 	for i := 0; i < diff; i++ {
 		cluster := clusters[i]
 		semaphore <- struct{}{}

--- a/pkg/controller/rayclusterreplicaset/rayclusterreplicaset_scale_down_test.go
+++ b/pkg/controller/rayclusterreplicaset/rayclusterreplicaset_scale_down_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rayclusterreplicaset
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	rayclusterv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/controller/util/expectation"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestScaleDownPrioritizesNotReadyThenLowerDeletionCost(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := rayclusterv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add RayCluster scheme: %v", err)
+	}
+
+	replicaSet := &orchestrationv1alpha1.RayClusterReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rs",
+			Namespace: "default",
+		},
+	}
+	keepReadyHighCost := readyRayCluster("keep-ready-high-cost", "default", "100", time.Unix(1, 0))
+	deleteNotReadyHighCost := notReadyRayCluster("delete-not-ready-high-cost", "default", "1000", time.Unix(2, 0))
+	deleteReadyLowCost := readyRayCluster("delete-ready-low-cost", "default", "-10", time.Unix(3, 0))
+
+	reconciler := &RayClusterReplicaSetReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&keepReadyHighCost, &deleteNotReadyHighCost, &deleteReadyLowCost).
+			Build(),
+		Expectations: expectation.NewControllerExpectations(),
+	}
+
+	if err := reconciler.scaleDown(ctx, replicaSet, []rayclusterv1.RayCluster{
+		keepReadyHighCost,
+		deleteNotReadyHighCost,
+		deleteReadyLowCost,
+	}, 2); err != nil {
+		t.Fatalf("scaleDown returned error: %v", err)
+	}
+
+	assertRayClusterExists(t, reconciler.Client, "default", "keep-ready-high-cost")
+	assertRayClusterDeleted(t, reconciler.Client, "default", "delete-not-ready-high-cost")
+	assertRayClusterDeleted(t, reconciler.Client, "default", "delete-ready-low-cost")
+}
+
+func TestScaleDownUsesNameAsFinalTieBreaker(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := rayclusterv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add RayCluster scheme: %v", err)
+	}
+
+	replicaSet := &orchestrationv1alpha1.RayClusterReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rs",
+			Namespace: "default",
+		},
+	}
+	createdAt := time.Unix(1, 0)
+	keepByName := readyRayCluster("raycluster-b", "default", "0", createdAt)
+	deleteByName := readyRayCluster("raycluster-a", "default", "0", createdAt)
+
+	reconciler := &RayClusterReplicaSetReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&keepByName, &deleteByName).
+			Build(),
+		Expectations: expectation.NewControllerExpectations(),
+	}
+
+	if err := reconciler.scaleDown(ctx, replicaSet, []rayclusterv1.RayCluster{
+		keepByName,
+		deleteByName,
+	}, 1); err != nil {
+		t.Fatalf("scaleDown returned error: %v", err)
+	}
+
+	assertRayClusterExists(t, reconciler.Client, "default", "raycluster-b")
+	assertRayClusterDeleted(t, reconciler.Client, "default", "raycluster-a")
+}
+
+func readyRayCluster(name, namespace, deletionCost string, createdAt time.Time) rayclusterv1.RayCluster {
+	cluster := rayCluster(name, namespace, deletionCost, createdAt)
+	cluster.Status.Conditions = []metav1.Condition{
+		{Type: string(rayclusterv1.RayClusterProvisioned), Status: metav1.ConditionTrue},
+		{Type: string(rayclusterv1.HeadPodReady), Status: metav1.ConditionTrue},
+	}
+	cluster.Status.DesiredWorkerReplicas = 1
+	cluster.Status.ReadyWorkerReplicas = 1
+	return cluster
+}
+
+func notReadyRayCluster(name, namespace, deletionCost string, createdAt time.Time) rayclusterv1.RayCluster {
+	return rayCluster(name, namespace, deletionCost, createdAt)
+}
+
+func rayCluster(name, namespace, deletionCost string, createdAt time.Time) rayclusterv1.RayCluster {
+	return rayclusterv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.NewTime(createdAt),
+			Annotations: map[string]string{
+				"controller.kubernetes.io/pod-deletion-cost": deletionCost,
+			},
+		},
+	}
+}
+
+func assertRayClusterExists(t *testing.T, c client.Client, namespace, name string) {
+	t.Helper()
+	cluster := &rayclusterv1.RayCluster{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, cluster); err != nil {
+		t.Fatalf("expected RayCluster %s/%s to exist, got error: %v", namespace, name, err)
+	}
+}
+
+func assertRayClusterDeleted(t *testing.T, c client.Client, namespace, name string) {
+	t.Helper()
+	cluster := &rayclusterv1.RayCluster{}
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, cluster)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected RayCluster %s/%s to be deleted, got error: %v", namespace, name, err)
+	}
+}

--- a/pkg/controller/rayclusterreplicaset/rayclusterreplicaset_utils.go
+++ b/pkg/controller/rayclusterreplicaset/rayclusterreplicaset_utils.go
@@ -18,6 +18,8 @@ package rayclusterreplicaset
 
 import (
 	"reflect"
+	"sort"
+	"strconv"
 
 	rayclusterv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
@@ -26,6 +28,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
+)
+
+const rayClusterDeletionCostAnnotation = "controller.kubernetes.io/pod-deletion-cost"
+
+type rayClusterOrderRule func(a, b *rayclusterv1.RayCluster) int
+
+const (
+	rayClusterOrderBefore = -1
+	rayClusterOrderSame   = 0
+	rayClusterOrderAfter  = 1
 )
 
 // NewCondition creates a new replicaset condition.
@@ -108,6 +120,91 @@ func filterActiveClusters(clusters []rayclusterv1.RayCluster) []rayclusterv1.Ray
 	}
 
 	return activeClusters
+}
+
+func sortRayClustersForScaleDown(clusters []rayclusterv1.RayCluster) {
+	sortRayClustersByRules(
+		clusters,
+		orderRayClusterNotReadyBeforeReady,
+		orderRayClusterLowerDeletionCostBeforeHigher,
+		orderRayClusterOlderCreationTimestampBeforeNewer,
+		orderRayClusterNamespacedName,
+	)
+}
+
+func sortRayClustersByRules(clusters []rayclusterv1.RayCluster, rules ...rayClusterOrderRule) {
+	sort.SliceStable(clusters, func(i, j int) bool {
+		for _, rule := range rules {
+			switch rule(&clusters[i], &clusters[j]) {
+			case rayClusterOrderBefore:
+				return true
+			case rayClusterOrderAfter:
+				return false
+			}
+		}
+		return false
+	})
+}
+
+func orderRayClusterNotReadyBeforeReady(a, b *rayclusterv1.RayCluster) int {
+	aReady := rayclusterutil.IsRayClusterReady(a)
+	bReady := rayclusterutil.IsRayClusterReady(b)
+	if aReady == bReady {
+		return rayClusterOrderSame
+	}
+	if !aReady && bReady {
+		return rayClusterOrderBefore
+	}
+	return rayClusterOrderAfter
+}
+
+func orderRayClusterLowerDeletionCostBeforeHigher(a, b *rayclusterv1.RayCluster) int {
+	aCost := getRayClusterDeletionCost(a)
+	bCost := getRayClusterDeletionCost(b)
+	if aCost == bCost {
+		return rayClusterOrderSame
+	}
+	if aCost < bCost {
+		return rayClusterOrderBefore
+	}
+	return rayClusterOrderAfter
+}
+
+func orderRayClusterOlderCreationTimestampBeforeNewer(a, b *rayclusterv1.RayCluster) int {
+	if a.CreationTimestamp.Equal(&b.CreationTimestamp) {
+		return rayClusterOrderSame
+	}
+	if a.CreationTimestamp.Before(&b.CreationTimestamp) {
+		return rayClusterOrderBefore
+	}
+	return rayClusterOrderAfter
+}
+
+func orderRayClusterNamespacedName(a, b *rayclusterv1.RayCluster) int {
+	if a.Namespace != b.Namespace {
+		if a.Namespace < b.Namespace {
+			return rayClusterOrderBefore
+		}
+		return rayClusterOrderAfter
+	}
+	if a.Name == b.Name {
+		return rayClusterOrderSame
+	}
+	if a.Name < b.Name {
+		return rayClusterOrderBefore
+	}
+	return rayClusterOrderAfter
+}
+
+func getRayClusterDeletionCost(cluster *rayclusterv1.RayCluster) int {
+	if cluster == nil || cluster.Annotations == nil {
+		return 0
+	}
+	cost, err := strconv.Atoi(cluster.Annotations[rayClusterDeletionCostAnnotation])
+	if err != nil {
+		return 0
+	}
+	return cost
 }
 
 func isClusterActive(c rayclusterv1.RayCluster) bool {

--- a/test/integration/controller/rayclusterreplicaset_test.go
+++ b/test/integration/controller/rayclusterreplicaset_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	orchestrationapi "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+)
+
+const rayClusterDeletionCostAnnotation = "controller.kubernetes.io/pod-deletion-cost"
+
+var _ = ginkgo.Describe("RayClusterReplicaSet controller test", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-rayclusterreplicaset-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+		gomega.Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKeyFromObject(ns), ns)
+		}, time.Second*3).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(k8sClient.Delete(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("creates, scales, reports status, and applies scale-down ordering", func() {
+		matchLabels := map[string]string{"app": "raycluster-replicaset-lifecycle"}
+		replicaSet := &orchestrationapi.RayClusterReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "raycluster-replicaset-lifecycle",
+				Namespace: ns.Name,
+			},
+			Spec: orchestrationapi.RayClusterReplicaSetSpec{
+				Replicas: ptr.To(int32(2)),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: matchLabels,
+				},
+				Template: orchestrationapi.RayClusterTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: matchLabels,
+					},
+					Spec: makeIntegrationRayClusterSpec(),
+				},
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, replicaSet)).To(gomega.Succeed())
+
+		clusters := waitForIntegrationRayClusters(ctx, k8sClient, ns.Name, matchLabels, 2)
+		for i := range clusters {
+			markIntegrationRayClusterReady(ctx, k8sClient, &clusters[i])
+		}
+		waitForIntegrationReplicaSetStatus(ctx, k8sClient, replicaSet, 2, 2, 2, 2)
+
+		latestReplicaSet := &orchestrationapi.RayClusterReplicaSet{}
+		gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(replicaSet), latestReplicaSet)).To(gomega.Succeed())
+		latestReplicaSet.Spec.Replicas = ptr.To(int32(3))
+		gomega.Expect(k8sClient.Update(ctx, latestReplicaSet)).To(gomega.Succeed())
+
+		clusters = waitForIntegrationRayClusters(ctx, k8sClient, ns.Name, matchLabels, 3)
+		sort.Slice(clusters, func(i, j int) bool {
+			return clusters[i].Name < clusters[j].Name
+		})
+		keepReadyHighCost := clusters[0]
+		deleteNotReadyHighCost := clusters[1]
+		deleteReadyLowCost := clusters[2]
+
+		setIntegrationRayClusterReadinessAndDeletionCost(ctx, k8sClient, &keepReadyHighCost, true, "100")
+		setIntegrationRayClusterReadinessAndDeletionCost(ctx, k8sClient, &deleteNotReadyHighCost, false, "1000")
+		setIntegrationRayClusterReadinessAndDeletionCost(ctx, k8sClient, &deleteReadyLowCost, true, "-10")
+
+		gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(replicaSet), latestReplicaSet)).To(gomega.Succeed())
+		latestReplicaSet.Spec.Replicas = ptr.To(int32(1))
+		gomega.Expect(k8sClient.Update(ctx, latestReplicaSet)).To(gomega.Succeed())
+
+		gomega.Eventually(func() ([]string, error) {
+			clusters := &rayv1.RayClusterList{}
+			if err := k8sClient.List(ctx, clusters,
+				client.InNamespace(ns.Name),
+				client.MatchingLabels(matchLabels),
+			); err != nil {
+				return nil, err
+			}
+			names := make([]string, 0, len(clusters.Items))
+			for _, cluster := range clusters.Items {
+				names = append(names, cluster.Name)
+			}
+			sort.Strings(names)
+			if len(names) != 1 {
+				return names, fmt.Errorf("expected 1 RayCluster, got %d", len(names))
+			}
+			return names, nil
+		}, time.Second*10, time.Millisecond*250).Should(gomega.Equal([]string{keepReadyHighCost.Name}))
+	})
+})
+
+func makeIntegrationRayCluster(
+	namespace string,
+	name string,
+	labels map[string]string,
+	deletionCost string,
+) *rayv1.RayCluster {
+	return &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				rayClusterDeletionCostAnnotation: deletionCost,
+			},
+		},
+		Spec: makeIntegrationRayClusterSpec(),
+	}
+}
+
+func makeIntegrationRayClusterSpec() rayv1.RayClusterSpec {
+	return rayv1.RayClusterSpec{
+		RayVersion: "fake-ray-version",
+		HeadGroupSpec: rayv1.HeadGroupSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "ray-head",
+							Image: "rayproject/ray:2.10.0",
+						},
+					},
+				},
+			},
+			RayStartParams: map[string]string{
+				"dashboard-host": "0.0.0.0",
+			},
+		},
+	}
+}
+
+func markIntegrationRayClusterReady(ctx context.Context, k8sClient client.Client, cluster *rayv1.RayCluster) {
+	setIntegrationRayClusterReadinessAndDeletionCost(ctx, k8sClient, cluster, true, "")
+}
+
+func setIntegrationRayClusterReadinessAndDeletionCost(
+	ctx context.Context,
+	k8sClient client.Client,
+	cluster *rayv1.RayCluster,
+	ready bool,
+	deletionCost string,
+) {
+	latest := &rayv1.RayCluster{}
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), latest)).To(gomega.Succeed())
+		if deletionCost != "" {
+			if latest.Annotations == nil {
+				latest.Annotations = map[string]string{}
+			}
+			latest.Annotations[rayClusterDeletionCostAnnotation] = deletionCost
+			g.Expect(k8sClient.Update(ctx, latest)).To(gomega.Succeed())
+		}
+		if ready {
+			latest.Status.Conditions = []metav1.Condition{
+				{Type: string(rayv1.RayClusterProvisioned), Status: metav1.ConditionTrue},
+				{Type: string(rayv1.HeadPodReady), Status: metav1.ConditionTrue},
+			}
+			latest.Status.DesiredWorkerReplicas = 1
+			latest.Status.ReadyWorkerReplicas = 1
+		} else {
+			latest.Status.Conditions = nil
+			latest.Status.DesiredWorkerReplicas = 1
+			latest.Status.ReadyWorkerReplicas = 0
+		}
+		g.Expect(k8sClient.Status().Update(ctx, latest)).To(gomega.Succeed())
+	}, time.Second*5, time.Millisecond*250).Should(gomega.Succeed())
+}
+
+func waitForIntegrationRayClusters(
+	ctx context.Context,
+	k8sClient client.Client,
+	namespace string,
+	matchLabels map[string]string,
+	expected int,
+) []rayv1.RayCluster {
+	var items []rayv1.RayCluster
+	gomega.Eventually(func(g gomega.Gomega) {
+		clusters := &rayv1.RayClusterList{}
+		g.Expect(k8sClient.List(ctx, clusters,
+			client.InNamespace(namespace),
+			client.MatchingLabels(matchLabels),
+		)).To(gomega.Succeed())
+		g.Expect(clusters.Items).To(gomega.HaveLen(expected))
+		items = clusters.Items
+	}, time.Second*10, time.Millisecond*250).Should(gomega.Succeed())
+	return items
+}
+
+func waitForIntegrationReplicaSetStatus(
+	ctx context.Context,
+	k8sClient client.Client,
+	replicaSet *orchestrationapi.RayClusterReplicaSet,
+	replicas int32,
+	fullyLabeledReplicas int32,
+	readyReplicas int32,
+	availableReplicas int32,
+) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		latest := &orchestrationapi.RayClusterReplicaSet{}
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(replicaSet), latest)).To(gomega.Succeed())
+		g.Expect(latest.Status.Replicas).To(gomega.Equal(replicas))
+		g.Expect(latest.Status.FullyLabeledReplicas).To(gomega.Equal(fullyLabeledReplicas))
+		g.Expect(latest.Status.ReadyReplicas).To(gomega.Equal(readyReplicas))
+		g.Expect(latest.Status.AvailableReplicas).To(gomega.Equal(availableReplicas))
+	}, time.Second*10, time.Millisecond*250).Should(gomega.Succeed())
+}

--- a/test/integration/controller/rayclusterreplicaset_test.go
+++ b/test/integration/controller/rayclusterreplicaset_test.go
@@ -186,9 +186,20 @@ func setIntegrationRayClusterReadinessAndDeletionCost(
 			g.Expect(k8sClient.Update(ctx, latest)).To(gomega.Succeed())
 		}
 		if ready {
+			now := metav1.Now()
 			latest.Status.Conditions = []metav1.Condition{
-				{Type: string(rayv1.RayClusterProvisioned), Status: metav1.ConditionTrue},
-				{Type: string(rayv1.HeadPodReady), Status: metav1.ConditionTrue},
+				{
+					Type:               string(rayv1.RayClusterProvisioned),
+					Status:             metav1.ConditionTrue,
+					Reason:             "TestReady",
+					LastTransitionTime: now,
+				},
+				{
+					Type:               string(rayv1.HeadPodReady),
+					Status:             metav1.ConditionTrue,
+					Reason:             "TestReady",
+					LastTransitionTime: now,
+				},
 			}
 			latest.Status.DesiredWorkerReplicas = 1
 			latest.Status.ReadyWorkerReplicas = 1


### PR DESCRIPTION
## Summary
- Sort RayClusterReplicaSet scale-down candidates before deletion.
- Prefer deleting NotReady RayClusters, then lower `controller.kubernetes.io/pod-deletion-cost`, then older creation timestamp, then namespace/name for deterministic tie-breaking.
- Add unit coverage and RayClusterReplicaSet lifecycle integration coverage.

Fixes #2425

## Test Plan
- `go test -count=1 ./pkg/controller/rayclusterreplicaset -run 'TestScaleDown(PrioritizesNotReadyThenLowerDeletionCost|UsesNameAsFinalTieBreaker)'`\n- `go test -count=1 ./pkg/controller/rayclusterreplicaset -run '^$'`\n- `go test -count=1 ./test/integration/controller -run '^$'`\n- `git diff --check`\n\nNote: focused integration execution was attempted locally, but envtest could not start because `bin/k8s/1.30.0-darwin-arm64/etcd` is not present in this workspace.