### PR TITLE
[test] Fix flaky gateway e2e tests

### DIFF
--- a/test/e2e/model_rps_limit_test.go
+++ b/test/e2e/model_rps_limit_test.go
@@ -19,11 +19,11 @@ package e2e
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/openai/openai-go/v3"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,53 +43,81 @@ func TestModelRPSLimit(t *testing.T) {
 		time.Sleep(time.Until(nextWindow))
 	}
 
-	sendRequest := func(t *testing.T, profile string) error {
-		t.Helper()
+	sendRequest := func(profile string) error {
 		client := createOpenAIClientWithConfigProfile(gatewayURL, apiKey, profile, nil)
 		_, err := client.Chat.Completions.New(context.TODO(), openai.ChatCompletionNewParams{
-			Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage(msg)},
-			Model:    modelNameQwen3,
+			Messages:  []openai.ChatCompletionMessageParamUnion{openai.UserMessage(msg)},
+			Model:     modelNameQwen3,
+			MaxTokens: openai.Int(1),
 		})
 		return err
+	}
+
+	sendConcurrentRequests := func(profile string, count int) []error {
+		errs := make([]error, count)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(count)
+		for i := range count {
+			go func(index int) {
+				defer wg.Done()
+				<-start
+				errs[index] = sendRequest(profile)
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+		return errs
+	}
+
+	requireOneAllowedOneRejected := func(t *testing.T, errs []error) {
+		t.Helper()
+		require.Len(t, errs, 2)
+
+		var allowed, rejected int
+		for _, err := range errs {
+			if err == nil {
+				allowed++
+				continue
+			}
+
+			var apiErr *openai.Error
+			require.True(t, errors.As(err, &apiErr), "error should be an openai API error, got: %v", err)
+			require.Equal(t, 429, apiErr.StatusCode, "exceeded RPS limit should return HTTP 429")
+			rejected++
+		}
+
+		require.Equal(t, 1, allowed, "exactly one request should be allowed within the 1 RPS window")
+		require.Equal(t, 1, rejected, "exactly one request should be rejected within the 1 RPS window")
 	}
 
 	t.Run("first_request_succeeds", func(t *testing.T) {
 		waitForFreshWindow()
 
-		err := sendRequest(t, "rps-limited")
+		err := sendRequest("rps-limited")
 		require.NoError(t, err, "first request within the RPS limit should succeed")
 	})
 
 	t.Run("second_request_in_same_window_is_rejected", func(t *testing.T) {
 		waitForFreshWindow()
 
-		// First request exhausts the 1 RPS budget.
-		err := sendRequest(t, "rps-limited")
-		require.NoError(t, err, "first request should succeed")
-
-		// Second request in the same 1-second window must be rejected.
-		err = sendRequest(t, "rps-limited")
-		require.Error(t, err, "second request should be rejected after RPS limit is exhausted")
-
-		var apiErr *openai.Error
-		require.True(t, errors.As(err, &apiErr), "error should be an openai API error, got: %v", err)
-		assert.Equal(t, 429, apiErr.StatusCode, "exceeded RPS limit should return HTTP 429")
+		// Start both requests together so both reach the gateway in the same
+		// fixed window regardless of backend completion latency.
+		errs := sendConcurrentRequests("rps-limited", 2)
+		requireOneAllowedOneRejected(t, errs)
 	})
 
 	t.Run("requests_succeed_after_window_resets", func(t *testing.T) {
 		waitForFreshWindow()
 
-		// Exhaust the window.
-		err := sendRequest(t, "rps-limited")
-		require.NoError(t, err, "first request should succeed")
-
-		err = sendRequest(t, "rps-limited")
-		require.Error(t, err, "second request should be throttled")
+		// Exhaust the window with a concurrent burst.
+		errs := sendConcurrentRequests("rps-limited", 2)
+		requireOneAllowedOneRejected(t, errs)
 
 		// Wait for the window to roll over, then verify requests succeed again.
 		waitForFreshWindow()
 
-		err = sendRequest(t, "rps-limited")
+		err := sendRequest("rps-limited")
 		require.NoError(t, err, "request in the next window should succeed after the counter resets")
 	})
 
@@ -97,7 +125,7 @@ func TestModelRPSLimit(t *testing.T) {
 		// The default profile has no requestsPerSecond, so multiple rapid requests
 		// to the same model must all succeed regardless of how many are sent.
 		for i := 0; i < 3; i++ {
-			err := sendRequest(t, "least-request")
+			err := sendRequest("least-request")
 			require.NoError(t, err, "request %d without RPS profile should succeed", i+1)
 		}
 	})

--- a/test/e2e/routing_strategy_test.go
+++ b/test/e2e/routing_strategy_test.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"testing"
 	"time"
@@ -126,8 +125,7 @@ func runRandomRoutingCheck() error {
 	return nil
 }
 
-// TestPrefixCacheRouting verifies that an identical prompt reuses the warm-up pod and
-// that a novel prefix tends to route elsewhere (best-effort; may retry up to 5 times).
+// TestPrefixCacheRouting verifies that an identical prompt reuses the warm-up pod.
 //
 //nolint:lll // long test prompts exceed line-length limit
 func TestPrefixCacheRouting(t *testing.T) {
@@ -143,21 +141,6 @@ func TestPrefixCacheRouting(t *testing.T) {
 	targetPod2 := getTargetPodFromChatCompletion(t, req, "prefix-cache")
 	t.Logf("req: %s, target pod: %v\n", req, targetPod2)
 	assert.Equal(t, targetPod, targetPod2)
-
-	// Novel prefix: prefer a different pod (probabilistic; retry if it matches by chance).
-	var count int
-	for count < 5 {
-		generateMessage := fmt.Sprintf("%d: completely different request prefix to avoid cache hits between "+
-			"iterations, and padding to exceed 128 bytes for prefix cache routing test!!", rand.Intn(1000))
-		targetPod3 := getTargetPodFromChatCompletion(t, generateMessage, "prefix-cache")
-		t.Logf("req: %s, target pod (novel prefix): %v\n", generateMessage, targetPod3)
-		if targetPod != targetPod3 {
-			break
-		}
-		count++
-	}
-
-	assert.NotEqual(t, 5, count)
 }
 
 // TestMultiTurnConversation verifies that a growing multi-turn context keeps routing


### PR DESCRIPTION
## Pull Request Description
flaky test fix

- TestModelRPSLimit: The Redis limiter uses fixed one-second windows. The test sent requests sequentially, and the first mock response could take long enough for the second request to enter the next window and succeed. The fix sends two short requests concurrently and verifies that one succeeds while the other receives HTTP 429.
- TestPrefixCacheRouting: A novel prefix has no cache affinity and falls back to least-request routing, which randomly breaks ties between equally loaded pods. Therefore, expecting it to select a different pod was probabilistic and flaky. The fix keeps only the deterministic assertion that an identical prompt reuses the warmed pod.

## Related Issues
Resolves: https://github.com/vllm-project/aibrix/issues/2498

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>