### PR TITLE
feat(brixbench): add workload PodMonitor setup

### DIFF
--- a/brixbench/README.md
+++ b/brixbench/README.md
@@ -185,6 +185,40 @@ Metrics export is disabled by default.
 - With `BENCHMARK_PUSHGATEWAY_URL`, the runner enables the Pushgateway exporter.
 - The current Pushgateway exporter returns an explicit not-implemented error until real export behavior is implemented.
 
+## Workload PodMonitoring
+
+The runner creates Prometheus Operator `PodMonitor` resources for benchmark
+workloads after the serving deployment becomes ready. This is separate from the
+benchmark result Pushgateway export above: PodMonitoring lets Prometheus or VMP
+scrape serving workload `/metrics` endpoints for Grafana dashboards.
+
+PodMonitoring is enabled by default. Disable it with either option:
+
+```bash
+BENCHMARK_POD_MONITORING=false go test -v ./benchmark -run TestAIBrixBenchmarkSuite -count=1
+go test -v ./benchmark -run TestAIBrixBenchmarkSuite -benchmark.pod-monitoring=false -count=1
+```
+
+By default, missing PodMonitor CRDs or apply permission errors are logged as
+warnings so benchmark execution can continue. Use strict mode when dashboard
+metric collection is required for validation:
+
+```bash
+BENCHMARK_POD_MONITORING_STRICT=true go test -v ./benchmark -run TestAIBrixBenchmarkSuite -count=1
+```
+
+Created PodMonitors are labeled with `volcengine.vmp=true` and
+`brixbench.aibrix.ai/managed=true`. For the integrated benchmark dashboard,
+select datasource `AIBrix_Benchmark` and keep `vllm_job` as `All`; plain vLLM
+and AIBrix StormService vLLM metrics are relabeled to `job=brixbench-vllm`.
+
+Useful checks:
+
+```bash
+kubectl get podmonitor -n brixbench-adhoc -l brixbench.aibrix.ai/managed=true
+kubectl get podmonitor brixbench-aibrix-vllm-metrics -n brixbench-adhoc -o yaml
+```
+
 ## Artifacts
 
 Run artifacts are written under:

--- a/brixbench/README.md
+++ b/brixbench/README.md
@@ -212,6 +212,20 @@ Created PodMonitors are labeled with `volcengine.vmp=true` and
 select datasource `AIBrix_Benchmark` and keep `vllm_job` as `All`; plain vLLM
 and AIBrix StormService vLLM metrics are relabeled to `job=brixbench-vllm`.
 
+Custom engine manifests must expose the metrics-serving container port with the
+name expected by the generated PodMonitor. For vLLM and AIBrix vLLM profiles,
+brixbench generates PodMonitors with `podMetricsEndpoints.port: http`, so the
+serving container must declare a named port:
+
+```yaml
+ports:
+- name: http
+  containerPort: 8000
+```
+
+Without this named container port, the PodMonitor resource may be created
+successfully, but Prometheus Operator may not discover a valid scrape target.
+
 Useful checks:
 
 ```bash

--- a/brixbench/benchmark/runner_cleanup_test.go
+++ b/brixbench/benchmark/runner_cleanup_test.go
@@ -65,3 +65,43 @@ func TestResetBeforeTestEnabledAcceptsOff(t *testing.T) {
 		t.Fatalf("expected reset to be disabled by off env override")
 	}
 }
+
+func TestPodMonitoringEnabledDefaultsToFlag(t *testing.T) {
+	t.Setenv("BENCHMARK_POD_MONITORING", "")
+
+	if !podMonitoringEnabled() {
+		t.Fatalf("expected pod monitoring to be enabled by default")
+	}
+}
+
+func TestPodMonitoringEnabledUsesEnvOverride(t *testing.T) {
+	t.Setenv("BENCHMARK_POD_MONITORING", "false")
+
+	if podMonitoringEnabled() {
+		t.Fatalf("expected pod monitoring to be disabled by env override")
+	}
+}
+
+func TestPodMonitoringEnabledAcceptsOff(t *testing.T) {
+	t.Setenv("BENCHMARK_POD_MONITORING", "off")
+
+	if podMonitoringEnabled() {
+		t.Fatalf("expected pod monitoring to be disabled by off env override")
+	}
+}
+
+func TestPodMonitoringStrictDefaultsFalse(t *testing.T) {
+	t.Setenv("BENCHMARK_POD_MONITORING_STRICT", "")
+
+	if podMonitoringStrictEnabled() {
+		t.Fatalf("expected pod monitoring strict mode to be disabled by default")
+	}
+}
+
+func TestPodMonitoringStrictUsesEnvOverride(t *testing.T) {
+	t.Setenv("BENCHMARK_POD_MONITORING_STRICT", "true")
+
+	if !podMonitoringStrictEnabled() {
+		t.Fatalf("expected pod monitoring strict mode to be enabled by env override")
+	}
+}

--- a/brixbench/benchmark/runner_support_test.go
+++ b/brixbench/benchmark/runner_support_test.go
@@ -32,6 +32,7 @@ import (
 var scenarioFlag = flag.String("scenario", "", "Path to the benchmark scenario YAML file")
 var cleanupAfterTestFlag = flag.Bool("benchmark.cleanup", true, "Clean up benchmark resources after each test case")
 var resetBeforeTestFlag = flag.Bool("benchmark.reset", true, "Reset the benchmark namespace before each test case")
+var podMonitoringFlag = flag.Bool("benchmark.pod-monitoring", true, "Create PodMonitor resources for benchmark workloads")
 
 func sanitizePathComponent(value string) string {
 	value = strings.TrimSpace(strings.ToLower(value))
@@ -148,30 +149,25 @@ func configureBenchmarkEnvironment(t *testing.T, testCaseName string, providerNa
 }
 
 func cleanupAfterTestEnabled() bool {
-	envValue := strings.TrimSpace(os.Getenv("BENCHMARK_CLEANUP_AFTER_TEST"))
-	if envValue == "" {
-		return *cleanupAfterTestFlag
-	}
-
-	enabled, err := strconv.ParseBool(envValue)
-	if err == nil {
-		return enabled
-	}
-
-	switch strings.ToLower(envValue) {
-	case "on", "yes", "y":
-		return true
-	case "off", "no", "n":
-		return false
-	default:
-		return *cleanupAfterTestFlag
-	}
+	return boolEnvOrDefault("BENCHMARK_CLEANUP_AFTER_TEST", *cleanupAfterTestFlag)
 }
 
 func resetBeforeTestEnabled() bool {
-	envValue := strings.TrimSpace(os.Getenv("BENCHMARK_RESET_BEFORE_TEST"))
+	return boolEnvOrDefault("BENCHMARK_RESET_BEFORE_TEST", *resetBeforeTestFlag)
+}
+
+func podMonitoringEnabled() bool {
+	return boolEnvOrDefault("BENCHMARK_POD_MONITORING", *podMonitoringFlag)
+}
+
+func podMonitoringStrictEnabled() bool {
+	return boolEnvOrDefault("BENCHMARK_POD_MONITORING_STRICT", false)
+}
+
+func boolEnvOrDefault(envName string, defaultValue bool) bool {
+	envValue := strings.TrimSpace(os.Getenv(envName))
 	if envValue == "" {
-		return *resetBeforeTestFlag
+		return defaultValue
 	}
 
 	enabled, err := strconv.ParseBool(envValue)
@@ -185,7 +181,7 @@ func resetBeforeTestEnabled() bool {
 	case "off", "no", "n":
 		return false
 	default:
-		return *resetBeforeTestFlag
+		return defaultValue
 	}
 }
 

--- a/brixbench/benchmark/runner_test.go
+++ b/brixbench/benchmark/runner_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/vllm-project/aibrix/brixbench/internal/deployers"
 	"github.com/vllm-project/aibrix/brixbench/internal/drivers"
+	"github.com/vllm-project/aibrix/brixbench/internal/monitoring"
 	"github.com/vllm-project/aibrix/brixbench/internal/observability"
 	"github.com/vllm-project/aibrix/brixbench/internal/resolver"
 )
@@ -209,6 +210,15 @@ func setupAndRunDeployment(ctx context.Context, t *testing.T, projectRoot string
 	}
 	if err := deployer.WaitForReady(ctx); err != nil {
 		return deployer, "", fmt.Errorf("engine not ready: %w", err)
+	}
+	if err := monitoring.Ensure(ctx, monitoring.Config{
+		Namespace: benchmarkNamespace,
+		Provider:  testCase.ProviderName(),
+		Engine:    testCase.Engine.Type,
+		Enabled:   podMonitoringEnabled(),
+		Strict:    podMonitoringStrictEnabled(),
+	}); err != nil {
+		return deployer, "", fmt.Errorf("pod monitoring setup failed: %w", err)
 	}
 
 	// Get dynamically assigned Gateway IP/URL

--- a/brixbench/benchmark/testdata/deployments/aibrix/models/model.yaml
+++ b/brixbench/benchmark/testdata/deployments/aibrix/models/model.yaml
@@ -113,6 +113,9 @@ spec:
                       value: info
                     - name: VLLM_LOGGING_LEVEL
                       value: info
+                  ports:
+                    - name: http
+                      containerPort: 8000
                   volumeMounts:
                     - name: model-vol
                       mountPath: /models

--- a/brixbench/benchmark/testdata/deployments/aibrix/models/pd-model.yaml
+++ b/brixbench/benchmark/testdata/deployments/aibrix/models/pd-model.yaml
@@ -93,6 +93,9 @@ spec:
                       value: info
                     - name: VLLM_LOGGING_LEVEL
                       value: info
+                  ports:
+                    - name: http
+                      containerPort: 8000
                   volumeMounts:
                     - name: model-vol
                       mountPath: /models
@@ -204,6 +207,9 @@ spec:
                       value: info
                     - name: VLLM_LOGGING_LEVEL
                       value: info
+                  ports:
+                    - name: http
+                      containerPort: 8000
                   volumeMounts:
                     - name: model-vol
                       mountPath: /models

--- a/brixbench/benchmark/testdata/deployments/aibrix/models/qwen3-8b-pd-4p4d.yaml
+++ b/brixbench/benchmark/testdata/deployments/aibrix/models/qwen3-8b-pd-4p4d.yaml
@@ -87,6 +87,9 @@ spec:
                       value: info
                     - name: VLLM_LOGGING_LEVEL
                       value: info
+                  ports:
+                    - name: http
+                      containerPort: 8000
                   volumeMounts:
                     - name: model-vol
                       mountPath: /models
@@ -191,6 +194,9 @@ spec:
                       value: info
                     - name: VLLM_LOGGING_LEVEL
                       value: info
+                  ports:
+                    - name: http
+                      containerPort: 8000
                   volumeMounts:
                     - name: model-vol
                       mountPath: /models

--- a/brixbench/benchmark/testdata/deployments/aibrix/models/qwen3-8b-pd-4p8d.yaml
+++ b/brixbench/benchmark/testdata/deployments/aibrix/models/qwen3-8b-pd-4p8d.yaml
@@ -87,6 +87,9 @@ spec:
                       value: info
                     - name: VLLM_LOGGING_LEVEL
                       value: info
+                  ports:
+                    - name: http
+                      containerPort: 8000
                   volumeMounts:
                     - name: model-vol
                       mountPath: /models
@@ -191,6 +194,9 @@ spec:
                       value: info
                     - name: VLLM_LOGGING_LEVEL
                       value: info
+                  ports:
+                    - name: http
+                      containerPort: 8000
                   volumeMounts:
                     - name: model-vol
                       mountPath: /models

--- a/brixbench/internal/monitoring/podmonitor.go
+++ b/brixbench/internal/monitoring/podmonitor.go
@@ -73,7 +73,9 @@ func Ensure(ctx context.Context, config Config) error {
 
 	for _, manifest := range manifests {
 		if _, err := config.run(ctx, manifest, "apply", "-f", "-"); err != nil {
-			return config.handleError("failed to apply benchmark PodMonitor", err)
+			if err := config.handleError("failed to apply benchmark PodMonitor", err); err != nil {
+				return err
+			}
 		}
 	}
 	fmt.Printf("[benchmark] PodMonitoring configured in namespace %s\n", config.Namespace)
@@ -82,6 +84,9 @@ func Ensure(ctx context.Context, config Config) error {
 
 // Cleanup deletes PodMonitors created by brixbench.
 func Cleanup(ctx context.Context, namespace string) error {
+	if strings.TrimSpace(namespace) == "" {
+		return fmt.Errorf("namespace is required for Cleanup")
+	}
 	config := Config{Namespace: namespace, Enabled: true}
 	_, err := config.run(ctx, "", "delete", "podmonitor", "-n", namespace, "-l", managedLabelSelector, "--ignore-not-found")
 	if err != nil {
@@ -138,7 +143,9 @@ func (config Config) labelDynamoChartPodMonitors(ctx context.Context) error {
 			continue
 		}
 		if _, err := config.run(ctx, "", "label", "podmonitor", name, "-n", config.Namespace, "volcengine.vmp=true", "--overwrite"); err != nil {
-			return config.handleError(fmt.Sprintf("failed to label Dynamo chart PodMonitor %s", name), err)
+			if err := config.handleError(fmt.Sprintf("failed to label Dynamo chart PodMonitor %s", name), err); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/brixbench/internal/monitoring/podmonitor.go
+++ b/brixbench/internal/monitoring/podmonitor.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const (
+	defaultKubectl       = "kubectl"
+	managedLabelKey      = "brixbench.aibrix.ai/managed"
+	managedLabelSelector = managedLabelKey + "=true"
+	podMonitorCRD        = "podmonitors.monitoring.coreos.com"
+)
+
+// CommandRunner executes kubectl commands. Tests can inject a fake runner.
+type CommandRunner func(ctx context.Context, stdin string, args ...string) (string, error)
+
+// Config controls benchmark workload PodMonitor setup.
+type Config struct {
+	Namespace string
+	Provider  string
+	Engine    string
+	Enabled   bool
+	Strict    bool
+	Kubectl   string
+	Runner    CommandRunner
+}
+
+// Ensure creates or updates PodMonitors needed by the benchmark dashboard.
+func Ensure(ctx context.Context, config Config) error {
+	if !config.Enabled {
+		fmt.Printf("[benchmark] PodMonitoring disabled\n")
+		return nil
+	}
+	if strings.TrimSpace(config.Namespace) == "" {
+		return config.handleError("namespace is required for PodMonitoring", nil)
+	}
+
+	if _, err := config.run(ctx, "", "get", "crd", podMonitorCRD); err != nil {
+		return config.handleError("PodMonitor CRD is not available; skipping scrape setup", err)
+	}
+
+	if strings.EqualFold(strings.TrimSpace(config.Provider), "dynamo") {
+		if err := config.labelDynamoChartPodMonitors(ctx); err != nil {
+			return err
+		}
+	}
+
+	manifests := podMonitorManifests(config)
+	if len(manifests) == 0 {
+		fmt.Printf("[benchmark] No PodMonitoring profile for provider=%q engine=%q\n", config.Provider, config.Engine)
+		return nil
+	}
+
+	for _, manifest := range manifests {
+		if _, err := config.run(ctx, manifest, "apply", "-f", "-"); err != nil {
+			return config.handleError("failed to apply benchmark PodMonitor", err)
+		}
+	}
+	fmt.Printf("[benchmark] PodMonitoring configured in namespace %s\n", config.Namespace)
+	return nil
+}
+
+// Cleanup deletes PodMonitors created by brixbench.
+func Cleanup(ctx context.Context, namespace string) error {
+	config := Config{Namespace: namespace, Enabled: true}
+	_, err := config.run(ctx, "", "delete", "podmonitor", "-n", namespace, "-l", managedLabelSelector, "--ignore-not-found")
+	if err != nil {
+		return fmt.Errorf("failed to cleanup brixbench PodMonitors in namespace %s: %w", namespace, err)
+	}
+	return nil
+}
+
+func (config Config) run(ctx context.Context, stdin string, args ...string) (string, error) {
+	if config.Runner != nil {
+		return config.Runner(ctx, stdin, args...)
+	}
+	kubectl := strings.TrimSpace(config.Kubectl)
+	if kubectl == "" {
+		kubectl = defaultKubectl
+	}
+	cmd := exec.CommandContext(ctx, kubectl, args...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	err := cmd.Run()
+	if err != nil {
+		return output.String(), fmt.Errorf("%s %s failed: %w, output: %s", kubectl, strings.Join(args, " "), err, strings.TrimSpace(output.String()))
+	}
+	return output.String(), nil
+}
+
+func (config Config) handleError(message string, err error) error {
+	if err == nil {
+		err = fmt.Errorf(message)
+	}
+	if config.Strict {
+		return fmt.Errorf("%s: %w", message, err)
+	}
+	fmt.Printf("[benchmark] PodMonitoring warning: %s: %v\n", message, err)
+	return nil
+}
+
+func (config Config) labelDynamoChartPodMonitors(ctx context.Context) error {
+	output, err := config.run(ctx, "", "get", "podmonitor", "-n", config.Namespace, "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
+	if err != nil {
+		return config.handleError("failed to list Dynamo chart PodMonitors", err)
+	}
+
+	existing := map[string]bool{}
+	for _, name := range strings.Fields(output) {
+		existing[name] = true
+	}
+	for _, name := range []string{"dynamo-frontend", "dynamo-worker", "dynamo-planner", "dynamo-router"} {
+		if !existing[name] {
+			continue
+		}
+		if _, err := config.run(ctx, "", "label", "podmonitor", name, "-n", config.Namespace, "volcengine.vmp=true", "--overwrite"); err != nil {
+			return config.handleError(fmt.Sprintf("failed to label Dynamo chart PodMonitor %s", name), err)
+		}
+	}
+	return nil
+}
+
+func podMonitorManifests(config Config) []string {
+	namespace := strings.TrimSpace(config.Namespace)
+	provider := strings.ToLower(strings.TrimSpace(config.Provider))
+	engine := strings.ToLower(strings.TrimSpace(config.Engine))
+
+	switch {
+	case provider == "" && engine == "vllm":
+		return []string{plainVLLMPodMonitor(namespace)}
+	case provider == "aibrix" && engine == "vllm":
+		return []string{aibrixVLLMPodMonitor(namespace)}
+	case provider == "dynamo":
+		return []string{
+			dynamoWorkerPodMonitor(namespace),
+			dynamoFrontendPodMonitor(namespace),
+			dynamoKVBMPodMonitor(namespace),
+		}
+	default:
+		return nil
+	}
+}
+
+func commonLabels() string {
+	return `    volcengine.vmp: "true"
+    app.kubernetes.io/part-of: brixbench
+    brixbench.aibrix.ai/managed: "true"`
+}
+
+func podMonitorHeader(name, namespace string) string {
+	return fmt.Sprintf(`apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+%s
+spec:
+  namespaceSelector:
+    matchNames:
+    - %s
+`, name, namespace, commonLabels(), namespace)
+}
+
+func plainVLLMPodMonitor(namespace string) string {
+	return podMonitorHeader("brixbench-vllm-metrics", namespace) + `  podMetricsEndpoints:
+  - interval: 15s
+    path: /metrics
+    port: http
+    honorLabels: true
+    relabelings:
+    - action: replace
+      replacement: brixbench-vllm
+      targetLabel: job
+  selector:
+    matchLabels:
+      app: vllm-basic
+`
+}
+
+func aibrixVLLMPodMonitor(namespace string) string {
+	return podMonitorHeader("brixbench-aibrix-vllm-metrics", namespace) + `  podMetricsEndpoints:
+  - interval: 15s
+    path: /metrics
+    port: http
+    honorLabels: true
+    relabelings:
+    - action: replace
+      replacement: brixbench-vllm
+      targetLabel: job
+  selector:
+    matchLabels:
+      model.aibrix.ai/engine: vllm
+`
+}
+
+func dynamoWorkerPodMonitor(namespace string) string {
+	return podMonitorHeader("brixbench-dynamo-vllm-worker-metrics", namespace) + `  podMetricsEndpoints:
+  - interval: 15s
+    path: /metrics
+    port: system
+    honorLabels: true
+    relabelings:
+    - action: replace
+      replacement: dynamo-vllm-worker
+      targetLabel: job
+  selector:
+    matchExpressions:
+    - key: nvidia.com/dynamo-component
+      operator: In
+      values:
+      - VllmDecodeWorker
+      - VllmPrefillWorker
+`
+}
+
+func dynamoFrontendPodMonitor(namespace string) string {
+	return podMonitorHeader("brixbench-dynamo-frontend-metrics", namespace) + `  podMetricsEndpoints:
+  - interval: 15s
+    path: /metrics
+    port: http
+    honorLabels: true
+    relabelings:
+    - action: replace
+      replacement: dynamo-vllm-frontend
+      targetLabel: job
+  selector:
+    matchLabels:
+      nvidia.com/dynamo-component: Frontend
+`
+}
+
+func dynamoKVBMPodMonitor(namespace string) string {
+	return podMonitorHeader("brixbench-dynamo-kvbm-metrics", namespace) + `  podMetricsEndpoints:
+  - interval: 15s
+    path: /metrics
+    port: kvbm-metrics
+    honorLabels: true
+    relabelings:
+    - action: replace
+      replacement: dynamo-kvbm
+      targetLabel: job
+  selector:
+    matchLabels:
+      nvidia.com/dynamo-component: VllmDecodeWorker
+`
+}

--- a/brixbench/internal/monitoring/podmonitor_test.go
+++ b/brixbench/internal/monitoring/podmonitor_test.go
@@ -181,6 +181,36 @@ func TestEnsureAppliesPlainVLLMManifest(t *testing.T) {
 	}
 }
 
+func TestEnsureContinuesApplyingManifestsAfterNonStrictFailure(t *testing.T) {
+	var applyCommands int
+	err := Ensure(context.Background(), Config{
+		Namespace: "brixbench-adhoc",
+		Provider:  "dynamo",
+		Engine:    "vllm",
+		Enabled:   true,
+		Strict:    false,
+		Runner: func(ctx context.Context, stdin string, args ...string) (string, error) {
+			joined := strings.Join(args, " ")
+			if joined == `get podmonitor -n brixbench-adhoc -o jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}` {
+				return "", nil
+			}
+			if joined == "apply -f -" {
+				applyCommands++
+				if applyCommands == 1 {
+					return "", errors.New("apply failed")
+				}
+			}
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected non-strict apply failure to continue, got %v", err)
+	}
+	if applyCommands != 3 {
+		t.Fatalf("expected all 3 Dynamo manifests to be applied, got %d", applyCommands)
+	}
+}
+
 func TestEnsureLabelsExistingDynamoChartPodMonitor(t *testing.T) {
 	var commands []recordedCommand
 	err := Ensure(context.Background(), Config{
@@ -212,5 +242,44 @@ func TestEnsureLabelsExistingDynamoChartPodMonitor(t *testing.T) {
 	}
 	if labelCommands != 2 {
 		t.Fatalf("expected 2 Dynamo chart label commands, got %d: %#v", labelCommands, commands)
+	}
+}
+
+func TestEnsureContinuesLabelingDynamoPodMonitorsAfterNonStrictFailure(t *testing.T) {
+	var labelCommands []string
+	err := Ensure(context.Background(), Config{
+		Namespace: "brixbench-adhoc",
+		Provider:  "dynamo",
+		Engine:    "vllm",
+		Enabled:   true,
+		Strict:    false,
+		Runner: func(ctx context.Context, stdin string, args ...string) (string, error) {
+			joined := strings.Join(args, " ")
+			if joined == `get podmonitor -n brixbench-adhoc -o jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}` {
+				return "dynamo-frontend\ndynamo-worker\n", nil
+			}
+			if strings.HasPrefix(joined, "label podmonitor dynamo-") {
+				labelCommands = append(labelCommands, joined)
+				if strings.Contains(joined, "dynamo-frontend") {
+					return "", errors.New("label failed")
+				}
+			}
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected non-strict label failure to continue, got %v", err)
+	}
+	if len(labelCommands) != 2 {
+		t.Fatalf("expected both Dynamo PodMonitors to be labeled, got %d: %#v", len(labelCommands), labelCommands)
+	}
+	if !strings.Contains(labelCommands[1], "dynamo-worker") {
+		t.Fatalf("expected labeling to continue to dynamo-worker, got %#v", labelCommands)
+	}
+}
+
+func TestCleanupRejectsEmptyNamespace(t *testing.T) {
+	if err := Cleanup(context.Background(), " "); err == nil {
+		t.Fatalf("expected empty namespace cleanup to fail")
 	}
 }

--- a/brixbench/internal/monitoring/podmonitor_test.go
+++ b/brixbench/internal/monitoring/podmonitor_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type recordedCommand struct {
+	stdin string
+	args  []string
+}
+
+func TestEnsureDisabledIsNoop(t *testing.T) {
+	called := false
+	err := Ensure(context.Background(), Config{
+		Namespace: "brixbench-adhoc",
+		Enabled:   false,
+		Runner: func(ctx context.Context, stdin string, args ...string) (string, error) {
+			called = true
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected disabled Ensure to succeed, got %v", err)
+	}
+	if called {
+		t.Fatalf("expected disabled Ensure not to call runner")
+	}
+}
+
+func TestEnsureMissingCRDNonStrictContinues(t *testing.T) {
+	err := Ensure(context.Background(), Config{
+		Namespace: "brixbench-adhoc",
+		Provider:  "",
+		Engine:    "vllm",
+		Enabled:   true,
+		Strict:    false,
+		Runner: func(ctx context.Context, stdin string, args ...string) (string, error) {
+			return "", errors.New("not found")
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected non-strict missing CRD to continue, got %v", err)
+	}
+}
+
+func TestEnsureMissingCRDStrictFails(t *testing.T) {
+	err := Ensure(context.Background(), Config{
+		Namespace: "brixbench-adhoc",
+		Provider:  "",
+		Engine:    "vllm",
+		Enabled:   true,
+		Strict:    true,
+		Runner: func(ctx context.Context, stdin string, args ...string) (string, error) {
+			return "", errors.New("not found")
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected strict missing CRD to fail")
+	}
+}
+
+func TestPlainVLLMPodMonitorManifest(t *testing.T) {
+	manifests := podMonitorManifests(Config{
+		Namespace: "brixbench-adhoc",
+		Provider:  "",
+		Engine:    "vllm",
+	})
+	if len(manifests) != 1 {
+		t.Fatalf("expected 1 manifest, got %d", len(manifests))
+	}
+
+	manifest := manifests[0]
+	for _, want := range []string{
+		"name: brixbench-vllm-metrics",
+		`volcengine.vmp: "true"`,
+		`brixbench.aibrix.ai/managed: "true"`,
+		"port: http",
+		"replacement: brixbench-vllm",
+		"app: vllm-basic",
+	} {
+		if !strings.Contains(manifest, want) {
+			t.Fatalf("expected manifest to contain %q:\n%s", want, manifest)
+		}
+	}
+}
+
+func TestAIBrixVLLMPodMonitorManifest(t *testing.T) {
+	manifests := podMonitorManifests(Config{
+		Namespace: "brixbench-adhoc",
+		Provider:  "aibrix",
+		Engine:    "vllm",
+	})
+	if len(manifests) != 1 {
+		t.Fatalf("expected 1 manifest, got %d", len(manifests))
+	}
+
+	manifest := manifests[0]
+	for _, want := range []string{
+		"name: brixbench-aibrix-vllm-metrics",
+		"model.aibrix.ai/engine: vllm",
+		"replacement: brixbench-vllm",
+	} {
+		if !strings.Contains(manifest, want) {
+			t.Fatalf("expected manifest to contain %q:\n%s", want, manifest)
+		}
+	}
+}
+
+func TestDynamoPodMonitorManifests(t *testing.T) {
+	manifests := podMonitorManifests(Config{
+		Namespace: "brixbench-adhoc",
+		Provider:  "dynamo",
+		Engine:    "vllm",
+	})
+	if len(manifests) != 3 {
+		t.Fatalf("expected 3 manifests, got %d", len(manifests))
+	}
+	joined := strings.Join(manifests, "\n---\n")
+	for _, want := range []string{
+		"name: brixbench-dynamo-vllm-worker-metrics",
+		"replacement: dynamo-vllm-worker",
+		"port: system",
+		"name: brixbench-dynamo-frontend-metrics",
+		"replacement: dynamo-vllm-frontend",
+		"port: http",
+		"name: brixbench-dynamo-kvbm-metrics",
+		"replacement: dynamo-kvbm",
+		"port: kvbm-metrics",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected manifests to contain %q:\n%s", want, joined)
+		}
+	}
+}
+
+func TestEnsureAppliesPlainVLLMManifest(t *testing.T) {
+	var commands []recordedCommand
+	err := Ensure(context.Background(), Config{
+		Namespace: "brixbench-adhoc",
+		Provider:  "",
+		Engine:    "vllm",
+		Enabled:   true,
+		Runner: func(ctx context.Context, stdin string, args ...string) (string, error) {
+			commands = append(commands, recordedCommand{stdin: stdin, args: append([]string(nil), args...)})
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected Ensure to succeed, got %v", err)
+	}
+	if len(commands) != 2 {
+		t.Fatalf("expected CRD check and apply, got %d commands", len(commands))
+	}
+	if strings.Join(commands[0].args, " ") != "get crd podmonitors.monitoring.coreos.com" {
+		t.Fatalf("unexpected CRD command: %v", commands[0].args)
+	}
+	if strings.Join(commands[1].args, " ") != "apply -f -" {
+		t.Fatalf("unexpected apply command: %v", commands[1].args)
+	}
+	if !strings.Contains(commands[1].stdin, "brixbench-vllm-metrics") {
+		t.Fatalf("expected apply stdin to contain PodMonitor manifest, got:\n%s", commands[1].stdin)
+	}
+}
+
+func TestEnsureLabelsExistingDynamoChartPodMonitor(t *testing.T) {
+	var commands []recordedCommand
+	err := Ensure(context.Background(), Config{
+		Namespace: "brixbench-adhoc",
+		Provider:  "dynamo",
+		Engine:    "vllm",
+		Enabled:   true,
+		Runner: func(ctx context.Context, stdin string, args ...string) (string, error) {
+			commands = append(commands, recordedCommand{stdin: stdin, args: append([]string(nil), args...)})
+			if strings.Join(args, " ") == `get podmonitor -n brixbench-adhoc -o jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}` {
+				return "dynamo-frontend\ndynamo-worker\n", nil
+			}
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected Ensure to succeed, got %v", err)
+	}
+
+	var labelCommands int
+	for _, command := range commands {
+		joined := strings.Join(command.args, " ")
+		if strings.HasPrefix(joined, "label podmonitor dynamo-") {
+			labelCommands++
+			if !strings.Contains(joined, "volcengine.vmp=true --overwrite") {
+				t.Fatalf("unexpected label command: %s", joined)
+			}
+		}
+	}
+	if labelCommands != 2 {
+		t.Fatalf("expected 2 Dynamo chart label commands, got %d: %#v", labelCommands, commands)
+	}
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds workload metric scraping setup to brixbench so existing benchmark
Grafana dashboards can show serving workload metrics during benchmark runs.

Brixbench already collects benchmark client results separately, but it did not
create Prometheus Operator scrape resources for vLLM, AIBrix, or Dynamo serving
pods. As a result, VMP/Grafana could miss workload `/metrics` endpoints even when
the benchmark itself completed successfully.

### 1. PodMonitor Setup (`internal/monitoring` — *new package*)

Adds a new monitoring package that creates or updates `PodMonitor` resources
after the benchmark workload becomes ready. Key behavior includes:

- Checks whether the `podmonitors.monitoring.coreos.com` CRD is available.

- Creates PodMonitors for supported workload profiles:
  - plain vLLM
  - AIBrix StormService vLLM
  - Dynamo vLLM worker, frontend, and KVBM metrics

- Adds common labels for discovery and cleanup:
  - `volcengine.vmp=true`
  - `app.kubernetes.io/part-of=brixbench`
  - `brixbench.aibrix.ai/managed=true`

- Relabels scrape jobs to match the integrated benchmark dashboard:
  - `brixbench-vllm`
  - `dynamo-vllm-worker`
  - `dynamo-vllm-frontend`
  - `dynamo-kvbm`

### 2. Runner Integration

Connects PodMonitoring setup into the benchmark runner after deployment
readiness and before benchmark execution.

By default, PodMonitoring setup is best-effort: missing CRDs or apply permission
errors are logged as warnings so benchmark execution can continue.

For validation runs where dashboard metric collection is required, strict mode
can be enabled to fail the test on PodMonitoring setup errors.

### 3. Configuration

Adds dedicated controls for workload PodMonitoring:

- `BENCHMARK_POD_MONITORING=true|false`
- `-benchmark.pod-monitoring=true|false`
- `BENCHMARK_POD_MONITORING_STRICT=true|false`

This keeps workload metric scraping independent from benchmark result export and
Pushgateway-related settings.

### 4. AIBrix vLLM Port Naming

Adds the `http` container port name to AIBrix vLLM benchmark manifests where the
vLLM server exposes OpenAI API and Prometheus metrics on port `8000`.

This lets PodMonitor profiles use the stable named port `http` instead of
depending on unnamed numeric container ports.

### 5. Documentation

Updates the brixbench README with:

- PodMonitoring behavior
- opt-out and strict-mode controls
- VMP/Grafana dashboard validation flow
- useful `kubectl get podmonitor` checks

### 6. Tests and Validation

Unit/static validation:

```bash
go test ./internal/monitoring ./benchmark -run 'Test.*Monitoring|Test.*PodMonitor' -count=1
gofmt -l internal/monitoring/podmonitor.go internal/monitoring/podmonitor_test.go benchmark/runner_cleanup_test.go benchmark/runner_support_test.go benchmark/runner_test.go
git diff --check
```

Cluster/dashboard validation:

- Ran brixbench scenario against AIBrix + vLLM workload.
- Confirmed brixbench-created PodMonitor resources in the benchmark namespace.
- Confirmed VMP/Grafana dashboard receives workload metrics with datasource
  `AIBrix_Benchmark` and `vllm_job=All`.

## Related Issues

Resolves: N/A