### PR TITLE
[Bug] Reserve space for service suffix so generated resource names stay within 63-char limit

### DIFF
--- a/apps/console/api/deployment/provider/kubernetes.go
+++ b/apps/console/api/deployment/provider/kubernetes.go
@@ -59,6 +59,19 @@ const (
 	defaultReplicaCount            int32 = 1
 	defaultReadyTimeoutSeconds     int32 = 600
 	kubernetesCleanupTimeout             = 30 * time.Second
+
+	// maxResourceNameLength is the Kubernetes DNS label limit (RFC 1035/1123) that
+	// applies to the Deployment, Service, and HPA names created by this provider.
+	maxResourceNameLength = 63
+	// resourceNamePrefix is prepended to every generated resource name.
+	resourceNamePrefix = "aibrix-"
+	// resourceNameUniqueSuffixLength is the length of the random suffix appended to
+	// generated names to keep them collision-free across deployments.
+	resourceNameUniqueSuffixLength = 8
+	// serviceNameSuffix is appended to the generated base name to derive the Service
+	// name. generateResourceName reserves room for it so the derived Service name also
+	// stays within maxResourceNameLength.
+	serviceNameSuffix = "-svc"
 )
 
 // KubernetesClientProvider resolves a Kubernetes client and its workload
@@ -244,7 +257,7 @@ func (d *kubernetesDeploymentProvider) Create(ctx context.Context, template *pb.
 	}
 	deploymentCreated := true
 
-	serviceName := resourceName + "-svc"
+	serviceName := resourceName + serviceNameSuffix
 	service := buildService(serviceName, namespace, labels, d.workload)
 	if _, err := clientset.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{}); err != nil {
 		createErr := status.Errorf(codes.Internal, "create service %q: %v", serviceName, err)
@@ -315,11 +328,11 @@ func (d *kubernetesDeploymentProvider) Observe(ctx context.Context, deployment *
 	}
 
 	serviceFound := true
-	if _, err := clientset.CoreV1().Services(namespace).Get(ctx, resourceName+"-svc", metav1.GetOptions{}); err != nil {
+	if _, err := clientset.CoreV1().Services(namespace).Get(ctx, resourceName+serviceNameSuffix, metav1.GetOptions{}); err != nil {
 		if apierrors.IsNotFound(err) {
 			serviceFound = false
 		} else {
-			return nil, status.Errorf(codes.Internal, "get service %q: %v", resourceName+"-svc", err)
+			return nil, status.Errorf(codes.Internal, "get service %q: %v", resourceName+serviceNameSuffix, err)
 		}
 	}
 
@@ -430,7 +443,7 @@ func cleanupCreatedKubernetesResources(ctx context.Context, clientset kubernetes
 		}
 	}
 	if serviceCreated {
-		serviceName := resourceName + "-svc"
+		serviceName := resourceName + serviceNameSuffix
 		if err := clientset.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			cleanupErrs = append(cleanupErrs, fmt.Sprintf("delete service %q: %v", serviceName, err))
 		}
@@ -670,7 +683,7 @@ func buildService(name, namespace string, labels map[string]string, cfg config.K
 		Spec: corev1.ServiceSpec{
 			Type: serviceType,
 			Selector: map[string]string{
-				"app.kubernetes.io/instance": strings.TrimSuffix(name, "-svc"),
+				"app.kubernetes.io/instance": strings.TrimSuffix(name, serviceNameSuffix),
 			},
 			Ports: []corev1.ServicePort{{
 				Name:       "http",
@@ -918,12 +931,17 @@ func generateResourceName(name string) string {
 	if base == "" {
 		base = "deployment"
 	}
-	suffix := strings.ToLower(uuid.NewString()[:8])
-	maxBaseLength := 63 - len("aibrix--") - len(suffix)
+	suffix := strings.ToLower(uuid.NewString()[:resourceNameUniqueSuffixLength])
+	// The base name is reused to derive related resources by appending a fixed suffix
+	// (e.g. the Service is named resourceName+serviceNameSuffix). Reserve room for the
+	// prefix, the joining dash, the unique suffix, and the longest derived suffix so
+	// those derived names also satisfy maxResourceNameLength. Without reserving the
+	// derived suffix, a base name that fills the limit yields an invalid Service name.
+	maxBaseLength := maxResourceNameLength - len(resourceNamePrefix) - len("-") - resourceNameUniqueSuffixLength - len(serviceNameSuffix)
 	if len(base) > maxBaseLength {
 		base = strings.Trim(base[:maxBaseLength], "-")
 	}
-	return fmt.Sprintf("aibrix-%s-%s", base, suffix)
+	return fmt.Sprintf("%s%s-%s", resourceNamePrefix, base, suffix)
 }
 
 func sanitizeName(value string) string {

--- a/apps/console/api/deployment/provider/kubernetes_test.go
+++ b/apps/console/api/deployment/provider/kubernetes_test.go
@@ -28,6 +28,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -251,6 +252,118 @@ func TestGenerateResourceNameRetainsUniqueSuffixAfterTruncation(t *testing.T) {
 	}
 	if first == second {
 		t.Fatalf("resource names should retain unique suffixes: %q", first)
+	}
+}
+
+func TestGenerateResourceNameDerivedNamesStayWithinKubernetesLimit(t *testing.T) {
+	// maxBaseLength is the largest base name generateResourceName keeps before it
+	// truncates, mirroring the reservation the implementation makes for the prefix,
+	// the joining dash, the unique suffix, and the derived service suffix.
+	maxBaseLength := maxResourceNameLength - len(resourceNamePrefix) - len("-") - resourceNameUniqueSuffixLength - len(serviceNameSuffix)
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "short name below boundary", input: "my-model"},
+		{name: "name exactly at the base boundary", input: strings.Repeat("a", maxBaseLength)},
+		{name: "name one over the base boundary", input: strings.Repeat("a", maxBaseLength+1)},
+		{name: "very long dashed name", input: strings.Repeat("long-name-", 10)},
+		{name: "hundred character name from the bug report", input: strings.Repeat("a", 100)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resourceName := generateResourceName(tc.input)
+
+			// The base name is used directly for the Deployment and HPA; it must be valid.
+			if errs := validation.IsDNS1035Label(resourceName); len(errs) > 0 {
+				t.Fatalf("resource name %q is not a valid DNS label: %v", resourceName, errs)
+			}
+
+			// The Service name is derived by appending serviceNameSuffix — this is the name
+			// the bug report showed exceeding 63 characters, so assert the final value, not
+			// just the base. The fake client used elsewhere does not enforce this limit.
+			serviceName := resourceName + serviceNameSuffix
+			if len(serviceName) > maxResourceNameLength {
+				t.Fatalf("service name %q exceeds %d characters (len=%d)", serviceName, maxResourceNameLength, len(serviceName))
+			}
+			if errs := validation.IsDNS1035Label(serviceName); len(errs) > 0 {
+				t.Fatalf("service name %q is not a valid DNS label: %v", serviceName, errs)
+			}
+
+			// Truncation must preserve the random suffix so names stay collision-free.
+			if !strings.HasPrefix(resourceName, resourceNamePrefix) {
+				t.Fatalf("resource name %q missing prefix %q", resourceName, resourceNamePrefix)
+			}
+			gotSuffix := resourceName[len(resourceName)-resourceNameUniqueSuffixLength:]
+			if strings.ContainsRune(gotSuffix, '-') {
+				t.Fatalf("resource name %q does not retain a %d-char unique suffix (got %q)", resourceName, resourceNameUniqueSuffixLength, gotSuffix)
+			}
+		})
+	}
+}
+
+func TestCreateWithLongNameProducesValidKubernetesResourceNames(t *testing.T) {
+	const namespace = "aibrix-console"
+	client := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	})
+	workload := config.KubernetesWorkloadConfig{
+		ServiceType:             string(corev1.ServiceTypeClusterIP),
+		ContainerPort:           8000,
+		ServicePort:             8000,
+		CPURequest:              "1",
+		HPATargetCPUUtilization: 80,
+	}
+	implementation := NewKubernetesDeploymentProvider(
+		staticKubernetesClientProvider{clientset: client, namespace: namespace},
+		workload,
+	)
+	template := &pb.ModelDeploymentTemplate{
+		Id:      "template-1",
+		Name:    "vllm-template",
+		Version: "v1.0.0",
+		ModelId: "model-1",
+		Spec: &pb.ModelDeploymentTemplateSpec{
+			Engine:      &pb.EngineSpec{Type: "vllm", Image: "example/vllm:latest"},
+			ModelSource: &pb.ModelSourceSpec{Uri: "org/model"},
+			Accelerator: &pb.AcceleratorSpec{Type: "CPU", Count: 1},
+		},
+	}
+	// A 100-character user-facing name, as in the bug report. The base resource name
+	// previously filled the 63-char limit on its own, so appending "-svc" for the Service
+	// produced an invalid name and Service creation failed after the Deployment existed.
+	req := &pb.CreateDeploymentRequest{
+		Name: strings.Repeat("a", 100),
+		Overrides: &pb.DeploymentOverrides{
+			MinReplicas:       1,
+			MaxReplicas:       3,
+			EnableAutoScaling: true,
+		},
+	}
+
+	if err := implementation.Validate(context.Background(), template, req); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if _, err := implementation.Create(context.Background(), template, req); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	deployments, _ := client.AppsV1().Deployments(namespace).List(context.Background(), metav1.ListOptions{})
+	services, _ := client.CoreV1().Services(namespace).List(context.Background(), metav1.ListOptions{})
+	hpas, _ := client.AutoscalingV2().HorizontalPodAutoscalers(namespace).List(context.Background(), metav1.ListOptions{})
+	if len(deployments.Items) != 1 || len(services.Items) != 1 || len(hpas.Items) != 1 {
+		t.Fatalf("created resources: deployments=%d services=%d hpas=%d", len(deployments.Items), len(services.Items), len(hpas.Items))
+	}
+
+	// The fake client does not enforce API-server name validation, so assert every
+	// generated resource name is a valid DNS label explicitly.
+	names := []string{deployments.Items[0].Name, services.Items[0].Name, hpas.Items[0].Name}
+	for _, name := range names {
+		if errs := validation.IsDNS1035Label(name); len(errs) > 0 {
+			t.Fatalf("generated resource name %q is not a valid DNS label: %v", name, errs)
+		}
 	}
 }
 


### PR DESCRIPTION
## Pull Request Description

### Problem
The Console Kubernetes provider's `generateResourceName` allowed the base resource name to occupy the **full 63-character DNS label limit**. Callers then append a fixed suffix to derive related resources — most importantly the Service, named `resourceName + "-svc"`. When the base already filled 63 characters, the Service name reached 67 and the API server rejected it:

```
create service "aibrix-…-svc": Service "…-svc" is invalid: metadata.name:
Invalid value: "…-svc": must be no more than 63 characters
```

Because the Deployment is created first, the request failed with HTTP 500 *after* the Deployment already existed (the rollback removed the Deployment, but the otherwise-valid user-facing request still failed).

### Fix
`generateResourceName` now reserves room for the longest suffix appended to the base name (the Service's `-svc`) in addition to the prefix, the joining dash, and the unique suffix — so every derived name stays within the limit. To make the invariant explicit and drift-proof (the root cause was the generator not knowing about the suffix callers append), the magic values are extracted into named constants and the `"-svc"` literal is replaced with `serviceNameSuffix` at every use site:

- `maxResourceNameLength` (63), `resourceNamePrefix` (`aibrix-`), `resourceNameUniqueSuffixLength` (8), `serviceNameSuffix` (`-svc`)
- The base name is truncated to `maxResourceNameLength - len(prefix) - len("-") - suffixLen - len(serviceNameSuffix)` before the unique suffix is appended, and the random suffix is always preserved.

Deployment and HPA names use the base name directly (no appended suffix), so they were already within the limit and remain so.

### Testing
`go test ./apps/console/api/deployment/provider/...`, `go vet`, `gofmt`, and `go build ./apps/console/...` all pass. Added two tests (verified they fail without the fix):

- `TestGenerateResourceNameDerivedNamesStayWithinKubernetesLimit` — table test over names **below, at, and above** the boundary (incl. the 100-char case from the report). Asserts the **final** `resourceName + "-svc"` — not just the base — is a valid label via `validation.IsDNS1035Label`, and that the unique suffix survives truncation.
- `TestCreateWithLongNameProducesValidKubernetesResourceNames` — end-to-end `Create` with a 100-character name that asserts the actual created Deployment, Service, and HPA object names are valid DNS labels. (The fake client does not enforce API-server name validation, so names are validated explicitly, as the issue suggests.)

### Acceptance criteria
- [x] Generated Deployment, Service, and HPA names satisfy their Kubernetes naming limits.
- [x] Long deployment names no longer cause Service creation to fail with HTTP 500.
- [x] The random suffix remains present after truncation.
- [x] Tests cover names below, at, and above the boundary.
- [x] Tests assert the validity of the final `resourceName + "-svc"`, not only the base name.

## Related Issues
Resolves: #2493
