### PR TITLE
feat(gateway): support opaque session affinity keys

### DIFF
--- a/pkg/plugins/gateway/algorithms/multi_router_readme.md
+++ b/pkg/plugins/gateway/algorithms/multi_router_readme.md
@@ -21,6 +21,7 @@ You can configure multi-strategy routing by setting the `AIBRIX_ROUTING_ALGORITH
 * If a weight is `0`, the strategy is completely ignored.
 * If an invalid strategy is specified, the Gateway rejects the request with **400 Bad Request** instead of silently falling back to `random`.
 * `session-affinity` is treated as a soft-scoring strategy in multi-strategy mode: it boosts the matching pod, but the final weighted winner may still be a different pod. The response session header is updated to the final selected pod.
+* A caller may send an opaque application session identifier in `x-aibrix-session-key`. When no valid gateway-issued `x-session-id` target is ready, rendezvous hashing selects a stable pod for that key. This is useful for concurrent Agent turns that start before a response cookie is available. The opaque key is never returned to the client.
 
 ## Examples
 

--- a/pkg/plugins/gateway/algorithms/simple_session_affinity.go
+++ b/pkg/plugins/gateway/algorithms/simple_session_affinity.go
@@ -17,9 +17,7 @@ limitations under the License.
 package routingalgorithms
 
 import (
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"net"
@@ -123,8 +121,23 @@ func rendezvousPod(ctx *types.RoutingContext, pods []*v1.Pod, sessionKey string)
 			continue
 		}
 		addr := net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(int(port)))
-		sum := sha256.Sum256([]byte(sessionKey + "\x00" + addr))
-		score := binary.BigEndian.Uint64(sum[:8])
+		const (
+			fnvOffset64 = 14695981039346656037
+			fnvPrime64  = 1099511628211
+		)
+		score := uint64(fnvOffset64)
+		for i := 0; i < len(sessionKey); i++ {
+			score ^= uint64(sessionKey[i])
+			score *= fnvPrime64
+		}
+		// Separate the two variable-length inputs so their concatenations
+		// cannot alias (for example, "ab"+"c" and "a"+"bc").
+		score ^= 0
+		score *= fnvPrime64
+		for i := 0; i < len(addr); i++ {
+			score ^= uint64(addr[i])
+			score *= fnvPrime64
+		}
 		if selected == nil || score > bestScore || (score == bestScore && addr < bestAddr) {
 			selected = pod
 			bestScore = score

--- a/pkg/plugins/gateway/algorithms/simple_session_affinity.go
+++ b/pkg/plugins/gateway/algorithms/simple_session_affinity.go
@@ -17,7 +17,9 @@ limitations under the License.
 package routingalgorithms
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"net"
@@ -34,7 +36,9 @@ const (
 	RouterSessionAffinity types.RoutingAlgorithm = "session-affinity"
 	// NOTE: sessionIDHeader must strictly match types.HeaderSessionID
 	// defined in pkg/plugins/gateway/types.go to prevent routing failures.
-	sessionIDHeader string = "x-session-id"
+	sessionIDHeader  string = "x-session-id"
+	sessionKeyHeader string = "x-aibrix-session-key"
+	maxSessionKeyLen        = 256
 )
 
 func init() {
@@ -88,9 +92,46 @@ func (r *sessionAffinityRouter) Route(ctx *types.RoutingContext, readyPodList ty
 		}
 	}
 
-	// Session ID missing, invalid, or pod not ready → fallback
+	if selected := rendezvousPod(ctx, readyPodList.All(), ctx.ReqHeaders[sessionKeyHeader]); selected != nil {
+		port := utils.GetModelPortForPod(ctx.RequestID, selected)
+		addr := net.JoinHostPort(selected.Status.PodIP, strconv.Itoa(int(port)))
+		ctx.SetTargetPod(selected)
+		r.setSessionHeader(ctx, addr)
+		klog.V(4).InfoS("Session key selected address", "request_id", ctx.RequestID, "addr", addr)
+		return ctx.TargetAddress(), nil
+	}
+
+	// Session ID and session key missing, invalid, or pod not ready → fallback
 	klog.V(4).InfoS("Session affinity failed, falling back", "request_id", ctx.RequestID, "session_id", sessionID)
 	return r.fallbackRoute(ctx, readyPodList)
+}
+
+// rendezvousPod maps an opaque caller-owned session key to a ready pod without
+// keeping gateway-side session state. Ties are broken by address so selection
+// does not depend on the PodList order.
+func rendezvousPod(ctx *types.RoutingContext, pods []*v1.Pod, sessionKey string) *v1.Pod {
+	if sessionKey == "" || len(sessionKey) > maxSessionKeyLen {
+		return nil
+	}
+
+	var selected *v1.Pod
+	var bestScore uint64
+	var bestAddr string
+	for _, pod := range pods {
+		port := utils.GetModelPortForPod(ctx.RequestID, pod)
+		if port == 0 || pod.Status.PodIP == "" {
+			continue
+		}
+		addr := net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(int(port)))
+		sum := sha256.Sum256([]byte(sessionKey + "\x00" + addr))
+		score := binary.BigEndian.Uint64(sum[:8])
+		if selected == nil || score > bestScore || (score == bestScore && addr < bestAddr) {
+			selected = pod
+			bestScore = score
+			bestAddr = addr
+		}
+	}
+	return selected
 }
 
 func (r *sessionAffinityRouter) setSessionHeader(ctx *types.RoutingContext, addr string) {
@@ -150,9 +191,10 @@ func (r *sessionAffinityRouter) ScoreAll(ctx *types.RoutingContext, readyPodList
 		}
 	}
 
+	matchedSessionID := false
 	for i, pod := range pods {
 		port := utils.GetModelPortForPod(ctx.RequestID, pod)
-		if port == 0 {
+		if port == 0 || pod.Status.PodIP == "" {
 			scores[i] = 0
 			scored[i] = true
 			continue
@@ -161,10 +203,22 @@ func (r *sessionAffinityRouter) ScoreAll(ctx *types.RoutingContext, readyPodList
 		addr := net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(int(port)))
 		if targetAddr != "" && addr == targetAddr {
 			scores[i] = 1
+			matchedSessionID = true
 		} else {
 			scores[i] = 0
 		}
 		scored[i] = true
+	}
+
+	if !matchedSessionID {
+		if selected := rendezvousPod(ctx, pods, ctx.ReqHeaders[sessionKeyHeader]); selected != nil {
+			for i, pod := range pods {
+				if pod == selected {
+					scores[i] = 1
+					break
+				}
+			}
+		}
 	}
 
 	return scores, scored, nil

--- a/pkg/plugins/gateway/algorithms/simple_session_affinity_test.go
+++ b/pkg/plugins/gateway/algorithms/simple_session_affinity_test.go
@@ -183,3 +183,66 @@ func TestSessionAffinityPostRouteUpdateFollowsFinalTargetPod(t *testing.T) {
 	assert.NoError(t, decodeErr)
 	assert.Equal(t, "2.2.2.2:8000", string(sessionBytes))
 }
+
+func TestSessionAffinityOpaqueKeyIsDeterministic(t *testing.T) {
+	podA := newPod("pod-a", "10.0.0.1", true, map[string]string{"model.aibrix.ai/port": "8000"})
+	podB := newPod("pod-b", "10.0.0.2", true, map[string]string{"model.aibrix.ai/port": "8000"})
+	podC := newPod("pod-c", "10.0.0.3", true, map[string]string{"model.aibrix.ai/port": "8000"})
+	router := &sessionAffinityRouter{}
+
+	route := func(pods []*v1.Pod) string {
+		ctx := types.NewRoutingContext(context.Background(), "test", "model1", "", "", "")
+		ctx.ReqHeaders = map[string]string{sessionKeyHeader: "agent-session-42"}
+		addr, err := router.Route(ctx, newMockPodList(pods, nil))
+		assert.NoError(t, err)
+		assert.NotEmpty(t, ctx.RespHeaders[sessionIDHeader])
+		assert.NotContains(t, ctx.RespHeaders, sessionKeyHeader)
+		return addr
+	}
+
+	first := route([]*v1.Pod{podA, podB, podC})
+	assert.Equal(t, first, route([]*v1.Pod{podC, podA, podB}))
+	assert.Equal(t, first, route([]*v1.Pod{podB, podC, podA}))
+}
+
+func TestSessionAffinityCookieTakesPrecedenceOverOpaqueKey(t *testing.T) {
+	podA := newPod("pod-a", "10.0.0.1", true, map[string]string{"model.aibrix.ai/port": "8000"})
+	podB := newPod("pod-b", "10.0.0.2", true, map[string]string{"model.aibrix.ai/port": "8000"})
+	router := &sessionAffinityRouter{}
+	ctx := types.NewRoutingContext(context.Background(), "test", "model1", "", "", "")
+	ctx.ReqHeaders = map[string]string{
+		sessionIDHeader:  base64.StdEncoding.EncodeToString([]byte("10.0.0.2:8000")),
+		sessionKeyHeader: "agent-session-42",
+	}
+
+	addr, err := router.Route(ctx, newMockPodList([]*v1.Pod{podA, podB}, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, "10.0.0.2:8000", addr)
+}
+
+func TestSessionAffinityOpaqueKeyScoreAll(t *testing.T) {
+	podA := newPod("pod-a", "10.0.0.1", true, map[string]string{"model.aibrix.ai/port": "8000"})
+	podB := newPod("pod-b", "10.0.0.2", true, map[string]string{"model.aibrix.ai/port": "8000"})
+	pods := []*v1.Pod{podA, podB}
+	router := &sessionAffinityRouter{}
+	ctx := types.NewRoutingContext(context.Background(), "test", "model1", "", "", "")
+	ctx.ReqHeaders = map[string]string{sessionKeyHeader: "agent-session-42"}
+
+	scores, scored, err := router.ScoreAll(ctx, newMockPodList(pods, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, []bool{true, true}, scored)
+	assert.Equal(t, 1, int(scores[0]+scores[1]))
+
+	selected := rendezvousPod(ctx, pods, "agent-session-42")
+	if selected == podA {
+		assert.Equal(t, []float64{1, 0}, scores)
+	} else {
+		assert.Equal(t, []float64{0, 1}, scores)
+	}
+}
+
+func TestSessionAffinityRejectsOversizedOpaqueKey(t *testing.T) {
+	pod := newPod("pod-a", "10.0.0.1", true, map[string]string{"model.aibrix.ai/port": "8000"})
+	ctx := types.NewRoutingContext(context.Background(), "test", "model1", "", "", "")
+	assert.Nil(t, rendezvousPod(ctx, []*v1.Pod{pod}, string(make([]byte, maxSessionKeyLen+1))))
+}

--- a/pkg/plugins/gateway/gateway_req_headers.go
+++ b/pkg/plugins/gateway/gateway_req_headers.go
@@ -72,6 +72,8 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, req
 			reqConfigProfile = strings.TrimSpace(string(n.RawValue))
 		case HeaderSessionID:
 			reqHeaders[n.Key] = string(n.RawValue)
+		case HeaderSessionKey:
+			reqHeaders[n.Key] = string(n.RawValue)
 		case HeaderTraceParent:
 			reqHeaders[n.Key] = string(n.RawValue)
 			requestID = GetTraceID(string(n.RawValue), requestID)

--- a/pkg/plugins/gateway/gateway_req_headers_test.go
+++ b/pkg/plugins/gateway/gateway_req_headers_test.go
@@ -187,6 +187,34 @@ func Test_handleRequestHeaders(t *testing.T) {
 			},
 			validate: defaultSuccessValidator,
 		},
+		{
+			name: "extract opaque session key for session affinity routing",
+			requestHeaders: []*configPb.HeaderValue{
+				{
+					Key:      HeaderSessionKey,
+					RawValue: []byte("agent-session-42"),
+				},
+				{
+					Key:      HeaderRoutingStrategy,
+					RawValue: []byte("session-affinity"),
+				},
+			},
+			expected: testResponse{
+				statusCode: envoyTypePb.StatusCode_OK,
+				headers: []*configPb.HeaderValueOption{
+					{Header: &configPb.HeaderValue{Key: HeaderWentIntoReqHeaders, RawValue: []byte("true")}},
+				},
+				routingCtx: &types.RoutingContext{
+					ReqHeaders: map[string]string{
+						HeaderSessionKey:      "agent-session-42",
+						HeaderRoutingStrategy: "session-affinity",
+					},
+				},
+				user: utils.User{},
+				rpm:  0,
+			},
+			validate: defaultSuccessValidator,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/plugins/gateway/types.go
+++ b/pkg/plugins/gateway/types.go
@@ -55,7 +55,10 @@ const (
 	// HeaderSessionID is the header used for session affinity routing.
 	// NOTE: If you change this value, you MUST also update sessionIDHeader in
 	// pkg/plugins/gateway/algorithms/simple_session_affinity.go
-	HeaderSessionID   = "x-session-id"
+	HeaderSessionID = "x-session-id"
+	// HeaderSessionKey carries a caller-owned, opaque session key. Unlike
+	// HeaderSessionID, it never encodes or exposes a backend address.
+	HeaderSessionKey  = "x-aibrix-session-key"
 	HeaderTraceParent = "traceparent"
 
 	// RPM & TPM Update Errors


### PR DESCRIPTION
## Summary

- accept an optional caller-owned `x-aibrix-session-key` for `session-affinity`
- use rendezvous hashing to map that opaque key to a ready pod without gateway-side session state
- preserve the current gateway-issued `x-session-id` (`base64(IP:port)`) contract and give a valid cookie precedence
- expose the same binary affinity score to multi-strategy routing, so operators can combine locality with `least-request` or another load signal
- do not echo or log the opaque application key

Closes #2484. This is a scoped complement to #633; it does not introduce scheduler-owned session state.

## Motivation

Agent and multi-turn clients often already have a stable application session ID. Parallel child calls can arrive before the first gateway response, so they cannot yet return AIBrix's address cookie and currently receive random first-hop placement. Reinterpreting `x-session-id` would break its established wire format.

Rendezvous hashing gives those calls a stable initial target independent of ready-pod list ordering and limits remapping when the set changes. The response still contains the existing `x-session-id`, so later calls continue using the current fast path.

## Behavior

1. valid `x-session-id` points to a ready pod: use it
2. otherwise, non-empty `x-aibrix-session-key` (up to 256 bytes): rendezvous-hash across routable ready pods
3. otherwise: preserve today's random fallback

## Tests

Added coverage for:

- gateway extraction of the new header
- deterministic selection across pod-list permutations
- legacy cookie precedence
- `ScoreAll` integration for multi-strategy routing
- oversized-key fallback

Validation:

- `gofmt -l` reports no changed files
- remote H20 node (`lingjun-101`) directly cloned commit `bfeaa973`
- installed Go 1.22.5 directly from go.dev on the node and used the module's local 1.22 toolchain compatibility mode
- `go test ./pkg/plugins/gateway/algorithms ./pkg/plugins/gateway -run 'SessionAffinity|HandleRequestHeaders' -count=1` passed for both packages
