### PR TITLE
docs: update AI Gateway integration samples

### DIFF
--- a/samples/ai-gateway-integration/README.md
+++ b/samples/ai-gateway-integration/README.md
@@ -8,14 +8,15 @@ This guide walks you through deploying a multi-model AI inference gateway using 
 samples/ai-gateway-integration
 ├── gateway.yaml                  # GatewayClass + Gateway
 ├── aigatewayroute.yaml           # Multi-model routing rules (llama2-7b, mistral-7b)
+├── envoy-gateway-inferencepool-rbac.yaml # Envoy Gateway access to InferencePool
 ├── llama-7b-inferencepool.yaml   # InferencePool + EPP for Llama2-7B
 ├── mistral-7b-inferencepool.yaml # InferencePool + EPP for Mistral-7B
-└── llama-7b.yaml                 # Mock model llama-7b deployments
+├── llama-7b.yaml                 # Mock model llama-7b deployments
 └── mistral-7b.yaml               # Mock model mistral-7b deployments
 ```
 
 ### Prerequisites
-- Kubernetes cluster (v1.24+)
+- Kubernetes cluster (v1.32+ recommended for Envoy AI Gateway v1.0.0)
 - kubectl configured
 - helm v3.8+
 - Internet access to pull images from docker.io and GitHub
@@ -46,7 +47,7 @@ gateway:
 
 ```bash
 helm upgrade -i aieg-crd oci://docker.io/envoyproxy/ai-gateway-crds-helm \
-  --version v0.0.0-latest \
+  --version v1.0.0 \
   --namespace envoy-ai-gateway-system \
   --create-namespace
 ```
@@ -58,7 +59,7 @@ helm upgrade -i aieg-crd oci://docker.io/envoyproxy/ai-gateway-crds-helm \
 
 ```bash
 helm upgrade -i aieg oci://docker.io/envoyproxy/ai-gateway-helm \
-  --version v0.0.0-latest \
+  --version v1.0.0 \
   --namespace envoy-ai-gateway-system \
   --create-namespace
 ```
@@ -73,28 +74,38 @@ kubectl wait --timeout=2m -n envoy-ai-gateway-system deployment/ai-gateway-contr
 4. Install Gateway API Inference Extension (EPP Framework)
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.0.1/manifests.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/manifests.yaml
 ```
 
 > For more details, see the official [installation guide](https://aigateway.envoyproxy.io/docs/capabilities/inference/httproute-inferencepool#step-1-install-gateway-api-inference-extension) for Gateway API Inference Extension.
 
 
 This deploys:
-CRDs (InferencePool, InferenceObjective)
+CRDs (InferencePool, InferenceObjective, InferenceModelRewrite)
 RBAC, webhooks, and core controllers
+
+> On arm64 local clusters such as Apple Silicon minikube, verify that the EPP image you load
+> matches the node architecture. An architecture mismatch can leave the EPP pod running while
+> its ext-proc gRPC port is not actually serving requests, which shows up as
+> `HTTP/1.1 500` with `ext_proc_error_gRPC_error_14` in Envoy logs.
 
 5. Install Envoy Gateway (Data Plane)
 
 ```bash
 helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm \
-  --version v0.0.0-latest \
+  --version v1.8.2 \
   --namespace envoy-gateway-system \
   --create-namespace \
-  -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/manifests/envoy-gateway-values.yaml \
-  -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/examples/inference-pool/envoy-gateway-values-addon.yaml
+  -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/v1.0.0/manifests/envoy-gateway-values.yaml \
+  -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/v1.0.0/examples/inference-pool/envoy-gateway-values-addon.yaml
 ```
 
 > For more details, see the official [installation guide](https://aigateway.envoyproxy.io/docs/getting-started/prerequisites#additional-features-rate-limiting-inferencepool-etc) for Envoy Gateway.
+> The InferencePool addon is required. Without it, `HTTPRoute` reports `ResolvedRefs=False`
+> with `InvalidKind` for `inference.networking.k8s.io/InferencePool`.
+
+The InferencePool addon does not grant Envoy Gateway access to `InferencePool` resources.
+The sample applies that RBAC in Step 6.
 
 
 6. Deploy Aibrix AI Gateway Resources
@@ -108,13 +119,26 @@ cd samples/ai-gateway-integration
 kubectl apply -f llama-7b.yaml
 kubectl apply -f mistral-7b.yaml
 
-# Deploy GatewayClass, Gateway, and AIGatewayRoute
+# Deploy GatewayClass, Gateway, and Envoy Gateway RBAC
 kubectl apply -f gateway.yaml
-kubectl apply -f aigatewayroute.yaml
+kubectl apply -f envoy-gateway-inferencepool-rbac.yaml
 
 # Deploy backend resources for each model
 kubectl apply -f llama-7b-inferencepool.yaml
 kubectl apply -f mistral-7b-inferencepool.yaml
+
+# Deploy routing rules after the backend references exist
+kubectl apply -f aigatewayroute.yaml
+```
+
+Wait for the model and EPP deployments to be ready:
+
+```bash
+kubectl wait --timeout=2m deployment/mock-llama2-7b --for=condition=Available
+kubectl wait --timeout=2m deployment/mock-mistral-7b --for=condition=Available
+kubectl wait --timeout=2m deployment/llama2-7b-epp --for=condition=Available
+kubectl wait --timeout=2m deployment/mistral-7b-epp --for=condition=Available
+kubectl wait --timeout=2m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
 ```
 
 ### Verify Deployment Status
@@ -205,14 +229,17 @@ curl -v http://<GATEWAY_IP>/v1/chat/completions \
       }'
 ```
 
-Replace `<GATEWAY_IP>` with:
-- localhost:8080 if using
+For local testing, discover the Envoy Gateway service and port-forward it:
 
 ```bash
-kubectl port-forward -n envoy-gateway-system svc/envoy-default-aibrix-ai-gateway-588291e8 8080:80
+GATEWAY_SERVICE=$(kubectl get svc -n envoy-gateway-system \
+  -l gateway.envoyproxy.io/owning-gateway-name=aibrix-ai-gateway,gateway.envoyproxy.io/owning-gateway-namespace=default \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl port-forward -n envoy-gateway-system "svc/${GATEWAY_SERVICE}" 8080:80
 ```
 
-Or the external IP of the `eg-envoy` Service if exposed via LoadBalancer.
+Then replace `<GATEWAY_IP>` with `localhost:8080`. Or use the external IP of the Envoy Gateway service if exposed via LoadBalancer.
 
 ### References
 - [Envoy AI Gateway](https://github.com/envoyproxy/ai-gateway)

--- a/samples/ai-gateway-integration/aigatewayroute.yaml
+++ b/samples/ai-gateway-integration/aigatewayroute.yaml
@@ -1,4 +1,4 @@
-apiVersion: aigateway.envoyproxy.io/v1alpha1
+apiVersion: aigateway.envoyproxy.io/v1beta1
 kind: AIGatewayRoute
 metadata:
   name: multi-model-route
@@ -35,4 +35,3 @@ spec:
         - group: inference.networking.k8s.io
           kind: InferencePool
           name: mistral-7b
-

--- a/samples/ai-gateway-integration/disaggregation/README.md
+++ b/samples/ai-gateway-integration/disaggregation/README.md
@@ -6,11 +6,12 @@ This guide demonstrates how to deploy **Qwen2-7B** with **Prefill/Decode (PD) di
 ## Project Structure
 
 ```bash
-samples/qwen2-7b-pd-disaggregation/
+samples/ai-gateway-integration/disaggregation/
 ├── gateway.yaml                        # GatewayClass + Gateway
 ├── aigatewayroute.yaml                 # AIGatewayRoute: routes by `x-ai-eg-model`
-├── llm-d-inference-scheduler-epp.yaml  # EPP deployment (standalone scheduler)
-├── qwen2-7b-inferencepool.yaml         # InferencePool + EPP + RBAC + ConfigMap
+├── envoy-gateway-inferencepool-rbac.yaml # Envoy Gateway access to InferencePool
+├── llm-d-inference-scheduler-epp.yaml  # llm-d-router EPP deployment, RBAC, and ConfigMap
+├── qwen2-7b-inferencepool.yaml         # InferencePool + InferenceObjective
 └── vllm-sim-pd-stormservice.yaml       # StormService: deploys prefill & decode pods
 ```
 
@@ -18,7 +19,7 @@ samples/qwen2-7b-pd-disaggregation/
 
 ## Prerequisites
 
-- Kubernetes cluster (**v1.29+ recommended**)
+- Kubernetes cluster (**v1.32+ recommended** for Envoy AI Gateway v1.0.0)
 - `kubectl` configured
 - Helm v3.8+
 - Internet access to pull images from `docker.io`, `ghcr.io`, and GitHub
@@ -50,7 +51,7 @@ gateway:
 
 ```bash
 helm upgrade -i aieg-crd oci://docker.io/envoyproxy/ai-gateway-crds-helm \
-  --version v0.0.0-latest \
+  --version v1.0.0 \
   --namespace envoy-ai-gateway-system \
   --create-namespace
 ```
@@ -63,7 +64,7 @@ helm upgrade -i aieg-crd oci://docker.io/envoyproxy/ai-gateway-crds-helm \
 
 ```bash
 helm upgrade -i aieg oci://docker.io/envoyproxy/ai-gateway-helm \
-  --version v0.0.0-latest \
+  --version v1.0.0 \
   --namespace envoy-ai-gateway-system \
   --create-namespace
 
@@ -77,11 +78,11 @@ kubectl wait --timeout=2m -n envoy-ai-gateway-system deployment/ai-gateway-contr
 ### 4. Install Gateway API Inference Extension (EPP Framework)
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.0.1/manifests.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/manifests.yaml
 ```
 
 This installs:
-- `InferencePool`, `InferenceObjective` CRDs
+- `InferencePool`, `InferenceObjective`, `InferenceModelRewrite` CRDs
 - Core controllers, webhooks, and RBAC
 
 > [Inference Extension Guide](https://aigateway.envoyproxy.io/docs/capabilities/inference/httproute-inferencepool#step-1-install-gateway-api-inference-extension)
@@ -92,14 +93,19 @@ This installs:
 
 ```bash
 helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm \
-  --version v0.0.0-latest \
+  --version v1.8.2 \
   --namespace envoy-gateway-system \
   --create-namespace \
-  -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/manifests/envoy-gateway-values.yaml \
-  -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/examples/inference-pool/envoy-gateway-values-addon.yaml
+  -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/v1.0.0/manifests/envoy-gateway-values.yaml \
+  -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/v1.0.0/examples/inference-pool/envoy-gateway-values-addon.yaml
 ```
 
 > [Envoy Gateway + Addons](https://aigateway.envoyproxy.io/docs/getting-started/prerequisites#additional-features-rate-limiting-inferencepool-etc)
+> The InferencePool addon is required. Without it, `HTTPRoute` reports `ResolvedRefs=False`
+> with `InvalidKind` for `inference.networking.k8s.io/InferencePool`.
+
+The InferencePool addon does not grant Envoy Gateway access to `InferencePool` resources.
+The sample applies that RBAC in Step 6.
 
 Wait for Envoy Gateway to be ready:
 ```bash
@@ -120,9 +126,19 @@ kubectl apply -f vllm-sim-pd-stormservice.yaml
 kubectl apply -f qwen2-7b-inferencepool.yaml
 kubectl apply -f llm-d-inference-scheduler-epp.yaml
 
-# Deploy Gateway and AIGatewayRoute
+# Deploy GatewayClass, Gateway, and Envoy Gateway RBAC
 kubectl apply -f gateway.yaml
+kubectl apply -f envoy-gateway-inferencepool-rbac.yaml
+
+# Deploy routing rules after the backend references exist
 kubectl apply -f aigatewayroute.yaml
+```
+
+Wait for the stack to be ready:
+
+```bash
+kubectl wait --timeout=2m deployment/qwen2-7b-epp --for=condition=Available
+kubectl wait --timeout=2m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
 ```
 
 ---
@@ -159,7 +175,8 @@ qwen2-7b   qwen2-7b         10         5m
 ### Check Envoy Gateway
 
 ```bash
-$ kubectl get svc -n envoy-gateway-system
+$ kubectl get svc -n envoy-gateway-system \
+  -l gateway.envoyproxy.io/owning-gateway-name=aibrix-ai-gateway,gateway.envoyproxy.io/owning-gateway-namespace=default
 NAME                                         TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)
 envoy-default-aibrix-ai-gateway-588291e8     LoadBalancer   10.96.xxx.xxx   <pending>     80:3xxxx/TCP
 ```
@@ -171,7 +188,11 @@ envoy-default-aibrix-ai-gateway-588291e8     LoadBalancer   10.96.xxx.xxx   <pen
 ### Port-forward to Gateway (for local testing)
 
 ```bash
-kubectl port-forward -n envoy-gateway-system svc/envoy-default-aibrix-ai-gateway-588291e8 8080:80
+GATEWAY_SERVICE=$(kubectl get svc -n envoy-gateway-system \
+  -l gateway.envoyproxy.io/owning-gateway-name=aibrix-ai-gateway,gateway.envoyproxy.io/owning-gateway-namespace=default \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl port-forward -n envoy-gateway-system "svc/${GATEWAY_SERVICE}" 8080:80
 ```
 
 ### Send Inference Request
@@ -199,32 +220,30 @@ curl http://localhost:8080/v1/chat/completions \
 |--------|------|
 | **StormService** | Deploys labeled prefill (`role=prefill`) and decode (`role=decode`) pods |
 | **InferencePool** | Selects all `app: vllm-sim-pd` pods; targets port `8000` (routing-sidecar) |
-| **EPP Scheduler** | Uses plugins (`by-label`, `prefix-cache-scorer`) to route to optimal endpoint |
+| **EPP Scheduler** | Uses `label-selector-filter` with Aibrix `role=prefill/decode`, plus prefix-cache and queue scorers |
 | **AIGatewayRoute** | Routes by custom header `x-ai-eg-model` |
 | **Routing Sidecar** | On decode pods, proxies requests from `8000` → `8200` (vLLM engine) |
 
----
-
-Sure! Here's the concise English version:
-
----
-
 ## LLM-D Inference Scheduler Overview
 
-The [LLM-D Inference Scheduler](https://github.com/llm-d/llm-d-inference-scheduler) is a specialized **Endpoint Picker Plugin (EPP)** designed for **Prefill/Decode (P/D) disaggregated** LLM serving. It runs within Envoy AI Gateway and intelligently routes inference requests to the optimal backend pod based on request phase (prefill vs. decode), KV cache state, and Kubernetes labels.
+The [llm-d Router](https://github.com/llm-d/llm-d-router) endpoint picker is a specialized **Endpoint Picker Plugin (EPP)** designed for **Prefill/Decode (P/D) disaggregated** LLM serving. It runs with Envoy AI Gateway and intelligently routes inference requests to the optimal backend pod based on request phase (prefill vs. decode), KV cache state, and Kubernetes labels.
 
-Built on top of the **Gateway API Inference Extension (GIE)**, it adds LLM-specific optimizations like prefix-cache awareness and automatic P/D classification.
+This sample uses `ghcr.io/llm-d/llm-d-router-endpoint-picker-dev:main`. The old `ghcr.io/llm-d/llm-d-inference-scheduler:*` image does not support the current llm-d-router plugin set used here.
 
 ---
 
 ## EPP Configuration Overview
 
+The Aibrix `StormService` labels generated pods with `role=prefill` and `role=decode`.
+The llm-d-router built-in `prefill-filter` and `decode-filter` expect `llm-d.ai/role`, so
+this sample intentionally uses `label-selector-filter` to match the existing Aibrix labels.
+
 Routing behavior is defined via a `ConfigMap`:
 
-- **`by-label`**: Filters pods by `role=prefill` or `role=decode`
+- **`prefill-filter` / `decode-filter`**: Filter pods by `role=prefill`, `role=decode`, or `role=both`
 - **`prefix-cache-scorer`**: Prioritizes decode endpoints that already cache parts of the prompt
-- **`pd-profile-handler`**: Automatically detects request type and selects the appropriate scheduling profile
-- **`prefill-header-handler`**: Treats a request as prefill when the `prefill-header-handler` header is set (typically to an `<ip>:<port>` address)
+- **`prefix-based-pd-decider`**: Chooses prefill or decode based on prefix-cache state
+- **`disagg-profile-handler`**: Selects the prefill or decode scheduling profile
 - **Two profiles**: Separate strategies for prefill and decode traffic, enabling efficient, cache-aware routing
 
 This setup enables seamless P/D disaggregation with maximal cache reuse and minimal latency.

--- a/samples/ai-gateway-integration/disaggregation/aigatewayroute.yaml
+++ b/samples/ai-gateway-integration/disaggregation/aigatewayroute.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: aigateway.envoyproxy.io/v1alpha1
+apiVersion: aigateway.envoyproxy.io/v1beta1
 kind: AIGatewayRoute
 metadata:
   name: multi-model-route-pd-disaggregation

--- a/samples/ai-gateway-integration/disaggregation/envoy-gateway-inferencepool-rbac.yaml
+++ b/samples/ai-gateway-integration/disaggregation/envoy-gateway-inferencepool-rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eg-inference-pool-access
+rules:
+  - apiGroups:
+      - inference.networking.k8s.io
+    resources:
+      - inferencepools
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eg-inference-pool-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eg-inference-pool-access
+subjects:
+  - kind: ServiceAccount
+    name: envoy-gateway
+    namespace: envoy-gateway-system

--- a/samples/ai-gateway-integration/disaggregation/llm-d-inference-scheduler-epp.yaml
+++ b/samples/ai-gateway-integration/disaggregation/llm-d-inference-scheduler-epp.yaml
@@ -24,7 +24,7 @@ spec:
   type: ClusterIP
 
 ---
-# EPP Deployment (using your custom image & config)
+# EPP Deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,7 +46,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
         - name: epp
-          image: ghcr.io/llm-d/llm-d-inference-scheduler:latest
+          image: ghcr.io/llm-d/llm-d-router-endpoint-picker-dev:main
           imagePullPolicy: IfNotPresent
           args:
             - --pool-name
@@ -105,7 +105,7 @@ metadata:
   namespace: default
 rules:
   - apiGroups: ["inference.networking.x-k8s.io"]
-    resources: ["inferenceobjectives", "inferencepools"]
+    resources: ["inferenceobjectives", "inferencepools", "inferencemodelrewrites"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["inference.networking.k8s.io"]
     resources: ["inferencepools"]
@@ -142,38 +142,50 @@ data:
     apiVersion: inference.networking.x-k8s.io/v1alpha1
     kind: EndpointPickerConfig
     plugins:
-      - type: by-label
-        name: "prefill"
+      - type: label-selector-filter
+        name: prefill-filter
         parameters:
-          label: "role"
-          validValues: ["prefill"]
-      - type: by-label
-        name: "decode"
+          matchLabels:
+            role: prefill
+      - type: label-selector-filter
+        name: decode-filter
         parameters:
-          label: "role"
-          validValues: ["decode", "both"]
-      - type: prefix-cache-scorer
+          matchExpressions:
+            - key: role
+              operator: In
+              values:
+                - decode
+                - both
+      - type: approx-prefix-cache-producer
         parameters:
-          hashBlockSize: 5
+          blockSizeTokens: 64
+          autoTune: false
           maxPrefixBlocksToMatch: 256
           lruCapacityPerServer: 31250
+      - type: prefix-cache-scorer
+      - type: queue-scorer
       - type: max-score-picker
-      - type: prefill-header-handler
-      - type: pd-profile-handler
+      - type: prefix-based-pd-decider
         parameters:
-          threshold: 0
-          hashBlockSize: 5
-          primaryPort: 8000
+          nonCachedTokens: 16
+      - type: disagg-profile-handler
+        parameters:
+          deciders:
+            prefill: prefix-based-pd-decider
     schedulingProfiles:
       - name: prefill
         plugins:
-          - pluginRef: prefill
+          - pluginRef: prefill-filter
           - pluginRef: max-score-picker
           - pluginRef: prefix-cache-scorer
             weight: 2
+          - pluginRef: queue-scorer
+            weight: 1
       - name: decode
         plugins:
-          - pluginRef: decode
+          - pluginRef: decode-filter
           - pluginRef: max-score-picker
           - pluginRef: prefix-cache-scorer
             weight: 2
+          - pluginRef: queue-scorer
+            weight: 1

--- a/samples/ai-gateway-integration/envoy-gateway-inferencepool-rbac.yaml
+++ b/samples/ai-gateway-integration/envoy-gateway-inferencepool-rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eg-inference-pool-access
+rules:
+  - apiGroups: ["inference.networking.k8s.io"]
+    resources: ["inferencepools"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eg-inference-pool-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eg-inference-pool-access
+subjects:
+  - kind: ServiceAccount
+    name: envoy-gateway
+    namespace: envoy-gateway-system

--- a/samples/ai-gateway-integration/llama-7b-inferencepool.yaml
+++ b/samples/ai-gateway-integration/llama-7b-inferencepool.yaml
@@ -73,7 +73,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
         - name: epp
-          image: registry.k8s.io/gateway-api-inference-extension/epp:v1.0.1
+          image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --pool-name
@@ -95,18 +95,6 @@ spec:
             - containerPort: 9003
             - name: metrics
               containerPort: 9090
-          livenessProbe:
-            grpc:
-              port: 9003
-              service: inference-extension
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          readinessProbe:
-            grpc:
-              port: 9003
-              service: inference-extension
-            initialDelaySeconds: 5
-            periodSeconds: 10
           volumeMounts:
             - name: plugins-config-volume
               mountPath: "/config"
@@ -122,7 +110,7 @@ metadata:
   namespace: default
 rules:
   - apiGroups: ["inference.networking.x-k8s.io"]
-    resources: ["inferenceobjectives", "inferencepools"]
+    resources: ["inferenceobjectives", "inferencepools", "inferencemodelrewrites"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["inference.networking.k8s.io"]
     resources: ["inferencepools"]

--- a/samples/ai-gateway-integration/mistral-7b-inferencepool.yaml
+++ b/samples/ai-gateway-integration/mistral-7b-inferencepool.yaml
@@ -71,7 +71,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
         - name: epp
-          image: registry.k8s.io/gateway-api-inference-extension/epp:v1.0.1
+          image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0
           args:
             - --pool-name
             - "mistral-7b"
@@ -100,7 +100,7 @@ metadata:
   namespace: default
 rules:
   - apiGroups: ["inference.networking.x-k8s.io"]
-    resources: ["inferenceobjectives", "inferencepools"]
+    resources: ["inferenceobjectives", "inferencepools", "inferencemodelrewrites"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["inference.networking.k8s.io"]
     resources: ["inferencepools"]


### PR DESCRIPTION
## Summary
Update the AI Gateway integration samples for the current Envoy AI Gateway / GIE flow.

This includes v1beta1 `AIGatewayRoute`, GIE v1.5.0, Envoy Gateway v1.8.2, missing InferencePool RBAC, and refreshed llm-d-router disaggregation docs.

## Testing
- `git diff --check -- samples/ai-gateway-integration`
- `kubectl apply --dry-run=client -f samples/ai-gateway-integration -R`
- Verified llama2, mistral, and qwen2 routes on arm64 minikube.
