### PR TITLE
fix(modelclaim): validate fixed GPU pool topology

### DIFF
--- a/cmd/controllers/main.go
+++ b/cmd/controllers/main.go
@@ -80,7 +80,8 @@ func init() {
 
 func RegisterSchemas(scheme *runtime.Scheme) error {
 	podAutoscalerEnabled := features.IsControllerEnabled(features.PodAutoscalerController)
-	modelAdapterEnabled := features.IsControllerEnabled(features.ModelAdapterController)
+	modelAPIEnabled := features.IsControllerEnabled(features.ModelAdapterController) ||
+		features.IsControllerEnabled(features.ModelClaimController)
 	distributedInferenceEnabled := features.IsControllerEnabled(features.DistributedInferenceController)
 	kvCacheEnabled := features.IsControllerEnabled(features.KVCacheController)
 	stormServiceEnabled := features.IsControllerEnabled(features.StormServiceController)
@@ -89,7 +90,7 @@ func RegisterSchemas(scheme *runtime.Scheme) error {
 		utilruntime.Must(autoscalingv1alpha1.AddToScheme(scheme))
 	}
 
-	if modelAdapterEnabled {
+	if modelAPIEnabled {
 		utilruntime.Must(modelv1alpha1.AddToScheme(scheme))
 	}
 

--- a/cmd/controllers/main_test.go
+++ b/cmd/controllers/main_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	modelv1alpha1 "github.com/vllm-project/aibrix/api/model/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/features"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestRegisterSchemasIncludesModelClaimAPI(t *testing.T) {
+	previous := features.EnabledControllers
+	features.EnabledControllers = map[string]bool{
+		features.ModelClaimController: true,
+	}
+	t.Cleanup(func() { features.EnabledControllers = previous })
+
+	testScheme := runtime.NewScheme()
+	require.NoError(t, RegisterSchemas(testScheme))
+	_, err := testScheme.New(schema.GroupVersionKind{
+		Group: modelv1alpha1.GroupVersion.Group, Version: modelv1alpha1.GroupVersion.Version, Kind: "ModelClaim",
+	})
+	require.NoError(t, err)
+}

--- a/pkg/controller/modelclaim/modelclaim_controller.go
+++ b/pkg/controller/modelclaim/modelclaim_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vllm-project/aibrix/pkg/config"
 	"github.com/vllm-project/aibrix/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -135,7 +136,7 @@ func (r *ModelClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			clearClaimMetrics(pm.Namespace, servedModelName(pm))
 			controllerutil.RemoveFinalizer(pm, ModelClaimFinalizer)
 			if err := r.Update(ctx, pm); err != nil {
-				return ctrl.Result{}, err
+				return requeueOnConflict(err)
 			}
 		}
 		return ctrl.Result{}, nil
@@ -145,7 +146,7 @@ func (r *ModelClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if !controllerutil.ContainsFinalizer(pm, ModelClaimFinalizer) {
 		controllerutil.AddFinalizer(pm, ModelClaimFinalizer)
 		if err := r.Update(ctx, pm); err != nil {
-			return ctrl.Result{}, err
+			return requeueOnConflict(err)
 		}
 		// A finalizer-only update changes neither generation, labels, nor
 		// annotations, so our watch predicate (GenerationChanged / LabelChanged /
@@ -178,7 +179,7 @@ func (r *ModelClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			})
 			pm.Status.Phase = modelv1alpha1.ModelClaimFailed
 			if uerr := r.Status().Update(ctx, pm); uerr != nil {
-				return ctrl.Result{}, uerr
+				return requeueOnConflict(uerr)
 			}
 			return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
 		}
@@ -192,9 +193,20 @@ func (r *ModelClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	r.recomputeReadiness(pm)
 	setClaimGauges(pm)
 	if err := r.Status().Update(ctx, pm); err != nil {
-		return ctrl.Result{}, err
+		return requeueOnConflict(err)
 	}
 	return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
+}
+
+// requeueOnConflict lets the next reconcile work from the latest API object.
+// Status updates can race with deletion/finalizer updates and must not surface
+// as a controller error when Kubernetes reports the expected resource-version
+// conflict.
+func requeueOnConflict(err error) (ctrl.Result, error) {
+	if apierrors.IsConflict(err) {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return ctrl.Result{}, err
 }
 
 // listCandidateWarmPods returns running pods that match the model's PodSelector
@@ -202,6 +214,10 @@ func (r *ModelClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *ModelClaimReconciler) listCandidateWarmPods(ctx context.Context, pm *modelv1alpha1.ModelClaim) ([]corev1.Pod, error) {
 	if pm.Spec.PodSelector == nil {
 		return nil, fmt.Errorf("spec.podSelector must not be nil")
+	}
+	parallelism, err := modelParallelism(pm)
+	if err != nil {
+		return nil, fmt.Errorf("invalid engineConfig parallelism: %w", err)
 	}
 	selector, err := metav1.LabelSelectorAsSelector(pm.Spec.PodSelector)
 	if err != nil {
@@ -229,6 +245,9 @@ func (r *ModelClaimReconciler) listCandidateWarmPods(ctx context.Context, pm *mo
 			continue
 		}
 		if !pod.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if isVLLMModel(pm) && !podSupportsVLLMParallelism(pod, parallelism) {
 			continue
 		}
 		candidates = append(candidates, pod)
@@ -326,7 +345,11 @@ func (r *ModelClaimReconciler) recomputeReadiness(pm *modelv1alpha1.ModelClaim) 
 // reconciles again); only runtime failures propagate.
 func (r *ModelClaimReconciler) ensureActivated(ctx context.Context, pm *modelv1alpha1.ModelClaim, candidates []corev1.Pod) error {
 	load := r.computePodLoad(ctx, pm.Namespace)
-	placementStates := r.collectPlacementStates(ctx, candidates, pm.Spec.ArtifactURL)
+	parallelism, err := modelParallelism(pm)
+	if err != nil {
+		return fmt.Errorf("invalid engineConfig parallelism: %w", err)
+	}
+	placementStates := r.collectPlacementStates(ctx, candidates, pm.Spec.ArtifactURL, parallelism)
 
 	for desiredReplicas(pm) > int32(len(pm.Status.Instances)) {
 		pod, err := selectPodForActivationWithState(
@@ -386,6 +409,7 @@ func (r *ModelClaimReconciler) collectPlacementStates(
 	ctx context.Context,
 	candidates []corev1.Pod,
 	artifactURL string,
+	parallelism int64,
 ) map[string]PodPlacementState {
 	states := make(map[string]PodPlacementState, len(candidates))
 	if r.SnapshotCache == nil {
@@ -400,7 +424,7 @@ func (r *ModelClaimReconciler) collectPlacementStates(
 		if !ok {
 			continue
 		}
-		states[pod.Name] = placementStateFromSnapshot(snapshot, artifactURL)
+		states[pod.Name] = placementStateFromSnapshot(snapshot, artifactURL, parallelism)
 	}
 	return states
 }

--- a/pkg/controller/modelclaim/modelclaim_controller.go
+++ b/pkg/controller/modelclaim/modelclaim_controller.go
@@ -156,6 +156,22 @@ func (r *ModelClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	if _, err := modelParallelism(pm); err != nil {
+		message := fmt.Sprintf("invalid engineConfig parallelism: %v", err)
+		r.Recorder.Event(pm, corev1.EventTypeWarning, "InvalidEngineConfig", message)
+		meta.SetStatusCondition(&pm.Status.Conditions, metav1.Condition{
+			Type:    string(modelv1alpha1.ModelClaimConditionReady),
+			Status:  metav1.ConditionFalse,
+			Reason:  "InvalidEngineConfig",
+			Message: message,
+		})
+		pm.Status.Phase = modelv1alpha1.ModelClaimFailed
+		if uerr := r.Status().Update(ctx, pm); uerr != nil {
+			return requeueOnConflict(uerr)
+		}
+		return ctrl.Result{}, nil
+	}
+
 	candidates, err := r.listCandidateWarmPods(ctx, pm)
 	if err != nil {
 		klog.ErrorS(err, "failed to list candidate warm pods", "modelClaim", req.NamespacedName)

--- a/pkg/controller/modelclaim/modelclaim_controller_test.go
+++ b/pkg/controller/modelclaim/modelclaim_controller_test.go
@@ -531,6 +531,31 @@ func TestReconcileActivateFailureSetsFailed(t *testing.T) {
 	assert.Equal(t, metav1.ConditionFalse, cond.Status)
 }
 
+func TestReconcileInvalidEngineConfigSetsFailed(t *testing.T) {
+	pm := withFinalizer(sampleModelClaim())
+	pm.Spec.EngineConfig.Args["--tensor-parallel-size"] = "invalid"
+	r, runtime := newReconciler(t,
+		pm,
+		warmPod("warm-1", "b300-pool-a", true, corev1.PodRunning),
+	)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: pm.Name},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.Requeue)
+	assert.Zero(t, result.RequeueAfter)
+	assert.Empty(t, runtime.activateCalls)
+
+	got := getModel(t, r, pm.Name)
+	assert.Equal(t, modelv1alpha1.ModelClaimFailed, got.Status.Phase)
+	cond := meta.FindStatusCondition(got.Status.Conditions, string(modelv1alpha1.ModelClaimConditionReady))
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "InvalidEngineConfig", cond.Reason)
+	assert.Contains(t, cond.Message, "--tensor-parallel-size must be a positive integer")
+}
+
 // TestReconcileReplicasZeroDeactivates verifies explicit replicas=0 deactivates instances.
 func TestReconcileReplicasZeroDeactivates(t *testing.T) {
 	zero := int32(0)

--- a/pkg/controller/modelclaim/modelclaim_controller_test.go
+++ b/pkg/controller/modelclaim/modelclaim_controller_test.go
@@ -25,9 +25,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -146,6 +149,17 @@ func warmPod(name, poolName string, enabled bool, phase corev1.PodPhase) *corev1
 	}
 }
 
+func warmPodWithGPUs(name, poolName string, gpuCount int64) *corev1.Pod {
+	pod := warmPod(name, poolName, true, corev1.PodRunning)
+	pod.Spec.Containers = []corev1.Container{{
+		Name: "aibrix-runtime",
+		Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+			corev1.ResourceName("nvidia.com/gpu"): *resource.NewQuantity(gpuCount, resource.DecimalSI),
+		}},
+	}}
+	return pod
+}
+
 func sampleModelClaim() *modelv1alpha1.ModelClaim {
 	return &modelv1alpha1.ModelClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: "qwen2-7b", Namespace: testNamespace},
@@ -190,6 +204,19 @@ func reconcileOnce(t *testing.T, r *ModelClaimReconciler, name string) {
 	require.NoError(t, err)
 }
 
+func TestRequeueOnConflict(t *testing.T) {
+	result, err := requeueOnConflict(apierrors.NewConflict(
+		schema.GroupResource{Group: "model.aibrix.ai", Resource: "modelclaims"},
+		"qwen", nil,
+	))
+	require.NoError(t, err)
+	assert.True(t, result.Requeue)
+
+	result, err = requeueOnConflict(fmt.Errorf("runtime unavailable"))
+	require.Error(t, err)
+	assert.False(t, result.Requeue)
+}
+
 func getModel(t *testing.T, r *ModelClaimReconciler, name string) *modelv1alpha1.ModelClaim {
 	t.Helper()
 	got := &modelv1alpha1.ModelClaim{}
@@ -218,6 +245,21 @@ func TestListCandidateWarmPods(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, "ready", got[0].Name)
+}
+
+func TestListCandidateWarmPodsFiltersMismatchedVLLMParallelism(t *testing.T) {
+	pm := sampleModelClaim()
+	pm.Spec.EngineConfig.Args["--tensor-parallel-size"] = "2"
+	r, _ := newReconciler(t,
+		warmPodWithGPUs("one-gpu", "b300-pool-a", 1),
+		warmPodWithGPUs("two-gpu", "b300-pool-a", 2),
+	)
+
+	got, err := r.listCandidateWarmPods(context.Background(), pm)
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "two-gpu", got[0].Name)
 }
 
 // TestReconcileAddsFinalizer verifies the first reconcile installs the finalizer

--- a/pkg/controller/modelclaim/parallelism.go
+++ b/pkg/controller/modelclaim/parallelism.go
@@ -18,6 +18,7 @@ package modelclaim
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -50,7 +51,7 @@ func vllmParallelism(config *modelv1alpha1.ModelClaimEngineConfig) (int64, error
 	if data != 1 {
 		return 0, fmt.Errorf("--data-parallel-size=%d is unsupported by fixed topology pools", data)
 	}
-	if tensor > int64(^uint64(0)>>1)/pipeline {
+	if tensor > math.MaxInt64/pipeline {
 		return 0, fmt.Errorf("tensor and pipeline parallelism product overflows int64")
 	}
 	return tensor * pipeline, nil

--- a/pkg/controller/modelclaim/parallelism.go
+++ b/pkg/controller/modelclaim/parallelism.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modelclaim
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	modelv1alpha1 "github.com/vllm-project/aibrix/api/model/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const nvidiaGPUResourceName corev1.ResourceName = "nvidia.com/gpu"
+
+// vllmParallelism returns the fixed GPU group size required by a vLLM engine.
+// ModelClaim deliberately keeps these engine options in engineConfig.args; the
+// pool Pod's GPU limit is the resource contract and must match TP * PP.
+func vllmParallelism(config *modelv1alpha1.ModelClaimEngineConfig) (int64, error) {
+	args := map[string]string{}
+	if config != nil && config.Args != nil {
+		args = config.Args
+	}
+	tensor, err := positiveEngineArg(args, "--tensor-parallel-size")
+	if err != nil {
+		return 0, err
+	}
+	pipeline, err := positiveEngineArg(args, "--pipeline-parallel-size")
+	if err != nil {
+		return 0, err
+	}
+	data, err := positiveEngineArg(args, "--data-parallel-size")
+	if err != nil {
+		return 0, err
+	}
+	if data != 1 {
+		return 0, fmt.Errorf("--data-parallel-size=%d is unsupported by fixed topology pools", data)
+	}
+	if tensor > int64(^uint64(0)>>1)/pipeline {
+		return 0, fmt.Errorf("tensor and pipeline parallelism product overflows int64")
+	}
+	return tensor * pipeline, nil
+}
+
+func positiveEngineArg(args map[string]string, name string) (int64, error) {
+	raw, found := args[name]
+	if !found || raw == "" {
+		return 1, nil
+	}
+	value, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil || value < 1 {
+		return 0, fmt.Errorf("%s must be a positive integer", name)
+	}
+	return value, nil
+}
+
+func isVLLMModel(pm *modelv1alpha1.ModelClaim) bool {
+	return pm.Spec.Engine == "" || pm.Spec.Engine == "vllm"
+}
+
+func modelParallelism(pm *modelv1alpha1.ModelClaim) (int64, error) {
+	if !isVLLMModel(pm) {
+		return 1, nil
+	}
+	return vllmParallelism(pm.Spec.EngineConfig)
+}
+
+// podGPUCount reports the GPU devices assigned to the warm runtime Pod. The
+// initial contract is one topology-homogeneous runtime container per Pod.
+func podGPUCount(pod corev1.Pod) int64 {
+	var count int64
+	for i := range pod.Spec.Containers {
+		resources := pod.Spec.Containers[i].Resources
+		if quantity, found := resources.Limits[nvidiaGPUResourceName]; found {
+			count += quantity.Value()
+			continue
+		}
+		if quantity, found := resources.Requests[nvidiaGPUResourceName]; found {
+			count += quantity.Value()
+		}
+	}
+	return count
+}
+
+// podSupportsVLLMParallelism accepts legacy/mock Pods without GPU resources so
+// existing CPU-only controller tests remain valid. Real warm pools declare a
+// GPU limit and must exactly match the requested TP * PP topology.
+func podSupportsVLLMParallelism(pod corev1.Pod, parallelism int64) bool {
+	gpuCount := podGPUCount(pod)
+	return gpuCount == 0 || gpuCount == parallelism
+}

--- a/pkg/controller/modelclaim/snapshot.go
+++ b/pkg/controller/modelclaim/snapshot.go
@@ -102,7 +102,7 @@ type PodPlacementState struct {
 	ModelCount     int
 }
 
-func placementStateFromSnapshot(snapshot *RuntimeSnapshot, artifactURL string) PodPlacementState {
+func placementStateFromSnapshot(snapshot *RuntimeSnapshot, artifactURL string, parallelism int64) PodPlacementState {
 	state := PodPlacementState{SnapshotKnown: true, ModelCount: len(snapshot.Models)}
 	for _, cached := range snapshot.CachedArtifacts {
 		if cached == artifactURL {
@@ -110,12 +110,18 @@ func placementStateFromSnapshot(snapshot *RuntimeSnapshot, artifactURL string) P
 			break
 		}
 	}
+	if parallelism < 1 {
+		parallelism = 1
+	}
+	if parallelism > 1 && int64(len(snapshot.Accelerators)) != parallelism {
+		return state
+	}
 	for _, accelerator := range snapshot.Accelerators {
-		// HBMFreeBytes describes the largest available single-GPU slot. Phase 2
-		// launches independent single-GPU engines, so pod ranking must use the
-		// most free HBM reported by any visible accelerator rather than aggregate
-		// or worst-device capacity.
-		if !state.MemoryKnown || accelerator.HBMFreeBytes > state.HBMFreeBytes {
+		// A single-GPU engine needs the largest available single-device slot. A
+		// fixed TP/PP group uses every visible GPU, so its safe headroom is the
+		// least-free rank rather than a misleading aggregate or maximum.
+		if !state.MemoryKnown || (parallelism == 1 && accelerator.HBMFreeBytes > state.HBMFreeBytes) ||
+			(parallelism > 1 && accelerator.HBMFreeBytes < state.HBMFreeBytes) {
 			state.HBMFreeBytes = accelerator.HBMFreeBytes
 			state.MemoryKnown = true
 		}

--- a/pkg/controller/modelclaim/snapshot_test.go
+++ b/pkg/controller/modelclaim/snapshot_test.go
@@ -93,12 +93,14 @@ func TestPlacementStateFromSnapshot(t *testing.T) {
 		CachedArtifacts: []string{"hf://Org/M1"},
 	}
 
-	state := placementStateFromSnapshot(snapshot, "hf://Org/M1")
+	singleGPUState := placementStateFromSnapshot(snapshot, "hf://Org/M1", 1)
+	groupState := placementStateFromSnapshot(snapshot, "hf://Org/M1", 2)
 
-	assert.True(t, state.SnapshotKnown)
-	assert.True(t, state.ArtifactCached)
-	assert.True(t, state.MemoryKnown)
-	assert.Equal(t, int64(800), state.HBMFreeBytes)
-	assert.Equal(t, int64(35), state.KVUsedBytes)
-	assert.Equal(t, 2, state.ModelCount)
+	assert.True(t, singleGPUState.SnapshotKnown)
+	assert.True(t, singleGPUState.ArtifactCached)
+	assert.True(t, singleGPUState.MemoryKnown)
+	assert.Equal(t, int64(800), singleGPUState.HBMFreeBytes)
+	assert.Equal(t, int64(300), groupState.HBMFreeBytes)
+	assert.Equal(t, int64(35), groupState.KVUsedBytes)
+	assert.Equal(t, 2, groupState.ModelCount)
 }

--- a/python/aibrix/aibrix/runtime/model_runtime.py
+++ b/python/aibrix/aibrix/runtime/model_runtime.py
@@ -437,6 +437,50 @@ def _engine_args(
     return args
 
 
+def _positive_engine_arg(args: Dict[str, str], name: str) -> int:
+    raw = args.get(name, "1")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+    if value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def vllm_parallelism(
+    engine_config: Optional[Dict], additional_config: Optional[Dict[str, str]]
+) -> int:
+    """Return the fixed GPU group size required by vLLM TP and PP."""
+    args = _engine_args(engine_config, additional_config)
+    tensor = _positive_engine_arg(args, "--tensor-parallel-size")
+    pipeline = _positive_engine_arg(args, "--pipeline-parallel-size")
+    data = _positive_engine_arg(args, "--data-parallel-size")
+    if data != 1:
+        raise ValueError(
+            f"--data-parallel-size={data} is unsupported by fixed topology pools"
+        )
+    return tensor * pipeline
+
+
+def validate_vllm_parallelism(
+    engine_config: Optional[Dict], additional_config: Optional[Dict[str, str]]
+) -> None:
+    """Require TP * PP to match the GPUs visible to this warm runtime pod."""
+    parallelism = vllm_parallelism(engine_config, additional_config)
+    visible_gpus = len(gpu_memory_snapshots())
+    if visible_gpus == 0:
+        if parallelism > 1:
+            raise RuntimeError(
+                "cannot validate vLLM TP/PP topology because no GPUs are visible to the runtime"
+            )
+        return
+    if visible_gpus != parallelism:
+        raise ValueError(
+            f"vLLM parallelism {parallelism} must equal {visible_gpus} GPU(s) visible to runtime"
+        )
+
+
 # --------------------------------------------------------------------------- #
 # Mock implementations (no GPU, no process, no network) for local testing
 # --------------------------------------------------------------------------- #
@@ -514,6 +558,8 @@ class ModelRuntime:
         claim_ref: Optional[Dict[str, str]] = None,
     ) -> ModelInstance:
         with self._lock:
+            if engine == "vllm":
+                validate_vllm_parallelism(engine_config, additional_config)
             existing = self._models.get(model_name)
             if existing is not None:
                 if self._instance_alive(existing):

--- a/python/aibrix/aibrix/runtime/model_runtime.py
+++ b/python/aibrix/aibrix/runtime/model_runtime.py
@@ -50,6 +50,10 @@ def sanitize_ipc_name(name: str) -> str:
 
 logger = logging.getLogger(__name__)
 
+# NVML owns a process-global initialization state. Snapshot requests can run
+# concurrently, so init/query/shutdown must be one uninterrupted operation.
+_nvml_lock = threading.Lock()
+
 
 @dataclass
 class ModelInstance:
@@ -202,36 +206,37 @@ def gpu_memory_snapshots() -> List[Dict[str, object]]:
     is therefore optional: lack of the module, driver, or visible device means
     the controller receives an empty accelerator list and falls back safely.
     """
-    initialized = False
-    try:
-        import pynvml  # type: ignore[import-not-found]
+    with _nvml_lock:
+        initialized = False
+        try:
+            import pynvml  # type: ignore[import-not-found]
 
-        pynvml.nvmlInit()
-        initialized = True
-        snapshots = []
-        for index in range(pynvml.nvmlDeviceGetCount()):
-            handle = pynvml.nvmlDeviceGetHandleByIndex(index)
-            info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-            device_id = pynvml.nvmlDeviceGetUUID(handle)
-            if isinstance(device_id, bytes):
-                device_id = device_id.decode()
-            snapshots.append(
-                {
-                    "id": str(device_id),
-                    "hbm_total_bytes": int(info.total),
-                    "hbm_free_bytes": int(info.free),
-                }
-            )
-        return snapshots
-    except Exception as exc:
-        logger.debug("NVML GPU observation is unavailable: %s", exc)
-        return []
-    finally:
-        if initialized:
-            try:
-                pynvml.nvmlShutdown()  # type: ignore[name-defined]
-            except Exception:
-                pass
+            pynvml.nvmlInit()
+            initialized = True
+            snapshots = []
+            for index in range(pynvml.nvmlDeviceGetCount()):
+                handle = pynvml.nvmlDeviceGetHandleByIndex(index)
+                info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                device_id = pynvml.nvmlDeviceGetUUID(handle)
+                if isinstance(device_id, bytes):
+                    device_id = device_id.decode()
+                snapshots.append(
+                    {
+                        "id": str(device_id),
+                        "hbm_total_bytes": int(info.total),
+                        "hbm_free_bytes": int(info.free),
+                    }
+                )
+            return snapshots
+        except Exception as exc:
+            logger.debug("NVML GPU observation is unavailable: %s", exc)
+            return []
+        finally:
+            if initialized:
+                try:
+                    pynvml.nvmlShutdown()  # type: ignore[name-defined]
+                except Exception:
+                    pass
 
 
 def write_cache_marker(

--- a/python/aibrix/aibrix/runtime/model_runtime_api.py
+++ b/python/aibrix/aibrix/runtime/model_runtime_api.py
@@ -72,6 +72,14 @@ def activate_runtime_model(request: ActivateRuntimeModelRequest):
                 else None
             ),
         )
+    except ValueError as exc:
+        logger.warning(f"invalid activation request for {request.model_name}: {exc}")
+        return JSONResponse(
+            status_code=400,
+            content=ActivateRuntimeModelResponse(
+                status="error", model_name=request.model_name, message=str(exc)
+            ).model_dump(),
+        )
     except Exception as exc:  # surface activation failure to the controller
         logger.error(f"failed to activate model {request.model_name}: {exc}")
         return JSONResponse(

--- a/python/aibrix/tests/runtime/test_model_runtime.py
+++ b/python/aibrix/tests/runtime/test_model_runtime.py
@@ -15,6 +15,10 @@
 """Tests for runtime model lifecycle, using mock actuators (no GPU)."""
 
 import os
+import sys
+import threading
+import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -26,6 +30,61 @@ from aibrix.runtime.model_runtime import (
 
 def make_agent():
     return ModelRuntime(MockEngineLauncher())
+
+
+def test_gpu_memory_snapshots_serializes_nvml_lifecycle(monkeypatch):
+    import aibrix.runtime.model_runtime as runtime_module
+
+    state_lock = threading.Lock()
+    active = 0
+    max_active = 0
+    init_calls = 0
+    shutdown_calls = 0
+
+    def nvml_init():
+        nonlocal active, init_calls, max_active
+        with state_lock:
+            init_calls += 1
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.01)
+
+    def nvml_shutdown():
+        nonlocal active, shutdown_calls
+        with state_lock:
+            shutdown_calls += 1
+            active -= 1
+
+    nvml = SimpleNamespace(
+        nvmlInit=nvml_init,
+        nvmlShutdown=nvml_shutdown,
+        nvmlDeviceGetCount=lambda: 1,
+        nvmlDeviceGetHandleByIndex=lambda index: index,
+        nvmlDeviceGetMemoryInfo=lambda handle: SimpleNamespace(total=100, free=50),
+        nvmlDeviceGetUUID=lambda handle: f"GPU-{handle}",
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", nvml)
+
+    start = threading.Barrier(4)
+    snapshots = []
+
+    def observe():
+        start.wait()
+        snapshots.append(runtime_module.gpu_memory_snapshots())
+
+    threads = [threading.Thread(target=observe) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert (
+        snapshots
+        == [[{"id": "GPU-0", "hbm_total_bytes": 100, "hbm_free_bytes": 50}]] * 4
+    )
+    assert init_calls == 4
+    assert shutdown_calls == 4
+    assert max_active == 1
 
 
 class _RecordingKVController:
@@ -239,10 +298,13 @@ def test_vllm_parallelism_defaults_and_combines_tp_pp():
     from aibrix.runtime.model_runtime import vllm_parallelism
 
     assert vllm_parallelism(None, None) == 1
-    assert vllm_parallelism(
-        {"args": {"--tensor-parallel-size": "2", "--pipeline-parallel-size": "2"}},
-        None,
-    ) == 4
+    assert (
+        vllm_parallelism(
+            {"args": {"--tensor-parallel-size": "2", "--pipeline-parallel-size": "2"}},
+            None,
+        )
+        == 4
+    )
 
 
 @pytest.mark.parametrize(
@@ -260,7 +322,9 @@ def test_vllm_parallelism_rejects_unsupported_or_invalid_args(args):
         vllm_parallelism({"args": args}, None)
 
 
-def test_activate_rejects_vllm_parallelism_that_does_not_match_visible_gpus(monkeypatch):
+def test_activate_rejects_vllm_parallelism_that_does_not_match_visible_gpus(
+    monkeypatch,
+):
     import aibrix.runtime.model_runtime as runtime_module
 
     monkeypatch.setattr(

--- a/python/aibrix/tests/runtime/test_model_runtime.py
+++ b/python/aibrix/tests/runtime/test_model_runtime.py
@@ -235,6 +235,71 @@ def test_engine_config_args_are_structured():
     ) == {"--max-model-len": "2048", "--enforce-eager": ""}
 
 
+def test_vllm_parallelism_defaults_and_combines_tp_pp():
+    from aibrix.runtime.model_runtime import vllm_parallelism
+
+    assert vllm_parallelism(None, None) == 1
+    assert vllm_parallelism(
+        {"args": {"--tensor-parallel-size": "2", "--pipeline-parallel-size": "2"}},
+        None,
+    ) == 4
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        {"--tensor-parallel-size": "0"},
+        {"--pipeline-parallel-size": "not-a-number"},
+        {"--data-parallel-size": "2"},
+    ],
+)
+def test_vllm_parallelism_rejects_unsupported_or_invalid_args(args):
+    from aibrix.runtime.model_runtime import vllm_parallelism
+
+    with pytest.raises(ValueError):
+        vllm_parallelism({"args": args}, None)
+
+
+def test_activate_rejects_vllm_parallelism_that_does_not_match_visible_gpus(monkeypatch):
+    import aibrix.runtime.model_runtime as runtime_module
+
+    monkeypatch.setattr(
+        runtime_module,
+        "gpu_memory_snapshots",
+        lambda: [{"id": "GPU-0", "hbm_total_bytes": 1000, "hbm_free_bytes": 900}],
+    )
+
+    with pytest.raises(ValueError, match="must equal 1 GPU"):
+        make_agent().activate(
+            model_name="tp2",
+            artifact_url="hf://Org/M1",
+            engine_config={"args": {"--tensor-parallel-size": "2"}},
+        )
+
+
+def test_activate_accepts_vllm_tp_pp_matching_visible_gpus(monkeypatch):
+    import aibrix.runtime.model_runtime as runtime_module
+
+    monkeypatch.setattr(
+        runtime_module,
+        "gpu_memory_snapshots",
+        lambda: [
+            {"id": f"GPU-{index}", "hbm_total_bytes": 1000, "hbm_free_bytes": 900}
+            for index in range(4)
+        ],
+    )
+
+    inst = make_agent().activate(
+        model_name="tp2pp2",
+        artifact_url="hf://Org/M1",
+        engine_config={
+            "args": {"--tensor-parallel-size": "2", "--pipeline-parallel-size": "2"}
+        },
+    )
+
+    assert inst.model_name == "tp2pp2"
+
+
 def test_legacy_additional_config_engine_arg_prefix_is_supported():
     from aibrix.runtime.model_runtime import _engine_args
 
@@ -324,6 +389,37 @@ def test_endpoints_activate_list_deactivate():
 
     listed = client.get("/v1/runtime/models").json()
     assert all(m["model_name"] != "ep1" for m in listed["models"])
+
+
+def test_activate_endpoint_rejects_mismatched_vllm_parallelism(monkeypatch):
+    import aibrix.runtime.model_runtime as runtime_module
+
+    monkeypatch.setattr(
+        runtime_module,
+        "gpu_memory_snapshots",
+        lambda: [
+            {
+                "id": "GPU-0",
+                "hbm_total_bytes": 1000,
+                "hbm_free_bytes": 700,
+            }
+        ],
+    )
+    client = _make_test_client()
+
+    response = client.post(
+        "/v1/runtime/models/activate",
+        json={
+            "model_name": "tp2-on-one-gpu",
+            "artifact_url": "hf://Org/Model",
+            "engine": "vllm",
+            "engine_config": {"args": {"--tensor-parallel-size": "2"}},
+        },
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["status"] == "error"
+    assert "must equal 1 GPU" in response.json()["message"]
 
 
 def test_control_endpoints_apply_kv_sleep_and_wake():


### PR DESCRIPTION
## Pull Request Description
This PR makes the fixed warm-pool topology explicit and validates it across the runtime and controller:

- Require vLLM `TP * PP` to match the GPUs visible to a warm runtime.
- Reject unsupported data parallelism and invalid topology arguments early.
- Filter controller candidates whose declared GPU count does not match the requested vLLM topology.
- Return HTTP 400 for invalid runtime activation configurations.
- Register the ModelClaim API when `model-claim-controller` is enabled independently.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>