### PR TITLE
docs(aws): Neuron (Trainium) DRA device allocation for disaggregated inference

### DIFF
--- a/docs/source/getting_started/installation/aws.rst
+++ b/docs/source/getting_started/installation/aws.rst
@@ -80,6 +80,10 @@ valid. The recommended way to request them together is Kubernetes
 Prerequisites
 ~~~~~~~~~~~~~
 
+- Kubernetes **1.34 or later**, where Dynamic Resource Allocation is GA and the
+  API group is ``resource.k8s.io/v1`` (a fixed device request is wrapped in
+  ``exactly:``). On 1.30–1.33 DRA is beta (``resource.k8s.io/v1beta1``) with a
+  different request schema.
 - An EKS nodegroup of ``trn2.48xlarge`` (or ``trn3-dev1.48xlarge``) with EFA
   enabled (``efaEnabled: true`` and ``privateNetworking: true`` in the eksctl
   nodegroup config). EFA capacity is typically obtained through an on-demand

--- a/docs/source/getting_started/installation/aws.rst
+++ b/docs/source/getting_started/installation/aws.rst
@@ -30,82 +30,11 @@ Prerequisites
 Steps
 ~~~~~
 
-1. Create an eks cluster: ``eksctl create cluster --name aibrix --node-type=g5.4xlarge --nodes 2 --auto-kubeconfig``.
+1. Create an eks cluster:
 
     .. code-block:: console
 
         eksctl create cluster --name aibrix --node-type=g5.4xlarge --nodes 2 --auto-kubeconfig
-        2025-04-28 21:47:55 [ℹ]  eksctl version 0.187.0-dev+707c73b66.2024-07-16T06:38:53Z
-        2025-04-28 21:47:55 [ℹ]  using region us-west-2
-        2025-04-28 21:47:55 [ℹ]  skipping us-west-2d from selection because it doesn't support the following instance type(s): g5.4xlarge
-        2025-04-28 21:47:55 [ℹ]  setting availability zones to [us-west-2a us-west-2c us-west-2b]
-        2025-04-28 21:47:55 [ℹ]  subnets for us-west-2a - public:192.168.0.0/19 private:192.168.96.0/19
-        2025-04-28 21:47:55 [ℹ]  subnets for us-west-2c - public:192.168.32.0/19 private:192.168.128.0/19
-        2025-04-28 21:47:55 [ℹ]  subnets for us-west-2b - public:192.168.64.0/19 private:192.168.160.0/19
-        2025-04-28 21:47:55 [ℹ]  nodegroup "ng-fc753bf9" will use "" [AmazonLinux2/1.30]
-        2025-04-28 21:47:55 [ℹ]  using Kubernetes version 1.30
-        2025-04-28 21:47:55 [ℹ]  creating EKS cluster "aibrix" in "us-west-2" region with managed nodes
-        2025-04-28 21:47:55 [ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial managed nodegroup
-        2025-04-28 21:47:55 [ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-west-2 --cluster=aibrix'
-        2025-04-28 21:47:55 [ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "aibrix" in "us-west-2"
-        2025-04-28 21:47:55 [ℹ]  CloudWatch logging will not be enabled for cluster "aibrix" in "us-west-2"
-        2025-04-28 21:47:55 [ℹ]  you can enable it with 'eksctl utils update-cluster-logging --enable-types={SPECIFY-YOUR-LOG-TYPES-HERE (e.g. all)} --region=us-west-2 --cluster=aibrix'
-        2025-04-28 21:47:55 [ℹ]  default addons vpc-cni, kube-proxy, coredns were not specified, will install them as EKS addons
-        2025-04-28 21:47:55 [ℹ]
-        2 sequential tasks: { create cluster control plane "aibrix",
-            2 sequential sub-tasks: {
-                2 sequential sub-tasks: {
-                    1 task: { create addons },
-                    wait for control plane to become ready,
-                },
-                create managed nodegroup "ng-fc753bf9",
-            }
-        }
-        2025-04-28 21:47:55 [ℹ]  building cluster stack "eksctl-aibrix-cluster"
-        2025-04-28 21:47:56 [ℹ]  deploying stack "eksctl-aibrix-cluster"
-        2025-04-28 21:48:26 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-cluster"
-        2025-04-28 21:48:56 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-cluster"
-        2025-04-28 21:49:56 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-cluster"
-        2025-04-28 21:50:56 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-cluster"
-        2025-04-28 21:51:56 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-cluster"
-        2025-04-28 21:52:56 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-cluster"
-        2025-04-28 21:53:57 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-cluster"
-        2025-04-28 21:54:57 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-cluster"
-        2025-04-28 21:55:57 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-cluster"
-        2025-04-28 21:55:59 [!]  recommended policies were found for "vpc-cni" addon, but since OIDC is disabled on the cluster, eksctl cannot configure the requested permissions; the recommended way to provide IAM permissions for "vpc-cni" addon is via pod identity associations; after addon creation is completed, add all recommended policies to the config file, under `addon.PodIdentityAssociations`, and run `eksctl update addon`
-        2025-04-28 21:55:59 [ℹ]  creating addon
-        2025-04-28 21:55:59 [ℹ]  successfully created addon
-        2025-04-28 21:55:59 [ℹ]  creating addon
-        2025-04-28 21:56:00 [ℹ]  successfully created addon
-        2025-04-28 21:56:00 [ℹ]  creating addon
-        2025-04-28 21:56:00 [ℹ]  successfully created addon
-        2025-04-28 21:58:01 [ℹ]  building managed nodegroup stack "eksctl-aibrix-nodegroup-ng-fc753bf9"
-        2025-04-28 21:58:01 [ℹ]  deploying stack "eksctl-aibrix-nodegroup-ng-fc753bf9"
-        2025-04-28 21:58:02 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-nodegroup-ng-fc753bf9"
-        2025-04-28 21:58:32 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-nodegroup-ng-fc753bf9"
-        2025-04-28 21:59:15 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-nodegroup-ng-fc753bf9"
-        2025-04-28 21:59:51 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-nodegroup-ng-fc753bf9"
-        2025-04-28 22:01:51 [ℹ]  waiting for CloudFormation stack "eksctl-aibrix-nodegroup-ng-fc753bf9"
-        2025-04-28 22:01:51 [ℹ]  waiting for the control plane to become ready
-        2025-04-28 22:01:52 [✔]  saved kubeconfig as "/Users/bytedance/.kube/eksctl/clusters/aibrix"
-        2025-04-28 22:01:52 [ℹ]  1 task: { install Nvidia device plugin }
-        W0428 22:01:52.922061   12610 warnings.go:70] spec.template.metadata.annotations[scheduler.alpha.kubernetes.io/critical-pod]: non-functional in v1.16+; use the "priorityClassName" field instead
-        2025-04-28 22:01:52 [ℹ]  created "kube-system:DaemonSet.apps/nvidia-device-plugin-daemonset"
-        2025-04-28 22:01:52 [ℹ]  as you are using the EKS-Optimized Accelerated AMI with a GPU-enabled instance type, the Nvidia Kubernetes device plugin was automatically installed.
-            to skip installing it, use --install-nvidia-plugin=false.
-        2025-04-28 22:01:52 [✔]  all EKS cluster resources for "aibrix" have been created
-        2025-04-28 22:01:52 [✔]  created 0 nodegroup(s) in cluster "aibrix"
-        2025-04-28 22:01:53 [ℹ]  nodegroup "ng-fc753bf9" has 2 node(s)
-        2025-04-28 22:01:53 [ℹ]  node "ip-192-168-24-13.us-west-2.compute.internal" is ready
-        2025-04-28 22:01:53 [ℹ]  node "ip-192-168-49-240.us-west-2.compute.internal" is ready
-        2025-04-28 22:01:53 [ℹ]  waiting for at least 2 node(s) to become ready in "ng-fc753bf9"
-        2025-04-28 22:01:53 [ℹ]  nodegroup "ng-fc753bf9" has 2 node(s)
-        2025-04-28 22:01:53 [ℹ]  node "ip-192-168-24-13.us-west-2.compute.internal" is ready
-        2025-04-28 22:01:53 [ℹ]  node "ip-192-168-49-240.us-west-2.compute.internal" is ready
-        2025-04-28 22:01:53 [✔]  created 1 managed nodegroup(s) in cluster "aibrix"
-        2025-04-28 22:01:54 [ℹ]  kubectl command should work with "/Users/user/.kube/eksctl/clusters/aibrix", try 'kubectl --kubeconfig=/Users/user/.kube/eksctl/clusters/aibrix get nodes'
-        2025-04-28 22:01:54 [✔]  EKS cluster "aibrix" in "us-west-2" region is ready
-
 
 2. Clone AIBrix code repo ``git clone https://github.com/vllm-project/aibrix.git``.
 3. Install AIBrix dependencies, CRDs, and core components:
@@ -135,3 +64,96 @@ Steps
           }'
 
 7. When you are finished testing and no longer want the resources, run ``eksctl delete cluster --name aibrix``.
+
+AWS Neuron (Trainium) with Dynamic Resource Allocation
+------------------------------------------------------
+
+AIBrix supports disaggregated inference (prefill/decode separation) on AWS
+Trainium (Trn2 / Trn3) using the ``pd`` routing algorithm. On Neuron, the KV
+cache is transferred from prefill to decode over NIXL on the ``LIBFABRIC``
+backend, which rides EFA (Elastic Fabric Adapter). This requires each serving
+pod to be allocated **both** a set of NeuronCores **and** EFA devices — and,
+critically, from the **same PCIe/NUMA group** so the fabric path between pods is
+valid. The recommended way to request them together is Kubernetes
+**Dynamic Resource Allocation (DRA)**.
+
+Prerequisites
+~~~~~~~~~~~~~
+
+- An EKS nodegroup of ``trn2.48xlarge`` (or ``trn3-dev1.48xlarge``) with EFA
+  enabled (``efaEnabled: true`` and ``privateNetworking: true`` in the eksctl
+  nodegroup config). EFA capacity is typically obtained through an on-demand
+  capacity reservation (ODCR).
+- Two DRA drivers installed:
+
+  - **Neuron DRA driver** — publishes ``neuron.aws.com`` devices. Install per the
+    `Neuron DRA guide <https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/neuron-dra.html>`_.
+    Do not also run the Neuron device plugin on the same cluster.
+  - **EFA DRA driver** (``aws-dranet``) — publishes ``efa.networking.k8s.aws``
+    devices. Install per the
+    `Amazon EKS DRA device-management guide <https://docs.aws.amazon.com/eks/latest/userguide/device-management-efa.html>`_.
+
+Verify both device classes are discovered:
+
+.. code-block:: bash
+
+    kubectl get deviceclass                # neuron.aws.com + efa.networking.k8s.aws
+    kubectl get resourceslice -o wide      # neuron + EFA devices per Neuron node
+
+Allocate Neuron + EFA together with a ResourceClaimTemplate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pair the two device classes in a single claim, constrained to one
+``devicegroup8_id`` so the NeuronCores and EFA devices are co-located and
+mutually routable:
+
+.. code-block:: yaml
+
+    apiVersion: resource.k8s.io/v1
+    kind: ResourceClaimTemplate
+    metadata:
+      name: xl-lnc2-trn2-efa
+    spec:
+      spec:
+        devices:
+          constraints:
+          # Same PCIe/NUMA group for neurons AND efas — required for the NIXL EFA path.
+          - matchAttribute: resource.aws.com/devicegroup8_id
+            requests: [neurons, efas]
+          requests:
+          - name: neurons
+            exactly:
+              deviceClassName: neuron.aws.com
+              allocationMode: ExactCount
+              count: 8                                   # 8 chips (half a 16-chip node)
+              selectors:
+              - cel:
+                  expression: device.attributes['neuron.aws.com'].instanceType == 'trn2.48xlarge'
+          - name: efas
+            exactly:
+              deviceClassName: efa.networking.k8s.aws
+              allocationMode: ExactCount
+              count: 8
+          config:
+          - requests: [neurons]
+            opaque:
+              driver: neuron.aws.com
+              parameters:
+                apiVersion: neuron.aws.com/v1
+                kind: NeuronConfig
+                logicalNeuronCore: 2
+
+A pod references the template via ``resourceClaims`` and ``resources.claims``.
+On a 16-chip ``trn2.48xlarge`` node, two such claims (one per pod) let the prefill
+and decode pods co-locate, each on its own aligned NeuronCore + EFA group. For
+Trn3, use the ``trn3-dev1.48xlarge`` selector.
+
+.. tip::
+
+    Validate the fabric before serving — run ``/opt/amazon/efa/bin/fi_pingpong -p efa``
+    (server) in one pod and ``fi_pingpong -p efa <server-pod-ip>`` (client) in the
+    other. A bandwidth table confirms EFA works pod-to-pod.
+
+Once the prefill/decode Deployments are running with these claims and the
+``role-name: prefill|decode`` labels, enable disaggregated routing on the gateway
+with ``ROUTING_ALGORITHM=pd`` and deploy a model as in the steps above.

--- a/docs/source/getting_started/installation/aws.rst
+++ b/docs/source/getting_started/installation/aws.rst
@@ -103,13 +103,26 @@ Verify both device classes are discovered:
 Allocate Neuron + EFA together with a ResourceClaimTemplate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Pair the two device classes in a single claim, constrained to one
-``devicegroup8_id`` so the NeuronCores and EFA devices are co-located and
-mutually routable:
+A single claim requests both device classes and, via a ``constraints`` block,
+pins them to the **same device group** — this is what keeps the NeuronCores and
+EFA NICs on the same PCIe/NUMA locality so the NIXL/LIBFABRIC path between pods
+is valid. Only the ``48xlarge`` Trn size is EFA-enabled.
+
+Two ready-to-use templates are provided in
+`samples/disaggregation/neuron <https://github.com/vllm-project/aibrix/tree/main/samples/disaggregation/neuron>`_:
+
+- ``xl-lnc2-trn2-efa-rct.yaml`` — **half an instance**: 8 NeuronCores + 8 EFA
+  from one ``devicegroup8``. A ``trn2.48xlarge`` has 16 Neuron devices in two
+  such groups, so this template carves the node into two 8-device chunks — one
+  per pod — letting a prefill and a decode pod co-reside on one node, each with
+  an aligned, mutually-routable Neuron + EFA set.
+- ``xxl-lnc2-trn2-efa-rct.yaml`` — **a full instance**: all 16 NeuronCores + 16
+  EFA aligned on one ``devicegroup16`` (a single pod owns the whole node).
+
+The essential shape (see the files for the full manifest):
 
 .. code-block:: yaml
 
-    apiVersion: resource.k8s.io/v1
     kind: ResourceClaimTemplate
     metadata:
       name: xl-lnc2-trn2-efa
@@ -118,35 +131,23 @@ mutually routable:
         devices:
           constraints:
           # Same PCIe/NUMA group for neurons AND efas — required for the NIXL EFA path.
-          - matchAttribute: resource.aws.com/devicegroup8_id
+          - matchAttribute: resource.aws.com/devicegroup8_id   # devicegroup16_id for xxl
             requests: [neurons, efas]
           requests:
           - name: neurons
             exactly:
               deviceClassName: neuron.aws.com
-              allocationMode: ExactCount
-              count: 8                                   # 8 chips (half a 16-chip node)
+              count: 8                                          # 16 for xxl
               selectors:
-              - cel:
-                  expression: device.attributes['neuron.aws.com'].instanceType == 'trn2.48xlarge'
+              - cel: {expression: "device.attributes['neuron.aws.com'].instanceType == 'trn2.48xlarge'"}
           - name: efas
             exactly:
               deviceClassName: efa.networking.k8s.aws
-              allocationMode: ExactCount
-              count: 8
-          config:
-          - requests: [neurons]
-            opaque:
-              driver: neuron.aws.com
-              parameters:
-                apiVersion: neuron.aws.com/v1
-                kind: NeuronConfig
-                logicalNeuronCore: 2
+              count: 8                                          # 16 for xxl
+          ...
 
 A pod references the template via ``resourceClaims`` and ``resources.claims``.
-On a 16-chip ``trn2.48xlarge`` node, two such claims (one per pod) let the prefill
-and decode pods co-locate, each on its own aligned NeuronCore + EFA group. For
-Trn3, use the ``trn3-dev1.48xlarge`` selector.
+For Trn3, use the ``trn3-dev1.48xlarge`` selector.
 
 .. tip::
 

--- a/samples/disaggregation/neuron/xl-lnc2-trn2-efa-rct.yaml
+++ b/samples/disaggregation/neuron/xl-lnc2-trn2-efa-rct.yaml
@@ -1,0 +1,43 @@
+# Half-instance claim: 8 NeuronCores + 8 EFA devices from ONE devicegroup8.
+# A trn2.48xlarge (the only EFA-enabled Trn2 size) has 16 Neuron devices split
+# into two devicegroup8 groups. This claim carves out one group, so a single
+# node can host two such claims — e.g. one prefill pod and one decode pod, each
+# with an aligned, mutually-routable Neuron + EFA set.
+#
+# The devicegroup8_id constraint spanning BOTH neurons and efas is required: it
+# forces the NeuronCores and EFA NICs onto the same PCIe/NUMA group so the
+# NIXL/LIBFABRIC KV-transfer path between pods is valid.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: xl-lnc2-trn2-efa
+spec:
+  spec:
+    devices:
+      constraints:
+      - matchAttribute: resource.aws.com/devicegroup8_id
+        requests:
+        - neurons
+        - efas
+      requests:
+      - name: neurons
+        exactly:
+          allocationMode: ExactCount
+          count: 8
+          deviceClassName: neuron.aws.com
+          selectors:
+          - cel:
+              expression: device.attributes['neuron.aws.com'].instanceType == 'trn2.48xlarge'
+      - name: efas
+        exactly:
+          allocationMode: ExactCount
+          count: 8
+          deviceClassName: efa.networking.k8s.aws
+      config:
+      - requests: ["neurons"]
+        opaque:
+          driver: neuron.aws.com
+          parameters:
+            apiVersion: neuron.aws.com/v1
+            kind: NeuronConfig
+            logicalNeuronCore: 2

--- a/samples/disaggregation/neuron/xxl-lnc2-trn2-efa-rct.yaml
+++ b/samples/disaggregation/neuron/xxl-lnc2-trn2-efa-rct.yaml
@@ -1,0 +1,42 @@
+# Full-instance claim: all 16 NeuronCores + 16 EFA devices of a trn2.48xlarge,
+# aligned on ONE devicegroup16. Use this when a single pod should own the whole
+# node (e.g. a large prefill or decode replica), versus xl-lnc2-trn2-efa which
+# carves the node into two 8-device halves.
+#
+# As with xl, the devicegroup constraint spanning BOTH neurons and efas keeps the
+# NeuronCores and EFA NICs on the same PCIe/NUMA group so the NIXL/LIBFABRIC
+# KV-transfer path is valid.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: xxl-lnc2-trn2-efa
+spec:
+  spec:
+    devices:
+      constraints:
+      - matchAttribute: resource.aws.com/devicegroup16_id
+        requests:
+        - neurons
+        - efas
+      requests:
+      - name: neurons
+        exactly:
+          allocationMode: ExactCount
+          count: 16
+          deviceClassName: neuron.aws.com
+          selectors:
+          - cel:
+              expression: device.attributes['neuron.aws.com'].instanceType == 'trn2.48xlarge'
+      - name: efas
+        exactly:
+          allocationMode: ExactCount
+          count: 16
+          deviceClassName: efa.networking.k8s.aws
+      config:
+      - requests: ["neurons"]
+        opaque:
+          driver: neuron.aws.com
+          parameters:
+            apiVersion: neuron.aws.com/v1
+            kind: NeuronConfig
+            logicalNeuronCore: 2


### PR DESCRIPTION
## What

Extends the **Manual** AWS install guide (`docs/source/getting_started/installation/aws.rst`) with a section on running **disaggregated inference (prefill/decode) on AWS Neuron (Trn2 / Trn3)** using Dynamic Resource Allocation.

## Details

- **Why DRA:** on Neuron the KV cache moves prefill→decode over NIXL/`LIBFABRIC` on EFA, so each pod needs NeuronCores **and** EFA devices from the **same PCIe/NUMA group**. The section shows a `ResourceClaimTemplate` that pairs `neuron.aws.com` + `efa.networking.k8s.aws` under one `devicegroup8_id` constraint.
- Prereqs: EFA-enabled nodegroup + the Neuron and EFA DRA drivers (linked to the authoritative docs).
- `fi_pingpong` fabric-validation tip and the pointer to enable `ROUTING_ALGORITHM=pd`.

## Also

- Trims the long `eksctl create cluster` console log dump from the Manual steps — keeps just the command.