### PR TITLE
[Misc]feat(modelclaim): surface invalid pool policy configuration to operators

### DIFF
--- a/pkg/controller/modelclaim/metrics.go
+++ b/pkg/controller/modelclaim/metrics.go
@@ -18,6 +18,7 @@ package modelclaim
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	modelv1alpha1 "github.com/vllm-project/aibrix/api/model/v1alpha1"
@@ -70,6 +71,15 @@ var (
 		},
 		[]string{"namespace", "model", "result"},
 	)
+	// Cardinality is namespace×deployment, bounded by the number of warm pools.
+	poolPolicyValid = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: constants.AibrixSubsystemName,
+			Name:      "modelclaim_pool_policy_valid",
+			Help:      "1 when the warm pool Deployment policy annotation parses and validates, else 0.",
+		},
+		[]string{"namespace", "deployment"},
+	)
 )
 
 func init() {
@@ -78,6 +88,7 @@ func init() {
 		claimReadyReplicas,
 		claimActivating,
 		claimActivationTotal,
+		poolPolicyValid,
 	)
 }
 
@@ -113,6 +124,18 @@ func clearClaimMetrics(namespace, model string) {
 	claimDesiredReplicas.DeleteLabelValues(namespace, model)
 	claimReadyReplicas.DeleteLabelValues(namespace, model)
 	claimActivating.DeleteLabelValues(namespace, model)
+}
+
+// setPoolPolicyValid tracks the latest parse/validation outcome of a warm pool
+// Deployment's policy annotation.
+func setPoolPolicyValid(pool types.NamespacedName, valid bool) {
+	poolPolicyValid.WithLabelValues(pool.Namespace, pool.Name).Set(b2f(valid))
+}
+
+// clearPoolPolicyMetrics drops the gauge series once the annotation is removed,
+// so a retired pool policy does not stay frozen at its last value.
+func clearPoolPolicyMetrics(pool types.NamespacedName) {
+	poolPolicyValid.DeleteLabelValues(pool.Namespace, pool.Name)
 }
 
 func recordActivation(namespace, model string, ok bool) {

--- a/pkg/controller/modelclaim/modelclaim_controller_test.go
+++ b/pkg/controller/modelclaim/modelclaim_controller_test.go
@@ -337,6 +337,100 @@ func TestReconcilePoolPoliciesSkipsNilRuntimeSnapshot(t *testing.T) {
 	assert.Empty(t, runtime.sleepCalls)
 }
 
+// warmPoolObjects builds the Deployment/ReplicaSet/Pod ownership chain of one
+// warm pool whose Deployment carries the given policy annotation.
+func warmPoolObjects(policy string) (*appsv1.Deployment, *appsv1.ReplicaSet, *corev1.Pod) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "warm-runtime-pool",
+			Namespace:   testNamespace,
+			Annotations: map[string]string{constants.ModelPoolPolicyAnnotationKey: policy},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": warmAppLabel}},
+		},
+	}
+	replicaSet := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "warm-runtime-pool-rs",
+			Namespace:       testNamespace,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deployment, appsv1.SchemeGroupVersion.WithKind("Deployment"))},
+		},
+	}
+	pod := warmPod("warm-1", "b300-pool-a", true, corev1.PodRunning)
+	pod.Labels["app"] = warmAppLabel
+	pod.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(replicaSet, appsv1.SchemeGroupVersion.WithKind("ReplicaSet"))}
+	return deployment, replicaSet, pod
+}
+
+func drainEvents(t *testing.T, r *ModelClaimReconciler) []string {
+	t.Helper()
+	recorder := r.Recorder.(*record.FakeRecorder)
+	var events []string
+	for {
+		select {
+		case event := <-recorder.Events:
+			events = append(events, event)
+		default:
+			return events
+		}
+	}
+}
+
+func TestReconcilePoolPoliciesWarnsOnceForUnchangedInvalidPolicy(t *testing.T) {
+	deployment, replicaSet, pod := warmPoolObjects(`{"reclaim":{"capacityBytes":0}}`)
+	r, runtime := newReconciler(t, deployment, replicaSet, pod)
+
+	r.reconcilePoolPolicies(context.Background(), []corev1.Pod{*pod})
+	r.reconcilePoolPolicies(context.Background(), []corev1.Pod{*pod})
+
+	events := drainEvents(t, r)
+	require.Len(t, events, 1)
+	assert.Contains(t, events[0], "Warning InvalidPoolPolicy")
+	assert.Contains(t, events[0], "invalid_capacity")
+	// Invalid configuration is fail-closed: no KV plan may run.
+	assert.Empty(t, runtime.kvLimitCalls)
+}
+
+func TestReconcilePoolPoliciesEmitsRecoveryOnceCorrected(t *testing.T) {
+	deployment, replicaSet, pod := warmPoolObjects(`{"reclaim":{"capacityBytes":0}}`)
+	r, runtime := newReconciler(t, deployment, replicaSet, pod)
+	requestSuccessTotal := int64(10)
+	runtime.snapshots = map[string]*RuntimeSnapshot{
+		pod.Status.PodIP: {
+			Accelerators: []RuntimeAcceleratorSnapshot{{ID: "GPU-0", HBMTotalBytes: 1000, HBMFreeBytes: 500}},
+			Models: []RuntimeSnapshotModel{{
+				ModelName: "hot", Phase: "active", Alive: true, Ready: true,
+				KVUsedBytes: 100, KVCapacityBytes: 200,
+				RequestMetricsObserved: true, RequestsRunning: 2, RequestSuccessTotal: &requestSuccessTotal,
+			}},
+		},
+	}
+
+	r.reconcilePoolPolicies(context.Background(), []corev1.Pod{*pod})
+
+	deployment.Annotations[constants.ModelPoolPolicyAnnotationKey] = `{"reclaim":{"capacityBytes":1000}}`
+	require.NoError(t, r.Update(context.Background(), deployment))
+
+	r.reconcilePoolPolicies(context.Background(), []corev1.Pod{*pod})
+
+	events := drainEvents(t, r)
+	require.Len(t, events, 2)
+	assert.Contains(t, events[0], "Warning InvalidPoolPolicy")
+	assert.Contains(t, events[1], "Normal PoolPolicyValid")
+	// Policy execution resumes with the corrected configuration.
+	assert.NotEmpty(t, runtime.kvLimitCalls)
+}
+
+func TestReconcilePoolPoliciesStaysQuietForValidPolicy(t *testing.T) {
+	deployment, replicaSet, pod := warmPoolObjects(`{"reclaim":{"capacityBytes":1000}}`)
+	r, _ := newReconciler(t, deployment, replicaSet, pod)
+
+	r.reconcilePoolPolicies(context.Background(), []corev1.Pod{*pod})
+
+	assert.Empty(t, drainEvents(t, r))
+}
+
 func reconcileOnce(t *testing.T, r *ModelClaimReconciler, name string) {
 	t.Helper()
 	_, err := r.Reconcile(context.Background(), ctrl.Request{

--- a/pkg/controller/modelclaim/pool_policy.go
+++ b/pkg/controller/modelclaim/pool_policy.go
@@ -23,13 +23,54 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 )
 
 const poolReclaimModeKVFirst = "kv-first"
 
+// Fixed pool policy configuration error classes. They stay low-cardinality so
+// Events can be deduplicated per class; the detailed parser message travels
+// only in the Event and log text.
+const (
+	poolPolicyErrorInvalidJSON     = "invalid_json"
+	poolPolicyErrorUnknownField    = "unknown_field"
+	poolPolicyErrorUnsupportedMode = "unsupported_mode"
+	poolPolicyErrorInvalidCapacity = "invalid_capacity"
+	poolPolicyErrorInvalidFloor    = "invalid_floor"
+)
+
 var errPoolKVUsageExceedsCapacity = errors.New(
 	"observed KV usage and protected floors exceed pool capacity",
 )
+
+// poolPolicyConfigError attaches a fixed error class to a configuration
+// failure so operator-facing signals key on the class while keeping the full
+// parser message for humans.
+type poolPolicyConfigError struct {
+	class string
+	err   error
+}
+
+func (e *poolPolicyConfigError) Error() string { return e.err.Error() }
+
+func (e *poolPolicyConfigError) Unwrap() error { return e.err }
+
+func poolPolicyErrorClass(err error) string {
+	var configErr *poolPolicyConfigError
+	if errors.As(err, &configErr) {
+		return configErr.class
+	}
+	return poolPolicyErrorInvalidJSON
+}
+
+func poolPolicyDecodeErrorClass(err error) string {
+	// encoding/json exposes DisallowUnknownFields violations only through the
+	// error text, so class detection has to match on it.
+	if strings.Contains(err.Error(), "unknown field") {
+		return poolPolicyErrorUnknownField
+	}
+	return poolPolicyErrorInvalidJSON
+}
 
 // poolPolicy is intentionally configured by one JSON Deployment annotation,
 // not another resource. Reclaim is KV-first by construction: it adjusts
@@ -52,27 +93,42 @@ func parsePoolPolicy(raw string) (*poolPolicy, error) {
 	decoder.DisallowUnknownFields()
 	policy := &poolPolicy{}
 	if err := decoder.Decode(policy); err != nil {
-		return nil, fmt.Errorf("decode pool policy: %w", err)
+		return nil, &poolPolicyConfigError{
+			class: poolPolicyDecodeErrorClass(err),
+			err:   fmt.Errorf("decode pool policy: %w", err),
+		}
 	}
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
 		if err == nil {
-			return nil, fmt.Errorf("decode pool policy: multiple JSON values")
+			err = errors.New("multiple JSON values")
 		}
-		return nil, fmt.Errorf("decode pool policy: %w", err)
+		return nil, &poolPolicyConfigError{
+			class: poolPolicyErrorInvalidJSON,
+			err:   fmt.Errorf("decode pool policy: %w", err),
+		}
 	}
 	if policy.Reclaim != nil {
 		if policy.Reclaim.Mode == "" {
 			policy.Reclaim.Mode = poolReclaimModeKVFirst
 		}
 		if policy.Reclaim.Mode != poolReclaimModeKVFirst {
-			return nil, fmt.Errorf("reclaim.mode must be %q", poolReclaimModeKVFirst)
+			return nil, &poolPolicyConfigError{
+				class: poolPolicyErrorUnsupportedMode,
+				err:   fmt.Errorf("reclaim.mode must be %q", poolReclaimModeKVFirst),
+			}
 		}
 		if policy.Reclaim.CapacityBytes <= 0 {
-			return nil, fmt.Errorf("reclaim.capacityBytes must be positive")
+			return nil, &poolPolicyConfigError{
+				class: poolPolicyErrorInvalidCapacity,
+				err:   errors.New("reclaim.capacityBytes must be positive"),
+			}
 		}
 		if policy.Reclaim.GuaranteedFloorPercent < 0 ||
 			policy.Reclaim.GuaranteedFloorPercent > 100 {
-			return nil, fmt.Errorf("reclaim.guaranteedFloorPercent must be between 0 and 100")
+			return nil, &poolPolicyConfigError{
+				class: poolPolicyErrorInvalidFloor,
+				err:   errors.New("reclaim.guaranteedFloorPercent must be between 0 and 100"),
+			}
 		}
 	}
 	return policy, nil

--- a/pkg/controller/modelclaim/pool_policy_controller.go
+++ b/pkg/controller/modelclaim/pool_policy_controller.go
@@ -40,11 +40,17 @@ type poolPolicyManager struct {
 	now      func() time.Time
 	lastRun  map[types.NamespacedName]time.Time
 	activity map[string]poolActivityRecord
+	config   map[types.NamespacedName]poolConfigRecord
 }
 
 type poolActivityRecord struct {
 	successTotal int64
 	known        bool
+}
+
+type poolConfigRecord struct {
+	raw        string
+	errorClass string
 }
 
 func newPoolPolicyManager(now func() time.Time) *poolPolicyManager {
@@ -55,7 +61,37 @@ func newPoolPolicyManager(now func() time.Time) *poolPolicyManager {
 		now:      now,
 		lastRun:  make(map[types.NamespacedName]time.Time),
 		activity: make(map[string]poolActivityRecord),
+		config:   make(map[types.NamespacedName]poolConfigRecord),
 	}
+}
+
+// observeConfig records the latest annotation parse outcome and reports
+// whether a warning or recovery Event is due. Deduplication keys on the
+// annotation content because metadata edits do not bump the generation.
+func (m *poolPolicyManager) observeConfig(
+	pool types.NamespacedName,
+	raw string,
+	errorClass string,
+) (warn, recovered bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	next := poolConfigRecord{raw: raw, errorClass: errorClass}
+	previous, known := m.config[pool]
+	m.config[pool] = next
+	if next.errorClass != "" {
+		return !known || previous != next, false
+	}
+	return false, known && previous.errorClass != ""
+}
+
+// forgetConfig clears tracking once the annotation is removed, so a re-added
+// policy is treated as fresh configuration.
+func (m *poolPolicyManager) forgetConfig(pool types.NamespacedName) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, known := m.config[pool]
+	delete(m.config, pool)
+	return known
 }
 
 func (m *poolPolicyManager) begin(pool types.NamespacedName) bool {
@@ -121,31 +157,37 @@ func (r *ModelClaimReconciler) reconcilePoolPolicies(ctx context.Context, candid
 	seen := make(map[types.NamespacedName]struct{}, len(candidates))
 	manager := r.poolPolicyManager()
 	for i := range candidates {
-		source, err := r.poolPolicyForPod(ctx, &candidates[i])
+		deployment, err := r.poolDeploymentForPod(ctx, &candidates[i])
 		if err != nil {
-			klog.ErrorS(err, "unable to resolve ModelClaim pool policy", "pod", klog.KObj(&candidates[i]))
+			klog.ErrorS(err, "unable to resolve ModelClaim pool deployment", "pod", klog.KObj(&candidates[i]))
 			continue
 		}
-		if source == nil {
+		if deployment == nil {
 			continue
 		}
-		if _, done := seen[source.key]; done {
+		key := types.NamespacedName{Namespace: deployment.Namespace, Name: deployment.Name}
+		if _, done := seen[key]; done {
 			continue
 		}
-		seen[source.key] = struct{}{}
-		if !manager.begin(source.key) {
+		seen[key] = struct{}{}
+		policy := r.resolvePoolPolicy(deployment, manager)
+		if policy == nil {
 			continue
 		}
+		if !manager.begin(key) {
+			continue
+		}
+		source := &poolPolicySource{key: key, deployment: deployment, policy: policy}
 		if err := r.reconcilePoolPolicy(ctx, source, manager); err != nil {
-			klog.ErrorS(err, "ModelClaim pool policy tick failed", "deployment", klog.KObj(source.deployment))
+			klog.ErrorS(err, "ModelClaim pool policy tick failed", "deployment", klog.KObj(deployment))
 		}
 	}
 }
 
-func (r *ModelClaimReconciler) poolPolicyForPod(
+func (r *ModelClaimReconciler) poolDeploymentForPod(
 	ctx context.Context,
 	pod *corev1.Pod,
-) (*poolPolicySource, error) {
+) (*appsv1.Deployment, error) {
 	podOwner := metav1.GetControllerOf(pod)
 	if podOwner == nil || podOwner.Kind != "ReplicaSet" {
 		return nil, nil
@@ -163,15 +205,44 @@ func (r *ModelClaimReconciler) poolPolicyForPod(
 	if err := r.Get(ctx, key, deployment); err != nil {
 		return nil, err
 	}
+	return deployment, nil
+}
+
+// resolvePoolPolicy parses the Deployment policy annotation and surfaces the
+// outcome to operators through Deployment Events and the policy-valid gauge.
+// Invalid configuration stays fail-closed: it returns nil so no KV plan runs.
+func (r *ModelClaimReconciler) resolvePoolPolicy(
+	deployment *appsv1.Deployment,
+	manager *poolPolicyManager,
+) *poolPolicy {
+	pool := types.NamespacedName{Namespace: deployment.Namespace, Name: deployment.Name}
 	raw := deployment.Annotations[constants.ModelPoolPolicyAnnotationKey]
 	if raw == "" {
-		return nil, nil
+		if manager.forgetConfig(pool) {
+			clearPoolPolicyMetrics(pool)
+		}
+		return nil
 	}
 	policy, err := parsePoolPolicy(raw)
 	if err != nil {
-		return nil, err
+		errorClass := poolPolicyErrorClass(err)
+		setPoolPolicyValid(pool, false)
+		if warn, _ := manager.observeConfig(pool, raw, errorClass); warn {
+			r.Recorder.Eventf(deployment, corev1.EventTypeWarning, "InvalidPoolPolicy",
+				"invalid %s annotation (%s), pool policy disabled: %v",
+				constants.ModelPoolPolicyAnnotationKey, errorClass, err)
+			klog.ErrorS(err, "invalid ModelClaim pool policy annotation",
+				"deployment", klog.KObj(deployment), "errorClass", errorClass)
+		}
+		return nil
 	}
-	return &poolPolicySource{key: key, deployment: deployment, policy: policy}, nil
+	setPoolPolicyValid(pool, true)
+	if _, recovered := manager.observeConfig(pool, raw, ""); recovered {
+		r.Recorder.Eventf(deployment, corev1.EventTypeNormal, "PoolPolicyValid",
+			"%s annotation is valid again, pool policy execution resumed",
+			constants.ModelPoolPolicyAnnotationKey)
+	}
+	return policy
 }
 
 func (r *ModelClaimReconciler) reconcilePoolPolicy(

--- a/pkg/controller/modelclaim/pool_policy_test.go
+++ b/pkg/controller/modelclaim/pool_policy_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestParsePoolPolicyUsesOneDeploymentAnnotation(t *testing.T) {
@@ -47,6 +48,62 @@ func TestParsePoolPolicyRejectsUnsupportedLifecyclePolicy(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, policy)
 	assert.Contains(t, err.Error(), "unknown field")
+}
+
+func TestParsePoolPolicyClassifiesConfigurationErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		raw   string
+		class string
+	}{
+		{"truncated JSON", `{"reclaim":`, poolPolicyErrorInvalidJSON},
+		{"multiple JSON values", `{} {}`, poolPolicyErrorInvalidJSON},
+		{"unknown field", `{"lifecycle":{}}`, poolPolicyErrorUnknownField},
+		{"unsupported mode", `{"reclaim":{"mode":"weight-first","capacityBytes":1000}}`, poolPolicyErrorUnsupportedMode},
+		{"non-positive capacity", `{"reclaim":{"capacityBytes":0}}`, poolPolicyErrorInvalidCapacity},
+		{"floor above 100", `{"reclaim":{"capacityBytes":1000,"guaranteedFloorPercent":101}}`, poolPolicyErrorInvalidFloor},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, err := parsePoolPolicy(tt.raw)
+
+			require.Error(t, err)
+			assert.Nil(t, policy)
+			assert.Equal(t, tt.class, poolPolicyErrorClass(err))
+		})
+	}
+}
+
+func TestPoolPolicyManagerObserveConfigDeduplicatesWarnings(t *testing.T) {
+	manager := newPoolPolicyManager(nil)
+	pool := types.NamespacedName{Namespace: "default", Name: "warm-pool"}
+
+	warn, recovered := manager.observeConfig(pool, `{"bad"`, poolPolicyErrorInvalidJSON)
+	assert.True(t, warn)
+	assert.False(t, recovered)
+
+	// The unchanged invalid annotation must not warn again.
+	warn, recovered = manager.observeConfig(pool, `{"bad"`, poolPolicyErrorInvalidJSON)
+	assert.False(t, warn)
+	assert.False(t, recovered)
+
+	// An edited annotation deserves fresh feedback even when it fails the
+	// same way.
+	warn, _ = manager.observeConfig(pool, `{"worse"`, poolPolicyErrorInvalidJSON)
+	assert.True(t, warn)
+
+	warn, recovered = manager.observeConfig(pool, `{}`, "")
+	assert.False(t, warn)
+	assert.True(t, recovered)
+
+	// A policy that stays valid produces no further signals.
+	_, recovered = manager.observeConfig(pool, `{}`, "")
+	assert.False(t, recovered)
+
+	// Removing and re-adding the annotation starts a fresh configuration.
+	assert.True(t, manager.forgetConfig(pool))
+	warn, _ = manager.observeConfig(pool, `{"bad"`, poolPolicyErrorInvalidJSON)
+	assert.True(t, warn)
 }
 
 func TestComputePoolKVTargetsGivesActiveModelTheBorrowedCapacity(t *testing.T) {


### PR DESCRIPTION
## Pull Request Description
Surfaces invalid ModelClaim pool policy configuration (`pool.aibrix.ai/policy` Deployment annotation) to operators through Kubernetes Events and a metric, instead of controller logs only.

### What changed
- **Fixed error classes**: `parsePoolPolicy` failures are now classified as `invalid_json`, `unknown_field`, `unsupported_mode`, `invalid_capacity`, or `invalid_floor`. The detailed parser message stays in the Event/log; classes stay low-cardinality.
- **Warning Event on the owning Deployment**: when the annotation fails to parse or validate, the controller emits `Warning InvalidPoolPolicy` on the warm-pool Deployment, so `kubectl describe deployment` reports it directly.
- **Event deduplication**: the manager tracks the last seen (annotation content, error class) per Deployment; an unchanged invalid annotation does not re-emit Events or logs across reconciliations. Dedup keys on annotation content because metadata edits do not bump the Deployment generation.
- **Recovery signal**: when a previously invalid annotation becomes valid, a `Normal PoolPolicyValid` Event is emitted once and policy execution resumes.
- **Metric**: new gauge `aibrix_modelclaim_pool_policy_valid{namespace, deployment}` (1/0), registered with the controller-runtime registry. The series is deleted when the annotation is removed.
- **Unchanged behavior**: invalid configuration remains fail-closed (no partial or speculative KV plan), strict unknown-field validation is retained, and no CRD/status/spec changes are introduced.
### How it was tested
- Unit tests cover all four required scenarios: invalid, unchanged-invalid (no Event flooding), corrected (recovery Event + policy resumes), and valid configurations, plus error-class classification and dedup state transitions.
- Manually verified on a kind cluster running the controller against a warm-pool Deployment:
  - `kubectl describe deployment` shows a single `Warning InvalidPoolPolicy` (count stays 1 across reconciliations);
  - correcting the annotation produces `Normal PoolPolicyValid` within seconds and the gauge flips 0 → 1;
  - no KV limits are applied while the policy is invalid.

## Related Issues
Resolves https://github.com/vllm-project/aibrix/issues/2456

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[x] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>