### PR TITLE
fix(gateway): measure streaming TTFT/KV-transfer from first chunk (fixes #2477)

### DIFF
--- a/pkg/plugins/gateway/gateway_rsp_body.go
+++ b/pkg/plugins/gateway/gateway_rsp_body.go
@@ -71,6 +71,15 @@ func (s *Server) HandleResponseBody(ctx context.Context, routerCtx *types.Routin
 	b := req.Request.(*extProcPb.ProcessingRequest_ResponseBody)
 	arrival := time.Now()
 
+	// Record the arrival time of the first response body chunk. For streaming
+	// responses HandleResponseBody runs once per SSE chunk, but request_end
+	// metrics are only emitted on the final chunk. Without capturing the first
+	// arrival here, TTFT and KV-transfer time would be measured from the last
+	// chunk (≈ total request time) instead of the first token.
+	if stream && routerCtx != nil && routerCtx.FirstTokenTime.IsZero() {
+		routerCtx.FirstTokenTime = arrival
+	}
+
 	var processingRes *extProcPb.ProcessingResponse
 	var promptTokens, completionTokens, totalTokens int64
 	var headers []*configPb.HeaderValueOption
@@ -202,7 +211,13 @@ func (s *Server) HandleResponseBody(ctx context.Context, routerCtx *types.Routin
 		}
 
 		headers = buildEnvoyProxyHeaders(headers, HeaderRequestID, routerCtx.RequestID)
-		fields := s.requestEndHelper(routerCtx, arrival, promptTokens, completionTokens, totalTokens)
+		// For streaming responses use the first chunk's arrival time so TTFT and
+		// KV-transfer time reflect the first token rather than the final chunk.
+		firstArrival := arrival
+		if stream && !routerCtx.FirstTokenTime.IsZero() {
+			firstArrival = routerCtx.FirstTokenTime
+		}
+		fields := s.requestEndHelper(routerCtx, firstArrival, promptTokens, completionTokens, totalTokens)
 		klog.InfoS("request_end", fields...)
 	} else if b.ResponseBody.EndOfStream {
 		complete = true

--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -99,6 +99,11 @@ type RoutingContext struct {
 	PrefillStartTime time.Time // Time when prefill request is started.
 	PrefillEndTime   time.Time // Time consumed during prefill.
 
+	// FirstTokenTime records the arrival time of the first response body chunk.
+	// Used to compute TTFT/KV-transfer time for streaming responses, where
+	// request_end metrics are only emitted on the final chunk.
+	FirstTokenTime time.Time
+
 	// RespHeaders holds response headers that the router intends to set.
 	// These are typically used to propagate control information back to the client,
 	// such as session affinity id.
@@ -352,6 +357,7 @@ func (r *RoutingContext) reset(ctx context.Context, algorithms RoutingAlgorithm,
 	r.ReqBody = []byte{}
 	r.PrefillStartTime = time.Time{}
 	r.PrefillEndTime = time.Time{}
+	r.FirstTokenTime = time.Time{}
 	// RoutedTime will not be reset, it must before ReqeustTime at this time.
 
 	r.RespHeaders = map[string]string{}


### PR DESCRIPTION
## Summary

In streaming mode the gateway logs `ttft` and `kv_transfer_time_taken` measured from the **last** SSE chunk instead of the **first** token, as reported in #2477.

`HandleResponseBody` sets `arrival = time.Now()` on every invocation, but `requestEndHelper` only runs on the final chunk (when `usage`/`total_tokens` arrive). So the `arrival` passed to it is the last chunk's timestamp, making:

- `ttft = last_chunk_arrival - RequestTime` ≈ `total_time_taken`
- `kv_transfer_time_taken = ttft - prefill` ≈ `decode_time_taken`

The reporter's log shows `decode_time_taken - kv_transfer_time_taken ≈ 58µs` for 128 generated tokens, which is clearly wrong.

## Fix

- Record the arrival time of the **first** response-body chunk on `RoutingContext.FirstTokenTime` (streaming only, set once).
- Use `FirstTokenTime` as the `arrival` for the TTFT / KV-transfer calculation in `requestEndHelper`.
- `decode_time_taken` and `total_time_taken` continue to be measured at completion (`time.Since` / `time.Now()`), so they are unaffected.

Non-streaming responses are unchanged (the guard keys off `stream`).

Fixes #2477

🤖 Generated with [Claude Code](https://claude.com/claude-code)
