### PR TITLE
[Batch] Fix runtime timeout setting

### DIFF
--- a/python/aibrix/aibrix/batch/job_driver/runtime/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/base.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import inspect
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -320,6 +321,30 @@ class RuntimeBase:
         """
         del handle, wait_mode
         return None
+
+    def _wait_ready_accepts_wait_mode(self) -> bool:
+        try:
+            parameters = inspect.signature(self._wait_ready).parameters.values()
+        except Exception:
+            return False
+        return any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            or (
+                parameter.name == "wait_mode"
+                and parameter.kind
+                in (
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                )
+            )
+            for parameter in parameters
+        )
+
+    async def _invoke_wait_ready(self, handle: Any, wait_mode: str) -> None:
+        if self._wait_ready_accepts_wait_mode():
+            await self._wait_ready(handle, wait_mode=wait_mode)
+            return
+        await self._wait_ready(handle)
 
     async def _check_liveness(self, handle: Any, reason: str = "unspecified") -> None:
         """Best-effort liveness probe for reconnect/recovery and live sessions."""
@@ -1155,10 +1180,7 @@ class RuntimeBase:
                         else RUNTIME_WAIT_MODE_RECONNECT
                     )
                     phase = "wait_ready"
-                    await self._wait_ready(
-                        handle,
-                        wait_mode=wait_mode,
-                    )
+                    await self._invoke_wait_ready(handle, wait_mode)
                     # Only yield a connected endpoint after both startup phases
                     # succeed within the same attempt.
                     break

--- a/python/aibrix/aibrix/batch/job_entity/aibrix_metadata.py
+++ b/python/aibrix/aibrix/batch/job_entity/aibrix_metadata.py
@@ -10,6 +10,7 @@ from aibrix.batch.job_entity.base import _Lenient, _Strict
 #: the gateway / inference endpoints from a single job requesting runaway
 #: concurrency while allowing high-throughput jobs to tune above the default.
 MAX_CLIENT_CONCURRENCY = 1024
+_MIN_CLIENT_REQUEST_TIMEOUT_SECONDS = 1.0
 
 
 class RuntimeTarget(str, Enum):
@@ -90,6 +91,9 @@ class ClientConfig(_Strict):
 
     max_concurrency: Optional[int] = Field(
         default=None, ge=1, le=MAX_CLIENT_CONCURRENCY
+    )
+    request_timeout_seconds: Optional[float] = Field(
+        default=None, ge=_MIN_CLIENT_REQUEST_TIMEOUT_SECONDS
     )
     adaptive_concurrency: Optional[bool] = None
     adaptive_max_factor: Optional[float] = Field(default=None, ge=1)

--- a/python/aibrix/tests/batch/job_driver/runtime/test_runtime.py
+++ b/python/aibrix/tests/batch/job_driver/runtime/test_runtime.py
@@ -198,6 +198,40 @@ async def test_runtime_base_session_runs_four_phases_in_order():
 
 
 @pytest.mark.asyncio
+async def test_runtime_base_session_supports_legacy_wait_ready_without_wait_mode():
+    calls: list[tuple[str, str]] = []
+
+    class _LegacyRuntime(RuntimeBase):
+        provisions = True
+
+        async def _provision(self, job, job_id):
+            del job, job_id
+            return "handle"
+
+        async def _wait_ready(self, handle):
+            calls.append(("wait_ready", handle))
+
+        async def _connect(self, handle):
+            del handle
+            return Endpoint(source=None, model_name="m")
+
+        def _build_runtime_ref(self, job):
+            del job
+            return None
+
+    runtime = _LegacyRuntime(InfrastructureContext())
+    async with runtime.session(
+        job=_make_test_job(),
+        job_id="j",
+        progress_manager=_FakeProgressManager(),
+        worker_id_generator=_fake_worker_id_generator,
+    ) as endpoint:
+        assert endpoint.model_name == "m"
+
+    assert calls == [("wait_ready", "handle")]
+
+
+@pytest.mark.asyncio
 async def test_runtime_base_session_forwards_provision_wait_mode_on_initial_provision():
     wait_modes: list[str] = []
 

--- a/python/aibrix/tests/batch/test_job_entity.py
+++ b/python/aibrix/tests/batch/test_job_entity.py
@@ -236,6 +236,7 @@ class TestBatchJobEntityCreation:
             client=ClientConfig.model_validate(
                 {
                     "max_concurrency": MAX_CLIENT_CONCURRENCY,
+                    "request_timeout_seconds": 45,
                     "adaptive_concurrency": True,
                     "adaptive_max_factor": 16,
                     "retry_policy": {
@@ -252,10 +253,16 @@ class TestBatchJobEntityCreation:
         restored = AibrixMetadata.from_extension_fields(**fields)
 
         assert fields["client"]["max_concurrency"] == MAX_CLIENT_CONCURRENCY
+        assert fields["client"]["request_timeout_seconds"] == 45
         assert restored is not None
         assert restored.client is not None
+        assert restored.client.request_timeout_seconds == 45
         assert restored.client.retry_policy is not None
         assert restored.client.retry_policy.base_delay_seconds == 2
+
+    def test_client_config_rejects_request_timeout_below_one_second(self):
+        with pytest.raises(ValueError):
+            ClientConfig(request_timeout_seconds=0.5)
 
     def test_resource_allocation_is_expiring_uses_deadline_timestamp(self):
         now = int(datetime.now(timezone.utc).timestamp())


### PR DESCRIPTION
## Pull Request Description
- Preserving compatibility with legacy runtime `_wait_ready(handle)` hooks while still forwarding `wait_mode` to newer implementations.
- Adding per-job `client.request_timeout_seconds` metadata with minimum timeout validation.
- Adding focused regression tests for readiness hook compatibility and request timeout metadata validation/round-trip behavior.
## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>