### PR TITLE
fix(gateway): support multimodal content-parts input for embeddings requests

### DIFF
--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -265,11 +265,154 @@ func validateCompletionRequest(requestID string, requestBody []byte) (model, mes
 	return
 }
 
+// embeddingReqRaw is a fallback parse target for embeddings requests whose `input` uses
+// multimodal content parts (e.g. image_url for vision-language embedding models), which
+// openai.EmbeddingNewParamsInputUnion does not support -- unlike chat completions, the
+// OpenAI embeddings spec has no content-parts shape, so backends that accept images this
+// way (e.g. qwen3-vl-embedding) are an extension. Input is kept raw so it can be
+// re-parsed once the shape is known.
+type embeddingReqRaw struct {
+	Model  string          `json:"model"`
+	Input  json.RawMessage `json:"input"`
+	Stream json.RawMessage `json:"stream"`
+}
+
+// embeddingContentPart supports two multimodal `input` part shapes:
+//   - the OpenAI chat-content-part shape: {"type": ..., "text": ..., "image_url": {...}}
+//   - sglang's flat MultimodalEmbeddingInput shape (no "type" discriminator):
+//     {"text": "..."} / {"image": "<data-uri>"} / {"video": "<data-uri>"}
+//
+// sglang's embeddings endpoint only understands the flat shape -- it silently ignores
+// unrecognized fields (extra="ignore"), so sending the OpenAI content-part shape leaves
+// text/image/video all unset and falls back to a fixed placeholder input.
+type embeddingContentPart struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text"`
+	ImageURL json.RawMessage `json:"image_url"`
+	VideoURL json.RawMessage `json:"video_url"`
+	Image    string          `json:"image"`
+	Video    string          `json:"video"`
+}
+
+// validateEmbeddingContentParts validates a multimodal embeddings `input` array. Only
+// "text" parts are tokenized and counted against MaxInputTokensPerModel / MaxTotalTokens;
+// image/video parts are excluded because the gateway's text tokenizer cannot estimate
+// their cost, and the backend's own multimodal processor is responsible for that
+// accounting.
+func validateEmbeddingContentParts(parts []embeddingContentPart) error {
+	if len(parts) == 0 {
+		return errors.New("input array cannot be empty")
+	}
+
+	totalEstimatedTokens := 0
+	for i, part := range parts {
+		typ := part.Type
+		if typ == "" {
+			// Flat sglang shape: infer the part kind from whichever field is set.
+			switch {
+			case part.Text != "":
+				typ = "text"
+			case part.Image != "":
+				typ = "image"
+			case part.Video != "":
+				typ = "video"
+			default:
+				return fmt.Errorf("input at index %d must set one of text, image, or video", i)
+			}
+		}
+
+		switch typ {
+		case "text":
+			if part.Text == "" {
+				return fmt.Errorf("input at index %d cannot be an empty string", i)
+			}
+			tokens, err := utils.TokenizeInputText(part.Text)
+			if err != nil {
+				return fmt.Errorf("failed to tokenize input for validation: %w", err)
+			}
+			estimatedTokens := len(tokens)
+			if estimatedTokens > MaxInputTokensPerModel {
+				return fmt.Errorf("input at index %d exceeds max tokens per model (%d), estimated tokens: %d",
+					i, MaxInputTokensPerModel, estimatedTokens)
+			}
+			totalEstimatedTokens += estimatedTokens
+		case "image_url", "image":
+			if len(part.ImageURL) == 0 && part.Image == "" {
+				return fmt.Errorf("input at index %d is missing image_url", i)
+			}
+		case "video_url", "video":
+			if len(part.VideoURL) == 0 && part.Video == "" {
+				return fmt.Errorf("input at index %d is missing video_url", i)
+			}
+		default:
+			return fmt.Errorf("input at index %d has unsupported content type %q", i, typ)
+		}
+	}
+
+	if totalEstimatedTokens > MaxTotalTokens {
+		return fmt.Errorf("total tokens across all inputs exceeds maximum (%d), estimated total: %d",
+			MaxTotalTokens, totalEstimatedTokens)
+	}
+
+	return nil
+}
+
+// validateMultimodalEmbeddingRequest re-parses an embeddings request body whose `input`
+// didn't fit openai.EmbeddingNewParamsInputUnion, checking whether it's instead an array
+// of multimodal content parts. matched is false if the body doesn't match that shape
+// either, signaling the caller to fall back to the original parse error.
+func validateMultimodalEmbeddingRequest(requestID string, requestBody []byte) (model string, errRes *extProcPb.ProcessingResponse, matched bool) {
+	var req embeddingReqRaw
+	if err := sonic.Unmarshal(requestBody, &req); err != nil {
+		return "", nil, false
+	}
+
+	trimmed := bytes.TrimSpace(req.Input)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return "", nil, false
+	}
+
+	var parts []embeddingContentPart
+	if err := sonic.Unmarshal(trimmed, &parts); err != nil || len(parts) == 0 {
+		return "", nil, false
+	}
+	// Confirm this is actually a content-parts array (typed or sglang's flat shape) and
+	// not some other array of objects that merely failed to unmarshal as expected -- an
+	// empty first part (no type/text/image_url/video_url/image/video set at all) means
+	// the shape doesn't match either content-parts variant, so fall back to the original
+	// parse error instead of reporting a misleading per-index validation error.
+	first := parts[0]
+	if first.Type == "" && first.Text == "" && len(first.ImageURL) == 0 && len(first.VideoURL) == 0 && first.Image == "" && first.Video == "" {
+		return "", nil, false
+	}
+
+	klog.V(4).InfoS("parsed multimodal embeddings input", "requestID", requestID, "parts", len(parts))
+
+	if err := validateEmbeddingContentParts(parts); err != nil {
+		return req.Model, buildErrorResponse(envoyTypePb.StatusCode_BadRequest, err.Error(), "", "input", HeaderErrorRequestBodyProcessing, "true"), true
+	}
+
+	if len(req.Stream) > 0 {
+		var streamBool bool
+		if err := sonic.Unmarshal(req.Stream, &streamBool); err != nil || streamBool {
+			return req.Model, buildErrorResponse(envoyTypePb.StatusCode_BadRequest, "stream not supported for embeddings", "", "stream", HeaderErrorRequestBodyProcessing, "true"), true
+		}
+	}
+
+	return req.Model, nil, true
+}
+
 // validateEmbeddingRequest parses and validates an embeddings request body.
 // nolint:nakedret
 func validateEmbeddingRequest(requestID string, requestBody []byte) (model string, errRes *extProcPb.ProcessingResponse) {
 	var embeddingReq embeddingReqMinimal
 	if err := sonic.Unmarshal(requestBody, &embeddingReq); err != nil {
+		// `input` may be an array of multimodal content parts (e.g. image_url), which
+		// the strict OpenAI union type above does not support. Retry with that shape
+		// before treating this as a hard parse failure.
+		if m, mmErrRes, matched := validateMultimodalEmbeddingRequest(requestID, requestBody); matched {
+			return m, mmErrRes
+		}
 		klog.ErrorS(err, "error to unmarshal embeddings object", "requestID", requestID, "requestBody", string(requestBody))
 		errRes = buildErrorResponse(envoyTypePb.StatusCode_BadRequest, "error processing request body", "", "", HeaderErrorRequestBodyProcessing, "true")
 		return

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -336,13 +336,21 @@ func validateEmbeddingContentParts(parts []embeddingContentPart) error {
 					i, MaxInputTokensPerModel, estimatedTokens)
 			}
 			totalEstimatedTokens += estimatedTokens
-		case "image_url", "image":
-			if len(part.ImageURL) == 0 && part.Image == "" {
+		case "image_url":
+			if len(part.ImageURL) == 0 {
 				return fmt.Errorf("input at index %d is missing image_url", i)
 			}
-		case "video_url", "video":
-			if len(part.VideoURL) == 0 && part.Video == "" {
+		case "image":
+			if part.Image == "" {
+				return fmt.Errorf("input at index %d is missing image", i)
+			}
+		case "video_url":
+			if len(part.VideoURL) == 0 {
 				return fmt.Errorf("input at index %d is missing video_url", i)
+			}
+		case "video":
+			if part.Video == "" {
+				return fmt.Errorf("input at index %d is missing video", i)
 			}
 		default:
 			return fmt.Errorf("input at index %d has unsupported content type %q", i, typ)

--- a/pkg/plugins/gateway/util_test.go
+++ b/pkg/plugins/gateway/util_test.go
@@ -324,6 +324,83 @@ func Test_ValidateRequestBody_Embeddings(t *testing.T) {
 			stream:      false,
 			statusCode:  envoyTypePb.StatusCode_OK,
 		},
+
+		// Multimodal content-parts input (e.g. image_url for vision-language embedding models)
+		{
+			message:     "/v1/embeddings multimodal image_url input",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "qwen3-vl-embedding-8b", "input": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,aGVsbG8="}}]}`),
+			model:       "qwen3-vl-embedding-8b",
+			statusCode:  envoyTypePb.StatusCode_OK,
+		},
+		{
+			message:     "/v1/embeddings multimodal text and image_url input",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "qwen3-vl-embedding-8b", "input": [{"type": "text", "text": "a photo of pets"}, {"type": "image_url", "image_url": {"url": "data:image/png;base64,aGVsbG8="}}]}`),
+			model:       "qwen3-vl-embedding-8b",
+			statusCode:  envoyTypePb.StatusCode_OK,
+		},
+		{
+			message:     "/v1/embeddings multimodal input with stream true - should fail",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "qwen3-vl-embedding-8b", "input": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,aGVsbG8="}}], "stream": true}`),
+			statusCode:  envoyTypePb.StatusCode_BadRequest,
+		},
+		{
+			message:     "/v1/embeddings multimodal input missing image_url",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "qwen3-vl-embedding-8b", "input": [{"type": "image_url"}]}`),
+			statusCode:  envoyTypePb.StatusCode_BadRequest,
+		},
+		{
+			message:     "/v1/embeddings multimodal video_url input",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "qwen3-vl-embedding-8b", "input": [{"type": "video_url", "video_url": {"url": "data:video/mp4;base64,aGVsbG8="}}]}`),
+			model:       "qwen3-vl-embedding-8b",
+			statusCode:  envoyTypePb.StatusCode_OK,
+		},
+		{
+			message:     "/v1/embeddings multimodal input missing video_url",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "qwen3-vl-embedding-8b", "input": [{"type": "video_url"}]}`),
+			statusCode:  envoyTypePb.StatusCode_BadRequest,
+		},
+		{
+			message:     "/v1/embeddings multimodal input unsupported content type",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "qwen3-vl-embedding-8b", "input": [{"type": "audio_url"}]}`),
+			statusCode:  envoyTypePb.StatusCode_BadRequest,
+		},
+
+		// sglang's flat MultimodalEmbeddingInput shape (no "type" discriminator):
+		// {"text": "..."} / {"image": "<data-uri>"} / {"video": "<data-uri>"}
+		{
+			message:     "/v1/embeddings flat image input",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "qwen3-vl-embedding-8b", "input": [{"image": "data:image/png;base64,aGVsbG8="}]}`),
+			model:       "qwen3-vl-embedding-8b",
+			statusCode:  envoyTypePb.StatusCode_OK,
+		},
+		{
+			message:     "/v1/embeddings flat video input",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "qwen3-vl-embedding-8b", "input": [{"video": "data:video/mp4;base64,aGVsbG8="}]}`),
+			model:       "qwen3-vl-embedding-8b",
+			statusCode:  envoyTypePb.StatusCode_OK,
+		},
+		{
+			message:     "/v1/embeddings flat text and image input",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "qwen3-vl-embedding-8b", "input": [{"text": "a photo of pets"}, {"image": "data:image/png;base64,aGVsbG8="}]}`),
+			model:       "qwen3-vl-embedding-8b",
+			statusCode:  envoyTypePb.StatusCode_OK,
+		},
+		{
+			message:     "/v1/embeddings flat input part with nothing set",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "qwen3-vl-embedding-8b", "input": [{}]}`),
+			statusCode:  envoyTypePb.StatusCode_BadRequest,
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
## Pull Request Description

## Description

The gateway's embeddings request validation previously only handled OpenAI's `EmbeddingNewParamsInputUnion` (a string or an array of strings/tokens). As a result, requests containing multimodal input content parts—which are utilized by vision-language embedding models like `qwen3-vl-embedding`—failed strict JSON parsing and were rejected with a generic `400: "error processing request body"` error.

This PR introduces a fallback parser (`validateMultimodalEmbeddingRequest`) to handle multimodal inputs gracefully when standard OpenAI parsing fails.

---

## Proposed Changes

* **Fallback Parser (`validateMultimodalEmbeddingRequest`)**: Retries parsing the input as an array of content parts when the strict OpenAI shape fails.
* **Dual-Format Support**: Supports both:
* **OpenAI chat-content-part shape**: `{"type": "image_url", "image_url": {...}}`
* **SGLang flat MultimodalEmbeddingInput shape**: `{"image": ""}`, `{"video": ""}`, `{"text": "..."}`


* **Token Estimation**: Only text parts are tokenized and counted against `MaxInputTokensPerModel` / `MaxTotalTokens`. Image and video parts are skipped during this stage, as the gateway's text tokenizer cannot accurately estimate their cost (leaving that accounting to the backend's multimodal processor).
* **Error Handling**: If neither shape matches, the parser falls back to the original parse-error behavior so that unrelated malformed requests remain unaffected.

---

## Testing Done

Added comprehensive unit tests in `util_test.go` covering the following scenarios:

* [x] `image_url` and `video_url` content parts
* [x] Mixed text and image inputs
* [x] SGLang's flat shape parsing
* [x] Missing or empty fields
* [x] Unsupported content types
* [x] Rejection of `stream: true` when multimodal input is provided

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>