### PR TITLE
fix(webhook): improve artifactURL unsupported schema error message

### DIFF
--- a/pkg/utils/modeladapter.go
+++ b/pkg/utils/modeladapter.go
@@ -23,12 +23,12 @@ import (
 
 var AllowedSchemas = []string{"s3://", "gcs://", "tos://", "huggingface://", "hf://", "/"}
 
-// ValidateArtifactURL checks if the ArtifactURL has a valid schema (s3://, gcs://, tos://, huggingface://, https://, /)
+// ValidateArtifactURL checks if the ArtifactURL has a valid schema (s3://, gcs://, tos://, huggingface://, hf://, /)
 func ValidateArtifactURL(artifactURL string) error {
 	for _, schema := range AllowedSchemas {
 		if strings.HasPrefix(artifactURL, schema) {
 			return nil
 		}
 	}
-	return fmt.Errorf("unsupported schema")
+	return fmt.Errorf("unsupported schema %q, supported schemas are %v", artifactURL, AllowedSchemas)
 }

--- a/pkg/utils/modeladapter_test.go
+++ b/pkg/utils/modeladapter_test.go
@@ -45,6 +45,10 @@ func TestValidateArtifactURL(t *testing.T) {
 	// Case 4: Invalid scheme
 	t.Run("invalid scheme", func(t *testing.T) {
 		err := ValidateArtifactURL("ftp://bucket/path")
-		assert.EqualError(t, err, "unsupported schema")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported schema")
+		assert.Contains(t, err.Error(), "ftp://bucket/path")
+		assert.Contains(t, err.Error(), "s3://")
+		assert.Contains(t, err.Error(), "huggingface://")
 	})
 }

--- a/pkg/webhook/modeladapter_webhook.go
+++ b/pkg/webhook/modeladapter_webhook.go
@@ -71,7 +71,7 @@ func (w *ModelAdapterWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 	}
 
 	if err := utils.ValidateArtifactURL(adapter.Spec.ArtifactURL); err != nil {
-		allErrs = append(allErrs, field.NotSupported(specPath.Child("artifactURL"), adapter.Spec.ArtifactURL, utils.AllowedSchemas))
+		allErrs = append(allErrs, field.Invalid(specPath.Child("artifactURL"), adapter.Spec.ArtifactURL, err.Error()))
 	}
 
 	return nil, allErrs.ToAggregate()

--- a/test/integration/webhook/modeladapter_test.go
+++ b/test/integration/webhook/modeladapter_test.go
@@ -123,5 +123,15 @@ var _ = ginkgo.Describe("modelAdapter default and validation", func() {
 			},
 			failed: true,
 		}),
+		ginkgo.Entry("adapter creation with misspelled huggingface schema should be failed", &testValidatingCase{
+			adapter: func() *modelapi.ModelAdapter {
+				return wrapper.MakeModelAdapter("test-adapter").
+					Namespace(ns.Name).
+					ArtifactURL("hugingface://yard1/llama-2-7b-sql-lora-tests").
+					PodSelector(&metav1.LabelSelector{}).
+					Obj()
+			},
+			failed: true,
+		}),
 	)
 })


### PR DESCRIPTION
## Problem

Issue #1887 reports that the `vmodeladapter.kb.io` admission webhook rejects ModelAdapter objects with a misspelled protocol such as `hugingface://`. The original error message was:

```
spec.artifactURL: Unsupported value: "hugingface://yard1/llama-2-7b-sql-lora-tests": supported values: "s3://", "gcs://", "huggingface://", "hf://", "/"
```

Because the supported list already contains the correct spelling `huggingface://`, users who typo the protocol can easily miss the single-character difference and believe their input should be accepted. The message also did not explicitly state that the *schema* was the unsupported part.

## Root Cause

1. `ValidateArtifactURL` in `pkg/utils/modeladapter.go` returned a bare `unsupported schema` error without mentioning the offending URL or the supported schemas.
2. The webhook used `field.NotSupported(...)` without any detail, so Kubernetes generated a generic `Unsupported value` message.
3. The GoDoc comment listed `https://` as an allowed schema, but `AllowedSchemas` did not include it, so the comment was misleading.

## Fix

This PR makes three focused changes:

1. **`pkg/utils/modeladapter.go`** — Update `ValidateArtifactURL` to return both the offending URL and the supported schemas in the error:
   ```go
   return fmt.Errorf("unsupported schema %q, supported schemas are %v", artifactURL, AllowedSchemas)
   ```

2. **`pkg/webhook/modeladapter_webhook.go`** — Use `field.Invalid` with the detailed error message:
   ```go
   allErrs = append(allErrs, field.Invalid(specPath.Child("artifactURL"), adapter.Spec.ArtifactURL, err.Error()))
   ```
   The resulting error looks like:
   ```
   spec.artifactURL: Invalid value: "hugingface://yard1/llama-2-7b-sql-lora-tests": unsupported schema "hugingface://yard1/llama-2-7b-sql-lora-tests", supported schemas are [s3:// gcs:// tos:// huggingface:// hf:// /]
   ```
   Users can now see both what they typed and the correct `huggingface://` value in the supported list.

3. **Tests & docs** — Update the unit test to assert the error contains the unsupported URL and the supported schemas, and add an integration test case for the exact `hugingface://` typo from #1887. Fix the outdated GoDoc comment.

## Why this approach?

- `field.Invalid` is available in the project's current `k8s.io/apimachinery` version (v0.31.8), whereas `field.NotSupported.WithDetail()` is not supported until a later version.
- Including both the rejected URL and the supported schema list makes it obvious when the user has made a typo such as `hugingface://` vs `huggingface://`.

## Verification

- `gofmt` passes on all modified files.
- Standalone validation of `ValidateArtifactURL` covers valid schemas (`s3://`, `gcs://`, `tos://`, `huggingface://`, `hf://`, `/`) and rejects invalid/misspelled schemas with a message that includes both the invalid URL and the supported schemas.
- Local `go test` is blocked by an unrelated `bytedance/sonic` darwin/arm64 build issue in the broader workspace; relying on CI for full test coverage.

## Related Issue

Fixes #1887
