### PR TITLE
feat: add Valkey as OSS metadata store option with external managed endpoint support

### DIFF
--- a/config/metadata/kustomization.yaml
+++ b/config/metadata/kustomization.yaml
@@ -1,6 +1,8 @@
 resources:
 - metadata.yaml
 - redis.yaml
+# To use Valkey (BSD-3 OSS alternative) instead of Redis:
+# - valkey.yaml
 
 patches:
 # Uncomment the following lines to enable S3 as the object store

--- a/config/metadata/valkey.yaml
+++ b/config/metadata/valkey.yaml
@@ -1,0 +1,64 @@
+# Valkey — OSS-licensed (BSD-3) alternative to Redis for AIBrix metadata store.
+# Wire-compatible drop-in; uses the same RESP protocol, same env vars
+# (REDIS_HOST, REDIS_PORT, REDIS_PASSWORD), same go-redis client.
+#
+# Usage (kustomize — recommended):
+#   Replace "redis.yaml" with "valkey.yaml" in config/metadata/kustomization.yaml,
+#   then deploy via: kubectl apply -k config/default
+#   The kustomize namePrefix ("aibrix-") will produce Service "aibrix-redis-master"
+#   which matches the REDIS_HOST env var in metadata.yaml.
+#
+# Usage (standalone — requires REDIS_HOST override):
+#   kubectl apply -f config/metadata/valkey.yaml
+#   Then set REDIS_HOST=redis-master in metadata-service (no "aibrix-" prefix).
+#
+# Note: Do not apply alongside redis.yaml — they share the same Service name
+# (redis-master) and will conflict. Use one or the other.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey-master # Unique name for the deployment
+  namespace: aibrix-system
+  labels:
+    app: valkey
+spec:
+  selector:
+    matchLabels:
+      app: valkey
+      role: master
+      tier: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: valkey
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - name: master
+        image: valkey/valkey:8-alpine
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  namespace: aibrix-system
+  labels:
+    app: valkey
+    role: master
+    tier: backend
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: valkey
+    role: master
+    tier: backend

--- a/deployment/standalone/README.md
+++ b/deployment/standalone/README.md
@@ -9,7 +9,7 @@ Simplified single-node AIBrix deployment without Kubernetes complexity. Perfect 
 - **vLLM Backend** - High-performance LLM inference engine
 - **P/D Disaggregation** - Optional separate prefill/decode engines for multi-GPU setups
 - **Metadata Service** - Model registry and file management
-- **Redis** - Shared state storage
+- **Redis** - Shared state storage (or Valkey as OSS-licensed BSD-3 alternative via `REDIS_IMAGE` env var)
 
 ## Quick Start
 
@@ -134,7 +134,7 @@ See `.env.example` for all available options.
 | `prefill-engine` | 8001 | Prefill engine (P/D mode) |
 | `decode-engine` | 8002 | Decode engine (P/D mode) |
 | `metadata-service` | 8090 | Model registry and file management |
-| `redis` | 6379 | State storage |
+| `redis` | 6379 | State storage (configurable: set `REDIS_IMAGE=valkey/valkey:8-alpine` for Valkey) |
 
 ## Endpoints
 
@@ -165,6 +165,9 @@ See `.env.example` for all available options.
 ```bash
 # Start (simple mode)
 docker compose up -d
+
+# Start with Valkey instead of Redis (OSS-licensed, BSD-3)
+REDIS_IMAGE=valkey/valkey:8-alpine REDIS_SERVER_CMD=valkey-server REDIS_CLI_CMD=valkey-cli docker compose up -d
 
 # Start (P/D mode)
 docker compose --profile pd up -d
@@ -293,6 +296,7 @@ For developing and testing the gateway plugin locally without Docker:
 - Python 3.9+ (for mock vLLM server)
 - Envoy proxy installed (`brew install envoy` on macOS)
 - Redis running locally (`brew install redis && redis-server`)
+  - Or Valkey: `brew install valkey && valkey-server` (OSS alternative, BSD-3)
 
 ### Network Setup (Important!)
 

--- a/deployment/standalone/docker-compose.yml
+++ b/deployment/standalone/docker-compose.yml
@@ -9,6 +9,7 @@
 #
 # Usage:
 #   Default mode:    docker compose up -d
+#   Valkey mode:     REDIS_IMAGE=valkey/valkey:8-alpine REDIS_SERVER_CMD=valkey-server REDIS_CLI_CMD=valkey-cli docker compose up -d
 #   P/D mode:        docker compose --profile pd up -d
 
 x-common-gpu: &common-gpu
@@ -30,19 +31,19 @@ services:
   # ============================================================================
 
   redis:
-    image: redis:7.4-alpine
+    image: ${REDIS_IMAGE:-redis:7.4-alpine}
     container_name: aibrix-redis
     ports:
       - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis-data:/data
     command: >
-      redis-server
+      ${REDIS_SERVER_CMD:-redis-server}
       --appendonly yes
       --maxmemory 256mb
       --maxmemory-policy allkeys-lru
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "${REDIS_CLI_CMD:-redis-cli}", "ping"]
       <<: *healthcheck-defaults
       start_period: 5s
     networks:

--- a/hack/release/sync-dependency-images.sh
+++ b/hack/release/sync-dependency-images.sh
@@ -13,6 +13,7 @@ TARGET_REGISTRY=$1
 # List of images to sync in the format "source_image:tag new_repo_path"
 IMAGES=(
     "redis:7.4 ${TARGET_REGISTRY}/aibrix/redis:7.4"
+    "valkey/valkey:8-alpine ${TARGET_REGISTRY}/aibrix/valkey:8-alpine"
     "envoyproxy/envoy:v1.33.2 ${TARGET_REGISTRY}/aibrix/envoy:v1.33.2"
     "envoyproxy/gateway:v1.2.8 ${TARGET_REGISTRY}/aibrix/gateway:v1.2.8"
     "aibrix/kuberay-operator:v1.2.1-patch-20250726 ${TARGET_REGISTRY}/aibrix/kuberay-operator:v1.2.1-patch-20250726"

--- a/pkg/controller/kvcache/backends/common.go
+++ b/pkg/controller/kvcache/backends/common.go
@@ -18,6 +18,7 @@ package backends
 
 import (
 	"fmt"
+	"strings"
 
 	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
 	"github.com/vllm-project/aibrix/pkg/constants"
@@ -185,4 +186,63 @@ func buildRoleBinding(kvCache *orchestrationv1alpha1.KVCache) *rbacv1.RoleBindin
 	}
 
 	return rb
+}
+
+// parseSecretRef parses a secret reference in "secretName/key" format.
+// If no key is specified, defaults to "password".
+func parseSecretRef(ref string) (name, key string) {
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return parts[0], "password"
+}
+
+// buildRedisWatcherEnvVars constructs the REDIS_ADDR and REDIS_PASSWORD env vars
+// for a watcher pod. If an ExternalConnection is configured, it uses the external
+// address and wires the password via SecretKeyRef. Otherwise falls back to the
+// in-cluster Redis service at <name>-redis:6379 with an empty password.
+//
+// Limitation: ReconcilePodObject only reconciles the container image, not env vars.
+// If an operator later changes which secret/key passwordSecretRef points at or changes
+// the external address, the running watcher pod retains the old env vars. The secret
+// *value* is re-read by kubelet on pod restart (SecretKeyRef is a reference, not a
+// snapshot), but a change to the secret *name* or the address field requires deleting
+// and recreating the watcher pod for the new config to take effect.
+func buildRedisWatcherEnvVars(kvCache *orchestrationv1alpha1.KVCache) []corev1.EnvVar {
+	redisAddr := fmt.Sprintf("%s-redis:%d", kvCache.Name, 6379)
+	var redisPasswordEnv corev1.EnvVar
+
+	if kvCache.Spec.Metadata != nil && kvCache.Spec.Metadata.Redis != nil &&
+		kvCache.Spec.Metadata.Redis.ExternalConnection != nil &&
+		kvCache.Spec.Metadata.Redis.ExternalConnection.Address != "" {
+		extConn := kvCache.Spec.Metadata.Redis.ExternalConnection
+		redisAddr = extConn.Address
+
+		// Wire PasswordSecretRef into the pod env via SecretKeyRef.
+		if extConn.PasswordSecretRef != "" {
+			secretName, secretKey := parseSecretRef(extConn.PasswordSecretRef)
+			redisPasswordEnv = corev1.EnvVar{
+				Name: "REDIS_PASSWORD",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+						Key:                  secretKey,
+					},
+				},
+			}
+		} else {
+			redisPasswordEnv = corev1.EnvVar{Name: "REDIS_PASSWORD", Value: ""}
+		}
+	} else {
+		redisPasswordEnv = corev1.EnvVar{Name: "REDIS_PASSWORD", Value: ""}
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name:  "REDIS_ADDR",
+			Value: redisAddr,
+		},
+		redisPasswordEnv,
+	}
 }

--- a/pkg/controller/kvcache/backends/distributed.go
+++ b/pkg/controller/kvcache/backends/distributed.go
@@ -20,9 +20,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 
 	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
 	"github.com/vllm-project/aibrix/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -106,8 +110,36 @@ func (r *DistributedReconciler) reconcileMetadataService(ctx context.Context, kv
 }
 
 func (r *DistributedReconciler) reconcileRedisService(ctx context.Context, kvCache *orchestrationv1alpha1.KVCache) error {
-	// We only support etcd at this moment, redis will be supported later.
-	replicas := int(kvCache.Spec.Metadata.Redis.Runtime.Replicas)
+	redisConfig := kvCache.Spec.Metadata.Redis
+
+	// If an external connection is configured, skip in-cluster Redis deployment.
+	// The operator is providing their own managed Valkey/Redis-compatible endpoint.
+	if redisConfig.ExternalConnection != nil && redisConfig.ExternalConnection.Address != "" {
+		// Validate first — only clean up in-cluster resources once the external
+		// config is confirmed to be well-formed
+		if err := r.validateExternalConnection(ctx, kvCache); err != nil {
+			return err
+		}
+
+		klog.Infof("Using external metadata connection at %s, skipping in-cluster Redis deployment", redisConfig.ExternalConnection.Address)
+
+		// Only tear down in-cluster Redis once the external config is known-good.
+		// Returning the error on failure is intentional — the reconcile loop will
+		// retry until cleanup succeeds. Partial cleanup (e.g., Pod deleted but
+		// Service remains) is safe because the retry will finish the job.
+		if err := r.cleanupInClusterRedis(ctx, kvCache); err != nil {
+			return fmt.Errorf("cleaning up in-cluster Redis: %w", err)
+		}
+
+		return nil
+	}
+
+	// Fall back to in-cluster Redis deployment (existing behavior).
+	if redisConfig.Runtime == nil {
+		return errors.New("redis metadata config requires either externalConnection or runtime to be set")
+	}
+
+	replicas := int(redisConfig.Runtime.Replicas)
 	if replicas != 1 {
 		klog.Warningf("replica %d > 1 is not supported at this moment, we will change to single replica", replicas)
 	}
@@ -117,10 +149,81 @@ func (r *DistributedReconciler) reconcileRedisService(ctx context.Context, kvCac
 		return err
 	}
 
-	// Create or update the etcd service for each pod
-	etcdService := r.Backend.BuildMetadataService(kvCache)
-	if err := r.ReconcileServiceObject(ctx, etcdService); err != nil {
+	// Create or update the metadata service for each pod
+	metadataService := r.Backend.BuildMetadataService(kvCache)
+	if err := r.ReconcileServiceObject(ctx, metadataService); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// validateExternalConnection validates the external connection configuration
+// without reading secret values into memory.
+func (r *DistributedReconciler) validateExternalConnection(ctx context.Context, kvCache *orchestrationv1alpha1.KVCache) error {
+	extConn := kvCache.Spec.Metadata.Redis.ExternalConnection
+
+	// Validate address format (host:port)
+	if _, _, err := net.SplitHostPort(extConn.Address); err != nil {
+		return fmt.Errorf("external connection address %q must be in host:port format: %w", extConn.Address, err)
+	}
+
+	// If a password secret reference is provided, verify the secret and key exist.
+	if extConn.PasswordSecretRef != "" {
+		if err := r.validateSecretExists(ctx, kvCache.Namespace, extConn.PasswordSecretRef); err != nil {
+			return fmt.Errorf("failed to resolve PasswordSecretRef %q: %w", extConn.PasswordSecretRef, err)
+		}
+	}
+
+	return nil
+}
+
+// validateSecretExists checks that a Kubernetes Secret and key exist without
+// reading the secret value into memory. Use this for validation-only paths
+// where the value will be injected via SecretKeyRef rather than resolved at runtime.
+func (r *DistributedReconciler) validateSecretExists(ctx context.Context, namespace, secretRef string) error {
+	secretName, secretKey := parseSecretRef(secretRef)
+
+	secret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      secretName,
+	}, secret); err != nil {
+		return fmt.Errorf("failed to get secret %q in namespace %q: %w", secretName, namespace, err)
+	}
+
+	if _, ok := secret.Data[secretKey]; !ok {
+		return fmt.Errorf("key %q not found in secret %q", secretKey, secretName)
+	}
+
+	return nil
+}
+
+// cleanupInClusterRedis deletes the in-cluster Redis Pod and Service that may
+// have been previously created. This handles the migration path from in-cluster
+// to external connection without leaving orphaned resources.
+func (r *DistributedReconciler) cleanupInClusterRedis(ctx context.Context, kvCache *orchestrationv1alpha1.KVCache) error {
+	redisPodName := fmt.Sprintf("%s-redis", kvCache.Name)
+	redisServiceName := fmt.Sprintf("%s-redis", kvCache.Name)
+
+	// Delete the Redis Pod (ignore NotFound — may not exist).
+	pod := &corev1.Pod{}
+	pod.Name = redisPodName
+	pod.Namespace = kvCache.Namespace
+	if err := r.Client.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete Redis Pod %s: %w", redisPodName, err)
+	} else if err == nil {
+		klog.Infof("Deleted orphaned in-cluster Redis Pod %s/%s", kvCache.Namespace, redisPodName)
+	}
+
+	// Delete the Redis Service (ignore NotFound — may not exist).
+	svc := &corev1.Service{}
+	svc.Name = redisServiceName
+	svc.Namespace = kvCache.Namespace
+	if err := r.Client.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete Redis Service %s: %w", redisServiceName, err)
+	} else if err == nil {
+		klog.Infof("Deleted orphaned in-cluster Redis Service %s/%s", kvCache.Namespace, redisServiceName)
 	}
 
 	return nil

--- a/pkg/controller/kvcache/backends/distributed_test.go
+++ b/pkg/controller/kvcache/backends/distributed_test.go
@@ -27,8 +27,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
 	"github.com/vllm-project/aibrix/pkg/constants"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -173,6 +175,420 @@ func TestReconcileRedisService_SingleReplicaAllowed(t *testing.T) {
 
 	err = r.reconcileRedisService(context.Background(), kv)
 	assert.NoError(t, err)
+}
+
+// -- Test for reconcileRedisService with ExternalConnection --
+
+func TestReconcileRedisService_ExternalConnection(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+
+	t.Run("skips in-cluster deployment when external connection is set", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "valkey-credentials",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"password": []byte("my-secret-password"),
+			},
+		}
+		// Pre-create an in-cluster Redis Pod and Service to verify they get cleaned up.
+		existingPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ext-test-redis",
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "redis", Image: "redis:7"}},
+			},
+		}
+		existingSvc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ext-test-redis",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Port: 6379, Protocol: corev1.ProtocolTCP}},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, existingPod, existingSvc).Build()
+		r := NewDistributedReconciler(c, constants.KVCacheBackendInfinistore)
+		r.Backend = mockBackend{}
+
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ext-test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.KVCacheSpec{
+				Metadata: &v1alpha1.MetadataSpec{
+					Redis: &v1alpha1.MetadataConfig{
+						ExternalConnection: &v1alpha1.ExternalConnectionConfig{
+							Address:           "valkey.example.com:6379",
+							PasswordSecretRef: "valkey-credentials",
+						},
+					},
+				},
+			},
+		}
+
+		err := r.reconcileRedisService(context.Background(), kv)
+		assert.NoError(t, err)
+
+		// Verify in-cluster Redis Pod was deleted.
+		pod := &corev1.Pod{}
+		err = c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "ext-test-redis"}, pod)
+		assert.True(t, apierrors.IsNotFound(err), "expected in-cluster Redis Pod to be deleted")
+
+		// Verify in-cluster Redis Service was deleted.
+		svc := &corev1.Service{}
+		err = c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "ext-test-redis"}, svc)
+		assert.True(t, apierrors.IsNotFound(err), "expected in-cluster Redis Service to be deleted")
+	})
+
+	t.Run("fails when external address has no port", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		r := NewDistributedReconciler(c, constants.KVCacheBackendInfinistore)
+		r.Backend = mockBackend{}
+
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ext-test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.KVCacheSpec{
+				Metadata: &v1alpha1.MetadataSpec{
+					Redis: &v1alpha1.MetadataConfig{
+						ExternalConnection: &v1alpha1.ExternalConnectionConfig{
+							Address: "valkey.example.com",
+						},
+					},
+				},
+			},
+		}
+
+		err := r.reconcileRedisService(context.Background(), kv)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must be in host:port format")
+	})
+
+	t.Run("fails when password secret does not exist", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		r := NewDistributedReconciler(c, constants.KVCacheBackendInfinistore)
+		r.Backend = mockBackend{}
+
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ext-test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.KVCacheSpec{
+				Metadata: &v1alpha1.MetadataSpec{
+					Redis: &v1alpha1.MetadataConfig{
+						ExternalConnection: &v1alpha1.ExternalConnectionConfig{
+							Address:           "valkey.example.com:6379",
+							PasswordSecretRef: "nonexistent-secret",
+						},
+					},
+				},
+			},
+		}
+
+		err := r.reconcileRedisService(context.Background(), kv)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to resolve PasswordSecretRef")
+	})
+
+	t.Run("fails when neither external connection nor runtime is set", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		r := NewDistributedReconciler(c, constants.KVCacheBackendInfinistore)
+		r.Backend = mockBackend{}
+
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ext-test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.KVCacheSpec{
+				Metadata: &v1alpha1.MetadataSpec{
+					Redis: &v1alpha1.MetadataConfig{},
+				},
+			},
+		}
+
+		err := r.reconcileRedisService(context.Background(), kv)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "requires either externalConnection or runtime to be set")
+	})
+
+	t.Run("resolves secret with custom key format", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-secret",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"redis-pass": []byte("custom-key-password"),
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+		r := NewDistributedReconciler(c, constants.KVCacheBackendInfinistore)
+		r.Backend = mockBackend{}
+
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ext-test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.KVCacheSpec{
+				Metadata: &v1alpha1.MetadataSpec{
+					Redis: &v1alpha1.MetadataConfig{
+						ExternalConnection: &v1alpha1.ExternalConnectionConfig{
+							Address:           "valkey.example.com:6379",
+							PasswordSecretRef: "my-secret/redis-pass",
+						},
+					},
+				},
+			},
+		}
+
+		err := r.reconcileRedisService(context.Background(), kv)
+		assert.NoError(t, err)
+	})
+}
+
+// -- Test for cleanupInClusterRedis --
+
+func TestCleanupInClusterRedis(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+
+	t.Run("deletes existing in-cluster Redis Pod and Service", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cleanup-test-redis",
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "redis", Image: "redis:7"}},
+			},
+		}
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cleanup-test-redis",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Port: 6379, Protocol: corev1.ProtocolTCP}},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, svc).Build()
+		r := NewDistributedReconciler(c, constants.KVCacheBackendInfinistore)
+
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cleanup-test",
+				Namespace: "default",
+			},
+		}
+
+		err := r.cleanupInClusterRedis(context.Background(), kv)
+		assert.NoError(t, err)
+
+		// Verify Pod is gone.
+		err = c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "cleanup-test-redis"}, &corev1.Pod{})
+		assert.True(t, apierrors.IsNotFound(err), "expected Redis Pod to be deleted")
+
+		// Verify Service is gone.
+		err = c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "cleanup-test-redis"}, &corev1.Service{})
+		assert.True(t, apierrors.IsNotFound(err), "expected Redis Service to be deleted")
+	})
+
+	t.Run("no-op when resources do not exist", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		r := NewDistributedReconciler(c, constants.KVCacheBackendInfinistore)
+
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "no-redis",
+				Namespace: "default",
+			},
+		}
+
+		err := r.cleanupInClusterRedis(context.Background(), kv)
+		assert.NoError(t, err)
+	})
+}
+
+// -- Test for watcher pod env wiring --
+
+func TestBuildRedisWatcherEnvVars(t *testing.T) {
+	t.Run("uses external address and SecretKeyRef when ExternalConnection is set", func(t *testing.T) {
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "env-test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.KVCacheSpec{
+				Metadata: &v1alpha1.MetadataSpec{
+					Redis: &v1alpha1.MetadataConfig{
+						ExternalConnection: &v1alpha1.ExternalConnectionConfig{
+							Address:           "valkey.prod.example.com:6380",
+							PasswordSecretRef: "prod-secret/auth-token",
+						},
+					},
+				},
+			},
+		}
+
+		envs := buildRedisWatcherEnvVars(kv)
+		assert.Len(t, envs, 2)
+
+		// REDIS_ADDR should be the external address.
+		assert.Equal(t, "REDIS_ADDR", envs[0].Name)
+		assert.Equal(t, "valkey.prod.example.com:6380", envs[0].Value)
+
+		// REDIS_PASSWORD should use SecretKeyRef.
+		assert.Equal(t, "REDIS_PASSWORD", envs[1].Name)
+		assert.NotNil(t, envs[1].ValueFrom)
+		assert.NotNil(t, envs[1].ValueFrom.SecretKeyRef)
+		assert.Equal(t, "prod-secret", envs[1].ValueFrom.SecretKeyRef.Name)
+		assert.Equal(t, "auth-token", envs[1].ValueFrom.SecretKeyRef.Key)
+	})
+
+	t.Run("uses external address with empty password when no PasswordSecretRef", func(t *testing.T) {
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "env-test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.KVCacheSpec{
+				Metadata: &v1alpha1.MetadataSpec{
+					Redis: &v1alpha1.MetadataConfig{
+						ExternalConnection: &v1alpha1.ExternalConnectionConfig{
+							Address: "valkey.dev.example.com:6379",
+						},
+					},
+				},
+			},
+		}
+
+		envs := buildRedisWatcherEnvVars(kv)
+		assert.Equal(t, "valkey.dev.example.com:6379", envs[0].Value)
+		assert.Equal(t, "REDIS_PASSWORD", envs[1].Name)
+		assert.Nil(t, envs[1].ValueFrom)
+		assert.Equal(t, "", envs[1].Value)
+	})
+
+	t.Run("falls back to in-cluster Redis when no ExternalConnection", func(t *testing.T) {
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fallback-test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.KVCacheSpec{
+				Metadata: &v1alpha1.MetadataSpec{
+					Redis: &v1alpha1.MetadataConfig{
+						Runtime: &v1alpha1.RuntimeSpec{Replicas: 1},
+					},
+				},
+			},
+		}
+
+		envs := buildRedisWatcherEnvVars(kv)
+		assert.Equal(t, "REDIS_ADDR", envs[0].Name)
+		assert.Equal(t, "fallback-test-redis:6379", envs[0].Value)
+		assert.Equal(t, "REDIS_PASSWORD", envs[1].Name)
+		assert.Equal(t, "", envs[1].Value)
+		assert.Nil(t, envs[1].ValueFrom)
+	})
+
+	t.Run("defaults secret key to password when no slash in ref", func(t *testing.T) {
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-key-test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.KVCacheSpec{
+				Metadata: &v1alpha1.MetadataSpec{
+					Redis: &v1alpha1.MetadataConfig{
+						ExternalConnection: &v1alpha1.ExternalConnectionConfig{
+							Address:           "valkey.example.com:6379",
+							PasswordSecretRef: "my-secret",
+						},
+					},
+				},
+			},
+		}
+
+		envs := buildRedisWatcherEnvVars(kv)
+		assert.Equal(t, "my-secret", envs[1].ValueFrom.SecretKeyRef.Name)
+		assert.Equal(t, "password", envs[1].ValueFrom.SecretKeyRef.Key)
+	})
+}
+
+// --Test for validation-before-cleanup ordering --
+
+func TestReconcileRedisService_ValidationBeforeCleanup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+
+	t.Run("invalid external config does not delete existing in-cluster Redis", func(t *testing.T) {
+		// Pre-create in-cluster Redis resources.
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "safe-test-redis",
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "redis", Image: "redis:7"}},
+			},
+		}
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "safe-test-redis",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Port: 6379, Protocol: corev1.ProtocolTCP}},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, svc).Build()
+		r := NewDistributedReconciler(c, constants.KVCacheBackendInfinistore)
+		r.Backend = mockBackend{}
+
+		// Set an invalid external connection (no port in address).
+		kv := &v1alpha1.KVCache{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "safe-test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.KVCacheSpec{
+				Metadata: &v1alpha1.MetadataSpec{
+					Redis: &v1alpha1.MetadataConfig{
+						ExternalConnection: &v1alpha1.ExternalConnectionConfig{
+							Address: "valkey.example.com",
+						},
+					},
+				},
+			},
+		}
+
+		err := r.reconcileRedisService(context.Background(), kv)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must be in host:port format")
+
+		// Verify in-cluster Redis resources were NOT deleted.
+		err = c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "safe-test-redis"}, &corev1.Pod{})
+		assert.NoError(t, err, "in-cluster Redis Pod should still exist after validation failure")
+
+		err = c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "safe-test-redis"}, &corev1.Service{})
+		assert.NoError(t, err, "in-cluster Redis Service should still exist after validation failure")
+	})
 }
 
 // -- Mock Backend for isolation --

--- a/pkg/controller/kvcache/backends/hpkv.go
+++ b/pkg/controller/kvcache/backends/hpkv.go
@@ -105,20 +105,14 @@ func (HpKVBackend) BuildService(kvCache *orchestrationv1alpha1.KVCache) *corev1.
 
 func buildKVCacheWatcherPod(kvCache *orchestrationv1alpha1.KVCache) *corev1.Pod {
 	params := getKVCacheParams(kvCache.GetAnnotations())
-	envs := []corev1.EnvVar{
-		{
-			Name:  "REDIS_ADDR",
-			Value: fmt.Sprintf("%s-redis:%d", kvCache.Name, 6379),
-		},
-		{
-			Name:  "REDIS_PASSWORD",
-			Value: "",
-		},
-		{
+
+	envs := buildRedisWatcherEnvVars(kvCache)
+	envs = append(envs,
+		corev1.EnvVar{
 			Name:  "REDIS_DATABASE",
 			Value: "0",
 		},
-		{
+		corev1.EnvVar{
 			Name: "AIBRIX_KVCACHE_WATCH_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
@@ -126,11 +120,11 @@ func buildKVCacheWatcherPod(kvCache *orchestrationv1alpha1.KVCache) *corev1.Pod 
 				},
 			},
 		},
-		{
+		corev1.EnvVar{
 			Name:  "AIBRIX_KVCACHE_WATCH_CLUSTER",
 			Value: kvCache.Name,
 		},
-	}
+	)
 
 	if len(kvCache.Spec.Watcher.Env) != 0 {
 		envs = append(envs, kvCache.Spec.Watcher.Env...)

--- a/pkg/controller/kvcache/backends/infinistore.go
+++ b/pkg/controller/kvcache/backends/infinistore.go
@@ -100,20 +100,13 @@ func (InfiniStoreBackend) BuildService(kvCache *orchestrationv1alpha1.KVCache) *
 
 func buildKVCacheWatcherPodForInfiniStore(kvCache *orchestrationv1alpha1.KVCache) *corev1.Pod {
 	params := getInfiniStoreParams(kvCache.GetAnnotations())
-	envs := []corev1.EnvVar{
-		{
-			Name:  "REDIS_ADDR",
-			Value: fmt.Sprintf("%s-redis:%d", kvCache.Name, 6379),
-		},
-		{
-			Name:  "REDIS_PASSWORD",
-			Value: "",
-		},
-		{
+	envs := buildRedisWatcherEnvVars(kvCache)
+	envs = append(envs,
+		corev1.EnvVar{
 			Name:  "REDIS_DATABASE",
 			Value: "0",
 		},
-		{
+		corev1.EnvVar{
 			Name: "AIBRIX_KVCACHE_WATCH_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
@@ -121,11 +114,11 @@ func buildKVCacheWatcherPodForInfiniStore(kvCache *orchestrationv1alpha1.KVCache
 				},
 			},
 		},
-		{
+		corev1.EnvVar{
 			Name:  "AIBRIX_KVCACHE_WATCH_CLUSTER",
 			Value: kvCache.Name,
 		},
-	}
+	)
 
 	if len(kvCache.Spec.Watcher.Env) != 0 {
 		envs = append(envs, kvCache.Spec.Watcher.Env...)

--- a/pkg/controller/kvcache/backends/integration_test.go
+++ b/pkg/controller/kvcache/backends/integration_test.go
@@ -1,0 +1,248 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Integration test for the external connection migration path.
+Requires a running Kubernetes cluster (e.g., minikube) with:
+- The KVCache CRD installed
+- A secret "valkey-credentials" in the default namespace
+
+Run with:
+  go test -tags=integration -run TestMigrationPath ./pkg/controller/kvcache/backends/ -v
+*/
+
+package backends
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func setupRealClient(t *testing.T) client.Client {
+	t.Helper()
+
+	// Use default kubeconfig (minikube sets this up)
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+
+	cfg, err := kubeConfig.ClientConfig()
+	require.NoError(t, err, "failed to load kubeconfig — is minikube running?")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, orchestrationv1alpha1.AddToScheme(scheme))
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	require.NoError(t, err, "failed to create Kubernetes client")
+
+	return c
+}
+
+// TestMigrationPath_CleanupInClusterRedis validates the migration path:
+// 1. Create in-cluster Redis Pod + Service (simulating existing state)
+// 2. Run reconcileRedisService with externalConnection configured
+// 3. Confirm the in-cluster resources are deleted
+func TestMigrationPath_CleanupInClusterRedis(t *testing.T) {
+	ctx := context.Background()
+	c := setupRealClient(t)
+	namespace := "default"
+	kvCacheName := fmt.Sprintf("migration-test-%d", time.Now().Unix())
+
+	// --- Step 1: Create in-cluster Redis Pod + Service (simulating prior state) ---
+	redisPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-redis", kvCacheName),
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.KVCacheLabelKeyIdentifier: kvCacheName,
+				constants.KVCacheLabelKeyRole:       constants.KVCacheLabelValueRoleMetadata,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "redis",
+					Image: "valkey/valkey:8",
+					Command: []string{"valkey-server"},
+				},
+			},
+		},
+	}
+	redisSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-redis", kvCacheName),
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.KVCacheLabelKeyIdentifier: kvCacheName,
+				constants.KVCacheLabelKeyRole:       constants.KVCacheLabelValueRoleMetadata,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Port: 6379, Protocol: corev1.ProtocolTCP},
+			},
+			Selector: map[string]string{
+				constants.KVCacheLabelKeyIdentifier: kvCacheName,
+			},
+		},
+	}
+
+	require.NoError(t, c.Create(ctx, redisPod))
+	require.NoError(t, c.Create(ctx, redisSvc))
+	t.Cleanup(func() {
+		// Ensure resources are cleaned up even if the test fails midway.
+		_ = c.Delete(context.Background(), redisPod)
+		_ = c.Delete(context.Background(), redisSvc)
+	})
+	t.Logf("Created in-cluster Redis Pod and Service: %s-redis", kvCacheName)
+
+	// Verify they exist
+	err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: redisPod.Name}, &corev1.Pod{})
+	require.NoError(t, err, "Pod should exist before migration")
+	err = c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: redisSvc.Name}, &corev1.Service{})
+	require.NoError(t, err, "Service should exist before migration")
+
+	// --- Step 2: Run reconcileRedisService with externalConnection ---
+	reconciler := NewDistributedReconciler(c, constants.KVCacheBackendInfinistore)
+	reconciler.Backend = InfiniStoreBackend{}
+
+	kvCache := &orchestrationv1alpha1.KVCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kvCacheName,
+			Namespace: namespace,
+		},
+		Spec: orchestrationv1alpha1.KVCacheSpec{
+			Metadata: &orchestrationv1alpha1.MetadataSpec{
+				Redis: &orchestrationv1alpha1.MetadataConfig{
+					ExternalConnection: &orchestrationv1alpha1.ExternalConnectionConfig{
+						Address:           "valkey.example.com:6379",
+						PasswordSecretRef: "valkey-credentials",
+					},
+				},
+			},
+		},
+	}
+
+	err = reconciler.reconcileRedisService(ctx, kvCache)
+	require.NoError(t, err, "reconcileRedisService should succeed with valid external connection")
+	t.Log("reconcileRedisService completed successfully with external connection")
+
+	// --- Step 3: Confirm in-cluster resources are deleted ---
+	// Poll for deletion rather than using a fixed sleep, to avoid flakiness in CI.
+	assert.Eventually(t, func() bool {
+		pod := &corev1.Pod{}
+		err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: redisPod.Name}, pod)
+		return apierrors.IsNotFound(err) || (err == nil && pod.DeletionTimestamp != nil)
+	}, 5*time.Second, 100*time.Millisecond, "Redis Pod should be deleted or terminating after migration")
+
+	assert.Eventually(t, func() bool {
+		svc := &corev1.Service{}
+		err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: redisSvc.Name}, svc)
+		return apierrors.IsNotFound(err) || (err == nil && svc.DeletionTimestamp != nil)
+	}, 5*time.Second, 100*time.Millisecond, "Redis Service should be deleted or terminating after migration")
+
+	t.Log("✓ Migration path validated: in-cluster Redis Pod and Service successfully cleaned up")
+}
+
+// TestMigrationPath_InvalidExternalConfig_PreservesResources validates that
+// an invalid external config does NOT delete existing in-cluster resources.
+func TestMigrationPath_InvalidExternalConfig_PreservesResources(t *testing.T) {
+	ctx := context.Background()
+	c := setupRealClient(t)
+	namespace := "default"
+	kvCacheName := fmt.Sprintf("safe-test-%d", time.Now().Unix())
+
+	// Create in-cluster Redis resources
+	redisPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-redis", kvCacheName),
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "redis", Image: "valkey/valkey:8", Command: []string{"valkey-server"}},
+			},
+		},
+	}
+	redisSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-redis", kvCacheName),
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:    []corev1.ServicePort{{Port: 6379, Protocol: corev1.ProtocolTCP}},
+			Selector: map[string]string{"app": "redis"},
+		},
+	}
+
+	require.NoError(t, c.Create(ctx, redisPod))
+	require.NoError(t, c.Create(ctx, redisSvc))
+
+	// Run reconcile with INVALID external connection (no port)
+	reconciler := NewDistributedReconciler(c, constants.KVCacheBackendInfinistore)
+	reconciler.Backend = InfiniStoreBackend{}
+
+	kvCache := &orchestrationv1alpha1.KVCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kvCacheName,
+			Namespace: namespace,
+		},
+		Spec: orchestrationv1alpha1.KVCacheSpec{
+			Metadata: &orchestrationv1alpha1.MetadataSpec{
+				Redis: &orchestrationv1alpha1.MetadataConfig{
+					ExternalConnection: &orchestrationv1alpha1.ExternalConnectionConfig{
+						Address: "valkey.example.com", // invalid — no port
+					},
+				},
+			},
+		},
+	}
+
+	err := reconciler.reconcileRedisService(ctx, kvCache)
+	assert.Error(t, err, "should fail validation")
+	assert.Contains(t, err.Error(), "must be in host:port format")
+
+	// Confirm resources were NOT deleted
+	err = c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: redisPod.Name}, &corev1.Pod{})
+	assert.NoError(t, err, "Redis Pod should still exist after validation failure")
+
+	err = c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: redisSvc.Name}, &corev1.Service{})
+	assert.NoError(t, err, "Redis Service should still exist after validation failure")
+
+	t.Log("✓ Safety validated: invalid external config did NOT delete in-cluster resources")
+
+	// Cleanup
+	_ = c.Delete(ctx, redisPod)
+	_ = c.Delete(ctx, redisSvc)
+}


### PR DESCRIPTION
## Pull Request Description

Adds [Valkey](https://valkey.io/) (Linux Foundation, BSD-3 licensed) as an OSS-licensed
alternative to Redis for the AIBrix metadata store, and wires the existing
`ExternalConnectionConfig` API so operators can point the KV-cache controller at a managed
Valkey/Redis-compatible endpoint (e.g., Amazon ElastiCache for Valkey) instead of an
in-cluster pod.

All changes are purely additive and backward-compatible. Existing Redis configuration is
untouched and remains the default.

### Why

Redis 7.x ships under RSALv2/SSPLv1 (not OSI-approved). Valkey is a wire-compatible fork
under BSD-3. The existing `go-redis` client and all `REDIS_*` env vars work unchanged over
the RESP protocol. This unblocks deployments where open-source license compliance is required.

The `ExternalConnectionConfig` struct already existed in the CRD API — this PR wires it into
the reconcile loop so it is actually functional.

### Changes

**Part 1 — Valkey as a drop-in image option**

- `config/metadata/valkey.yaml` — New K8s Deployment + Service using `valkey/valkey:8-alpine`.
  Service name is `redis-master` so all `REDIS_HOST` references work with no modification.
  Mutually exclusive with `redis.yaml`.
- `deployment/standalone/docker-compose.yml` — Redis image made configurable via `REDIS_IMAGE`
  env var (defaults to `redis:7.4-alpine`). Added `REDIS_SERVER_CMD` / `REDIS_CLI_CMD` for
  healthcheck compatibility with Valkey.
- `hack/release/sync-dependency-images.sh` — Added `valkey/valkey:8` to the release image
  mirror list.
- `deployment/standalone/README.md` — Documented Valkey as an available OSS alternative with
  usage examples.

**Part 2 — ExternalConnectionConfig wiring**

- `pkg/controller/kvcache/backends/distributed.go`:
  - `reconcileRedisService()` now checks `ExternalConnection` first — if set, skips in-cluster
    Redis deployment entirely and cleans up any existing in-cluster Pod/Service during migration
  - Added `validateExternalConnection()` — validates `host:port` format and verifies
    `PasswordSecretRef` secret/key exist (without reading the value)
  - Extracted `parseSecretRef()` and `buildRedisWatcherEnvVars()` — sets `REDIS_ADDR` and
    `REDIS_PASSWORD` via `SecretKeyRef` for both `hpkv` and `infinistore` watchers
  - Added nil-guard for `Runtime` field to prevent panic when only `ExternalConnection` is
    configured
  - Renamed `etcdService` to `metadataService`
- `pkg/controller/kvcache/backends/distributed_test.go` — 5 new subtests covering all
  reconcile paths

### Usage

**Kubernetes — external managed endpoint:**

```yaml
apiVersion: orchestration.aibrix.ai/v1alpha1
kind: KVCache
spec:
  metadata:
    redis:
      externalConnection:
        address: "valkey.example.com:6379"
        passwordSecretRef: "valkey-credentials/password"
```

**Kubernetes — Valkey in-cluster** (swap `redis.yaml` for `valkey.yaml` in kustomization.yaml):

```bash
kubectl apply -f config/metadata/valkey.yaml
```

**Docker Compose — Valkey:**

```bash
REDIS_IMAGE=valkey/valkey:8-alpine \
REDIS_SERVER_CMD=valkey-server \
REDIS_CLI_CMD=valkey-cli \
docker compose up -d
```

### Testing

- Part 1: existing integration tests pass (no behavior change to default Redis path)
- Part 2: 5 new unit subtests — skip in-cluster deployment when external connection is set,
  invalid address format, missing password secret, nil Runtime guard, custom secret key format

## Related Issues

Resolves: 

- Wire compatibility confirmed: https://github.com/vllm-project/aibrix/issues/928

## Submission Checklist

- [x] PR title includes appropriate prefix(es)
- [x] Changes are clearly explained in the PR description
- [x] New and existing tests pass successfully
- [x] Code adheres to project style and best practices
- [x] Documentation updated to reflect changes
- [x] Thorough testing completed, no regressions introduced
