### PR TITLE
fix(test): remove sync.Map iteration order dependency in TestUpdateModelReplicaMetrics

### DIFF
--- a/pkg/cache/cache_metrics_test.go
+++ b/pkg/cache/cache_metrics_test.go
@@ -480,11 +480,14 @@ func TestUpdateModelReplicaMetrics(t *testing.T) {
 
 	store.updateModelReplicaMetrics()
 	require.Len(t, emitted, 2)
-	require.Equal(t, "prefill", emitted[0]["role"])
-	require.Equal(t, "qwen3-8B", emitted[0]["model_name"])
-	require.Equal(t, "prefill-0", emitted[0]["pod"])
-	require.Equal(t, "decode", emitted[1]["role"])
-	require.Equal(t, "decode-0", emitted[1]["pod"])
+	byPod := make(map[string]map[string]string, len(emitted))
+	for _, labels := range emitted {
+		byPod[labels["pod"]] = labels
+	}
+	require.Equal(t, "prefill", byPod["prefill-0"]["role"])
+	require.Equal(t, "qwen3-8B", byPod["prefill-0"]["model_name"])
+	require.Equal(t, "decode", byPod["decode-0"]["role"])
+	require.Equal(t, "qwen3-8B", byPod["decode-0"]["model_name"])
 	require.Equal(t, 2, store.modelReplicaEmitted.Len())
 
 	store.metaPods.Delete("default/prefill-0")


### PR DESCRIPTION
## Pull Request Description
Go's sync.Map.Range iteration order is unspecified, so the test flaked whenever the decode pod was visited before the prefill pod. Index the emitted metrics by pod name and assert per-pod instead of by slice position.

## Related Issues
Resolves: #2497

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>