### PR TITLE
[Bug]Batch: Fix recovery cleanup for recovered active batch jobs staged in pending

### DIFF
--- a/python/aibrix/aibrix/batch/batch_manager.py
+++ b/python/aibrix/aibrix/batch/batch_manager.py
@@ -201,19 +201,21 @@ class BatchManager(RunningJobs, SchedulableJobs):
         meta_job.status = job.status
         return meta_job
 
-    def _normalize_recovered_in_progress_job_for_cleanup(
+    def _normalize_recovered_active_job_for_cleanup(
         self, job_id: str, job: BatchJob
     ) -> JobMetaInfo | BatchJob:
         """Move a recovered active job into the in-progress registry if needed.
 
-        Restart/bootstrap can temporarily stage a persisted ``IN_PROGRESS`` job
-        in ``_pending_jobs`` before scheduler admission rebuilds the runtime
-        state. Expire/cancel cleanup paths operate on the in-progress registry,
-        so normalize that recovered shape before persisting status updates or
-        clearing durable execution metadata.
+        Restart/bootstrap can temporarily stage a persisted active job in
+        ``_pending_jobs`` on first sight because recovery defers runtime
+        reattachment until after the scheduler is rebuilt. Cleanup paths later
+        operate on the in-progress registry, so normalize that recovered shape
+        before persisting status updates or clearing durable execution
+        metadata.
         """
 
-        if job.status.state != BatchJobState.IN_PROGRESS:
+        category, _ = self._categorize_jobs(job, first_seen=False)
+        if category is not self._in_progress_jobs:
             return job
         if job_id in self._in_progress_jobs:
             return self._in_progress_jobs[job_id]
@@ -224,8 +226,9 @@ class BatchManager(RunningJobs, SchedulableJobs):
         del self._pending_jobs[job_id]
         self._in_progress_jobs[job_id] = meta_data
         logger.debug(
-            "Normalized recovered in-progress job for cleanup",
+            "Normalized recovered active job for cleanup",
             job_id=job_id,
+            state=job.status.state,
         )  # type: ignore[call-arg]
         return meta_data
 
@@ -1095,7 +1098,7 @@ class BatchManager(RunningJobs, SchedulableJobs):
             )  # type: ignore[call-arg]
             return False
 
-        old_job = self._normalize_recovered_in_progress_job_for_cleanup(job_id, old_job)
+        old_job = self._normalize_recovered_active_job_for_cleanup(job_id, old_job)
 
         job_expired = self._build_expired_job_update(old_job)
         if old_job.status.state in (BatchJobState.CREATED, BatchJobState.VALIDATING):

--- a/python/aibrix/tests/batch/test_batch_manager.py
+++ b/python/aibrix/tests/batch/test_batch_manager.py
@@ -642,10 +642,26 @@ async def test_expire_job_skips_already_finalizing_job():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("job_id", "owner_ref", "initial_bucket"),
+    ("job_id", "owner_ref", "initial_bucket", "recovered_state"),
     [
-        ("test-job-id-expire-orphaned", "owner-2", "in_progress"),
-        ("test-job-id-expire-recovered-pending", "owner-3", "pending"),
+        (
+            "test-job-id-expire-orphaned",
+            "owner-2",
+            "in_progress",
+            BatchJobState.IN_PROGRESS,
+        ),
+        (
+            "test-job-id-expire-recovered-pending",
+            "owner-3",
+            "pending",
+            BatchJobState.IN_PROGRESS,
+        ),
+        (
+            "test-job-id-expire-recovered-cancelling",
+            "owner-4",
+            "pending",
+            BatchJobState.CANCELLING,
+        ),
     ],
 )
 async def test_expired_job_cleans_up_during_recovery(
@@ -653,9 +669,11 @@ async def test_expired_job_cleans_up_during_recovery(
     job_id: str,
     owner_ref: str,
     initial_bucket: str,
+    recovered_state: BatchJobState,
 ):
     job_manager = _job_manager()
     recovered_job = _in_progress_meta_job(job_id, total_requests=1)
+    recovered_job.status.state = recovered_state
     recovered_job.status.set_runtime_ref(
         "fake",
         JobRuntimeRef(driverType="fake", ownerRef=owner_ref, attempt=1),


### PR DESCRIPTION
## Pull Request Description
Fix batch recovery cleanup for recovered active jobs that bootstrap temporarily stages in `_pending_jobs`.

During metadata service startup, recovery can replay an unfinished batch job that is already in an active non-created state such as `CANCELLING`. The first-seen recovery path may still place that job in `_pending_jobs`, but the cleanup path later assumes active jobs live in `_in_progress_jobs`. That mismatch can cause stale execution cleanup to fail with:

- `Job is not in old category, ignore updating`
- `JobUnexpectedStateError: Job has not been scheduled yet or has been processed`

This change normalizes any recovered active job back into `_in_progress_jobs` before cleanup persists status updates or clears durable execution metadata.

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>