### PR TITLE
fix(types): reset traceAdded when recycling RoutingContext from the pool

### DIFF
--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -364,6 +364,7 @@ func (r *RoutingContext) reset(ctx context.Context, algorithms RoutingAlgorithm,
 	r.tokens = nil
 	r.predictor = nil
 	r.statsUpdated = statusInitial
+	r.traceAdded = statusInitial
 }
 
 func (r *RoutingContext) debugWait() {

--- a/pkg/types/router_context_test.go
+++ b/pkg/types/router_context_test.go
@@ -127,6 +127,23 @@ var _ = Describe("RouterContext", func() {
 		ctx2.Delete()
 	})
 
+	It("should reset traceAdded when reused", func() {
+		ctx := NewRoutingContext(context.Background(), "algorithm", "model", "message", "r1", "")
+		// First trace attempt on a fresh context must succeed.
+		Expect(ctx.CanAddTrace()).To(BeTrue())
+		// A second attempt on the same request must fail (trace already added).
+		Expect(ctx.CanAddTrace()).To(BeFalse())
+
+		ctx.Delete()
+		ctx2 := NewRoutingContext(context.Background(), "algorithm", "model", "message", "r2", "")
+		Expect(ctx2).To(BeIdenticalTo(ctx))
+		// After recycling from the pool, the new request must be able to add
+		// its trace again; otherwise pendingRequests +1 is silently skipped.
+		Expect(ctx2.CanAddTrace()).To(BeTrue())
+
+		ctx2.Delete()
+	})
+
 	It("should SetTargetPod twice ok but will not change original value", func() {
 		ctx := NewRoutingContext(context.Background(), "algorithm", "model", "message", "r1", "")
 		pod := &v1.Pod{}


### PR DESCRIPTION
## Summary

`RoutingContext` is pooled via `sync.Pool` and reused across requests. `reset()`
re-initializes per-request state on reuse, but while it resets `statsUpdated` to
`statusInitial` it **omits `traceAdded`**:

```go
// pkg/types/router_context.go  reset()
r.statsUpdated = statusInitial
// r.traceAdded is never reset
```

`traceAdded` is only ever written by `CanAddTrace()`, a
`CompareAndSwapInt32(&r.traceAdded, statusInitial, statusAdded)`. So once a
request has added its trace, the field stays at `statusAdded`. When that object
is recycled from the pool for the next request, `reset()` leaves `traceAdded`
at `statusAdded`, and the new request's `CanAddTrace()` CAS fails → the trace is
never added and the matching `pendingRequests +1` is silently skipped,
undercounting pending requests over time.

This is **Defect C1** from #2440.

## Fix

Reset `traceAdded` alongside `statsUpdated` in `reset()` (one line), and add a
regression test that a context recycled from the pool can add its trace again.

## Scope

Deliberately narrow. This only fixes the missed field reset, which is a clear,
self-contained bug regardless of the surrounding lifecycle. The broader
use-after-free / premature-`Delete()` and double-`pool.Put` concerns raised in
#2440 (Defects A / B1 / N1) involve the request lifecycle across
`gateway.go` / `gateway_rsp_headers.go` / `gateway_rsp_body.go` and the design
question the reporter raised — those are left for maintainer design and are not
touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
