### PR TITLE
fix(benchmarks/client): honor per-request output_length from the workload (#2505)

### DIFF
--- a/benchmarks/client/client.py
+++ b/benchmarks/client/client.py
@@ -18,6 +18,24 @@ session_history_lock = threading.Lock()  # Use threading lock for thread safety
 pending_sessioned_requests: Dict[str, List[Tuple[Dict, float]]] = {}
 completed_sessions = asyncio.Queue()
 
+def resolve_output_tokens(request: Dict, max_output: Optional[int]) -> Tuple[Optional[int], Optional[Dict]]:
+    """Resolve how many output tokens a single request should generate.
+
+    Workloads emitted by the generator carry a per-request ``output_length``, and
+    replaying a recorded trace faithfully means honoring it instead of letting
+    every request run up to one global cap. When it is present the response is
+    pinned to exactly that many tokens (``min_tokens`` is a vLLM extension, so it
+    travels in ``extra_body``). ``--output-token-limit`` keeps its documented
+    meaning as a ceiling, and requests without a usable ``output_length`` fall
+    back to it unchanged.
+    """
+    output_length = request.get("output_length", None)
+    if not isinstance(output_length, int) or output_length <= 0:
+        return max_output, None
+    if max_output is not None:
+        output_length = min(output_length, max_output)
+    return output_length, {"min_tokens": output_length}
+
 async def send_request_streaming(client: openai.AsyncOpenAI,
                              model: str,
                              max_output: int, 
@@ -42,11 +60,13 @@ async def send_request_streaming(client: openai.AsyncOpenAI,
         if target_time > start_time:
             await asyncio.sleep(target_time - start_time)
         dispatch_time = asyncio.get_event_loop().time()
+        max_tokens, extra_body = resolve_output_tokens(request, max_output)
         response_stream = await client.chat.completions.create(
             model=model,
             messages=prompt,
             temperature=0,
-            max_tokens=max_output,
+            max_tokens=max_tokens,
+            extra_body=extra_body,
             stream=True,
             stream_options={"include_usage": True},
         )
@@ -182,11 +202,13 @@ async def send_request_batch(client: openai.AsyncOpenAI,
         if target_time > start_time:
             await asyncio.sleep(target_time - start_time)
         dispatch_time = asyncio.get_event_loop().time()
+        max_tokens, extra_body = resolve_output_tokens(request, max_output)
         response = await client.chat.completions.create(
             model=model,
             messages=prompt,
             temperature=0,
-            max_tokens=max_output,
+            max_tokens=max_tokens,
+            extra_body=extra_body,
         )
         if hasattr(response, 'response') and hasattr(response.response, 'headers'):
             target_pod = response.response.headers.get('target-pod')


### PR DESCRIPTION
Fixes #2505.

## Problem

`benchmarks/generator/workload_generator/workload_generator.py` writes a per-request `output_length` into every request it emits:

```python
current_group["requests"].append({
    "prompt": prompt,
    "prompt_length": len(tokenizer.encode(prompt_concat)),
    "output_length": output_length
})
```

But `benchmarks/client/client.py` never reads it. Both `send_request_streaming` and `send_request_batch` pass the single global `max_output` (`--output-token-limit`, default `None`) as `max_tokens` for every call. Replaying a trace that records output lengths — e.g. the Mooncake FAST25 traces — therefore cannot reproduce the recorded decode lengths, which is what makes the replay realistic in the first place.

## Change

Resolve the output budget per request instead of globally:

- When a request carries a usable `output_length`, pin the response to exactly that many tokens by sending it as both `max_tokens` and `min_tokens`.
- `min_tokens` is a vLLM extension rather than a standard OpenAI Chat Completions field, so it travels through `extra_body` (passing it as a top-level kwarg would raise `TypeError` in the OpenAI SDK).
- `--output-token-limit` keeps its documented meaning as a *ceiling*: if a trace asks for more tokens than the operator allowed, the request is clamped rather than silently exceeding the limit.
- Requests with no `output_length`, a `null` one, or a non-positive/non-integer one fall back to the previous behavior exactly.

The logic lives in one small helper so both the streaming and batch paths stay in sync.

## Verification

The `benchmarks/` tree has no pytest suite, so I exercised the helper directly against the cases the change has to get right:

| case | `--output-token-limit` | result |
|---|---|---|
| generator workload, no CLI cap | `None` | `max_tokens=512`, `min_tokens=512` |
| `output_length` under CLI cap | `256` | `max_tokens=100`, `min_tokens=100` |
| `output_length` above CLI cap | `256` | clamped to `256` / `256` |
| no `output_length` field | `256` | `max_tokens=256`, no `extra_body` |
| `output_length: null` | `256` | `max_tokens=256`, no `extra_body` |
| no field, no cap | `None` | `max_tokens=None`, no `extra_body` |
| `output_length: 0` / negative / non-int | `128` | ignored, falls back to `128` |

9/9 as expected. The fallback path passes `extra_body=None`, which is the OpenAI SDK default, so non-trace workloads issue byte-identical requests to before.

## Note for reviewers

`min_tokens` is understood by vLLM (and by the aibrix gateway in front of it) but is not part of the OpenAI spec, so a non-vLLM endpoint could reject it. It is only ever sent for requests that actually carry an `output_length`, so today that means generator-produced trace workloads. If you would rather have it behind an explicit opt-in flag (e.g. `--strict-output-length`) I am happy to rework it that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
