### PR TITLE
docs: fix broken license links in python READMEs

### DIFF
--- a/python/aibrix/README.md
+++ b/python/aibrix/README.md
@@ -48,4 +48,4 @@ bash ./scripts/format.sh
 
 ## License
 
-AI Runtime is licensed under the [APACHE License](https://github.com/vllm-project/aibrix/LICENSE.md).
+AI Runtime is licensed under the [APACHE License](https://github.com/vllm-project/aibrix/blob/main/LICENSE).

--- a/python/aibrix_kvcache/README.md
+++ b/python/aibrix_kvcache/README.md
@@ -42,4 +42,4 @@ bash ./scripts/format.sh
 
 ## License
 
-AI Runtime is licensed under the [APACHE License](https://github.com/vllm-project/aibrix/LICENSE.md).
+AI Runtime is licensed under the [APACHE License](https://github.com/vllm-project/aibrix/blob/main/LICENSE).


### PR DESCRIPTION
## Description
Fix broken Apache License links in `python/aibrix/README.md` and `python/aibrix_kvcache/README.md`. The previous links pointed to `LICENSE.md`, which returns 404; the repository'\''s license file is `LICENSE`.

## Related Issue
N/A (minor documentation fix)

## Type of Change
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
- [x] I have verified the updated links return HTTP 200.