### PR TITLE
[Batch] fix: use dedicated file upload timeout

### DIFF
--- a/apps/console/api/config/config.go
+++ b/apps/console/api/config/config.go
@@ -22,10 +22,13 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 )
 
 // AuthModeDev is the development auth mode name.
 const AuthModeDev = "dev"
+
+const defaultMetadataFileUploadTimeout = 30 * time.Minute
 
 // KubernetesProviderConfig identifies the cluster and namespace used by the
 // Kubernetes deployment provider.
@@ -61,6 +64,8 @@ type Config struct {
 	GatewayEndpoint string
 	// MetadataServiceURL is the metadata service URL for file proxy operations.
 	MetadataServiceURL string
+	// MetadataFileUploadTimeout bounds file uploads proxied to metadata service.
+	MetadataFileUploadTimeout time.Duration
 	// DefaultBatchModelDeploymentTemplate is injected as aibrix.model_template
 	// on CreateJob requests when the caller does not provide one. Temporary
 	// stop-gap until the Model entity carries a per-model batch_template.
@@ -189,11 +194,19 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	metadataFileUploadTimeout, err := envDurationOrDefault(
+		"METADATA_FILE_UPLOAD_TIMEOUT",
+		defaultMetadataFileUploadTimeout,
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Config{
 		StoreURI:                            envOrDefault("STORE_URI", "sqlite:/tmp/aibrix-console.db"),
 		GatewayEndpoint:                     envOrDefault("GATEWAY_ENDPOINT", "http://localhost:8888"),
 		MetadataServiceURL:                  envOrDefault("METADATA_SERVICE_URL", "http://localhost:8090"),
+		MetadataFileUploadTimeout:           metadataFileUploadTimeout,
 		DefaultBatchModelDeploymentTemplate: envOrDefault("DEFAULT_BATCH_MODEL_DEPLOYMENT_TEMPLATE", ""),
 		Provisioner:                         envOrDefault("PROVISIONER", "kubernetes"),
 		PlanningPolicy:                      envOrDefault("PLANNING_POLICY", "simple"),
@@ -283,6 +296,21 @@ func envInt32Compat(key, legacyKey string, fallback int32) int32 {
 		}
 	}
 	return fallback
+}
+
+func envDurationOrDefault(key string, fallback time.Duration) (time.Duration, error) {
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback, nil
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a valid duration: %w", key, err)
+	}
+	if duration <= 0 {
+		return 0, fmt.Errorf("%s must be greater than zero", key)
+	}
+	return duration, nil
 }
 
 // requiredSecret returns the env var value if set. In dev mode it generates a

--- a/apps/console/api/config/config_test.go
+++ b/apps/console/api/config/config_test.go
@@ -16,7 +16,16 @@ limitations under the License.
 
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testMetadataFileUploadTimeout    = 45 * time.Minute
+	testMetadataFileUploadTimeoutEnv = "45m"
+)
 
 func TestLoadSeparatesKubernetesClusterAndWorkloadConfig(t *testing.T) {
 	t.Setenv("AUTH_MODE", AuthModeDev)
@@ -42,5 +51,35 @@ func TestLoadSeparatesKubernetesClusterAndWorkloadConfig(t *testing.T) {
 		got.ContainerPort != 9000 || got.ServicePort != 9001 ||
 		got.CPURequest != "500m" || got.HPATargetCPUUtilization != 70 {
 		t.Fatalf("unexpected Kubernetes workload config: %+v", got)
+	}
+}
+
+func TestLoadMetadataFileUploadTimeout(t *testing.T) {
+	t.Setenv("AUTH_MODE", AuthModeDev)
+	t.Setenv("METADATA_FILE_UPLOAD_TIMEOUT", testMetadataFileUploadTimeoutEnv)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.MetadataFileUploadTimeout != testMetadataFileUploadTimeout {
+		t.Fatalf(
+			"MetadataFileUploadTimeout = %v, want %v",
+			cfg.MetadataFileUploadTimeout,
+			testMetadataFileUploadTimeout,
+		)
+	}
+}
+
+func TestLoadRejectsNonPositiveMetadataFileUploadTimeout(t *testing.T) {
+	t.Setenv("AUTH_MODE", AuthModeDev)
+	t.Setenv("METADATA_FILE_UPLOAD_TIMEOUT", "0s")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() error = nil, want invalid upload timeout error")
+	}
+	if !strings.Contains(err.Error(), "METADATA_FILE_UPLOAD_TIMEOUT must be greater than zero") {
+		t.Fatalf("Load() error = %q, want upload timeout validation error", err)
 	}
 }

--- a/apps/console/api/handler/file.go
+++ b/apps/console/api/handler/file.go
@@ -46,12 +46,18 @@ const (
 type FileHandler struct {
 	metadataServiceURL string
 	httpClient         *http.Client
+	uploadHTTPClient   *http.Client
 	store              store.Store
 	injector           error_injection.Injector
 }
 
 // NewFileHandler creates a new file proxy handler.
-func NewFileHandler(metadataServiceURL string, injector error_injection.Injector, stores ...store.Store) *FileHandler {
+func NewFileHandler(
+	metadataServiceURL string,
+	uploadTimeout time.Duration,
+	injector error_injection.Injector,
+	stores ...store.Store,
+) *FileHandler {
 	var st store.Store
 	if len(stores) > 0 {
 		st = stores[0]
@@ -59,6 +65,7 @@ func NewFileHandler(metadataServiceURL string, injector error_injection.Injector
 	return &FileHandler{
 		metadataServiceURL: strings.TrimRight(metadataServiceURL, "/"),
 		httpClient:         &http.Client{Timeout: fileHTTPClientTimeout},
+		uploadHTTPClient:   &http.Client{Timeout: uploadTimeout},
 		store:              st,
 		injector:           injector,
 	}
@@ -91,7 +98,7 @@ func (h *FileHandler) handleUpload(w http.ResponseWriter, r *http.Request, _ map
 		}
 	}
 	targetURL := h.metadataServiceURL + "/v1/files"
-	h.proxyRequest(w, r, "POST", targetURL, "upload", start)
+	h.proxyRequest(w, r, "POST", targetURL, "upload", start, h.uploadHTTPClient)
 }
 
 // handleList proxies file listing to GET {metadataServiceURL}/v1/files.
@@ -101,7 +108,7 @@ func (h *FileHandler) handleList(w http.ResponseWriter, r *http.Request, _ map[s
 	if r.URL.RawQuery != "" {
 		targetURL += "?" + r.URL.RawQuery
 	}
-	h.proxyRequest(w, r, "GET", targetURL, "list", start)
+	h.proxyRequest(w, r, "GET", targetURL, "list", start, h.httpClient)
 }
 
 // handleGetMetadata proxies file metadata retrieval to GET {metadataServiceURL}/v1/files/{file_id}.
@@ -112,7 +119,7 @@ func (h *FileHandler) handleGetMetadata(w http.ResponseWriter, r *http.Request, 
 	if r.URL.RawQuery != "" {
 		targetURL += "?" + r.URL.RawQuery
 	}
-	h.proxyRequest(w, r, "GET", targetURL, "get_metadata", start)
+	h.proxyRequest(w, r, "GET", targetURL, "get_metadata", start, h.httpClient)
 }
 
 // handleDownloadContent proxies file content download to GET {metadataServiceURL}/v1/files/{file_id}/content.
@@ -135,7 +142,7 @@ func (h *FileHandler) handleDownloadContent(w http.ResponseWriter, r *http.Reque
 	if r.URL.RawQuery != "" {
 		targetURL += "?" + r.URL.RawQuery
 	}
-	h.proxyRequest(w, r, "GET", targetURL, "download", start)
+	h.proxyRequest(w, r, "GET", targetURL, "download", start, h.httpClient)
 }
 
 type fileAuthorizationError struct {
@@ -194,7 +201,20 @@ func (h *FileHandler) authorizeFileDownload(ctx context.Context, fileID string) 
 }
 
 // proxyRequest forwards an HTTP request to the target URL and copies the response back.
-func (h *FileHandler) proxyRequest(w http.ResponseWriter, r *http.Request, method, targetURL, op string, start time.Time) {
+func (h *FileHandler) proxyRequest(
+	w http.ResponseWriter,
+	r *http.Request,
+	method, targetURL, op string,
+	start time.Time,
+	client *http.Client,
+) {
+	if client == nil {
+		client = h.httpClient
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+
 	defer func() {
 		metrics.Duration(metrics.Emitter, metricConsoleFileDuration, start, metrics.T("method", op))
 	}()
@@ -220,9 +240,16 @@ func (h *FileHandler) proxyRequest(w http.ResponseWriter, r *http.Request, metho
 		proxyReq.Header.Set("Authorization", auth)
 	}
 
-	resp, err := h.httpClient.Do(proxyReq)
+	resp, err := client.Do(proxyReq)
 	if err != nil {
-		klog.Errorf("Failed to proxy to metadata service: %v", err)
+		klog.Errorf(
+			"Failed to proxy to metadata service: op=%s elapsed=%s request_context_err=%v client_timeout=%s: %v",
+			op,
+			time.Since(start),
+			r.Context().Err(),
+			client.Timeout,
+			err,
+		)
 		metrics.Emitter.Counter(metricConsoleFileError, 1, metrics.T("method", op), metrics.T("reason", "upstream_unreachable"))
 		http.Error(w, `{"error":"metadata service unreachable"}`, http.StatusBadGateway)
 		return

--- a/apps/console/api/handler/file.go
+++ b/apps/console/api/handler/file.go
@@ -38,6 +38,11 @@ import (
 const fileHTTPClientTimeout = 60 * time.Second
 
 const (
+	fileOperationUpload      = "upload"
+	fileOperationList        = "list"
+	fileOperationGetMetadata = "get_metadata"
+	fileOperationDownload    = "download"
+
 	metricConsoleFileError    = "console.file.error"
 	metricConsoleFileDuration = "console.file.duration"
 )
@@ -92,13 +97,13 @@ func (h *FileHandler) handleUpload(w http.ResponseWriter, r *http.Request, _ map
 	start := time.Now().UTC()
 	if h.injector != nil {
 		if err := h.injector.CheckPoint(r.Context(), error_injection.POINT_CONSOLE_UPLOAD_FILE); err != nil {
-			metrics.Emitter.Counter(metricConsoleFileError, 1, metrics.T("method", "upload"), metrics.T("reason", "injected"))
+			metrics.Emitter.Counter(metricConsoleFileError, 1, metrics.T("method", fileOperationUpload), metrics.T("reason", "injected"))
 			http.Error(w, err.Error(), convertInjectedErrorToHttpCode(err))
 			return
 		}
 	}
 	targetURL := h.metadataServiceURL + "/v1/files"
-	h.proxyRequest(w, r, "POST", targetURL, "upload", start, h.uploadHTTPClient)
+	h.proxyRequest(w, r, http.MethodPost, targetURL, fileOperationUpload, start)
 }
 
 // handleList proxies file listing to GET {metadataServiceURL}/v1/files.
@@ -108,7 +113,7 @@ func (h *FileHandler) handleList(w http.ResponseWriter, r *http.Request, _ map[s
 	if r.URL.RawQuery != "" {
 		targetURL += "?" + r.URL.RawQuery
 	}
-	h.proxyRequest(w, r, "GET", targetURL, "list", start, h.httpClient)
+	h.proxyRequest(w, r, http.MethodGet, targetURL, fileOperationList, start)
 }
 
 // handleGetMetadata proxies file metadata retrieval to GET {metadataServiceURL}/v1/files/{file_id}.
@@ -119,7 +124,7 @@ func (h *FileHandler) handleGetMetadata(w http.ResponseWriter, r *http.Request, 
 	if r.URL.RawQuery != "" {
 		targetURL += "?" + r.URL.RawQuery
 	}
-	h.proxyRequest(w, r, "GET", targetURL, "get_metadata", start, h.httpClient)
+	h.proxyRequest(w, r, http.MethodGet, targetURL, fileOperationGetMetadata, start)
 }
 
 // handleDownloadContent proxies file content download to GET {metadataServiceURL}/v1/files/{file_id}/content.
@@ -127,14 +132,14 @@ func (h *FileHandler) handleDownloadContent(w http.ResponseWriter, r *http.Reque
 	start := time.Now().UTC()
 	if h.injector != nil {
 		if err := h.injector.CheckPoint(r.Context(), error_injection.POINT_CONSOLE_DOWNLOAD_FILE); err != nil {
-			metrics.Emitter.Counter(metricConsoleFileError, 1, metrics.T("method", "download"), metrics.T("reason", "injected"))
+			metrics.Emitter.Counter(metricConsoleFileError, 1, metrics.T("method", fileOperationDownload), metrics.T("reason", "injected"))
 			http.Error(w, err.Error(), convertInjectedErrorToHttpCode(err))
 			return
 		}
 	}
 	fileID := pathParams["file_id"]
 	if err := h.authorizeFileDownload(r.Context(), fileID); err != nil {
-		metrics.Emitter.Counter(metricConsoleFileError, 1, metrics.T("method", "download"), metrics.T("reason", "auth_failed"))
+		metrics.Emitter.Counter(metricConsoleFileError, 1, metrics.T("method", fileOperationDownload), metrics.T("reason", "auth_failed"))
 		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.message), err.status)
 		return
 	}
@@ -142,7 +147,7 @@ func (h *FileHandler) handleDownloadContent(w http.ResponseWriter, r *http.Reque
 	if r.URL.RawQuery != "" {
 		targetURL += "?" + r.URL.RawQuery
 	}
-	h.proxyRequest(w, r, "GET", targetURL, "download", start, h.httpClient)
+	h.proxyRequest(w, r, http.MethodGet, targetURL, fileOperationDownload, start)
 }
 
 type fileAuthorizationError struct {
@@ -200,20 +205,25 @@ func (h *FileHandler) authorizeFileDownload(ctx context.Context, fileID string) 
 	}
 }
 
+func (h *FileHandler) clientForOperation(op string) *http.Client {
+	client := h.httpClient
+	if op == fileOperationUpload && h.uploadHTTPClient != nil {
+		client = h.uploadHTTPClient
+	}
+	if client == nil {
+		return http.DefaultClient
+	}
+	return client
+}
+
 // proxyRequest forwards an HTTP request to the target URL and copies the response back.
 func (h *FileHandler) proxyRequest(
 	w http.ResponseWriter,
 	r *http.Request,
 	method, targetURL, op string,
 	start time.Time,
-	client *http.Client,
 ) {
-	if client == nil {
-		client = h.httpClient
-	}
-	if client == nil {
-		client = http.DefaultClient
-	}
+	client := h.clientForOperation(op)
 
 	defer func() {
 		metrics.Duration(metrics.Emitter, metricConsoleFileDuration, start, metrics.T("method", op))

--- a/apps/console/api/handler/file_test.go
+++ b/apps/console/api/handler/file_test.go
@@ -172,7 +172,7 @@ func TestProxyRequestHandlesNilClient(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/files", nil)
 	rec := httptest.NewRecorder()
 
-	handler.proxyRequest(rec, req, http.MethodGet, upstream.URL, "list", time.Now(), nil)
+	handler.proxyRequest(rec, req, http.MethodGet, upstream.URL, fileOperationList, time.Now())
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())

--- a/apps/console/api/handler/file_test.go
+++ b/apps/console/api/handler/file_test.go
@@ -18,14 +18,34 @@ package handler
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/vllm-project/aibrix/apps/console/api/middleware"
 	"github.com/vllm-project/aibrix/apps/console/api/store"
 	"github.com/vllm-project/aibrix/apps/console/api/store/models"
 )
+
+const (
+	testFileUploadTimeout     = 500 * time.Millisecond
+	testMetadataClientTimeout = 25 * time.Millisecond
+	testMetadataUploadDelay   = 75 * time.Millisecond
+	testCancellationWait      = time.Second
+)
+
+type contextBlockingTransport struct {
+	requestStarted chan struct{}
+}
+
+func (t *contextBlockingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	close(t.requestStarted)
+	<-r.Context().Done()
+	return nil, r.Context().Err()
+}
 
 func requestWithUserEmail(r *http.Request, email string) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), middleware.UserContextKey, &middleware.UserInfo{
@@ -45,7 +65,7 @@ func TestFileDownloadRejectsKnownNonOwner(t *testing.T) {
 		t.Fatalf("UpsertJob failed: %v", err)
 	}
 
-	handler := NewFileHandler("http://metadata.invalid", nil, s)
+	handler := NewFileHandler("http://metadata.invalid", testFileUploadTimeout, nil, s)
 	req := requestWithUserEmail(httptest.NewRequest(http.MethodGet, "/api/v1/files/"+fileID+"/content", nil), "other@example.com")
 	rec := httptest.NewRecorder()
 
@@ -69,7 +89,7 @@ func TestFileDownloadRejectsNonOwnerWhenFileAlsoHasUnownedJob(t *testing.T) {
 		}
 	}
 
-	handler := NewFileHandler("http://metadata.invalid", nil, s)
+	handler := NewFileHandler("http://metadata.invalid", testFileUploadTimeout, nil, s)
 	req := requestWithUserEmail(httptest.NewRequest(http.MethodGet, "/api/v1/files/"+fileID+"/content", nil), "other@example.com")
 	rec := httptest.NewRecorder()
 
@@ -100,7 +120,7 @@ func TestFileDownloadAllowsOwner(t *testing.T) {
 	}))
 	t.Cleanup(upstream.Close)
 
-	handler := NewFileHandler(upstream.URL, nil, s)
+	handler := NewFileHandler(upstream.URL, testFileUploadTimeout, nil, s)
 	req := requestWithUserEmail(httptest.NewRequest(http.MethodGet, "/api/v1/files/"+fileID+"/content", nil), "owner@example.com")
 	rec := httptest.NewRecorder()
 
@@ -111,5 +131,90 @@ func TestFileDownloadAllowsOwner(t *testing.T) {
 	}
 	if rec.Body.String() != "download ok" {
 		t.Fatalf("body = %q, want download ok", rec.Body.String())
+	}
+}
+
+func TestFileUploadUsesDedicatedTimeout(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		time.Sleep(testMetadataUploadDelay)
+		_, _ = w.Write([]byte("upload ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	handler := NewFileHandler(upstream.URL, testFileUploadTimeout, nil)
+	handler.httpClient.Timeout = testMetadataClientTimeout
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/files/upload",
+		strings.NewReader("multipart payload"),
+	)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=test")
+	rec := httptest.NewRecorder()
+
+	handler.handleUpload(rec, req, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != "upload ok" {
+		t.Fatalf("body = %q, want upload ok", rec.Body.String())
+	}
+}
+
+func TestProxyRequestHandlesNilClient(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("proxy ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	handler := &FileHandler{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/files", nil)
+	rec := httptest.NewRecorder()
+
+	handler.proxyRequest(rec, req, http.MethodGet, upstream.URL, "list", time.Now(), nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != "proxy ok" {
+		t.Fatalf("body = %q, want proxy ok", rec.Body.String())
+	}
+}
+
+func TestFileUploadPropagatesRequestCancellation(t *testing.T) {
+	handler := NewFileHandler("http://metadata.invalid", testFileUploadTimeout, nil)
+	requestStarted := make(chan struct{})
+	handler.uploadHTTPClient.Transport = &contextBlockingTransport{
+		requestStarted: requestStarted,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/files/upload",
+		strings.NewReader("multipart payload"),
+	).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		handler.handleUpload(rec, req, nil)
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(testCancellationWait):
+		t.Fatal("metadata request did not start")
+	}
+	cancel()
+
+	select {
+	case <-handlerDone:
+	case <-time.After(testCancellationWait):
+		t.Fatal("file handler did not stop after request cancellation")
+	}
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body=%s", rec.Code, rec.Body.String())
 	}
 }

--- a/apps/console/api/server/server.go
+++ b/apps/console/api/server/server.go
@@ -289,6 +289,8 @@ func (s *Server) StartHTTP(httpAddr, grpcAddr string) error {
 		httpHandler = staticFileMiddleware(s.cfg.StaticFilesDir, httpHandler)
 	}
 
+	// A server-level ReadTimeout would independently cap inbound file uploads.
+	// Keep it aligned with MetadataFileUploadTimeout if one is introduced.
 	s.httpServer = &http.Server{
 		Addr:    httpAddr,
 		Handler: httpHandler,

--- a/apps/console/api/server/server.go
+++ b/apps/console/api/server/server.go
@@ -235,7 +235,12 @@ func (s *Server) StartHTTP(httpAddr, grpcAddr string) error {
 	}
 
 	// Register file proxy routes
-	fileHandler := handler.NewFileHandler(s.cfg.MetadataServiceURL, s.injector, s.store)
+	fileHandler := handler.NewFileHandler(
+		s.cfg.MetadataServiceURL,
+		s.cfg.MetadataFileUploadTimeout,
+		s.injector,
+		s.store,
+	)
 	fileHandler.RegisterRoutes(mux)
 
 	// Register the Kubernetes-backed ModelAdapter BFF.


### PR DESCRIPTION
## Pull Request Description

Large multipart uploads can exceed the metadata client's 60-second timeout even when the metadata service stores the file successfully. Use a configurable upload-specific timeout while preserving the shorter timeout for regular file operations and inbound request cancellation.


## Timeout Behavior

- Upload requests use `METADATA_FILE_UPLOAD_TIMEOUT`, which defaults to `30m` and accepts any positive Go duration.
- The 30-minute default is a conservative finite ceiling intended to prevent the proxy timeout from becoming the bottleneck for large uploads. Deployments can reduce it as needed.
- The inbound request context is propagated to the metadata request, so client disconnection cancels the upload early.
- List, metadata, and download operations retain the existing 60-second timeout.
- A server-level `ReadTimeout` would independently limit inbound uploads. This dependency is documented next to the HTTP server configuration.



## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>