### PR TITLE
Remove deprecated exportloopref linter and pin CI action

### DIFF
--- a/.github/workflows/python-aibrix-kvcache-tests.yml
+++ b/.github/workflows/python-aibrix-kvcache-tests.yml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     steps:
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
       - name: Check out source repository

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -150,7 +150,7 @@ jobs:
     name: publish
     steps:
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
       - name: Check out source repository

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,6 @@ linters:
   enable:
     - dupl
     - errcheck
-    - exportloopref
     - goconst
     - gocyclo
     - gofmt


### PR DESCRIPTION
## Summary

Removes the deprecated exportloopref linter from .golangci.yml (removed in golangci-lint v2) and pins jlumbroso/free-disk-space to a versioned tag for supply-chain safety.

## Changes

- Removed `exportloopref` from `.golangci.yml` linter list (deprecated, check now built into Go itself)
- Pinned `jlumbroso/free-disk-space@main` → `@v1.3.1` in `.github/workflows/python-aibrix-kvcache-tests.yml`
- Pinned `jlumbroso/free-disk-space@main` → `@v1.3.1` in `.github/workflows/release-build.yaml`

## Testing

N/A — verified by grep / go build / visual inspection.