### PR TITLE
[Bug]Batch: harden runtime lifecycle recovery, deregister stale runtime refs, and improve interruption control

### DIFF
--- a/python/aibrix/aibrix/batch/batch_manager.py
+++ b/python/aibrix/aibrix/batch/batch_manager.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import asyncio
+import copy
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Collection, Dict, List, Optional, Tuple, cast
 
 from aibrix.batch.batch_scheduler import BatchScheduler
 from aibrix.batch.client import EndpointSource
@@ -24,6 +25,11 @@ from aibrix.batch.job_driver import (
     RunningJobs,
     TerminateResult,
     create_job_driver,
+)
+from aibrix.batch.job_driver.running_jobs import (
+    LOCAL_STATUS_COPY_KEYS,
+    LOCAL_STATUS_UPDATE_KEYS,
+    LocalStatusKey,
 )
 from aibrix.batch.job_entity import (
     BatchJob,
@@ -732,7 +738,10 @@ class BatchManager(RunningJobs, SchedulableJobs):
             return None
 
         job = self._pending_jobs[job_id]
-        needs_validation = job.status.state == BatchJobState.CREATED or (
+        needs_validation = job.status.state in {
+            BatchJobState.CREATED,
+            BatchJobState.VALIDATING,
+        } or (
             job.status.state == BatchJobState.IN_PROGRESS
             and job.status.in_progress_at is None
         )
@@ -820,19 +829,52 @@ class BatchManager(RunningJobs, SchedulableJobs):
         return updated
 
     async def update_job_local_status(
-        self, job_id: str, worker_id: str, status: BatchJobStatus
+        self,
+        job_id: str,
+        worker_id: str,
+        status: BatchJobStatus,
+        update_keys: Collection[LocalStatusKey] | None = None,
     ) -> BatchJob:
         # Cancel, failing, expiring will not move job out of in_progress state
         meta_data = await self._meta_from_in_progress_job(job_id)
         persisted = meta_data.copy()
-        persisted.status.execution = status.execution
-        # Set worker-wise status copies.
-        if persisted.status.status_copies is None:
-            persisted.status.status_copies = {}
-        persisted.status.status_copies[worker_id] = BatchJobStatusCopy.from_status(
-            status
+        keys = (
+            set(LOCAL_STATUS_UPDATE_KEYS) if update_keys is None else set(update_keys)
         )
-        persisted.status.status_copies[worker_id].updated = True
+        unknown_keys = keys.difference(LOCAL_STATUS_UPDATE_KEYS)
+        if unknown_keys:
+            raise ValueError(
+                f"Unsupported local status update keys: {sorted(unknown_keys)}"
+            )
+
+        if "execution" in keys:
+            persisted.status.execution = copy.deepcopy(status.execution)
+
+        copy_keys = keys.intersection(LOCAL_STATUS_COPY_KEYS)
+        if copy_keys:
+            # Only touch worker-local copies when worker-local fields changed.
+            if persisted.status.status_copies is None:
+                persisted.status.status_copies = {}
+            status_copy = persisted.status.status_copies.get(worker_id)
+            if status_copy is None:
+                status_copy = BatchJobStatusCopy.from_status(status)
+                persisted.status.status_copies[worker_id] = status_copy
+            else:
+                if "state" in copy_keys:
+                    status_copy.state = status.state
+                if "errors" in copy_keys:
+                    status_copy.errors = copy.deepcopy(status.errors)
+                if "request_counts" in copy_keys:
+                    status_copy.request_counts = status.request_counts.model_copy(
+                        deep=True
+                    )
+                if "usage" in copy_keys:
+                    status_copy.usage = (
+                        status.usage.model_copy(deep=True)
+                        if status.usage is not None
+                        else None
+                    )
+            status_copy.updated = True
         persisted.status = aggregate_batch_job_status(persisted.status)
 
         if self._job_entity_manager is not None:

--- a/python/aibrix/aibrix/batch/constant.py
+++ b/python/aibrix/aibrix/batch/constant.py
@@ -39,6 +39,7 @@ if not (1 <= DEFAULT_JOB_POOL_SIZE <= 100):
 BATCH_OPTS_FAIL_INIT_RUNTIME = "fail_init_runtime"
 BATCH_OPTS_FAIL_PREPARATION = "fail_preparation"
 BATCH_OPTS_FAIL_AFTER_N_REQUESTS = "fail_after_n_requests"
+BATCH_OPTS_INTERRUPT_RUNTIME_AFTER_N_REQUESTS = "interrupt_runtime_after_n_requests"
 
 # Runtime selection moved to the RuntimeTarget enum
 # (aibrix.batch.job_entity) and the runtime registry keys.

--- a/python/aibrix/aibrix/batch/job_driver/__init__.py
+++ b/python/aibrix/aibrix/batch/job_driver/__init__.py
@@ -20,7 +20,12 @@ from aibrix.batch.job_driver.driver import (
     TerminateResult,
 )
 from aibrix.batch.job_driver.driver_factory import create_job_driver
-from aibrix.batch.job_driver.running_jobs import RunningJobs
+from aibrix.batch.job_driver.running_jobs import (
+    LOCAL_STATUS_COPY_KEYS,
+    LOCAL_STATUS_UPDATE_KEYS,
+    LocalStatusKey,
+    RunningJobs,
+)
 from aibrix.batch.job_driver.runtime import (
     Completion,
     Endpoint,
@@ -52,4 +57,7 @@ __all__ = [
     "Completion",
     "Endpoint",
     "RunningJobs",
+    "LocalStatusKey",
+    "LOCAL_STATUS_COPY_KEYS",
+    "LOCAL_STATUS_UPDATE_KEYS",
 ]

--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -40,7 +40,6 @@ from datetime import datetime, timezone
 from math import isfinite
 from typing import Any, Dict, Iterable, Optional, Set, Tuple
 
-import aibrix.batch.constant as constant
 import aibrix.batch.storage as storage
 from aibrix.batch.client import (
     DispatchEngine,
@@ -51,6 +50,14 @@ from aibrix.batch.client import (
     RetryConfig,
 )
 from aibrix.batch.job_driver.driver import TerminateResult
+from aibrix.batch.job_driver.error_injection import (
+    ACTION_INTERRUPT_RUNTIME,
+    BREAKPOINT_AFTER_N_REQUESTS,
+    BREAKPOINT_PREPARATION,
+    JobDriverErrorInjectionEvent,
+    JobDriverErrorInjectionRaisedAction,
+    JobDriverErrorInjector,
+)
 from aibrix.batch.job_driver.running_jobs import RunningJobs
 from aibrix.batch.job_driver.runtime import Endpoint, NoopRuntime, Runtime
 from aibrix.batch.job_entity import (
@@ -236,6 +243,7 @@ class BaseJobDriver:
         self._usage_counted_ids: Set[str] = set()
         self._request_counts: Optional[RequestCountStats] = None
         self._launched_request_ids: Set[int] = set()
+        self._error_injection = JobDriverErrorInjector(job)
         self._usage_lock = asyncio.Lock()
 
     # ── protocol methods ──────────────────────────────────────────
@@ -291,6 +299,7 @@ class BaseJobDriver:
         if job is None:
             self._log_missing_job(job_id)
             return
+        self._set_error_injection(job)
 
         if self._should_resume_finalizing_job(job):
             job = await self._resume_finalizing_job(job)
@@ -315,6 +324,16 @@ class BaseJobDriver:
                 return
             raise
         except Exception as e:
+            latest = await self._progress_manager.get_job(job_id)
+            if latest is not None and latest.status.finished:
+                logger.info(
+                    "Ignoring late execution error because job already finished",
+                    job_id=job_id,
+                    state=latest.status.state.value,
+                    error=str(e),
+                )  # type: ignore[call-arg]
+                self._log_completed(latest)
+                return
             # Guard mark_job_failed: if it raises (e.g. the job is no
             # longer in_progress) the exception must not escape and tear
             # down the loop, stranding all future jobs.
@@ -883,6 +902,7 @@ class BaseJobDriver:
             job.job_id,
             progress_manager=self._progress_manager,
             worker_id_generator=self._assign_worker_id,
+            error_injection=self._ensure_error_injection(job),
         ) as endpoint:
             self._engine = (
                 DispatchEngine(
@@ -957,13 +977,17 @@ class BaseJobDriver:
     async def prepare_job(self, job: BatchJob) -> BatchJob:
         """Prepare job output files by creating multipart uploads."""
         logger.debug("Preparing job output files")  # type: ignore[call-arg]
+        self._ensure_error_injection(job)
         job, stopped = await self._is_job_stopped(job.job_id)
         if stopped:
             # Simply return and leave caller to handle interruption.
             return job
 
         # Handle preparation failure injection
-        self._maybe_fail_preparation(job)
+        await self._apply_error_injection_breakpoint(
+            job,
+            BREAKPOINT_PREPARATION,
+        )
         job = await storage.prepare_job_ouput_files(job)
         job = await self._progress_manager.update_job_status(job.job_id, job.status)
         logger.debug("Job output files prepared")  # type: ignore[call-arg]
@@ -991,6 +1015,7 @@ class BaseJobDriver:
         job, stopped = await self._is_job_stopped(job_id)
         if stopped:
             return await self._finish_stopped_job(job)
+        self._ensure_error_injection(job)
 
         if job.status.request_counts.total > 0:
             return await self._execute_worker_concurrent(job)
@@ -1025,8 +1050,6 @@ class BaseJobDriver:
                 "Resuming job", job_id=job_id, request_id=line_no, opts=job.spec.opts
             )  # type: ignore[call-arg]
 
-        fail_after_n_requests = self._parse_fail_after_n_requests(job)
-
         processed_requests = 0
         # The loop is necessary in cases of job driver lock a request but unable to process it (complete or fail), e.g., server crash.
         while line_no >= 0:
@@ -1045,20 +1068,11 @@ class BaseJobDriver:
                     job, [completed_task.result()]
                 )
                 processed_requests += completed
-
-                # fail_after_n_requests injection check
-                if fail_after_n_requests is not None:
-                    if processed_requests >= fail_after_n_requests:
-                        logger.info(
-                            "Triggering artificial failure due to fail_after_n_requests",
-                            job_id=job_id,
-                            processed_requests=processed_requests,
-                            fail_after_n_requests=fail_after_n_requests,
-                        )  # type: ignore[call-arg]
-                        raise RuntimeError(
-                            f"Artificial failure triggered after processing {processed_requests} requests "
-                            f"(fail_after_n_requests={fail_after_n_requests})"
-                        )
+                await self._apply_error_injection_breakpoint(
+                    job,
+                    BREAKPOINT_AFTER_N_REQUESTS,
+                    n=processed_requests,
+                )
 
                 # After-task job interruption check
                 # Since job is reload during _sync_completed_request_tasks, no reloading neeaded.
@@ -1102,9 +1116,7 @@ class BaseJobDriver:
             asyncio.Queue()
         )
         start_index = await self._get_next_pass_start(job)
-        fail_after_n_requests = self._parse_fail_after_n_requests(job)
         processed_requests = 0
-        fail_after_triggered = False
         if start_index < 0:
             logger.warning(
                 "Job has something wrong with metadata in batch manager, nothing left to execute",
@@ -1140,6 +1152,13 @@ class BaseJobDriver:
                 async for request_input in storage.read_job_next_request(
                     job, start_index
                 ):
+                    # Mirror the serial worker: before pulling the next request
+                    # into dispatch, observe the latest persisted job state so
+                    # cancel / expire / restart stop future scheduling promptly.
+                    job, stopped = await self._is_job_stopped(job_id)
+                    if stopped:
+                        return
+
                     request_id = request_input.pop("_request_index", -1)
                     if request_id < 0:
                         continue
@@ -1166,6 +1185,8 @@ class BaseJobDriver:
                 if reloaded_job is None:
                     raise RuntimeError(f"Job metadata missing for {job_id}")
                 job = reloaded_job
+                if self._should_stop_before_proceed(job):
+                    return
                 start_index = await self._get_next_pass_start(job)
                 local_request_counts = self._get_local_request_counts(job_id)
                 if start_index < 0 and local_request_counts.total > 0:
@@ -1214,7 +1235,7 @@ class BaseJobDriver:
             response: Optional[dict[str, Any]],
             error: Optional[InferenceError],
         ) -> None:
-            nonlocal job, processed_requests, fail_after_triggered
+            nonlocal job, processed_requests
             request_id, custom_id = request.ref
             if error is None and isinstance(response, dict):
                 async with self._usage_lock:
@@ -1226,16 +1247,11 @@ class BaseJobDriver:
             await storage.write_job_output_data(job, request_id, record)
             await completed_request_ids.put((request_id, error is not None))
             processed_requests += 1
-            if (
-                not fail_after_triggered
-                and fail_after_n_requests is not None
-                and processed_requests >= fail_after_n_requests
-            ):
-                fail_after_triggered = True
-                raise RuntimeError(
-                    f"Artificial failure triggered after processing {processed_requests} requests "
-                    f"(fail_after_n_requests={fail_after_n_requests})"
-                )
+            await self._apply_error_injection_breakpoint(
+                job,
+                BREAKPOINT_AFTER_N_REQUESTS,
+                n=processed_requests,
+            )
 
         stats = DispatchStats()
         telemetry_interval = _telemetry_interval_seconds()
@@ -1261,8 +1277,13 @@ class BaseJobDriver:
             )
         finally:
             await completed_request_ids.put(None)
-            with contextlib.suppress(asyncio.CancelledError):
-                await sync_task
+            if not sync_task.done():
+                try:
+                    await asyncio.wait_for(sync_task, timeout=2.0)
+                except (asyncio.TimeoutError, asyncio.CancelledError):
+                    sync_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await sync_task
             if telemetry_task is not None:
                 telemetry_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
@@ -1364,42 +1385,43 @@ class BaseJobDriver:
         normalized = str(value).strip().lower()
         return normalized not in {"", "0", "false", "no", "off"}
 
-    def _maybe_fail_preparation(self, job: BatchJob) -> None:
-        """Inject a preparation failure when test opts request it.
-
-        This is overridable because subclasses may prepare outputs differently
-        or need backend-specific failure codes for preparation-stage faults.
-        """
-        if not self._opt_enabled(job, constant.BATCH_OPTS_FAIL_PREPARATION):
-            return
-        raise BatchJobError(
-            code=BatchJobErrorCode.PREPARE_OUTPUT_ERROR,
-            message=(
-                "Artificial preparation failure triggered "
-                f"({constant.BATCH_OPTS_FAIL_PREPARATION})"
-            ),
+    def _set_error_injection(self, job: BatchJob) -> JobDriverErrorInjector:
+        self._error_injection = JobDriverErrorInjector(
+            job,
+            raise_helpers={
+                ACTION_INTERRUPT_RUNTIME: JobDriverErrorInjectionRaisedAction,
+            },
         )
+        return self._error_injection
 
-    def _parse_fail_after_n_requests(self, job: BatchJob) -> Optional[int]:
-        """Parse the test-only fail-after counter from job opts.
+    def _ensure_error_injection(self, job: BatchJob) -> JobDriverErrorInjector:
+        if self._error_injection.job_id != job.job_id:
+            return self._set_error_injection(job)
+        return self._error_injection
 
-        Subclasses override this when request accounting or failure injection
-        should key off different option names or counting semantics.
-        """
-        if (
-            not job.spec.opts
-            or constant.BATCH_OPTS_FAIL_AFTER_N_REQUESTS not in job.spec.opts
-        ):
-            return None
+    async def _apply_error_injection_breakpoint(
+        self,
+        job: BatchJob,
+        breakpoint: str,
+        **kwargs: Any,
+    ) -> None:
         try:
-            return int(job.spec.opts[constant.BATCH_OPTS_FAIL_AFTER_N_REQUESTS])
-        except (ValueError, TypeError):
-            logger.warning(
-                "Invalid fail_after_n_requests value, ignoring",
-                job_id=job.job_id,
-                value=job.spec.opts[constant.BATCH_OPTS_FAIL_AFTER_N_REQUESTS],
-            )  # type: ignore[call-arg]
-            return None
+            self._ensure_error_injection(job).raise_for_breakpoint(breakpoint, **kwargs)
+        except JobDriverErrorInjectionRaisedAction as exc:
+            await self._apply_error_injection_event(job, exc.event)
+
+    async def _apply_error_injection_event(
+        self,
+        job: BatchJob,
+        event: JobDriverErrorInjectionEvent,
+    ) -> None:
+        if event.action == ACTION_INTERRUPT_RUNTIME:
+            await self._runtime.cleanup(job)
+            return
+        raise RuntimeError(
+            f"Unexpected helper-raised error injection action {event.action} "
+            f"for {event.opt_key}"
+        )
 
     def _shape_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Adjust a request body before dispatch. Pins the request to the

--- a/python/aibrix/aibrix/batch/job_driver/error_injection.py
+++ b/python/aibrix/aibrix/batch/job_driver/error_injection.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+import aibrix.batch.constant as constant
+from aibrix.batch.job_entity import BatchJob, BatchJobError, BatchJobErrorCode
+from aibrix.logger import init_logger
+
+logger = init_logger(__name__)
+
+BREAKPOINT_RUNTIME_INITIALIZATION = "runtime_initialization"
+BREAKPOINT_PREPARATION = "preparation"
+BREAKPOINT_AFTER_N_REQUESTS = "after_n_requests"
+
+ACTION_RAISE = "raise"
+ACTION_INTERRUPT_RUNTIME = "interrupt_runtime"
+
+
+@dataclass(frozen=True)
+class JobDriverErrorInjectionEvent:
+    opt_key: str
+    breakpoint: str
+    action: str
+    configured_n: Optional[int] = None
+    current_n: Optional[int] = None
+
+    def to_exception(self) -> Exception:
+        if self.opt_key == constant.BATCH_OPTS_FAIL_INIT_RUNTIME:
+            return BatchJobError(
+                code=BatchJobErrorCode.RESOURCE_CREATION_ERROR,
+                message=(
+                    "Artificial runtime initialization failure triggered "
+                    f"({constant.BATCH_OPTS_FAIL_INIT_RUNTIME})"
+                ),
+            )
+        if self.opt_key == constant.BATCH_OPTS_FAIL_PREPARATION:
+            return BatchJobError(
+                code=BatchJobErrorCode.PREPARE_OUTPUT_ERROR,
+                message=(
+                    "Artificial preparation failure triggered "
+                    f"({constant.BATCH_OPTS_FAIL_PREPARATION})"
+                ),
+            )
+        if self.opt_key == constant.BATCH_OPTS_FAIL_AFTER_N_REQUESTS:
+            return RuntimeError(
+                "Artificial failure triggered after processing "
+                f"{self.current_n} requests "
+                f"({constant.BATCH_OPTS_FAIL_AFTER_N_REQUESTS}={self.configured_n})"
+            )
+        raise RuntimeError(
+            f"Unsupported error injection event for {self.opt_key} at {self.breakpoint}"
+        )
+
+
+class JobDriverErrorInjectionRaisedAction(RuntimeError):
+    def __init__(self, event: JobDriverErrorInjectionEvent) -> None:
+        self.event = event
+        super().__init__(
+            f"Injected action {event.action} triggered for {event.opt_key} "
+            f"at {event.breakpoint}"
+        )
+
+
+class JobDriverErrorInjector:
+    def __init__(
+        self,
+        job: Optional[BatchJob],
+        *,
+        raise_helpers: Optional[
+            Mapping[str, Callable[[JobDriverErrorInjectionEvent], BaseException]]
+        ] = None,
+    ) -> None:
+        self._job_id = job.job_id if job is not None else None
+        opts = dict(job.spec.opts or {}) if job is not None and job.spec.opts else {}
+        self._fail_init_runtime = self._parse_enabled(
+            opts, constant.BATCH_OPTS_FAIL_INIT_RUNTIME
+        )
+        self._fail_preparation = self._parse_enabled(
+            opts, constant.BATCH_OPTS_FAIL_PREPARATION
+        )
+        self._fail_after_n_requests = self._parse_positive_int(
+            opts, constant.BATCH_OPTS_FAIL_AFTER_N_REQUESTS
+        )
+        self._interrupt_runtime_after_n_requests = self._parse_positive_int(
+            opts, constant.BATCH_OPTS_INTERRUPT_RUNTIME_AFTER_N_REQUESTS
+        )
+        self._one_shot_triggers: set[str] = set()
+        self._raise_helpers = dict(raise_helpers or {})
+
+    @property
+    def job_id(self) -> Optional[str]:
+        return self._job_id
+
+    def threshold_for(self, opt_key: str) -> Optional[int]:
+        if opt_key == constant.BATCH_OPTS_FAIL_AFTER_N_REQUESTS:
+            return self._fail_after_n_requests
+        if opt_key == constant.BATCH_OPTS_INTERRUPT_RUNTIME_AFTER_N_REQUESTS:
+            return self._interrupt_runtime_after_n_requests
+        return None
+
+    def events_at(
+        self,
+        breakpoint: str,
+        **kwargs: Any,
+    ) -> tuple[JobDriverErrorInjectionEvent, ...]:
+        if breakpoint == BREAKPOINT_RUNTIME_INITIALIZATION:
+            return self._flag_events(
+                enabled=self._fail_init_runtime,
+                opt_key=constant.BATCH_OPTS_FAIL_INIT_RUNTIME,
+                breakpoint=breakpoint,
+            )
+        if breakpoint == BREAKPOINT_PREPARATION:
+            return self._flag_events(
+                enabled=self._fail_preparation,
+                opt_key=constant.BATCH_OPTS_FAIL_PREPARATION,
+                breakpoint=breakpoint,
+            )
+        if breakpoint == BREAKPOINT_AFTER_N_REQUESTS:
+            current_n = self._coerce_positive_int(kwargs.get("n"))
+            if current_n is None:
+                return ()
+
+            events: list[JobDriverErrorInjectionEvent] = []
+            if (
+                self._interrupt_runtime_after_n_requests is not None
+                and current_n == self._interrupt_runtime_after_n_requests
+                and self._mark_one_shot(
+                    constant.BATCH_OPTS_INTERRUPT_RUNTIME_AFTER_N_REQUESTS
+                )
+            ):
+                events.append(
+                    JobDriverErrorInjectionEvent(
+                        opt_key=constant.BATCH_OPTS_INTERRUPT_RUNTIME_AFTER_N_REQUESTS,
+                        breakpoint=breakpoint,
+                        action=ACTION_INTERRUPT_RUNTIME,
+                        configured_n=self._interrupt_runtime_after_n_requests,
+                        current_n=current_n,
+                    )
+                )
+            if (
+                self._fail_after_n_requests is not None
+                and current_n >= self._fail_after_n_requests
+                and self._mark_one_shot(constant.BATCH_OPTS_FAIL_AFTER_N_REQUESTS)
+            ):
+                events.append(
+                    JobDriverErrorInjectionEvent(
+                        opt_key=constant.BATCH_OPTS_FAIL_AFTER_N_REQUESTS,
+                        breakpoint=breakpoint,
+                        action=ACTION_RAISE,
+                        configured_n=self._fail_after_n_requests,
+                        current_n=current_n,
+                    )
+                )
+            return tuple(events)
+        return ()
+
+    def raise_for_breakpoint(
+        self,
+        breakpoint: str,
+        **kwargs: Any,
+    ) -> None:
+        for event in self.events_at(breakpoint, **kwargs):
+            self._log_event(event)
+            if event.action in self._raise_helpers:
+                raise self._raise_helpers[event.action](event)
+            if event.action != ACTION_RAISE:
+                raise RuntimeError(
+                    f"No raise helper registered for action {event.action} "
+                    f"at breakpoint {breakpoint}"
+                )
+            raise event.to_exception()
+
+    def _flag_events(
+        self,
+        *,
+        enabled: bool,
+        opt_key: str,
+        breakpoint: str,
+    ) -> tuple[JobDriverErrorInjectionEvent, ...]:
+        if not enabled:
+            return ()
+        return (
+            JobDriverErrorInjectionEvent(
+                opt_key=opt_key,
+                breakpoint=breakpoint,
+                action=ACTION_RAISE,
+            ),
+        )
+
+    def _log_event(self, event: JobDriverErrorInjectionEvent) -> None:
+        log_data: dict[str, Any] = {
+            "job_id": self._job_id,
+            "opt_key": event.opt_key,
+            "breakpoint": event.breakpoint,
+            "action": event.action,
+        }
+        if event.current_n is not None:
+            log_data["current_n"] = event.current_n
+        if event.configured_n is not None:
+            log_data["configured_n"] = event.configured_n
+        logger.info("Triggering error injection", **log_data)  # type: ignore[call-arg]
+
+    @staticmethod
+    def _parse_enabled(opts: dict[str, Any], opt_key: str) -> bool:
+        if opt_key not in opts:
+            return False
+        value = opts[opt_key]
+        normalized = str(value).strip().lower()
+        return normalized not in {"", "0", "false", "no", "off"}
+
+    def _parse_positive_int(self, opts: dict[str, Any], opt_key: str) -> Optional[int]:
+        if opt_key not in opts:
+            return None
+        parsed = self._coerce_positive_int(opts[opt_key])
+        if parsed is None:
+            logger.warning(
+                "Invalid error injection value, ignoring",
+                job_id=self._job_id,
+                opt_key=opt_key,
+                value=opts[opt_key],
+            )  # type: ignore[call-arg]
+        return parsed
+
+    @staticmethod
+    def _coerce_positive_int(value: Any) -> Optional[int]:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None
+
+    def _mark_one_shot(self, opt_key: str) -> bool:
+        if opt_key in self._one_shot_triggers:
+            return False
+        self._one_shot_triggers.add(opt_key)
+        return True

--- a/python/aibrix/aibrix/batch/job_driver/running_jobs.py
+++ b/python/aibrix/aibrix/batch/job_driver/running_jobs.py
@@ -24,9 +24,17 @@ interface the driver calls; the manager answers the per-request calls below from
 each job's tracker. A driver never touches a tracker directly.
 """
 
-from typing import Optional, Protocol, runtime_checkable
+from typing import Collection, Final, Literal, Optional, Protocol, runtime_checkable
 
 from aibrix.batch.job_entity import BatchJob, BatchJobError, BatchJobStatus
+
+LocalStatusKey = Literal["state", "errors", "request_counts", "usage", "execution"]
+LOCAL_STATUS_COPY_KEYS: Final[frozenset[LocalStatusKey]] = frozenset(
+    {"state", "errors", "request_counts", "usage"}
+)
+LOCAL_STATUS_UPDATE_KEYS: Final[frozenset[LocalStatusKey]] = frozenset(
+    {*LOCAL_STATUS_COPY_KEYS, "execution"}
+)
 
 
 @runtime_checkable
@@ -54,9 +62,18 @@ class RunningJobs(Protocol):
         ...
 
     async def update_job_local_status(
-        self, job_id: str, worker_id: str, status: BatchJobStatus
+        self,
+        job_id: str,
+        worker_id: str,
+        status: BatchJobStatus,
+        update_keys: Collection[LocalStatusKey] | None = None,
     ) -> BatchJob:
-        """Persist a worker-local status snapshot for aggregation. This operation is thread-safe."""
+        """Persist selected worker-local status fields for aggregation.
+
+        ``update_keys`` limits the fields applied from ``status``. When omitted,
+        implementations should preserve the historical "update all local fields"
+        behavior.
+        """
         ...
 
     async def mark_job_finalizing(self, job_id: str) -> BatchJob:

--- a/python/aibrix/aibrix/batch/job_driver/runtime/__init__.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/__init__.py
@@ -28,6 +28,8 @@ These re-exports keep ``from aibrix.batch.job_driver.runtime import X`` stable.
 
 from aibrix.batch.job_driver.runtime.base import (
     _RUNTIME_FACTORIES,
+    RUNTIME_WAIT_MODE_PROVISION,
+    RUNTIME_WAIT_MODE_RECONNECT,
     AsyncRuntimeSession,
     Completion,
     Endpoint,
@@ -48,6 +50,8 @@ __all__ = [
     "NoopRuntime",
     "Runtime",
     "RuntimeBase",
+    "RUNTIME_WAIT_MODE_PROVISION",
+    "RUNTIME_WAIT_MODE_RECONNECT",
     "create_runtime",
     "register_runtime",
     "registered_runtimes",

--- a/python/aibrix/aibrix/batch/job_driver/runtime/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/base.py
@@ -37,6 +37,7 @@ built here.
 from __future__ import annotations
 
 import asyncio
+import copy
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -51,9 +52,13 @@ from typing import (
     runtime_checkable,
 )
 
-import aibrix.batch.constant as constant
+from aibrix import envs
 from aibrix.batch.client import EndpointSource
 from aibrix.batch.job_driver.driver import TerminateResult
+from aibrix.batch.job_driver.error_injection import (
+    BREAKPOINT_RUNTIME_INITIALIZATION,
+    JobDriverErrorInjector,
+)
 from aibrix.batch.job_driver.running_jobs import RunningJobs
 from aibrix.batch.job_entity import (
     BatchJob,
@@ -62,12 +67,14 @@ from aibrix.batch.job_entity import (
     BatchJobStatus,
     ConditionType,
     JobRuntimeRef,
-    RequestCountStats,
 )
 from aibrix.context import InfrastructureContext
 from aibrix.logger import init_logger
 
 logger = init_logger(__name__)
+
+RUNTIME_WAIT_MODE_PROVISION = "provision"
+RUNTIME_WAIT_MODE_RECONNECT = "reconnect"
 
 
 @dataclass(slots=True)
@@ -118,6 +125,7 @@ class Runtime(Protocol):
         *,
         progress_manager: Optional[RunningJobs] = None,
         worker_id_generator: Optional[Callable[[Optional[str]], str]] = None,
+        error_injection: Optional[JobDriverErrorInjector] = None,
     ) -> "AsyncRuntimeSession":
         """Async context manager: provision -> yield Endpoint -> teardown."""
         ...
@@ -165,6 +173,8 @@ class RuntimeBase:
     provisions: bool = False
     session_retry_attempts: int = 3
     session_retry_base_delay_s: float = 2.0
+    session_liveness_check_interval_s: float = 30.0
+    session_liveness_failure_threshold: Optional[int] = None
 
     def __init__(
         self,
@@ -173,6 +183,16 @@ class RuntimeBase:
     ) -> None:
         self._context = context
         self._ready_timeout_seconds = ready_timeout_seconds
+        configured_liveness_failure_threshold = type(
+            self
+        ).session_liveness_failure_threshold
+        if configured_liveness_failure_threshold is None:
+            configured_liveness_failure_threshold = (
+                envs.BATCH_SESSION_LIVENESS_FAILURE_THRESHOLD
+            )
+        self.session_liveness_failure_threshold = max(
+            1, int(configured_liveness_failure_threshold)
+        )
         self._active_job_id: Optional[str] = None
         self._active_task: Optional[asyncio.Task[None]] = None
         self._active_runtime: Any | None = None
@@ -200,8 +220,21 @@ class RuntimeBase:
         """Create/lease/launch compute. Returns an opaque handle. NOOP default."""
         return None
 
-    async def _wait_ready(self, handle: Any) -> None:
-        """Poll until the compute is serving. NOOP default."""
+    async def _wait_ready(
+        self, handle: Any, wait_mode: str = RUNTIME_WAIT_MODE_PROVISION
+    ) -> None:
+        """Poll until runtime startup is usable for this session attempt.
+
+        ``wait_mode`` distinguishes a fresh provision from a reconnect startup
+        check, because some runtimes need stronger validation on reconnect than
+        a lightweight liveness probe.
+        """
+        del handle, wait_mode
+        return None
+
+    async def _check_liveness(self, handle: Any) -> None:
+        """Best-effort liveness probe for reconnect/recovery and live sessions."""
+        del handle
         return None
 
     async def _connect(self, handle: Any) -> Endpoint:
@@ -351,9 +384,20 @@ class RuntimeBase:
         if runtime_ref is None:
             return
 
+        saved_active_job_id = self._active_job_id
+        saved_active_task = self._active_task
+        saved_active_runtime = self._active_runtime
+        saved_progress_manager = self._progress_manager
+        saved_stop_requested = self._stop_requested.is_set()
+        saved_stopped = self._stopped.is_set()
+        saved_stop_job_id = self._stop_job_id
+        saved_stopped_job_id = self._stopped_job_id
+
         # Recovery cleanup does not re-enter a live runtime session; it only
         # reconnects long enough to tear the backend down. Keep the tracked job
-        # id for teardown/debugging, but do not re-bind the full active session.
+        # id for teardown/debugging. Restore any pre-existing live-session state
+        # afterward so callers may also use cleanup as a best-effort runtime
+        # interruption helper during in-progress execution.
         self._active_job_id = job.job_id
         self._stop_requested.clear()
         self._stopped.clear()
@@ -369,7 +413,11 @@ class RuntimeBase:
                 # Recovered FINALIZING cleanup only needs a quick liveness probe.
                 # If the runtime was already deleted before restart, avoid the
                 # full readiness wait loop and let finalization continue.
-                await asyncio.wait_for(self._wait_ready(handle), timeout=1.0)
+                # Keep a hard timeout here because liveness semantics answer
+                # "what to check", not "how long it may block"; cleanup must
+                # remain a fast recovery path even if a runtime-specific probe
+                # stalls on remote control-plane calls.
+                await asyncio.wait_for(self._check_liveness(handle), timeout=1.0)
             except TimeoutError:
                 return
             except Exception as exc:
@@ -378,12 +426,20 @@ class RuntimeBase:
                 raise
             await self._teardown(handle)
         finally:
-            self._active_job_id = None
-            self._active_runtime = None
-            self._stop_requested.clear()
-            self._stopped.clear()
-            self._stop_job_id = None
-            self._stopped_job_id = None
+            self._active_job_id = saved_active_job_id
+            self._active_task = saved_active_task
+            self._active_runtime = saved_active_runtime
+            self._progress_manager = saved_progress_manager
+            if saved_stop_requested:
+                self._stop_requested.set()
+            else:
+                self._stop_requested.clear()
+            if saved_stopped:
+                self._stopped.set()
+            else:
+                self._stopped.clear()
+            self._stop_job_id = saved_stop_job_id
+            self._stopped_job_id = saved_stopped_job_id
 
     async def _persist_runtime_ref(
         self,
@@ -391,27 +447,67 @@ class RuntimeBase:
         *,
         progress_manager: Optional[RunningJobs],
         worker_id_generator: Optional[Callable[[Optional[str]], str]],
-    ) -> BatchJob:
+    ) -> tuple[BatchJob, Optional[str]]:
+        # This helper is used after both reconnect and fresh provision. The
+        # name is historical: on a fresh provision it persists the current
+        # runtime ref, but on reconnect it also serves to rebind execution to
+        # the worker-local status slot derived from owner_ref. That local
+        # rebinding must happen even when the persisted runtime ref itself is
+        # logically unchanged.
         execution_ref = self._build_runtime_ref(job)
         if execution_ref is None:
-            return job
+            return job, None
         if progress_manager is None or worker_id_generator is None:
             raise RuntimeError(
                 "Execution tracking is not configured for session(); provide "
                 "progress_manager and worker_id_generator when starting a runtime session "
                 "for a batch job"
             )
-        status: BatchJobStatus = job.status.model_copy(deep=True)
-        # This update should not update request_counts and usage
-        status.request_counts = RequestCountStats()
-        status.usage = None
+        status = self._execution_update_status(job)
         status.set_runtime_ref(
             self._get_runtime_key(job),
             execution_ref,
         )
         worker_id = worker_id_generator(execution_ref.owner_ref)
+        # This update include execution only
+        return (
+            await progress_manager.update_job_local_status(
+                job.job_id, worker_id, status, update_keys={"execution"}
+            ),
+            worker_id,
+        )
+
+    def _execution_update_status(self, job: BatchJob) -> BatchJobStatus:
+        return BatchJobStatus(
+            jobID=job.job_id,
+            state=job.status.state,
+            createdAt=job.status.created_at,
+            execution=copy.deepcopy(job.status.execution),
+        )
+
+    async def _clear_runtime_ref(
+        self,
+        job: BatchJob,
+        *,
+        progress_manager: Optional[RunningJobs],
+        worker_id: str,
+    ) -> BatchJob:
+        execution_ref = self._load_runtime_ref(job)
+        if execution_ref is None:
+            return job
+        if progress_manager is None:
+            raise RuntimeError(
+                "Execution tracking is not configured for session(); provide "
+                "progress_manager and worker_id_generator when starting a runtime session "
+                "for a batch job"
+            )
+        status = self._execution_update_status(job)
+        status.remove_runtime_ref(self._get_runtime_key(job))
         return await progress_manager.update_job_local_status(
-            job.job_id, worker_id, status
+            job.job_id,
+            worker_id,
+            status,
+            update_keys={"execution"},
         )
 
     @staticmethod
@@ -421,17 +517,6 @@ class RuntimeBase:
         value = job.spec.opts[opt_key]
         normalized = str(value).strip().lower()
         return normalized not in {"", "0", "false", "no", "off"}
-
-    def _maybe_fail_runtime_initialization(self, job: BatchJob) -> None:
-        if not self._opt_enabled(job, constant.BATCH_OPTS_FAIL_INIT_RUNTIME):
-            return
-        raise BatchJobError(
-            code=BatchJobErrorCode.RESOURCE_CREATION_ERROR,
-            message=(
-                "Artificial runtime initialization failure triggered "
-                f"({constant.BATCH_OPTS_FAIL_INIT_RUNTIME})"
-            ),
-        )
 
     @staticmethod
     def _is_not_found_error(exc: Exception) -> bool:
@@ -451,9 +536,6 @@ class RuntimeBase:
         name = type(exc).__name__.lower()
         return "notfound" in name or "not_found" in name
 
-    def _should_retry_wait_ready(self, exc: Exception) -> bool:
-        return self._is_not_found_error(exc)
-
     def _should_teardown_failed_wait_ready(self, exc: Exception) -> bool:
         # If readiness proves the resource no longer exists, there is nothing
         # meaningful left to tear down; retry by provisioning a fresh resource.
@@ -461,6 +543,9 @@ class RuntimeBase:
 
     async def _sleep_before_session_retry(self, attempt: int) -> None:
         await asyncio.sleep(self.session_retry_base_delay_s * (2**attempt))
+
+    def _should_run_session_liveness_checks(self, handle: Any) -> bool:
+        return handle is not None and self.session_liveness_check_interval_s > 0
 
     @asynccontextmanager
     async def session(
@@ -470,12 +555,18 @@ class RuntimeBase:
         *,
         progress_manager: Optional[RunningJobs] = None,
         worker_id_generator: Optional[Callable[[Optional[str]], str]] = None,
+        error_injection: Optional[JobDriverErrorInjector] = None,
     ) -> AsyncIterator[Endpoint]:
         runtimeRef = self._load_runtime_ref(job)
+        error_injection = error_injection or JobDriverErrorInjector(job)
+        session_worker_id: Optional[str] = None
         handle = None
         max_attempts = self.session_retry_attempts + 1
         self._bind_active_session(job_id, progress_manager)
         error: BaseException | None = None
+        body_error: BaseException | None = None
+        liveness_error: BaseException | None = None
+        liveness_task: asyncio.Task[None] | None = None
         try:
             if self._stop_requested.is_set() or self._stopped.is_set():
                 raise asyncio.CancelledError(
@@ -494,35 +585,36 @@ class RuntimeBase:
                         if handle is None:
                             phase = "provision"
                     if handle is None:
-                        self._maybe_fail_runtime_initialization(job)
+                        error_injection.raise_for_breakpoint(
+                            BREAKPOINT_RUNTIME_INITIALIZATION
+                        )
                         handle = await self._provision(job, job_id)
-                    job = await self._persist_runtime_ref(
+                    # Run after both reconnect and provision. On provision this
+                    # persists the active runtime ref; on reconnect it refreshes
+                    # the worker-local execution binding so the recovered/live
+                    # session continues updating the correct owner_ref slot.
+                    job, session_worker_id = await self._persist_runtime_ref(
                         job,
                         progress_manager=progress_manager,
                         worker_id_generator=worker_id_generator,
                     )
                     phase = "wait_ready"
-                    await self._wait_ready(handle)
+                    await self._wait_ready(
+                        handle,
+                        wait_mode=RUNTIME_WAIT_MODE_PROVISION
+                        if phase == "provision"
+                        else RUNTIME_WAIT_MODE_RECONNECT,
+                    )
                     # Only yield a connected endpoint after both startup phases
                     # succeed within the same attempt.
                     break
                 except Exception as exc:
-                    should_retry = False
+                    # Any startup failure, including readiness checks run as
+                    # part of reconnect/provision, consumes an attempt and
+                    # falls back to provisioning fresh compute on retry.
+                    should_retry = attempt + 1 < max_attempts
                     should_teardown = handle is not None
-
-                    if phase in {"reconnect", "provision"}:
-                        # Reconnect is treated as the first startup attempt. Any
-                        # startup failure before readiness consumes an attempt and
-                        # falls back to provisioning fresh compute on retry.
-                        should_retry = attempt + 1 < max_attempts
-                    elif phase == "wait_ready":
-                        # A not-found during readiness means provisioning looked
-                        # successful but the backend resource vanished before it
-                        # became reachable, so reprovision instead of failing fast.
-                        should_retry = (
-                            self._should_retry_wait_ready(exc)
-                            and attempt + 1 < max_attempts
-                        )
+                    if phase == "wait_ready":
                         should_teardown = self._should_teardown_failed_wait_ready(exc)
 
                     if should_teardown and handle is not None:
@@ -543,14 +635,83 @@ class RuntimeBase:
                     handle = None
                     runtimeRef = None
                     await self._sleep_before_session_retry(attempt)
-            yield await self._connect(handle)
+
+            endpoint = await self._connect(handle)
+            current_task = asyncio.current_task()
+            if current_task is None:
+                raise RuntimeError("session() requires a running asyncio task")
+            configured_liveness_failure_threshold = (
+                self.session_liveness_failure_threshold
+            )
+            if configured_liveness_failure_threshold is None:
+                raise RuntimeError(
+                    "session_liveness_failure_threshold must be configured"
+                )
+            liveness_failure_threshold = max(1, configured_liveness_failure_threshold)
+
+            async def _session_liveness_loop() -> None:
+                nonlocal liveness_error
+                consecutive_failures = 0
+                try:
+                    while True:
+                        await asyncio.sleep(self.session_liveness_check_interval_s)
+                        if self._stop_requested.is_set():
+                            return
+                        try:
+                            await self._check_liveness(handle)
+                            consecutive_failures = 0
+                        except BaseException as exc:
+                            if isinstance(exc, asyncio.CancelledError):
+                                raise
+                            consecutive_failures += 1
+                            if consecutive_failures < liveness_failure_threshold:
+                                logger.warning(
+                                    "Runtime liveness check failed; retrying",
+                                    job_id=job_id,
+                                    consecutive_failures=consecutive_failures,
+                                    abort_after_failures=liveness_failure_threshold,
+                                    error=str(exc),
+                                )  # type: ignore[call-arg]
+                                continue
+                            liveness_error = exc
+                            current_task.cancel()
+                            return
+                except asyncio.CancelledError:
+                    raise
+
+            if self._should_run_session_liveness_checks(handle):
+                liveness_task = asyncio.create_task(_session_liveness_loop())
+            try:
+                yield endpoint
+            except BaseException as ex:
+                body_error = ex
+                raise
         except BaseException as ex:
             # Capture any exception that happens during the session lifecycle.
             # Will raise it and be propagated to the caller after teardown.
             error = ex
         finally:
+            if liveness_task is not None:
+                liveness_task.cancel()
+                try:
+                    await liveness_task
+                except asyncio.CancelledError:
+                    pass
+            if (
+                isinstance(body_error, asyncio.CancelledError)
+                and liveness_error is not None
+            ):
+                error = liveness_error
+            elif error is None and liveness_error is not None:
+                error = liveness_error
             if handle is not None:
                 await self._teardown(handle)
+            if session_worker_id is not None:
+                job = await self._clear_runtime_ref(
+                    job,
+                    progress_manager=progress_manager,
+                    worker_id=session_worker_id,
+                )
             if self._stop_requested.is_set():
                 self._stopped_job_id = job_id
                 self._stopped.set()

--- a/python/aibrix/aibrix/batch/job_driver/runtime/k8s_deployment.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/k8s_deployment.py
@@ -74,6 +74,7 @@ class DeploymentRuntime(RuntimeBase):
     """Provision a Deployment+Service per job, reach it over HTTP, tear it down."""
 
     provisions = True
+    session_liveness_failure_threshold = 1
 
     def __init__(
         self,
@@ -227,12 +228,34 @@ class DeploymentRuntime(RuntimeBase):
         )  # type: ignore[call-arg]
         return handle
 
-    async def _wait_ready(self, handle: DeploymentHandle) -> None:
+    async def _wait_ready(
+        self, handle: DeploymentHandle, wait_mode: str = "provision"
+    ) -> None:
+        del wait_mode
         await self._wait_for_deployment_ready(
             namespace=handle.namespace,
             deployment_name=handle.deployment_name,
             replicas=handle.replicas,
         )
+
+    async def _check_liveness(self, handle: DeploymentHandle) -> None:
+        try:
+            await asyncio.to_thread(
+                self._apps_v1_api.read_namespaced_deployment_status,
+                name=handle.deployment_name,
+                namespace=handle.namespace,
+            )
+        except ApiException as ex:
+            if ex.status == 404:
+                raise BatchJobError(
+                    BatchJobErrorCode.RESOURCE_NOTFOUND_ERROR,
+                    f"Deployment '{handle.deployment_name}' in namespace "
+                    f"'{handle.namespace}' no longer exists",
+                ) from ex
+            raise RuntimeError(
+                f"Failed to read Deployment '{handle.deployment_name}' in "
+                f"namespace '{handle.namespace}': {ex}"
+            ) from ex
 
     async def _connect(self, handle: DeploymentHandle) -> Endpoint:
         handle.source = self._build_endpoint_source(handle)

--- a/python/aibrix/aibrix/batch/job_driver/runtime/ssh_launch.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/ssh_launch.py
@@ -166,7 +166,10 @@ class SSHLaunchRuntime(RuntimeBase, abc.ABC):
             payload["image"] = info.image
         return payload
 
-    async def _wait_ready(self, handle: SSHHandle) -> None:
+    async def _wait_ready(
+        self, handle: SSHHandle, wait_mode: str = "provision"
+    ) -> None:
+        del wait_mode
         url = self._base_url(handle) + "/health"
         loop = asyncio.get_event_loop()
         deadline = loop.time() + self._ready_timeout_s
@@ -183,6 +186,18 @@ class SSHLaunchRuntime(RuntimeBase, abc.ABC):
                         f"vLLM not ready at {url} after {self._ready_timeout_s}s"
                     )
                 await asyncio.sleep(self._poll_interval_s)
+
+    async def _check_liveness(self, handle: SSHHandle) -> None:
+        url = self._base_url(handle) + "/health"
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            try:
+                resp = await client.get(url)
+            except Exception as ex:
+                raise RuntimeError(f"vLLM liveness check failed at {url}: {ex}") from ex
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"vLLM liveness check returned {resp.status_code} at {url}"
+            )
 
     async def _connect(self, handle: SSHHandle) -> Endpoint:
         # Origin only (no path); HttpChannel does urljoin(base_url, path).

--- a/python/aibrix/aibrix/batch/worker.py
+++ b/python/aibrix/aibrix/batch/worker.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import copy
 import json
 import os
 import signal
@@ -19,7 +20,7 @@ import subprocess
 import sys
 import time
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Collection, Optional
 from urllib.parse import urlparse
 
 import httpx
@@ -27,7 +28,11 @@ import httpx
 import aibrix.batch.constant as constant
 from aibrix.batch.client import GatewayEndpointSource
 from aibrix.batch.job_driver.base import BaseJobDriver
-from aibrix.batch.job_driver.running_jobs import RunningJobs
+from aibrix.batch.job_driver.running_jobs import (
+    LOCAL_STATUS_UPDATE_KEYS,
+    LocalStatusKey,
+    RunningJobs,
+)
 from aibrix.batch.job_driver.runtime import ExternalRuntime
 from aibrix.batch.job_entity import (
     AibrixMetadata,
@@ -133,10 +138,35 @@ class SingleJobRunner(RunningJobs):
         return self._meta
 
     async def update_job_local_status(
-        self, job_id: str, worker_id: str, status: BatchJobStatus
+        self,
+        job_id: str,
+        worker_id: str,
+        status: BatchJobStatus,
+        update_keys: Collection[LocalStatusKey] | None = None,
     ) -> BatchJob:
         del job_id, worker_id
-        self._meta.status = status
+        keys = (
+            set(LOCAL_STATUS_UPDATE_KEYS) if update_keys is None else set(update_keys)
+        )
+        unknown_keys = keys.difference(LOCAL_STATUS_UPDATE_KEYS)
+        if unknown_keys:
+            raise ValueError(
+                f"Unsupported local status update keys: {sorted(unknown_keys)}"
+            )
+        if "state" in keys:
+            self._meta.status.state = status.state
+        if "errors" in keys:
+            self._meta.status.errors = copy.deepcopy(status.errors)
+        if "request_counts" in keys:
+            self._meta.status.request_counts = status.request_counts.model_copy(
+                deep=True
+            )
+        if "usage" in keys:
+            self._meta.status.usage = (
+                status.usage.model_copy(deep=True) if status.usage is not None else None
+            )
+        if "execution" in keys:
+            self._meta.status.execution = copy.deepcopy(status.execution)
         return self._meta
 
     async def mark_job_finalizing(self, job_id: str) -> BatchJob:

--- a/python/aibrix/aibrix/envs.py
+++ b/python/aibrix/aibrix/envs.py
@@ -116,6 +116,9 @@ STORAGE_REDIS_PASSWORD = os.getenv("STORAGE_REDIS_PASSWORD") or os.getenv(
 DB_REDIS_PREFIX = os.getenv("DB_REDIS_PREFIX", "")
 
 BATCH_JOB_POOL_SIZE = int(os.getenv("AIBRIX_BATCH_JOB_POOL_SIZE", "10"))
+BATCH_SESSION_LIVENESS_FAILURE_THRESHOLD = int(
+    os.getenv("AIBRIX_BATCH_SESSION_LIVENESS_FAILURE_THRESHOLD", "3")
+)
 
 # Metric Standardizing Related Config
 # Scrape config

--- a/python/aibrix/tests/batch/conftest.py
+++ b/python/aibrix/tests/batch/conftest.py
@@ -35,6 +35,9 @@ import aibrix.batch.job_driver.runtime.k8s_deployment as deployment_runtime_modu
 import aibrix.batch.job_driver.runtime.k8s_job as k8s_job_runtime_module
 import aibrix.client.redis as redis_client
 from aibrix import envs
+from aibrix.batch.client.channel import EchoChannel
+from aibrix.batch.client.engine import DispatchEngine
+from aibrix.batch.client.errors import InferenceError, InferenceErrorCode
 from aibrix.batch.client.sources import NoopEndpointSource
 from aibrix.batch.job_driver.base import BaseJobDriver
 from aibrix.batch.job_driver.runtime import ExternalRuntime
@@ -50,6 +53,75 @@ logger = init_logger(__name__)
 ORIGINAL_DEPLOYMENT_TEARDOWN_RUNTIME = (
     deployment_runtime_module.DeploymentRuntime._teardown_runtime
 )
+
+
+def pin_job_concurrency_to_serial(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    per_request_delay: float = 0.0,
+) -> None:
+    """Opt a test into the serial worker path; concurrent remains the default."""
+
+    async def serial_execute_worker(self, job_id):
+        if self._engine is None:
+            raise RuntimeError(
+                "JobDriver was constructed without an engine; execute_worker "
+                "requires one."
+            )
+
+        job, stopped = await self._is_job_stopped(job_id)
+        if stopped:
+            return await self._finish_stopped_job(job)
+        return await self._execute_worker_serial(job)
+
+    monkeypatch.setattr(
+        BaseJobDriver,
+        "execute_worker",
+        serial_execute_worker,
+    )
+
+    if per_request_delay <= 0:
+        return
+
+    original_send = DispatchEngine._send_with_failover
+
+    async def delayed_send(self, request):
+        await asyncio.sleep(per_request_delay)
+        return await original_send(self, request)
+
+    monkeypatch.setattr(DispatchEngine, "_send_with_failover", delayed_send)
+
+
+@pytest.fixture
+def serial_worker(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    per_request_delay = float(getattr(request, "param", 0.0) or 0.0)
+    pin_job_concurrency_to_serial(
+        monkeypatch,
+        per_request_delay=per_request_delay,
+    )
+
+
+def _keyword_enables_serial_worker(keyword: str) -> bool:
+    return "serial_worker" in keyword
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        item.extra_keyword_matches.add("serial_worker")
+
+
+@pytest.fixture(autouse=True)
+def keyword_serial_worker(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if "test_backend" not in request.fixturenames:
+        return
+    test_backend = get_e2e_backend(request.getfixturevalue("test_backend"))
+    if not test_backend.serial_worker:
+        return
+    pin_job_concurrency_to_serial(monkeypatch)
 
 
 @pytest.fixture(scope="session")
@@ -429,7 +501,7 @@ class MockMetadataStore:
 
 
 class FastNoopEndpointSource(NoopEndpointSource):
-    def __init__(self, context):
+    def __init__(self, context, *, availability_check=None, channel_id: str = "echo"):
         self._context = context
         super().__init__(
             delay=context.values.get(
@@ -437,12 +509,42 @@ class FastNoopEndpointSource(NoopEndpointSource):
                 0.0,
             )
         )
+        self._channel = InterruptibleEchoChannel(
+            delay=context.values.get("endpoint_source_delay_seconds", 0.0),
+            availability_check=availability_check,
+            id=channel_id,
+        )
 
 
 class ParallelNoopEndpointSource(FastNoopEndpointSource):
-    def __init__(self, context, capacity: int):
-        super().__init__(context)
+    def __init__(self, context, capacity: int, *, availability_check=None):
+        super().__init__(context, availability_check=availability_check)
         self._capacity = capacity
+
+
+class InterruptibleEchoChannel(EchoChannel):
+    """Echo requests while the fake runtime endpoint remains available."""
+
+    def __init__(
+        self,
+        *,
+        delay: float = 0.0,
+        availability_check=None,
+        id: str = "echo",
+    ) -> None:
+        super().__init__(delay=delay, id=id)
+        self._availability_check = availability_check
+
+    async def send(self, request):
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        if callable(self._availability_check) and not self._availability_check():
+            raise InferenceError(
+                InferenceErrorCode.NO_ENDPOINT,
+                f"fake runtime endpoint {self.id} is unavailable",
+                retryable=False,
+            )
+        return request.payload
 
 
 class FakeDeploymentAppsV1Api:
@@ -466,6 +568,9 @@ class FakeDeploymentAppsV1Api:
         self.deleted.append((namespace, name))
         self._existing.remove((namespace, name))
 
+    def deployment_exists(self, namespace: str, name: str) -> bool:
+        return (namespace, name) in self._existing
+
 
 class FakeDeploymentCoreV1Api:
     def __init__(self):
@@ -487,6 +592,9 @@ class FakeDeploymentCoreV1Api:
             raise client.ApiException(status=404)
         self.deleted.append((namespace, name))
         self._existing.remove((namespace, name))
+
+    def service_exists(self, namespace: str, name: str) -> bool:
+        return (namespace, name) in self._existing
 
 
 class FakeDeploymentRenderer:
@@ -618,7 +726,14 @@ def configure_local_metastore_deployment_backend(app, monkeypatch) -> None:
         self._context.values["deployment_endpoint_source_builds"].append(
             handle.deployment_name
         )
-        return FastNoopEndpointSource(self._context)
+        return FastNoopEndpointSource(
+            self._context,
+            availability_check=lambda: (
+                apps_v1_api.deployment_exists(handle.namespace, handle.deployment_name)
+                and core_v1_api.service_exists(handle.namespace, handle.deployment_name)
+            ),
+            channel_id=handle.deployment_name,
+        )
 
     async def _recording_teardown(self, runtime):
         self._context.values["deployment_teardown_calls"].append(
@@ -755,6 +870,7 @@ class E2ETestBackend(str):
     max_concurrency: int
     storage_type: StorageType
     metastore_type: StorageType
+    serial_worker: bool
 
     def __new__(
         cls,
@@ -766,6 +882,7 @@ class E2ETestBackend(str):
         max_concurrency: int = 1,
         storage_type: StorageType = StorageType.LOCAL,
         metastore_type: StorageType = StorageType.LOCAL,
+        serial_worker: bool = False,
     ):
         backend = str.__new__(cls, name)
         backend.request_kwargs = dict(request_kwargs or {})
@@ -776,6 +893,7 @@ class E2ETestBackend(str):
         backend.max_concurrency = max_concurrency
         backend.storage_type = storage_type
         backend.metastore_type = metastore_type
+        backend.serial_worker = serial_worker
         return backend
 
     def has_feature(self, feature: str) -> bool:
@@ -792,6 +910,21 @@ class E2ETestBackend(str):
             max_concurrency=self.max_concurrency,
             storage_type=self.storage_type,
             metastore_type=metastore_type,
+            serial_worker=self.serial_worker,
+        )
+
+    def with_serial_worker(self, serial_worker: bool = True) -> "E2ETestBackend":
+        if self.serial_worker == serial_worker:
+            return self
+        return type(self)(
+            str(self),
+            request_kwargs=self.request_kwargs,
+            features=tuple(self.features),
+            runtime_debug_config=self.runtime_debug_config,
+            max_concurrency=self.max_concurrency,
+            storage_type=self.storage_type,
+            metastore_type=self.metastore_type,
+            serial_worker=serial_worker,
         )
 
     @property
@@ -830,16 +963,14 @@ class E2ETestBackend(str):
             parts.append(f"{self.storage_type.value}_storage")
         if self.metastore_type != StorageType.LOCAL:
             parts.append(f"{self.metastore_type.value}_metastore")
-        return "_".join(parts)
+        if self.serial_worker:
+            parts.append("serial_worker")
+        return "][".join(parts)
 
 
 E2E_BACKENDS: dict[str, E2ETestBackend] = {
     "local_metastore_job": E2ETestBackend(
         "local_metastore_job",
-    ),
-    "local_metastore_job_parallel": E2ETestBackend(
-        "local_metastore_job_parallel",
-        max_concurrency=5,
     ),
     "local_job_using_deployment": E2ETestBackend(
         "local_job_using_deployment",
@@ -908,6 +1039,8 @@ def apply_e2e_backend_keyword_overrides(
     # override whatever defaults the E2ETestBackend entry started with.
     if "redis_metastore" in keyword:
         test_backend = test_backend.with_metastore(StorageType.REDIS)
+    if _keyword_enables_serial_worker(keyword):
+        test_backend = test_backend.with_serial_worker()
     return test_backend
 
 
@@ -1166,15 +1299,6 @@ def build_e2e_test_app(
     )
     app.state.metadata_store = MockMetadataStore()
     app.state.redis_client = None
-
-    if test_backend == "local_metastore_job_parallel":
-        endpoint_source = ParallelNoopEndpointSource(
-            app.state.batch_driver._context,
-            capacity=test_backend.max_concurrency,
-        )
-        app.state.batch_driver._endpoint_source = endpoint_source
-        app.state.batch_driver.job_manager.set_endpoint_source(endpoint_source)
-        return app
 
     if not test_backend.uses_runtime:
         return app

--- a/python/aibrix/tests/batch/job_driver/runtime/test_k8s_deployment.py
+++ b/python/aibrix/tests/batch/job_driver/runtime/test_k8s_deployment.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
+from kubernetes.client import ApiException
 
 from aibrix.batch.client.sources import (
     InClusterEndpointSource,
@@ -329,6 +330,65 @@ async def test_k8s_deployment_runtime_reconnect_accepts_current_payload_keys():
 
 
 @pytest.mark.asyncio
+async def test_k8s_deployment_runtime_check_liveness_accepts_ready_deployment():
+    runtime = _make_runtime(apps_v1_api=FakeAppsV1Api(available_replicas=1))
+
+    await runtime._check_liveness(
+        DeploymentHandle(
+            namespace="default",
+            deployment_name="rendered-deployment",
+            service_name="rendered-service",
+            model_name="rendered-model",
+            base_url="http://rendered-service.default.svc.cluster.local:8000",
+            service_port=8000,
+            replicas=1,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_k8s_deployment_runtime_check_liveness_accepts_existing_unready_deployment():
+    runtime = _make_runtime(apps_v1_api=FakeAppsV1Api(available_replicas=0))
+
+    await runtime._check_liveness(
+        DeploymentHandle(
+            namespace="default",
+            deployment_name="rendered-deployment",
+            service_name="rendered-service",
+            model_name="rendered-model",
+            base_url="http://rendered-service.default.svc.cluster.local:8000",
+            service_port=8000,
+            replicas=1,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_k8s_deployment_runtime_check_liveness_reports_missing_deployment():
+    class _MissingAppsV1Api(FakeAppsV1Api):
+        def read_namespaced_deployment_status(self, name: str, namespace: str):
+            del name, namespace
+            raise ApiException(status=404, reason="Not Found")
+
+    runtime = _make_runtime(apps_v1_api=_MissingAppsV1Api())
+
+    with pytest.raises(BatchJobError) as exc_info:
+        await runtime._check_liveness(
+            DeploymentHandle(
+                namespace="default",
+                deployment_name="rendered-deployment",
+                service_name="rendered-service",
+                model_name="rendered-model",
+                base_url="http://rendered-service.default.svc.cluster.local:8000",
+                service_port=8000,
+                replicas=1,
+            )
+        )
+
+    assert exc_info.value.code == BatchJobErrorCode.RESOURCE_NOTFOUND_ERROR
+
+
+@pytest.mark.asyncio
 async def test_k8s_deployment_runtime_connect_uses_in_cluster_source(monkeypatch):
     runtime = _make_runtime(renderer=FakeRenderer())
     handle = DeploymentHandle(
@@ -381,15 +441,15 @@ async def test_k8s_deployment_runtime_terminate_cancels_session_and_tears_down()
         renderer=FakeRenderer(),
     )
 
-    async def _update_job_local_status(job_id, worker_id, status):
-        del worker_id
+    async def _update_job_local_status(job_id, worker_id, status, update_keys=None):
+        del worker_id, update_keys
         return SimpleNamespace(job_id=job_id, status=status)
 
     progress_manager = SimpleNamespace(update_job_local_status=_update_job_local_status)
     wait_entered = asyncio.Event()
 
-    async def _blocked_wait_ready(handle):
-        del handle
+    async def _blocked_wait_ready(handle, wait_mode="provision"):
+        del handle, wait_mode
         wait_entered.set()
         await runtime._stop_requested.wait()
         raise asyncio.CancelledError

--- a/python/aibrix/tests/batch/job_driver/runtime/test_ssh_launch.py
+++ b/python/aibrix/tests/batch/job_driver/runtime/test_ssh_launch.py
@@ -151,6 +151,39 @@ async def test_wait_ready_times_out():
 
 
 @pytest.mark.asyncio
+async def test_check_liveness_accepts_healthy_endpoint():
+    rt = RunPodRuntime()
+
+    async def healthy(url, *a, **k):
+        del url, a, k
+
+        class R:
+            status_code = 200
+
+        return R()
+
+    with patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=healthy)):
+        await rt._check_liveness(_handle())
+
+
+@pytest.mark.asyncio
+async def test_check_liveness_rejects_unhealthy_endpoint():
+    rt = RunPodRuntime()
+
+    async def unhealthy(url, *a, **k):
+        del url, a, k
+
+        class R:
+            status_code = 503
+
+        return R()
+
+    with patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=unhealthy)):
+        with pytest.raises(RuntimeError, match="returned 503"):
+            await rt._check_liveness(_handle())
+
+
+@pytest.mark.asyncio
 async def test_provision_connects_and_launches(monkeypatch):
     rt = RunPodRuntime()
     fake_conn = Mock()

--- a/python/aibrix/tests/batch/test_base_job_driver_concurrent.py
+++ b/python/aibrix/tests/batch/test_base_job_driver_concurrent.py
@@ -379,7 +379,8 @@ async def test_execute_worker_stats_fallback_preserves_failed_count(monkeypatch)
     _patch_storage(monkeypatch, requests)
     persisted_statuses = []
 
-    async def update_job_local_status(job_id, worker_id, status):
+    async def update_job_local_status(job_id, worker_id, status, update_keys=None):
+        del update_keys
         persisted_statuses.append(status.model_copy(deep=True))
         updated = job.model_copy(deep=True)
         updated.status = status.model_copy(deep=True)

--- a/python/aibrix/tests/batch/test_batch_manager.py
+++ b/python/aibrix/tests/batch/test_batch_manager.py
@@ -32,12 +32,14 @@ from aibrix.batch.job_entity import (
     BatchJobSpec,
     BatchJobState,
     BatchJobStatus,
+    BatchJobStatusCopy,
     CompletionWindow,
     Condition,
     ConditionStatus,
     ConditionType,
     JobRuntimeRef,
     ObjectMeta,
+    RequestCountStats,
     TypeMeta,
 )
 from aibrix.batch.state import JobEntityManager, JobMetaInfo
@@ -110,6 +112,47 @@ class _FakeJobDriver:
 
     async def cleanup(self, job: BatchJob) -> None:
         self.cleanup_calls.append(job.job_id)
+
+
+@pytest.mark.asyncio
+async def test_update_job_local_status_execution_only_preserves_worker_snapshot():
+    job_manager = _job_manager()
+    meta_job = _in_progress_meta_job("job-execution-only", total_requests=10)
+    meta_job.status.set_runtime_ref(
+        "base",
+        JobRuntimeRef(driverType="base", ownerRef="worker-1", attempt=1),
+    )
+    meta_job.status.status_copies = {
+        "worker-1": BatchJobStatusCopy(
+            state=BatchJobState.IN_PROGRESS,
+            requestCounts=RequestCountStats(
+                total=10,
+                launched=4,
+                completed=3,
+                failed=1,
+            ),
+        )
+    }
+    job_manager._in_progress_jobs[meta_job.job_id] = meta_job
+
+    status = meta_job.status.model_copy(deep=True)
+    status.remove_runtime_ref("base")
+    status.request_counts = RequestCountStats()
+
+    updated = await job_manager.update_job_local_status(
+        meta_job.job_id,
+        "worker-1",
+        status,
+        update_keys={"execution"},
+    )
+
+    assert updated.status.execution is None
+    assert updated.status.status_copies is not None
+    assert updated.status.status_copies["worker-1"].request_counts.total == 10
+    assert updated.status.status_copies["worker-1"].request_counts.launched == 4
+    assert updated.status.status_copies["worker-1"].request_counts.completed == 3
+    assert updated.status.status_copies["worker-1"].request_counts.failed == 1
+    assert updated.status.status_copies["worker-1"].updated is False
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/batch/test_deployment_driver.py
+++ b/python/aibrix/tests/batch/test_deployment_driver.py
@@ -101,8 +101,10 @@ class FakeProgressManager:
         self.validated_job_ids.append(job_id)
         return True
 
-    async def update_job_local_status(self, job_id: str, worker_id: str, status):
-        del job_id, worker_id
+    async def update_job_local_status(
+        self, job_id: str, worker_id: str, status, update_keys=None
+    ):
+        del job_id, worker_id, update_keys
         self.job.status = status
         return self.job
 

--- a/python/aibrix/tests/batch/test_deployment_driver.py
+++ b/python/aibrix/tests/batch/test_deployment_driver.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import contextlib
+import copy
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Optional
@@ -104,8 +105,23 @@ class FakeProgressManager:
     async def update_job_local_status(
         self, job_id: str, worker_id: str, status, update_keys=None
     ):
-        del job_id, worker_id, update_keys
-        self.job.status = status
+        del job_id, worker_id
+        if update_keys is None:
+            self.job.status = status
+            return self.job
+
+        if "execution" in update_keys:
+            self.job.status.execution = copy.deepcopy(status.execution)
+        if "state" in update_keys:
+            self.job.status.state = status.state
+        if "errors" in update_keys:
+            self.job.status.errors = copy.deepcopy(status.errors)
+        if "request_counts" in update_keys:
+            self.job.status.request_counts = status.request_counts.model_copy(deep=True)
+        if "usage" in update_keys:
+            self.job.status.usage = (
+                status.usage.model_copy(deep=True) if status.usage is not None else None
+            )
         return self.job
 
     async def mark_job_finalizing(self, job_id: str):

--- a/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
+++ b/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
@@ -36,6 +36,10 @@ from fastapi.testclient import TestClient
 import aibrix.batch.constant as constant
 from aibrix.batch.batch_manager import BatchManager
 from aibrix.batch.job_driver import BaseJobDriver, JobDriver, TerminateResult
+from aibrix.batch.job_driver.error_injection import (
+    BREAKPOINT_RUNTIME_INITIALIZATION,
+    JobDriverErrorInjector,
+)
 from aibrix.batch.job_entity import (
     AibrixMetadata,
     BatchJob,
@@ -119,8 +123,10 @@ def backend_prepare_entry_timeout_seconds(test_backend) -> float:
     return 5.0
 
 
-def backend_expect_exact_request_counts(test_backend) -> bool:
-    return _backend(test_backend).max_concurrency == 1
+def is_keyword_serial_worker(driver: Any) -> bool:
+    execute_worker = getattr(driver, "execute_worker", None)
+    execute_worker_func = getattr(execute_worker, "__func__", execute_worker)
+    return getattr(execute_worker_func, "__name__", "") == "serial_execute_worker"
 
 
 def backend_has_runtime_debug_state(test_backend) -> bool:
@@ -183,6 +189,18 @@ def backend_uses_fake_provisioning_runtime(test_backend) -> bool:
     return _backend(test_backend).has_feature("fake_provisioning_runtime")
 
 
+def backend_supports_runtime_cleanup_interruption(test_backend) -> bool:
+    return backend_uses_fake_provisioning_runtime(
+        test_backend
+    ) and not backend_uses_kubernetes_provider(test_backend)
+
+
+def backend_runtime_cleanup_delete_delta(test_backend) -> int:
+    if backend_uses_deployment_provider(test_backend):
+        return 1
+    return 2
+
+
 def backend_observes_restart_validation_runtime_delta(test_backend) -> bool:
     return _backend(test_backend).has_feature(
         "restart_validation_runtime_delta_observable"
@@ -199,7 +217,6 @@ def pytest_generate_tests(metafunc):
     select_e2e_backends(
         metafunc,
         [
-            "local_metastore_job_parallel",
             "local_job_using_deployment",
             "local_job_using_k8s_job",
         ],
@@ -301,12 +318,14 @@ def force_batch_driver_crash_on_shutdown(monkeypatch, app) -> None:
         *,
         progress_manager=None,
         worker_id_generator=None,
+        error_injection=None,
     ):
         self._bind_active_session(job_id, progress_manager)
         try:
             runtimeRef = self._load_runtime_ref(job)
             handle = None
             max_attempts = self.session_retry_attempts + 1
+            error_injection = error_injection or JobDriverErrorInjector(job)
             try:
                 for attempt in range(max_attempts):
                     try:
@@ -321,9 +340,11 @@ def force_batch_driver_crash_on_shutdown(monkeypatch, app) -> None:
                             if handle is None:
                                 phase = "provision"
                         if handle is None:
-                            self._maybe_fail_runtime_initialization(job)
+                            error_injection.raise_for_breakpoint(
+                                BREAKPOINT_RUNTIME_INITIALIZATION
+                            )
                             handle = await self._provision(job, job_id)
-                        job = await self._persist_runtime_ref(
+                        job, _ = await self._persist_runtime_ref(
                             job,
                             progress_manager=progress_manager,
                             worker_id_generator=worker_id_generator,
@@ -338,10 +359,7 @@ def force_batch_driver_crash_on_shutdown(monkeypatch, app) -> None:
                         if phase in {"reconnect", "provision"}:
                             should_retry = attempt + 1 < max_attempts
                         elif phase == "wait_ready":
-                            should_retry = (
-                                self._should_retry_wait_ready(exc)
-                                and attempt + 1 < max_attempts
-                            )
+                            should_retry = attempt + 1 < max_attempts
                             should_teardown = self._should_teardown_failed_wait_ready(
                                 exc
                             )
@@ -520,7 +538,15 @@ def install_pending_after_n_requests_barrier(
                 if latest_job is not None:
                     return latest_job, completed
             else:
-                await asyncio.sleep(3600)
+                try:
+                    await asyncio.sleep(3600)
+                except asyncio.CancelledError:
+                    if is_keyword_serial_worker(self):
+                        raise
+                    latest_job = await job_manager.get_job(job.job_id)
+                    if latest_job is not None:
+                        return latest_job, completed
+                    raise
         return job, completed
 
     async def blocked_sync_completed_request_tasks(self, job, completed_request_tasks):
@@ -537,44 +563,6 @@ def install_pending_after_n_requests_barrier(
         blocked_sync_completed_request_tasks,
     )
     return entered_pending, release_pending
-
-
-def pin_job_concurrency_to_serial(
-    monkeypatch, test_backend, *, per_request_delay: float = 0.0
-) -> None:
-    """Make request-persistence barriers deterministic for timing tests."""
-    target_driver = backend_runtime_driver_class(test_backend)
-
-    async def serial_execute_worker(self, job_id):
-        if self._engine is None:
-            raise RuntimeError(
-                "JobDriver was constructed without an engine; execute_worker "
-                "requires one."
-            )
-
-        job, stopped = await self._is_job_stopped(job_id)
-        if stopped:
-            return await self._finish_stopped_job(job)
-        return await self._execute_worker_serial(job)
-
-    monkeypatch.setattr(
-        target_driver,
-        "execute_worker",
-        serial_execute_worker,
-    )
-
-    if per_request_delay <= 0:
-        return
-
-    from aibrix.batch.client.engine import DispatchEngine
-
-    original_send = DispatchEngine._send_with_failover
-
-    async def delayed_send(self, request):
-        await asyncio.sleep(per_request_delay)
-        return await original_send(self, request)
-
-    monkeypatch.setattr(DispatchEngine, "_send_with_failover", delayed_send)
 
 
 async def wait_for_status(
@@ -1393,6 +1381,9 @@ async def test_job_processing_failure(e2e_test_app, test_backend):
         try:
             # Step 3: Create batch job with failing manager that injects fail_after metadata
             debug_state = capture_runtime_debug_state(e2e_test_app, test_backend)
+            expect_exact_request_counts = is_keyword_serial_worker(
+                e2e_test_app.state.batch_driver
+            )
             batch_id = create_batch_job(
                 client, input_file_id, test_backend=test_backend
             )
@@ -1428,13 +1419,13 @@ async def test_job_processing_failure(e2e_test_app, test_backend):
                 expected_request_counts=(
                     {
                         "total": 10,
-                        "completed_at_least": 1,
+                        "completed": 1,
                         "failed": 0,
                     }
-                    if test_backend == "local_metastore_job_parallel"
+                    if expect_exact_request_counts
                     else {
                         "total": 10,
-                        "completed": 1,
+                        "completed_at_least": 1,
                         "failed": 0,
                     }
                 ),
@@ -1508,6 +1499,114 @@ async def test_job_runtime_initialization_failure(e2e_test_app, test_backend):
                 client, e2e_test_app, test_backend, input_file_id, 2
             )
         finally:
+            if batch_id is not None:
+                await e2e_test_app.state.batch_driver.clear_job(batch_id)
+            restore_job_manager(e2e_test_app, original_manager)
+
+
+@pytest.mark.asyncio
+async def test_job_runtime_failure_in_progress(e2e_test_app, test_backend):
+    if not backend_supports_runtime_cleanup_interruption(test_backend):
+        pytest.skip(
+            "Runtime interruption injection requires a fake provisioning runtime "
+            "with a live endpoint source"
+        )
+
+    print("Test 2c: Job runtime failure during in-progress scenario")
+
+    with create_test_client(e2e_test_app) as client:
+        input_file_id = upload_batch_input_file(client, 10)
+        original_delay = set_runtime_inference_delay(
+            e2e_test_app, test_backend, delay_seconds=1.0
+        )
+        failing_manager = FailingBatchManager(
+            injected_opts={constant.BATCH_OPTS_INTERRUPT_RUNTIME_AFTER_N_REQUESTS: "3"}
+        )
+        original_manager = await swap_job_manager(e2e_test_app, failing_manager)
+        batch_id = None
+
+        try:
+            debug_state = capture_runtime_debug_state(e2e_test_app, test_backend)
+            expect_exact_request_counts = is_keyword_serial_worker(
+                e2e_test_app.state.batch_driver
+            )
+            completed_wait_kwargs = {
+                "max_polls": 120,
+                "poll_interval": 0.5,
+                **backend_status_wait_kwargs(test_backend, expected_status="completed"),
+            }
+            batch_id = create_batch_job(
+                client, input_file_id, test_backend=test_backend
+            )
+
+            await wait_for_status(
+                client,
+                batch_id,
+                "in_progress",
+                **backend_status_wait_kwargs(
+                    test_backend, expected_status="in_progress"
+                ),
+            )
+            final_status = await wait_for_status(
+                client,
+                batch_id,
+                "completed",
+                **completed_wait_kwargs,
+            )
+
+            validate_batch_response(
+                final_status,
+                expected_status="completed",
+                expected_endpoint="/v1/chat/completions",
+                expected_input_file_id=input_file_id,
+                expected_in_progress_at=True,
+                expected_finalizing_at=True,
+                expected_completed_at=True,
+                expected_failed_at=False,
+                expected_errors=False,
+                expected_output_file_id=True,
+                expected_error_file_id=True,
+                expected_request_counts=(
+                    {
+                        "total": 10,
+                        "completed": 3,
+                        "failed": 7,
+                    }
+                    if expect_exact_request_counts
+                    else {
+                        "total": 10,
+                        "completed_at_least": 3,
+                        "failed_at_least": 1,
+                    }
+                ),
+            )
+
+            handles = get_runtime_debug_handles(e2e_test_app, test_backend)
+            assert handles is not None
+            assert debug_state is not None
+            assert len(handles["runtime_create_calls"]) == (
+                debug_state["runtime_create_calls"] + 1
+            )
+            assert len(handles["inference_client_builds"]) == (
+                debug_state["inference_client_builds"] + 1
+            )
+            assert len(handles["teardown_calls"]) >= debug_state["teardown_calls"] + 2
+            assert len(handles["runtime_delete_calls"]) >= (
+                debug_state["runtime_delete_calls"]
+                + backend_runtime_cleanup_delete_delta(test_backend)
+            )
+
+            print(
+                "✅ Runtime interruption during processing test completed successfully"
+            )
+            failing_manager.injected_opts = {}
+            await run_follow_up_success_with_same_input(
+                client, e2e_test_app, test_backend, input_file_id, 10
+            )
+        finally:
+            set_runtime_inference_delay(
+                e2e_test_app, test_backend, delay_seconds=original_delay or 0.0
+            )
             if batch_id is not None:
                 await e2e_test_app.state.batch_driver.clear_job(batch_id)
             restore_job_manager(e2e_test_app, original_manager)
@@ -1806,7 +1905,10 @@ async def test_job_cancellation_in_progress_during_init_runtime(
 
             try:
                 # Step 3: Wait until the job is pinned inside runtime initialization
-                await asyncio.wait_for(entered_init_runtime.wait(), timeout=5)
+                await asyncio.wait_for(
+                    entered_init_runtime.wait(),
+                    timeout=backend_prepare_entry_timeout_seconds(test_backend),
+                )
 
                 # Step 4: Verify the job is pending in progress before runtime init completes
                 status_during_init = client.get(f"/v1/batches/{batch_id}")
@@ -1821,7 +1923,15 @@ async def test_job_cancellation_in_progress_during_init_runtime(
                 release_init_runtime.set()
 
                 final_status = await wait_for_status(
-                    client, batch_id, "cancelled", max_polls=40, poll_interval=0.5
+                    client,
+                    batch_id,
+                    "cancelled",
+                    **(
+                        {"max_polls": 40, "poll_interval": 0.5}
+                        | backend_status_wait_kwargs(
+                            test_backend, expected_status="cancelled"
+                        )
+                    ),
                 )
                 # Step 7: Verify cancelled status using comprehensive validation
                 validate_batch_response(
@@ -1902,7 +2012,10 @@ async def test_job_cancellation_in_progress_during_service_discovery(
             test_backend=test_backend,
         )
         try:
-            await asyncio.wait_for(entered_discovery.wait(), timeout=5)
+            await asyncio.wait_for(
+                entered_discovery.wait(),
+                timeout=backend_prepare_entry_timeout_seconds(test_backend),
+            )
 
             status_during_discovery = client.get(f"/v1/batches/{batch_id}")
             assert status_during_discovery.status_code == 200
@@ -1913,7 +2026,15 @@ async def test_job_cancellation_in_progress_during_service_discovery(
             assert cancel_response.json()["status"] == "cancelling"
 
             final_status = await wait_for_status(
-                client, batch_id, "cancelled", max_polls=40, poll_interval=0.1
+                client,
+                batch_id,
+                "cancelled",
+                **(
+                    {"max_polls": 40, "poll_interval": 0.1}
+                    | backend_status_wait_kwargs(
+                        test_backend, expected_status="cancelled"
+                    )
+                ),
             )
             await wait_for_runtime_teardown_delta(
                 e2e_test_app,
@@ -1944,7 +2065,6 @@ async def test_job_cancellation_in_progress_during_service_discovery(
 async def test_job_cancellation_in_progress(e2e_test_app, test_backend, monkeypatch):
     """Test case 5: Create job, cancel during in progress, finalizing, validate finalized result."""
     print("Test 5: Job cancellation during processing scenario")
-    pin_job_concurrency_to_serial(monkeypatch, test_backend, per_request_delay=0.3)
     entered_pending, release_pending = install_pending_after_n_requests_barrier(
         monkeypatch,
         e2e_test_app,
@@ -1962,8 +2082,9 @@ async def test_job_cancellation_in_progress(e2e_test_app, test_backend, monkeypa
         # Step 2: Create batch job
         debug_state = capture_runtime_debug_state(e2e_test_app, test_backend)
         batch_id = create_batch_job(client, input_file_id, test_backend=test_backend)
-        expect_exact_request_counts = backend_expect_exact_request_counts(test_backend)
-
+        expect_exact_request_counts = is_keyword_serial_worker(
+            e2e_test_app.state.batch_driver
+        )
         try:
             # Step 3: Wait until exactly 3 requests have been persisted and the job blocks
             entered = await asyncio.to_thread(entered_pending.wait, 10)
@@ -1994,7 +2115,15 @@ async def test_job_cancellation_in_progress(e2e_test_app, test_backend, monkeypa
 
             # Step 5: Wait for cancellation and finalization
             final_status = await wait_for_status(
-                client, batch_id, "cancelled", max_polls=40, poll_interval=0.5
+                client,
+                batch_id,
+                "cancelled",
+                **(
+                    {"max_polls": 40, "poll_interval": 0.5}
+                    | backend_status_wait_kwargs(
+                        test_backend, expected_status="cancelled"
+                    )
+                ),
             )
 
             # Step 6: Verify cancelled status using comprehensive validation
@@ -2017,7 +2146,7 @@ async def test_job_cancellation_in_progress(e2e_test_app, test_backend, monkeypa
                 expected_request_counts=(
                     {"total": 10, "completed": 3, "failed": 0}
                     if expect_exact_request_counts
-                    else True
+                    else {"total": 10, "completed_at_least": 3, "failed": 0}
                 ),
             )
             if not expect_exact_request_counts:
@@ -2253,21 +2382,16 @@ async def test_job_expiration_during_validation(e2e_test_app, test_backend):
 
 
 @pytest.mark.asyncio
-async def test_job_expiration_during_processing(
-    e2e_test_app, test_backend, monkeypatch
-):
+async def test_job_expiration_during_processing(e2e_test_app, test_backend):
     """Test case 8: Create job, set expire to 1min, expired during in progress, finalizing, validate result."""
     print("Test 8: Job expiration during processing scenario")
-    pin_job_concurrency_to_serial(monkeypatch, test_backend)
 
     with create_test_client(e2e_test_app) as client:
         input_file_id = upload_batch_input_file(client, 3)
         original_delay = set_runtime_inference_delay(
             e2e_test_app,
             test_backend,
-            delay_seconds=(
-                3.0 if test_backend == "local_metastore_job_parallel" else 1.0
-            ),
+            delay_seconds=1.0,
         )
 
         # Step 2: Inject FailingBatchManager to add fail_after metadata during job creation
@@ -2403,7 +2527,6 @@ async def test_job_restart_during_in_progress(
         pytest.skip("Restart phase recovery is not covered for this backend")
 
     # Test setup
-    pin_job_concurrency_to_serial(monkeypatch, test_backend)
     force_batch_driver_crash_on_shutdown(monkeypatch, e2e_test_app)
     entered_pending, _ = install_pending_after_n_requests_barrier(
         monkeypatch,

--- a/python/aibrix/tests/batch/test_k8s_job_runtime.py
+++ b/python/aibrix/tests/batch/test_k8s_job_runtime.py
@@ -138,7 +138,7 @@ async def test_deletion_cancels_wait():
 
     async def _persist_runtime_ref(job, **kwargs):
         del kwargs
-        return job
+        return job, None
 
     async def _wait_until_done(handle):
         wait_entered.set()

--- a/python/aibrix/tests/batch/test_runtime.py
+++ b/python/aibrix/tests/batch/test_runtime.py
@@ -22,6 +22,8 @@ import pytest
 
 from aibrix.batch.job_driver.driver import TerminateResult
 from aibrix.batch.job_driver.runtime import (
+    RUNTIME_WAIT_MODE_PROVISION,
+    RUNTIME_WAIT_MODE_RECONNECT,
     Endpoint,
     ExternalRuntime,
     NoopRuntime,
@@ -46,9 +48,9 @@ from aibrix.context import InfrastructureContext
 
 class _FakeProgressManager:
     async def update_job_local_status(
-        self, job_id: str, worker_id: str, status
+        self, job_id: str, worker_id: str, status, update_keys=None
     ) -> object:
-        del worker_id
+        del worker_id, update_keys
         return SimpleNamespace(job_id=job_id, status=status)
 
 
@@ -101,12 +103,14 @@ class _R(RuntimeBase):
         *,
         provision=None,
         wait_ready=None,
+        check_liveness=None,
         connect=None,
         teardown=None,
     ) -> None:
         super().__init__(InfrastructureContext())
         self._provision_hook = provision
         self._wait_ready_hook = wait_ready
+        self._check_liveness_hook = check_liveness
         self._connect_hook = connect
         self._teardown_hook = teardown
 
@@ -115,10 +119,20 @@ class _R(RuntimeBase):
             return "handle"
         return await _maybe_await(self._provision_hook(job, job_id))
 
-    async def _wait_ready(self, handle):
+    async def _wait_ready(self, handle, wait_mode="provision"):
         if self._wait_ready_hook is None:
             return None
+        parameters = inspect.signature(self._wait_ready_hook).parameters
+        if "wait_mode" in parameters:
+            return await _maybe_await(
+                self._wait_ready_hook(handle, wait_mode=wait_mode)
+            )
         return await _maybe_await(self._wait_ready_hook(handle))
+
+    async def _check_liveness(self, handle):
+        if self._check_liveness_hook is None:
+            return await super()._check_liveness(handle)
+        return await _maybe_await(self._check_liveness_hook(handle))
 
     async def _connect(self, handle):
         if self._connect_hook is None:
@@ -407,6 +421,34 @@ async def test_runtime_base_terminate_different_id_inside_session_is_rejected():
 
 
 @pytest.mark.asyncio
+async def test_runtime_base_session_passes_reconnect_wait_mode_on_reconnect_attempt():
+    execution = JobRuntimeRef(driverType="base", reconnectPayload={})
+    job = _make_test_job(job_id="job-1", execution={"base": execution})
+    wait_calls: list[tuple[str, str]] = []
+
+    class _ReconnectRuntime(_R):
+        async def _reconnect(self, job, job_id, runtime_ref):
+            del job, job_id
+            assert runtime_ref is execution
+            return "reconnected-handle"
+
+    async def _wait_ready(handle, *, wait_mode=RUNTIME_WAIT_MODE_PROVISION):
+        wait_calls.append((handle, wait_mode))
+
+    runtime = _ReconnectRuntime(wait_ready=_wait_ready)
+
+    async with runtime.session(
+        job=job,
+        job_id="job-1",
+        progress_manager=_FakeProgressManager(),
+        worker_id_generator=_fake_worker_id_generator,
+    ) as endpoint:
+        assert endpoint.model_name == "m"
+
+    assert wait_calls == [("reconnected-handle", RUNTIME_WAIT_MODE_RECONNECT)]
+
+
+@pytest.mark.asyncio
 async def test_runtime_base_session_retries_provision_with_exponential_backoff(
     monkeypatch,
 ):
@@ -562,9 +604,6 @@ async def test_runtime_base_session_ignores_teardown_failure_during_retry(
             raise RuntimeError("teardown failed")
 
     class _RetryRuntime(_R):
-        def _should_retry_wait_ready(self, exc: Exception) -> bool:
-            return isinstance(exc, _RetryableReadyError)
-
         def _should_teardown_failed_wait_ready(self, exc: Exception) -> bool:
             del exc
             return True
@@ -608,6 +647,130 @@ async def test_runtime_base_session_ignores_teardown_failure_during_retry(
 
 
 @pytest.mark.asyncio
+async def test_runtime_base_session_periodically_checks_liveness_and_surfaces_failure():
+    third_check_started = asyncio.Event()
+    calls: list[tuple[str, str]] = []
+
+    async def _check_liveness(handle):
+        calls.append(("check_liveness", handle))
+        if len(calls) == 3:
+            third_check_started.set()
+        raise RuntimeError("runtime lost")
+
+    async def _teardown(handle):
+        calls.append(("teardown", handle))
+
+    class _LivenessRuntime(_R):
+        session_liveness_check_interval_s = 0.01
+
+    runtime = _LivenessRuntime(
+        check_liveness=_check_liveness,
+        teardown=_teardown,
+    )
+
+    with pytest.raises(RuntimeError, match="runtime lost"):
+        async with runtime.session(
+            job=_make_test_job(job_id="job-1"),
+            job_id="job-1",
+            progress_manager=_FakeProgressManager(),
+            worker_id_generator=_fake_worker_id_generator,
+        ):
+            await asyncio.wait_for(third_check_started.wait(), timeout=1)
+            await asyncio.sleep(1)
+
+    assert calls == [
+        ("check_liveness", "handle"),
+        ("check_liveness", "handle"),
+        ("check_liveness", "handle"),
+        ("teardown", "handle"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_base_session_liveness_uses_runtime_failure_threshold_override():
+    second_check_started = asyncio.Event()
+    calls: list[tuple[str, str]] = []
+
+    async def _check_liveness(handle):
+        calls.append(("check_liveness", handle))
+        if len(calls) == 2:
+            second_check_started.set()
+        raise RuntimeError("runtime lost")
+
+    async def _teardown(handle):
+        calls.append(("teardown", handle))
+
+    class _LivenessRuntime(_R):
+        session_liveness_check_interval_s = 0.01
+        session_liveness_failure_threshold = 2
+
+    runtime = _LivenessRuntime(
+        check_liveness=_check_liveness,
+        teardown=_teardown,
+    )
+
+    with pytest.raises(RuntimeError, match="runtime lost"):
+        async with runtime.session(
+            job=_make_test_job(job_id="job-1"),
+            job_id="job-1",
+            progress_manager=_FakeProgressManager(),
+            worker_id_generator=_fake_worker_id_generator,
+        ):
+            await asyncio.wait_for(second_check_started.wait(), timeout=1)
+            await asyncio.sleep(1)
+
+    assert calls == [
+        ("check_liveness", "handle"),
+        ("check_liveness", "handle"),
+        ("teardown", "handle"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_base_session_liveness_uses_global_failure_threshold(
+    monkeypatch,
+):
+    second_check_started = asyncio.Event()
+    calls: list[tuple[str, str]] = []
+
+    async def _check_liveness(handle):
+        calls.append(("check_liveness", handle))
+        if len(calls) == 2:
+            second_check_started.set()
+        raise RuntimeError("runtime lost")
+
+    async def _teardown(handle):
+        calls.append(("teardown", handle))
+
+    class _LivenessRuntime(_R):
+        session_liveness_check_interval_s = 0.01
+
+    monkeypatch.setattr(
+        runtime_base_mod.envs, "BATCH_SESSION_LIVENESS_FAILURE_THRESHOLD", 2
+    )
+    runtime = _LivenessRuntime(
+        check_liveness=_check_liveness,
+        teardown=_teardown,
+    )
+
+    with pytest.raises(RuntimeError, match="runtime lost"):
+        async with runtime.session(
+            job=_make_test_job(job_id="job-1"),
+            job_id="job-1",
+            progress_manager=_FakeProgressManager(),
+            worker_id_generator=_fake_worker_id_generator,
+        ):
+            await asyncio.wait_for(second_check_started.wait(), timeout=1)
+            await asyncio.sleep(1)
+
+    assert calls == [
+        ("check_liveness", "handle"),
+        ("check_liveness", "handle"),
+        ("teardown", "handle"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_runtime_base_session_reprovisions_after_reconnect_not_found(
     monkeypatch,
 ):
@@ -638,7 +801,7 @@ async def test_runtime_base_session_reprovisions_after_reconnect_not_found(
         assert worker_id_generator is not None
         assert worker_id_generator("base") == "base-worker-1"
         calls.append(("persist", job.job_id))
-        return job
+        return job, "base-worker-1"
 
     async def _wait_ready(handle):
         calls.append(("wait_ready", handle))
@@ -725,20 +888,26 @@ async def test_runtime_base_session_raises_if_execution_tracking_not_bound():
 
 
 @pytest.mark.asyncio
-async def test_persist_runtime_ref_resets_new_worker_local_counts():
+async def test_persist_runtime_ref_updates_execution_only():
     class _CapturingProgressManager:
         def __init__(self) -> None:
             self.last_status: BatchJobStatus | None = None
             self.last_worker_id: str | None = None
+            self.last_update_keys = None
             self.execution: dict[str, JobRuntimeRef] | None = None
             self.status_copy: BatchJobStatusCopy | None = None
 
         async def update_job_local_status(
-            self, job_id: str, worker_id: str, status: BatchJobStatus
+            self,
+            job_id: str,
+            worker_id: str,
+            status: BatchJobStatus,
+            update_keys=None,
         ):
             assert job_id == "job-1"
             self.last_worker_id = worker_id
             self.last_status = status
+            self.last_update_keys = update_keys
             self.execution = status.execution
             self.status_copy = BatchJobStatusCopy.from_status(status)
             return SimpleNamespace(job_id=job_id, status=status)
@@ -764,12 +933,13 @@ async def test_persist_runtime_ref_resets_new_worker_local_counts():
     )
     runtime = _PersistingRuntime()
 
-    persisted = await runtime._persist_runtime_ref(
+    persisted, worker_id = await runtime._persist_runtime_ref(
         job,
         progress_manager=progress_manager,
         worker_id_generator=_fake_worker_id_generator,
     )
 
+    assert worker_id == "owner-ref-worker-1"
     assert progress_manager.last_worker_id == "owner-ref-worker-1"
     assert progress_manager.execution is not None
     assert progress_manager.status_copy is not None
@@ -778,7 +948,55 @@ async def test_persist_runtime_ref_resets_new_worker_local_counts():
     assert progress_manager.status_copy.request_counts.completed == 0
     assert progress_manager.status_copy.request_counts.failed == 0
     assert progress_manager.status_copy.usage is None
+    assert progress_manager.last_update_keys == {"execution"}
     assert persisted.status is progress_manager.last_status
+
+
+@pytest.mark.asyncio
+async def test_session_clears_runtime_ref_with_execution_only_update():
+    class _CapturingProgressManager:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, BatchJobStatus, object]] = []
+
+        async def update_job_local_status(
+            self,
+            job_id: str,
+            worker_id: str,
+            status: BatchJobStatus,
+            update_keys=None,
+        ):
+            self.calls.append((worker_id, status.model_copy(deep=True), update_keys))
+            return SimpleNamespace(job_id=job_id, status=status)
+
+    class _PersistingRuntime(_R):
+        def _build_runtime_ref(self, job):
+            del job
+            return JobRuntimeRef(
+                driverType="base",
+                ownerRef="owner-ref",
+            )
+
+    progress_manager = _CapturingProgressManager()
+    runtime = _PersistingRuntime()
+    job = _make_test_job(job_id="job-1")
+
+    async with runtime.session(
+        job=job,
+        job_id="job-1",
+        progress_manager=progress_manager,
+        worker_id_generator=_fake_worker_id_generator,
+    ):
+        pass
+
+    assert len(progress_manager.calls) == 2
+    first_worker_id, first_status, first_update_keys = progress_manager.calls[0]
+    second_worker_id, second_status, second_update_keys = progress_manager.calls[1]
+    assert first_worker_id == "owner-ref-worker-1"
+    assert first_status.get_runtime_ref("base") is not None
+    assert first_update_keys == {"execution"}
+    assert second_worker_id == "owner-ref-worker-1"
+    assert second_status.execution is None
+    assert second_update_keys == {"execution"}
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/fake/batch_runtime.py
+++ b/python/aibrix/tests/fake/batch_runtime.py
@@ -42,7 +42,8 @@ class FakeRuntime(RuntimeBase):
             return None
         return self.reconnect_handle
 
-    async def _wait_ready(self, handle: Any) -> None:
+    async def _wait_ready(self, handle: Any, wait_mode: str = "provision") -> None:
+        del wait_mode
         self.wait_ready_handles.append(handle)
 
     async def _teardown(self, handle: Any) -> None:


### PR DESCRIPTION
## Pull Request Description

- Previously, runtime teardown did not guarantee cleanup of the persisted runtime ref. After MDS restart, batch recovery could try to reconnect to a runtime that had already been deleted. This is especially risky for backends whose control plane is eventually consistent and does not provide read-after-write guarantees.
- Previously, runtime health was only checked during startup readiness. If a runtime was evicted after initial readiness, the job driver could continue running without noticing promptly (The execution became extremely slow due to waiting for request timeout)
- Previously, the concurrent worker path lacked complete interruption control during active execution, which made cancellation and expiration handling unreliable.

### Root Cause

- Runtime session teardown persisted runtime refs on startup but did not symmetrically clear them on exit.
- Worker-local status persistence updated more state than necessary, so execution-ref rebinding and cleanup were coupled to unrelated aggregated fields.
- Runtime session management had readiness checks, but no steady-state liveness monitoring after the session became active.
- Concurrent worker execution and completion-sync paths did not consistently propagate interruption conditions during long-running execution and shutdown/recovery windows.

### Fix

- Add explicit runtime-ref cleanup during runtime session teardown.
- Restrict reconnect/rebind persistence to execution-local status fields through selective update_job_local_status(..., update_keys=...) .
- Add session liveness monitoring in RuntimeBase so runtime eviction after startup interrupts the active session.
- Introduce configurable liveness failure threshold with AIBRIX_BATCH_SESSION_LIVENESS_FAILURE_THRESHOLD .
- Distinguish provision-time startup checks from reconnect/liveness checks via explicit runtime wait modes.
- Harden concurrent worker interruption behavior so cancellation and expiration can interrupt execution correctly.
- Ignore late execution errors once a job is already finished, preventing post-completion failures from corrupting terminal state.
- Fix recovery admission so jobs restored in validating re-run validation before execution resumes.

### Error Injection

- Add a centralized JobDriverErrorInjector for abnormal-path testing.
- Parse all current batch-driver/runtime injection opts in one place.
- Trigger failures through named breakpoints instead of scattered helper logic.
- Support:
  - fail_init_runtime
  - fail_preparation
  - fail_after_n_requests
  - interrupt_runtime_after_n_requests
- Centralize logging for injected failures.

### Testing

- Add and update runtime lifecycle tests for:
  - runtime-ref persistence and cleanup
  - reconnect/provision retry handling
  - liveness failure interruption
  - selective local-status updates
- Add/update batch manager tests for:
  - recovery from validating
  - execution-only status rebinding
- Add/update concurrent driver tests for interruption behavior.
- Expand abnormal E2E coverage for:
  - restart during validation
  - restart during in-progress
  - restart during finalizing
  - runtime interruption during in-progress
  - default worker is changed to concurrent-worker. Serial-worker variants are supported with the test keyword "serial_worker"

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>