### PR TITLE
[Feat] Add llm-d provider support to brixbench

### DIFF
--- a/brixbench/benchmark/runner_fallback_test.go
+++ b/brixbench/benchmark/runner_fallback_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vllm-project/aibrix/brixbench/internal/deployers"
 	"github.com/vllm-project/aibrix/brixbench/internal/resolver"
 )
 
@@ -80,6 +81,7 @@ func TestResolveGatewayEndpointFailsWithoutDetectedEndpointOrOverride(t *testing
 func TestShouldRunStormServicePreflightOnlyForAIBrix(t *testing.T) {
 	aibrixProvider := "aibrix"
 	dynamoProvider := "dynamo"
+	llmdProvider := "llmd"
 	for _, tc := range []struct {
 		name string
 		test resolver.Test
@@ -93,6 +95,11 @@ func TestShouldRunStormServicePreflightOnlyForAIBrix(t *testing.T) {
 		{
 			name: "dynamo",
 			test: resolver.Test{Provider: &dynamoProvider},
+			want: false,
+		},
+		{
+			name: "llmd",
+			test: resolver.Test{Provider: &llmdProvider},
 			want: false,
 		},
 		{
@@ -140,6 +147,45 @@ func TestShouldRunDynamoStaleCleanupRequiresResetEnabled(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := shouldRunDynamoStaleCleanup(tc.test, tc.resetBefore); got != tc.want {
 				t.Fatalf("shouldRunDynamoStaleCleanup() = %t, want %t", got, tc.want)
+                        }
+                })
+        }
+}
+
+func TestBenchmarkNamespaceForProvider(t *testing.T) {
+	dynamoProvider := "dynamo"
+	llmdProvider := "llmd"
+	aibrixProvider := "aibrix"
+
+	for _, tc := range []struct {
+		name string
+		test resolver.Test
+		want string
+	}{
+		{
+			name: "dynamo",
+			test: resolver.Test{Provider: &dynamoProvider},
+			want: deployers.DynamoBenchmarkNamespace,
+		},
+		{
+			name: "llmd",
+			test: resolver.Test{Provider: &llmdProvider},
+			want: deployers.LLMdBenchmarkNamespace,
+		},
+		{
+			name: "aibrix",
+			test: resolver.Test{Provider: &aibrixProvider},
+			want: defaultBenchmarkNamespace,
+		},
+		{
+			name: "null provider",
+			test: resolver.Test{},
+			want: defaultBenchmarkNamespace,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := benchmarkNamespaceForTestCase(tc.test); got != tc.want {
+				t.Fatalf("benchmarkNamespaceForTestCase() = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/brixbench/benchmark/runner_fallback_test.go
+++ b/brixbench/benchmark/runner_fallback_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package benchmark
 
 import (
-	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/vllm-project/aibrix/brixbench/internal/deployers"
@@ -188,27 +186,5 @@ func TestBenchmarkNamespaceForProvider(t *testing.T) {
 				t.Fatalf("benchmarkNamespaceForTestCase() = %q, want %q", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestSetupAndRunDeploymentRejectsLLMdProvider(t *testing.T) {
-	provider := "llmd"
-	testCase := &resolver.Test{
-		Name:     "manual-llmd",
-		Provider: &provider,
-	}
-
-	deployer, gatewayURL, err := setupAndRunDeployment(context.Background(), t, t.TempDir(), testCase, "benchmark", t.TempDir())
-	if err == nil {
-		t.Fatalf("expected llmd not implemented error")
-	}
-	if deployer != nil {
-		t.Fatalf("expected nil deployer, got %T", deployer)
-	}
-	if gatewayURL != "" {
-		t.Fatalf("expected empty gateway URL, got %q", gatewayURL)
-	}
-	if !strings.Contains(err.Error(), "provider llmd is not implemented") {
-		t.Fatalf("expected llmd not implemented error, got %v", err)
 	}
 }

--- a/brixbench/benchmark/runner_test.go
+++ b/brixbench/benchmark/runner_test.go
@@ -178,8 +178,11 @@ func executeScenarioTestCase(t *testing.T, scenarioName string, scenarioLogRoot 
 }
 
 func benchmarkNamespaceForTestCase(testCase resolver.Test) string {
-	if testCase.ProviderName() == "dynamo" {
+	switch testCase.ProviderName() {
+	case "dynamo":
 		return deployers.DynamoBenchmarkNamespace
+	case "llmd":
+		return deployers.LLMdBenchmarkNamespace
 	}
 	return defaultBenchmarkNamespace
 }
@@ -200,7 +203,8 @@ func setupAndRunDeployment(ctx context.Context, t *testing.T, projectRoot string
 		deployer = deployers.NewAIBrixDeployer()
 		t.Log("Using AIBrix deployer")
 	case "llmd":
-		return nil, "", fmt.Errorf("provider llmd is not implemented")
+		deployer = deployers.NewLLMdDeployer()
+		t.Log("Using LLM-d deployer")
 	case "dynamo":
 		deployer = deployers.NewDynamoDeployer()
 		t.Log("Using Dynamo deployer")

--- a/brixbench/benchmark/testdata/benchmarks/routing/qwen3-8b-tc-rt-02-llmd-pd-4p4d-r8.yaml
+++ b/brixbench/benchmark/testdata/benchmarks/routing/qwen3-8b-tc-rt-02-llmd-pd-4p4d-r8.yaml
@@ -1,0 +1,37 @@
+kind: vllm-bench
+execution: cluster
+image: aibrix-public-release-cn-beijing.cr.volces.com/aibrix/vllm-bench:v0.21.0-20260521
+namespace: brixbench-llmd
+podName: vllm-bench-client
+modelHostPath: /data01/models
+rootHostPath: /root
+podResources:
+  requests:
+    cpu: "4"
+    memory: 32Gi
+artifacts:
+  resultFilename: bench_results.json
+  logDir: testdata/logs
+vllmArgs:
+  base-url: http://llmd-brixbench-epp.brixbench-llmd.svc.cluster.local:80
+  endpoint: /v1/completions
+  backend: openai
+  model: qwen3-8b
+  tokenizer: /data01/models/Qwen3-8B
+  num-prompts: 1000
+  request-rate: 8
+  concurrency: 32
+  metric-percentiles: "50,90,95,99"
+  percentile-metrics: "ttft,tpot,itl,e2el"
+  goodput:
+    - "ttft:5000"
+    - "tpot:250"
+  ignore-eos: true
+  seed: 111
+  save-detailed: true
+  ready-check-timeout-sec: 30
+  dataset-name: prefix_repetition
+  prefix-repetition-num-prefixes: 20
+  prefix-repetition-prefix-len: 6000
+  prefix-repetition-suffix-len: 2000
+  prefix-repetition-output-len: 1024

--- a/brixbench/benchmark/testdata/deployments/llmd/README.md
+++ b/brixbench/benchmark/testdata/deployments/llmd/README.md
@@ -1,0 +1,33 @@
+# llm-d Deployment Notes
+
+This directory contains Kubernetes manifests and Helm values for the Brixbench
+llm-d scenario. It does not contain container images or model artifacts.
+
+Model files are expected to already exist on the test cluster under
+`/data01/models`, and the modelserver manifest mounts that host path.
+
+## Images
+
+The llm-d Brixbench testdata uses internal registry image names. If an image is
+missing, mirror the matching upstream image before running the smoke benchmark.
+
+Modelserver image:
+
+- Source: `guides/recipes/modelserver/components/images/gpu-vllm`
+- Upstream image: `vllm/vllm-openai:v0.23.0`
+- Brixbench image: `aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llmd-vllm-openai:v0.23.0`
+
+Routing sidecar image:
+
+- Source: `guides/recipes/modelserver/components/images/routing-sidecar`
+- Upstream image: `ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0`
+- Brixbench image: `aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llmd-router-disagg-sidecar:v0.9.0`
+
+Router/EPP image:
+
+- Source: `oci://ghcr.io/llm-d/charts/llm-d-router-standalone`
+- Chart version: `v0.9.0`
+- Upstream EPP image: `ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0`
+- Brixbench EPP image: `aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llm-d-router-endpoint-picker:v0.9.0`
+- Upstream Envoy image: `docker.io/envoyproxy/envoy:distroless-v1.33.2`
+- Brixbench Envoy image: `aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/envoyproxy-envoy:distroless-v1.33.2`

--- a/brixbench/benchmark/testdata/deployments/llmd/README.md
+++ b/brixbench/benchmark/testdata/deployments/llmd/README.md
@@ -31,3 +31,41 @@ Router/EPP image:
 - Brixbench EPP image: `aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llm-d-router-endpoint-picker:v0.9.0`
 - Upstream Envoy image: `docker.io/envoyproxy/envoy:distroless-v1.33.2`
 - Brixbench Envoy image: `aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/envoyproxy-envoy:distroless-v1.33.2`
+
+## Routing Policy
+
+The checked-in llm-d scenario uses the upstream llm-d v0.8.1 P/D
+disaggregation **cache-plus-load** policy:
+
+```text
+brixbench/benchmark/testdata/deployments/llmd/router/policies/pd-disaggregation-official.yaml
+```
+
+It keeps prefill and decode endpoints separate and uses the Endpoint Picker
+(EPP) default `max-score-picker` with cache and load signals:
+
+- prefill: prefix-cache (weight 3), queue (2), KV-cache utilization (2)
+- decode: active requests (2), prefix-cache (3)
+
+The policy is selected by the scenario's ordered `controlplane` Helm values
+files:
+
+```yaml
+controlplane:
+- brixbench/benchmark/testdata/deployments/llmd/router/base-values.yaml
+- brixbench/benchmark/testdata/deployments/llmd/router/policies/pd-disaggregation-official.yaml
+```
+
+To benchmark another llm-d policy, create a new values overlay under
+`brixbench/benchmark/testdata/deployments/llmd/router/policies/` and reference
+it as the second `controlplane` file in a new scenario test under
+`brixbench/benchmark/testdata/scenarios/`. The runner passes the files to Helm
+in order, so the policy overlay replaces the EPP plugin configuration without
+changes to the deployer, modelserver manifest, or benchmark client.
+
+llm-d endpoint routing is a filter, scorer, and picker pipeline rather than a
+single `router-mode` value. In particular, `round-robin-fairness-policy`
+controls flow-control queue fairness and is not equivalent to Dynamo's
+`--router-mode round-robin`. See the [llm-d EPP scheduling
+reference](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/scheduling.md)
+for supported filters, scorers, and pickers.

--- a/brixbench/benchmark/testdata/deployments/llmd/README.md
+++ b/brixbench/benchmark/testdata/deployments/llmd/README.md
@@ -32,6 +32,34 @@ Router/EPP image:
 - Upstream Envoy image: `docker.io/envoyproxy/envoy:distroless-v1.33.2`
 - Brixbench Envoy image: `aibrix-public-release-cn-beijing.cr.volces.com/aibrix/envoyproxy-envoy:distroless-v1.33.2`
 
+## Scenario `version` vs router chart version
+
+These are intentionally separate pins for the smoke path:
+
+- Scenario YAML `version` (for example `v0.8.1`) is the **llm-d git release
+  tag**. The deployer validates that tag in the local `LLMD_REPO` checkout
+  (guides / recipe alignment). It does **not** select the Helm chart version.
+- The standalone router chart is pinned in the deployer as
+  `llmdRouterChartVersion` (`v0.9.0` today), matching the Images section above
+  and `router/base-values.yaml`.
+
+Supporting arbitrary chart versions from scenario YAML is out of scope for this
+smoke fixture; bump the deployer constant (and matching images/values) together
+when upgrading the router stack.
+
+## Engine deployment name contract
+
+`LLMdDeployer.WaitForReady` currently waits on fixed Deployment names for the
+checked-in P/D smoke manifests:
+
+- `llmd-brixbench-epp` (Helm release `llmd-brixbench`)
+- `pd-disaggregation-nvidia-gpu-vllm-prefill`
+- `pd-disaggregation-nvidia-gpu-vllm-decode`
+
+Custom engine manifests used with this provider must keep those Deployment
+names (or update the deployer constants in lockstep). Arbitrary Deployment
+name discovery is not supported yet.
+
 ## Routing Policy
 
 The checked-in llm-d scenario uses the upstream llm-d v0.8.1 P/D

--- a/brixbench/benchmark/testdata/deployments/llmd/README.md
+++ b/brixbench/benchmark/testdata/deployments/llmd/README.md
@@ -15,22 +15,22 @@ Modelserver image:
 
 - Source: `guides/recipes/modelserver/components/images/gpu-vllm`
 - Upstream image: `vllm/vllm-openai:v0.23.0`
-- Brixbench image: `aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llmd-vllm-openai:v0.23.0`
+- Brixbench image: `aibrix-public-release-cn-beijing.cr.volces.com/aibrix/llmd-vllm-openai:v0.23.0`
 
 Routing sidecar image:
 
 - Source: `guides/recipes/modelserver/components/images/routing-sidecar`
 - Upstream image: `ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0`
-- Brixbench image: `aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llmd-router-disagg-sidecar:v0.9.0`
+- Brixbench image: `aibrix-public-release-cn-beijing.cr.volces.com/aibrix/llmd-router-disagg-sidecar:v0.9.0`
 
 Router/EPP image:
 
 - Source: `oci://ghcr.io/llm-d/charts/llm-d-router-standalone`
 - Chart version: `v0.9.0`
 - Upstream EPP image: `ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0`
-- Brixbench EPP image: `aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llm-d-router-endpoint-picker:v0.9.0`
+- Brixbench EPP image: `aibrix-public-release-cn-beijing.cr.volces.com/aibrix/llm-d-router-endpoint-picker:v0.9.0`
 - Upstream Envoy image: `docker.io/envoyproxy/envoy:distroless-v1.33.2`
-- Brixbench Envoy image: `aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/envoyproxy-envoy:distroless-v1.33.2`
+- Brixbench Envoy image: `aibrix-public-release-cn-beijing.cr.volces.com/aibrix/envoyproxy-envoy:distroless-v1.33.2`
 
 ## Routing Policy
 

--- a/brixbench/benchmark/testdata/deployments/llmd/llmd-engine-vllm.yaml
+++ b/brixbench/benchmark/testdata/deployments/llmd/llmd-engine-vllm.yaml
@@ -1,0 +1,3 @@
+# Placeholder kept for compatibility with earlier llm-d scaffolding.
+# Active 4p4d vLLM P/D modelserver manifest:
+# testdata/deployments/llmd/models/qwen3-8b-pd-4p4d.yaml

--- a/brixbench/benchmark/testdata/deployments/llmd/llmd-v1.yaml
+++ b/brixbench/benchmark/testdata/deployments/llmd/llmd-v1.yaml
@@ -1,0 +1,4 @@
+# Placeholder kept for compatibility with earlier llm-d scaffolding.
+# Active router values live under:
+# - testdata/deployments/llmd/router/base-values.yaml
+# - testdata/deployments/llmd/router/policies/pd-disaggregation-official.yaml

--- a/brixbench/benchmark/testdata/deployments/llmd/models/qwen3-8b-pd-4p4d.yaml
+++ b/brixbench/benchmark/testdata/deployments/llmd/models/qwen3-8b-pd-4p4d.yaml
@@ -45,13 +45,11 @@ spec:
         llm-d.ai/engine-type: vllm
     spec:
       serviceAccountName: pd-disaggregation-nvidia-gpu-vllm-sa
-      imagePullSecrets:
-        - name: aibrix-registry-secret
       nodeSelector:
         kubernetes.io/hostname: 192.168.0.6
       containers:
         - name: modelserver
-          image: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llmd-vllm-openai:v0.23.0
+          image: aibrix-public-release-cn-beijing.cr.volces.com/aibrix/llmd-vllm-openai:v0.23.0
           command: ["vllm", "serve"]
           args:
             - "/models/Qwen3-8B"
@@ -210,13 +208,11 @@ spec:
         llm-d.ai/engine-type: vllm
     spec:
       serviceAccountName: pd-disaggregation-nvidia-gpu-vllm-sa
-      imagePullSecrets:
-        - name: aibrix-registry-secret
       nodeSelector:
         kubernetes.io/hostname: 192.168.0.6
       initContainers:
         - name: routing-proxy
-          image: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llmd-router-disagg-sidecar:v0.9.0
+          image: aibrix-public-release-cn-beijing.cr.volces.com/aibrix/llmd-router-disagg-sidecar:v0.9.0
           imagePullPolicy: Always
           restartPolicy: Always
           args:
@@ -235,7 +231,7 @@ spec:
             runAsNonRoot: true
       containers:
         - name: modelserver
-          image: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llmd-vllm-openai:v0.23.0
+          image: aibrix-public-release-cn-beijing.cr.volces.com/aibrix/llmd-vllm-openai:v0.23.0
           command: ["vllm", "serve"]
           args:
             - "/models/Qwen3-8B"

--- a/brixbench/benchmark/testdata/deployments/llmd/models/qwen3-8b-pd-4p4d.yaml
+++ b/brixbench/benchmark/testdata/deployments/llmd/models/qwen3-8b-pd-4p4d.yaml
@@ -1,0 +1,359 @@
+# Rendered-equivalent llm-d v0.8.1 P/D vLLM modelserver manifest for Brixbench.
+# Traceability:
+# - guides/pd-disaggregation/modelserver/gpu/vllm/base
+# - guides/recipes/modelserver/base/single-host/pd/vllm
+# - guides/recipes/modelserver/components/images/gpu-vllm
+# - guides/recipes/modelserver/components/images/routing-sidecar
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pd-disaggregation-nvidia-gpu-vllm-sa
+automountServiceAccountToken: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pd-disaggregation-nvidia-gpu-vllm-prefill
+  labels:
+    llm-d.ai/role: prefill
+    llm-d.ai/model: qwen3-8b
+    llm-d.ai/guide: pd-disaggregation
+    llm-d.ai/accelerator-variant: gpu
+    llm-d.ai/accelerator-vendor: nvidia
+    llm-d.ai/engine-type: vllm
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      llm-d.ai/role: prefill
+      llm-d.ai/model: qwen3-8b
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/engine-type: vllm
+  template:
+    metadata:
+      annotations:
+        k8s.volcengine.com/pod-networks: |
+          [{"cniConf":{"name":"rdma"}}]
+      labels:
+        llm-d.ai/role: prefill
+        llm-d.ai/model: qwen3-8b
+        llm-d.ai/guide: pd-disaggregation
+        llm-d.ai/accelerator-variant: gpu
+        llm-d.ai/accelerator-vendor: nvidia
+        llm-d.ai/engine-type: vllm
+    spec:
+      serviceAccountName: pd-disaggregation-nvidia-gpu-vllm-sa
+      imagePullSecrets:
+        - name: aibrix-registry-secret
+      nodeSelector:
+        kubernetes.io/hostname: 192.168.0.6
+      containers:
+        - name: modelserver
+          image: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llmd-vllm-openai:v0.23.0
+          command: ["vllm", "serve"]
+          args:
+            - "/models/Qwen3-8B"
+            - "--served-model-name=qwen3-8b"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--tensor-parallel-size=1"
+            - "--block-size=128"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - "--no-disable-hybrid-kv-cache-manager"
+            - "--max-model-len=16384"
+          env:
+            - name: USER
+              value: llm-d
+            - name: UCX_TLS
+              value: "^gga"
+            - name: GLOO_SOCKET_IFNAME
+              value: "eth0"
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0"
+            - name: NCCL_IB_DISABLE
+              value: "0"
+            - name: NCCL_IB_GID_INDEX
+              value: "7"
+            - name: NCCL_DEBUG
+              value: "INFO"
+            - name: PYTHONHASHSEED
+              value: "1047"
+            - name: VLLM_NIXL_ABORT_REQUEST_TIMEOUT
+              value: "600"
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5600"
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+              value: "120"
+            - name: VLLM_SERVER_DEV_MODE
+              value: "1"
+            - name: VLLM_USE_V1
+              value: "1"
+            - name: VLLM_ENABLE_V1_MULTIPROCESSING
+              value: "1"
+            - name: VLLM_WORKER_MULTIPROC_METHOD
+              value: "spawn"
+            - name: UCX_LOG_LEVEL
+              value: info
+            - name: NIXL_LOG_LEVEL
+              value: info
+            - name: VLLM_LOGGING_LEVEL
+              value: info
+          ports:
+            - name: modelserver
+              containerPort: 8000
+              protocol: TCP
+            - name: nixl
+              containerPort: 5600
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "8"
+              memory: 32Gi
+              nvidia.com/gpu: "1"
+              vke.volcengine.com/rdma: "1"
+            requests:
+              cpu: "8"
+              memory: 32Gi
+              nvidia.com/gpu: "1"
+          volumeMounts:
+            - mountPath: /models
+              name: model-vol
+              readOnly: true
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /.config
+              name: vllm-config
+            - mountPath: /.triton
+              name: triton-cache
+          startupProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: modelserver
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+      volumes:
+        - name: model-vol
+          hostPath:
+            path: /data01/models
+            type: Directory
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 20Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: vllm-config
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pd-disaggregation-nvidia-gpu-vllm-decode
+  labels:
+    llm-d.ai/role: decode
+    llm-d.ai/model: qwen3-8b
+    llm-d.ai/guide: pd-disaggregation
+    llm-d.ai/accelerator-variant: gpu
+    llm-d.ai/accelerator-vendor: nvidia
+    llm-d.ai/engine-type: vllm
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      llm-d.ai/role: decode
+      llm-d.ai/model: qwen3-8b
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/engine-type: vllm
+  template:
+    metadata:
+      annotations:
+        k8s.volcengine.com/pod-networks: |
+          [{"cniConf":{"name":"rdma"}}]
+      labels:
+        llm-d.ai/role: decode
+        llm-d.ai/model: qwen3-8b
+        llm-d.ai/guide: pd-disaggregation
+        llm-d.ai/accelerator-variant: gpu
+        llm-d.ai/accelerator-vendor: nvidia
+        llm-d.ai/engine-type: vllm
+    spec:
+      serviceAccountName: pd-disaggregation-nvidia-gpu-vllm-sa
+      imagePullSecrets:
+        - name: aibrix-registry-secret
+      nodeSelector:
+        kubernetes.io/hostname: 192.168.0.6
+      initContainers:
+        - name: routing-proxy
+          image: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llmd-router-disagg-sidecar:v0.9.0
+          imagePullPolicy: Always
+          restartPolicy: Always
+          args:
+            - --port=8000
+            - --vllm-port=8200
+            - --kv-connector=nixlv2
+            - --zap-log-level=1
+            - --secure-proxy=false
+          ports:
+            - containerPort: 8000
+              name: sidecar
+              protocol: TCP
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+      containers:
+        - name: modelserver
+          image: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/llmd-vllm-openai:v0.23.0
+          command: ["vllm", "serve"]
+          args:
+            - "/models/Qwen3-8B"
+            - "--served-model-name=qwen3-8b"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--tensor-parallel-size=1"
+            - "--block-size=128"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - "--no-disable-hybrid-kv-cache-manager"
+            - "--max-model-len=16384"
+            - "--port=8200"
+          env:
+            - name: USER
+              value: llm-d
+            - name: UCX_TLS
+              value: "^gga"
+            - name: GLOO_SOCKET_IFNAME
+              value: "eth0"
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0"
+            - name: NCCL_IB_DISABLE
+              value: "0"
+            - name: NCCL_IB_GID_INDEX
+              value: "7"
+            - name: NCCL_DEBUG
+              value: "INFO"
+            - name: PYTHONHASHSEED
+              value: "1047"
+            - name: VLLM_NIXL_ABORT_REQUEST_TIMEOUT
+              value: "600"
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5600"
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VLLM_SERVER_DEV_MODE
+              value: "1"
+            - name: VLLM_USE_V1
+              value: "1"
+            - name: VLLM_ENABLE_V1_MULTIPROCESSING
+              value: "1"
+            - name: VLLM_WORKER_MULTIPROC_METHOD
+              value: "spawn"
+            - name: UCX_LOG_LEVEL
+              value: info
+            - name: NIXL_LOG_LEVEL
+              value: info
+            - name: VLLM_LOGGING_LEVEL
+              value: info
+          ports:
+            - name: modelserver
+              containerPort: 8200
+              protocol: TCP
+            - name: nixl
+              containerPort: 5600
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "8"
+              memory: 32Gi
+              nvidia.com/gpu: "1"
+              vke.volcengine.com/rdma: "1"
+            requests:
+              cpu: "8"
+              memory: 32Gi
+              nvidia.com/gpu: "1"
+          volumeMounts:
+            - mountPath: /models
+              name: model-vol
+              readOnly: true
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /.config
+              name: vllm-config
+            - mountPath: /.triton
+              name: triton-cache
+          startupProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: modelserver
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+      volumes:
+        - name: model-vol
+          hostPath:
+            path: /data01/models
+            type: Directory
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 20Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: vllm-config
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}

--- a/brixbench/benchmark/testdata/deployments/llmd/router/base-values.yaml
+++ b/brixbench/benchmark/testdata/deployments/llmd/router/base-values.yaml
@@ -3,7 +3,7 @@ router:
   epp:
     replicas: 1
     image:
-      registry: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix
+      registry: aibrix-public-release-cn-beijing.cr.volces.com/aibrix
       repository: llm-d-router-endpoint-picker
       tag: v0.9.0
       pullPolicy: IfNotPresent
@@ -24,7 +24,7 @@ router:
     protocol: http
 
   proxy:
-    image: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/envoyproxy-envoy:distroless-v1.33.2
+    image: aibrix-public-release-cn-beijing.cr.volces.com/aibrix/envoyproxy-envoy:distroless-v1.33.2
     args:
       - "--service-node"
       - "envoy-sidecar"

--- a/brixbench/benchmark/testdata/deployments/llmd/router/base-values.yaml
+++ b/brixbench/benchmark/testdata/deployments/llmd/router/base-values.yaml
@@ -1,0 +1,52 @@
+## Derived from llm-d v0.8.1 guides/recipes/router/base.values.yaml.
+router:
+  epp:
+    replicas: 1
+    image:
+      registry: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix
+      repository: llm-d-router-endpoint-picker
+      tag: v0.9.0
+      pullPolicy: IfNotPresent
+    flags:
+      v: 2
+    pluginsConfigFile: "default-plugins.yaml"
+    resources:
+      requests:
+        cpu: "4"
+        memory: 8Gi
+      limits:
+        memory: 16Gi
+
+  inferencePool:
+    failureMode: "FailOpen"
+
+  modelServers:
+    protocol: http
+
+  proxy:
+    image: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/envoyproxy-envoy:distroless-v1.33.2
+    args:
+      - "--service-node"
+      - "envoy-sidecar"
+      - "--log-level"
+      - "warn"
+      - "--concurrency"
+      - "8"
+      - "--drain-strategy"
+      - "immediate"
+      - "--drain-time-s"
+      - "60"
+      - "-c"
+      - "/etc/envoy/envoy.yaml"
+    resources:
+      requests:
+        cpu: "4"
+        memory: 8Gi
+      limits:
+        memory: 16Gi
+
+  tracing:
+    otelExporterEndpoint: "http://localhost:4317"
+    sampling:
+      sampler: "parentbased_traceidratio"
+      samplerArg: "0.1"

--- a/brixbench/benchmark/testdata/deployments/llmd/router/policies/pd-disaggregation-official.yaml
+++ b/brixbench/benchmark/testdata/deployments/llmd/router/policies/pd-disaggregation-official.yaml
@@ -1,0 +1,47 @@
+## Derived from llm-d v0.8.1 guides/pd-disaggregation/router/pd-disaggregation.values.yaml.
+router:
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+
+  epp:
+    pluginsConfigFile: "pd-config.yaml"
+    pluginsCustomConfig:
+      pd-config.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: disagg-headers-handler
+        - type: always-disagg-pd-decider
+        - type: disagg-profile-handler
+          parameters:
+            deciderPluginName: always-disagg-pd-decider
+        - type: prefill-filter
+        - type: decode-filter
+        - type: prefix-cache-scorer
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: active-request-scorer
+        schedulingProfiles:
+        - name: prefill
+          plugins:
+          - pluginRef: prefill-filter
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+        - name: decode
+          plugins:
+          - pluginRef: decode-filter
+          - pluginRef: active-request-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+
+  modelServers:
+    matchLabels:
+      llm-d.ai/guide: "pd-disaggregation"

--- a/brixbench/benchmark/testdata/scenarios/llmd-routing-qwen3-8b-v0.8.1.yaml
+++ b/brixbench/benchmark/testdata/scenarios/llmd-routing-qwen3-8b-v0.8.1.yaml
@@ -1,0 +1,13 @@
+# Benchmarks Qwen3-8B PD routing through llm-d v0.8.1 standalone router.
+Scenario: llmd-routing-qwen3-8b-v0.8.1
+Tests:
+- name: lat-tc-rt-02-llmd-pd-4p4d-r8
+  provider: llmd
+  version: v0.8.1
+  controlplane:
+  - testdata/deployments/llmd/router/base-values.yaml
+  - testdata/deployments/llmd/router/policies/pd-disaggregation-official.yaml
+  engine:
+    type: vllm
+    manifest: testdata/deployments/llmd/models/qwen3-8b-pd-4p4d.yaml
+  benchmark: testdata/benchmarks/routing/qwen3-8b-tc-rt-02-llmd-pd-4p4d-r8.yaml

--- a/brixbench/internal/deployers/aibrix_source.go
+++ b/brixbench/internal/deployers/aibrix_source.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package deployers
 
 import (

--- a/brixbench/internal/deployers/dynamo_artifacts.go
+++ b/brixbench/internal/deployers/dynamo_artifacts.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package deployers
 
 import (

--- a/brixbench/internal/deployers/dynamo_release.go
+++ b/brixbench/internal/deployers/dynamo_release.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package deployers
 
 import (

--- a/brixbench/internal/deployers/dynamo_test.go
+++ b/brixbench/internal/deployers/dynamo_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package deployers
 
 import (

--- a/brixbench/internal/deployers/llmd.go
+++ b/brixbench/internal/deployers/llmd.go
@@ -18,50 +18,566 @@ package deployers
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 )
 
-// LLMdDeployer is a placeholder deployer for future LLM-d support.
+const llmdRouterHelmReleaseName = "llmd-brixbench"
+const LLMdBenchmarkNamespace = "brixbench-llmd"
+const llmdRouterChart = "oci://ghcr.io/llm-d/charts/llm-d-router-standalone"
+const llmdRouterChartVersion = "v0.9.0"
+const llmdGAIEVersion = "v1.5.0"
+const llmdGAIEManifestURL = "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/v1-manifests.yaml"
+const llmdDefaultRepoPath = "/home/jinhyu.kim/workspace/Setup_Benchmark/llm-d"
+const llmdReadinessTimeout = 10 * time.Minute
+const llmdReadinessPollInterval = 5 * time.Second
+const llmdHelmStateDirName = "llmd-helm"
+const llmdRegistrySecretName = "aibrix-registry-secret"
+const llmdRegistryServer = "aibrix-container-registry-cn-beijing.cr.volces.com"
+const llmdRouterDeploymentName = llmdRouterHelmReleaseName + "-epp"
+const llmdRouterServiceName = llmdRouterHelmReleaseName + "-epp"
+const llmdModelDeploymentPrefix = "pd-disaggregation-nvidia-gpu-vllm-"
+const llmdDecodeDeploymentName = llmdModelDeploymentPrefix + "decode"
+const llmdPrefillDeploymentName = llmdModelDeploymentPrefix + "prefill"
+
+// LLMdDeployer deploys llm-d standalone router and user-provided vLLM manifests.
 type LLMdDeployer struct {
-	namespace string
+	namespace         string
+	logDir            string
+	projectRoot       string
+	version           string
+	engineManifest    string
+	controlPlanePaths []string
+	llmdRepoPath      string
+	registrySecret    bool
+	runner            commandRunner
 }
 
 var _ Deployer = (*LLMdDeployer)(nil)
 
-// NewLLMdDeployer creates a placeholder deployer for LLM-d.
+// NewLLMdDeployer creates a release-based LLM-d deployer.
 func NewLLMdDeployer() *LLMdDeployer {
-	return &LLMdDeployer{}
+	return &LLMdDeployer{
+		runner: execCommandRunner{},
+	}
 }
 
 func (d *LLMdDeployer) Initialize(ctx context.Context, config Config) error {
-	d.namespace = config.Namespace
+	if d.runner == nil {
+		d.runner = execCommandRunner{}
+	}
+
+	d.namespace = LLMdBenchmarkNamespace
+	d.logDir = strings.TrimSpace(config.LogDir)
+	d.projectRoot = strings.TrimSpace(config.ProjectRoot)
+	d.engineManifest = strings.TrimSpace(config.EnginePath)
+	d.controlPlanePaths = trimStringSlice(config.ControlPlanePaths)
+	d.llmdRepoPath = strings.TrimSpace(os.Getenv("LLMD_REPO"))
+	if d.llmdRepoPath == "" {
+		d.llmdRepoPath = llmdDefaultRepoPath
+	}
+	if config.TestCase != nil {
+		d.version = strings.TrimSpace(config.TestCase.Version)
+		if d.engineManifest == "" {
+			d.engineManifest = strings.TrimSpace(config.TestCase.Engine.Manifest)
+		}
+		if len(d.controlPlanePaths) == 0 {
+			d.controlPlanePaths = trimStringSlice(config.TestCase.ControlPlane)
+		}
+	}
+
+	if d.version == "" {
+		return fmt.Errorf("LLM-d deployer requires version")
+	}
+	if d.namespace == "" {
+		return fmt.Errorf("LLM-d deployer requires namespace")
+	}
+	if d.projectRoot == "" {
+		return fmt.Errorf("LLM-d deployer requires project root")
+	}
+	if d.engineManifest == "" {
+		return fmt.Errorf("LLM-d deployer requires engine manifest")
+	}
+	if !pathExists(d.engineManifest) {
+		return fmt.Errorf("LLM-d engine manifest %s was not found", d.engineManifest)
+	}
+	if len(d.controlPlanePaths) == 0 {
+		return fmt.Errorf("LLM-d deployer requires router values files in controlplane")
+	}
+	for _, path := range d.controlPlanePaths {
+		if !pathExists(path) {
+			return fmt.Errorf("LLM-d controlplane values file %s was not found", path)
+		}
+	}
+	_ = ctx
 	return nil
 }
 
 func (d *LLMdDeployer) DeployControlPlane(ctx context.Context) error {
-	return fmt.Errorf("LLM-d deployer is not implemented")
+	if err := d.ensureLLMdRuntimePrerequisites(ctx); err != nil {
+		return err
+	}
+	if err := d.validateLLMdReleaseTag(ctx); err != nil {
+		return err
+	}
+	if err := d.runLLMdCommand(ctx, "apply-llmd-gaie-crds", "kubectl", "apply", "-f", llmdGAIEManifestURL); err != nil {
+		return err
+	}
+	return d.installLLMdRouter(ctx)
 }
 
 func (d *LLMdDeployer) DeployGateway(ctx context.Context) error {
-	return fmt.Errorf("LLM-d deployer is not implemented")
+	return nil
 }
 
 func (d *LLMdDeployer) DeployEngine(ctx context.Context) error {
-	return fmt.Errorf("LLM-d deployer is not implemented")
+	if strings.TrimSpace(d.engineManifest) == "" {
+		return fmt.Errorf("LLM-d deployer requires engine manifest")
+	}
+	return d.runLLMdCommand(ctx, "apply-llmd-engine", "kubectl", "apply", "-n", d.namespace, "-f", d.engineManifest)
 }
 
 func (d *LLMdDeployer) WaitForReady(ctx context.Context) error {
-	return fmt.Errorf("LLM-d deployer is not implemented")
+	for _, deployment := range []string{llmdRouterDeploymentName, llmdDecodeDeploymentName, llmdPrefillDeploymentName} {
+		if err := d.waitForLLMdDeploymentReady(ctx, deployment); err != nil {
+			return err
+		}
+	}
+	if _, _, err := d.waitForLLMdRouterService(ctx, llmdReadinessTimeout, llmdReadinessPollInterval); err != nil {
+		return fmt.Errorf("LLM-d router service is not ready: %w", err)
+	}
+	return nil
 }
 
 func (d *LLMdDeployer) GetGatewayEndpoint(ctx context.Context) (string, error) {
-	return "", fmt.Errorf("LLM-d deployer is not implemented")
+	service, port, err := d.resolveLLMdRouterService(ctx)
+	if err != nil {
+		return "", err
+	}
+	host := strings.TrimSpace(service.ClusterIP)
+	if host == "" || strings.EqualFold(host, "None") {
+		host = fmt.Sprintf("%s.%s.svc.cluster.local", service.Name, d.namespace)
+	}
+	return fmt.Sprintf("http://%s:%d", host, port), nil
 }
 
 func (d *LLMdDeployer) CaptureArtifacts(ctx context.Context) error {
+	if strings.TrimSpace(d.logDir) == "" {
+		return nil
+	}
+	if d.runner == nil {
+		d.runner = execCommandRunner{}
+	}
+
+	namespace := strings.TrimSpace(d.namespace)
+	if namespace == "" {
+		return nil
+	}
+	artifactDir := filepath.Join(d.logDir, "llmd-artifacts")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create LLM-d artifact directory %s: %w", artifactDir, err)
+	}
+
+	for _, capture := range d.llmdArtifactCaptures(namespace) {
+		output, err := d.captureLLMdCommand(ctx, capture.stage, capture.name, capture.args...)
+		if err != nil {
+			output = fmt.Sprintf("capture failed: %v\n", err)
+		}
+		if err := os.WriteFile(filepath.Join(artifactDir, capture.file), []byte(output), 0o644); err != nil {
+			return err
+		}
+	}
+
+	helmStatus, err := d.captureLLMdHelmCommand(ctx, "capture-llmd-helm-status", "status", llmdRouterHelmReleaseName, "-n", namespace)
+	if err != nil {
+		helmStatus = fmt.Sprintf("capture failed: %v\n", err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactDir, "helm-status.txt"), []byte(helmStatus), 0o644); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(d.engineManifest) != "" {
+		content, err := os.ReadFile(d.engineManifest)
+		if err != nil {
+			content = []byte(fmt.Sprintf("capture failed: failed to read LLM-d engine manifest %s: %v\n", d.engineManifest, err))
+		}
+		if err := os.WriteFile(filepath.Join(artifactDir, "engine-manifest.yaml"), content, 0o644); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
 func (d *LLMdDeployer) Teardown(ctx context.Context) error {
-	return fmt.Errorf("LLM-d deployer is not implemented")
+	namespace := strings.TrimSpace(d.namespace)
+	var criticalErrs []error
+	addCriticalErr := func(err error) {
+		if err != nil {
+			criticalErrs = append(criticalErrs, err)
+		}
+	}
+	addCriticalErrUnlessNotFound := func(err error) {
+		if err != nil && !isDynamoCleanupNotFoundError(err) {
+			criticalErrs = append(criticalErrs, err)
+		}
+	}
+	if strings.TrimSpace(d.engineManifest) != "" && namespace != "" {
+		addCriticalErr(d.runLLMdCleanupCommand(ctx, "delete-llmd-engine", "kubectl", "delete", "-n", namespace, "-f", d.engineManifest, "--ignore-not-found", "--wait=false"))
+		addCriticalErrUnlessNotFound(d.runLLMdCleanupCommand(ctx, "wait-delete-llmd-engine", "kubectl", "wait", "--for=delete", "-n", namespace, "-f", d.engineManifest, "--timeout=2m"))
+	}
+	if namespace != "" {
+		addCriticalErr(d.runLLMdHelmCleanupCommand(ctx, "uninstall-llmd-router", "uninstall", llmdRouterHelmReleaseName, "-n", namespace, "--ignore-not-found", "--wait", "--timeout", "5m"))
+		addCriticalErr(d.runLLMdCleanupCommand(ctx, "delete-llmd-namespace", "kubectl", "delete", "namespace", namespace, "--ignore-not-found"))
+		addCriticalErr(d.runLLMdCleanupCommand(ctx, "wait-delete-llmd-namespace", "kubectl", "wait", "--for=delete", "namespace/"+namespace, "--timeout=10m"))
+	}
+	return errors.Join(criticalErrs...)
+}
+
+func (d *LLMdDeployer) ensureLLMdRuntimePrerequisites(ctx context.Context) error {
+	if err := d.runLLMdCommand(ctx, "ensure-llmd-namespace", "bash", "-lc", fmt.Sprintf("kubectl create namespace %s --dry-run=client -o yaml | kubectl apply -f -", shellQuote(d.namespace))); err != nil {
+		return err
+	}
+	registrySecret, err := d.ensureLLMdImagePullSecret(ctx)
+	if err != nil {
+		return err
+	}
+	d.registrySecret = registrySecret
+	return nil
+}
+
+func (d *LLMdDeployer) ensureLLMdImagePullSecret(ctx context.Context) (bool, error) {
+	err := d.runLLMdCommand(ctx, "check-llmd-registry-secret", "kubectl", "get", "secret", llmdRegistrySecretName, "-n", d.namespace)
+	if err == nil {
+		return true, nil
+	}
+
+	username := strings.TrimSpace(os.Getenv("LLMD_REGISTRY_USERNAME"))
+	password := os.Getenv("LLMD_REGISTRY_PASSWORD")
+	if username == "" && password == "" {
+		fmt.Printf("Warning: LLM-d image pull secret %s is missing in namespace %s; continuing without imagePullSecrets\n", llmdRegistrySecretName, d.namespace)
+		return false, nil
+	}
+	if username == "" || password == "" {
+		return false, fmt.Errorf("LLM-d image pull secret %s is missing in namespace %s; set both LLMD_REGISTRY_USERNAME and LLMD_REGISTRY_PASSWORD or unset both to run without imagePullSecrets", llmdRegistrySecretName, d.namespace)
+	}
+
+	command := fmt.Sprintf(
+		"kubectl create secret docker-registry %s --docker-server=%s --docker-username=\"$LLMD_REGISTRY_USERNAME\" --docker-password=\"$LLMD_REGISTRY_PASSWORD\" -n %s --dry-run=client -o yaml | kubectl apply -f -",
+		shellQuote(llmdRegistrySecretName),
+		shellQuote(llmdRegistryServer),
+		shellQuote(d.namespace),
+	)
+	if err := d.runLLMdCommand(ctx, "create-llmd-registry-secret", "bash", "-lc", command); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (d *LLMdDeployer) validateLLMdReleaseTag(ctx context.Context) error {
+	repoPath := strings.TrimSpace(d.llmdRepoPath)
+	if repoPath == "" || !dirExists(repoPath) {
+		return fmt.Errorf("LLM-d repo path %s was not found; set LLMD_REPO to a local llm-d checkout", repoPath)
+	}
+	output, err := d.captureLLMdCommand(ctx, "validate-llmd-release-tag", "git", "-C", repoPath, "rev-parse", d.version+"^{tag}")
+	if err != nil {
+		return fmt.Errorf("failed to validate LLM-d release tag %s in %s: %w", d.version, repoPath, err)
+	}
+	if strings.TrimSpace(output) == "" {
+		return fmt.Errorf("LLM-d release tag %s was not found in %s", d.version, repoPath)
+	}
+	return nil
+}
+
+func (d *LLMdDeployer) installLLMdRouter(ctx context.Context) error {
+	args := []string{
+		"upgrade", "--install", llmdRouterHelmReleaseName, llmdRouterChart,
+		"-n", d.namespace,
+		"--create-namespace",
+		"--version", llmdRouterChartVersion,
+	}
+	for _, valuesFile := range d.controlPlanePaths {
+		args = append(args, "-f", valuesFile)
+	}
+	if err := d.runLLMdHelmCommand(ctx, "helm-install-llmd-router", args...); err != nil {
+		return err
+	}
+	if d.registrySecret {
+		if err := d.patchLLMdRouterImagePullSecret(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *LLMdDeployer) patchLLMdRouterImagePullSecret(ctx context.Context) error {
+	patch := fmt.Sprintf(`{"imagePullSecrets":[{"name":%q}]}`, llmdRegistrySecretName)
+	if err := d.runLLMdCommand(ctx, "patch-llmd-router-serviceaccount-image-pull-secret", "kubectl", "patch", "serviceaccount", llmdRouterDeploymentName, "-n", d.namespace, "--type=merge", "-p", patch); err != nil {
+		return err
+	}
+	return d.runLLMdCommand(ctx, "restart-llmd-router-after-image-pull-secret", "kubectl", "rollout", "restart", "deployment/"+llmdRouterDeploymentName, "-n", d.namespace)
+}
+
+func (d *LLMdDeployer) waitForLLMdDeploymentReady(ctx context.Context, deployment string) error {
+	if err := d.runLLMdCommand(ctx, "rollout-llmd-"+deployment, "kubectl", "rollout", "status", "deployment/"+deployment, "-n", d.namespace, "--timeout=10m"); err != nil {
+		return fmt.Errorf("LLM-d deployment %s is not ready: %w", deployment, err)
+	}
+	return nil
+}
+
+func (d *LLMdDeployer) waitForLLMdRouterService(ctx context.Context, timeout time.Duration, interval time.Duration) (llmdService, int, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		service, port, err := d.resolveLLMdRouterService(ctx)
+		if err == nil {
+			return service, port, nil
+		}
+		lastErr = err
+		if err := sleepOrContextDone(ctx, interval); err != nil {
+			return llmdService{}, 0, err
+		}
+	}
+	if lastErr != nil {
+		return llmdService{}, 0, lastErr
+	}
+	return llmdService{}, 0, fmt.Errorf("timed out waiting for LLM-d router service")
+}
+
+func (d *LLMdDeployer) resolveLLMdRouterService(ctx context.Context) (llmdService, int, error) {
+	output, err := d.captureLLMdCommand(ctx, "get-llmd-router-service", "kubectl", "get", "svc", llmdRouterServiceName, "-n", d.namespace, "-o", "json")
+	if err != nil {
+		return llmdService{}, 0, err
+	}
+	service, err := parseLLMdService(output)
+	if err != nil {
+		return llmdService{}, 0, err
+	}
+	port, err := selectLLMdRouterServicePort(service)
+	if err != nil {
+		return llmdService{}, 0, err
+	}
+	return service, port, nil
+}
+
+type llmdService struct {
+	Name      string
+	ClusterIP string
+	Ports     []int
+}
+
+func parseLLMdService(output string) (llmdService, error) {
+	var service struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+		Spec struct {
+			ClusterIP string `json:"clusterIP"`
+			Ports     []struct {
+				Port int `json:"port"`
+			} `json:"ports"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal([]byte(output), &service); err != nil {
+		return llmdService{}, fmt.Errorf("failed to parse LLM-d router service: %w", err)
+	}
+	if strings.TrimSpace(service.Metadata.Name) == "" {
+		return llmdService{}, fmt.Errorf("LLM-d router service has no metadata.name")
+	}
+	ports := make([]int, 0, len(service.Spec.Ports))
+	for _, port := range service.Spec.Ports {
+		ports = append(ports, port.Port)
+	}
+	return llmdService{Name: service.Metadata.Name, ClusterIP: service.Spec.ClusterIP, Ports: ports}, nil
+}
+
+func selectLLMdRouterServicePort(service llmdService) (int, error) {
+	for _, port := range service.Ports {
+		if port == 80 {
+			return port, nil
+		}
+	}
+	for _, port := range service.Ports {
+		if port == 8081 {
+			return port, nil
+		}
+	}
+	if len(service.Ports) == 1 {
+		return service.Ports[0], nil
+	}
+	return 0, fmt.Errorf("LLM-d router service %s has no HTTP port 80 or 8081", service.Name)
+}
+
+type llmdArtifactCapture struct {
+	file  string
+	stage string
+	name  string
+	args  []string
+}
+
+func (d *LLMdDeployer) llmdArtifactCaptures(namespace string) []llmdArtifactCapture {
+	return []llmdArtifactCapture{
+		{file: "pods.yaml", stage: "capture-llmd-pods", name: "kubectl", args: []string{"get", "pods", "-n", namespace, "-o", "yaml"}},
+		{file: "services.yaml", stage: "capture-llmd-services", name: "kubectl", args: []string{"get", "services", "-n", namespace, "-o", "yaml"}},
+		{file: "endpoints.yaml", stage: "capture-llmd-endpoints", name: "kubectl", args: []string{"get", "endpoints", "-n", namespace, "-o", "yaml"}},
+		{file: "events.yaml", stage: "capture-llmd-events", name: "kubectl", args: []string{"get", "events", "-n", namespace, "--sort-by=.lastTimestamp", "-o", "yaml"}},
+		{file: "deployments.yaml", stage: "capture-llmd-deployments", name: "kubectl", args: []string{"get", "deployments", "-n", namespace, "-o", "yaml"}},
+		{file: "inferencepools.yaml", stage: "capture-llmd-inferencepools", name: "kubectl", args: []string{"get", "inferencepools.inference.networking.x-k8s.io", "-n", namespace, "-o", "yaml"}},
+		{file: "router-logs.txt", stage: "capture-llmd-router-logs", name: "kubectl", args: []string{"logs", "-n", namespace, "deployment/" + llmdRouterDeploymentName, "--all-containers=true", "--prefix=true", "--tail=-1"}},
+		{file: "modelserver-logs.txt", stage: "capture-llmd-modelserver-logs", name: "kubectl", args: []string{"logs", "-n", namespace, "-l", "llm-d.ai/guide=pd-disaggregation", "--all-containers=true", "--prefix=true", "--tail=-1"}},
+	}
+}
+
+func (d *LLMdDeployer) runLLMdCommand(ctx context.Context, stage string, name string, args ...string) error {
+	startedAt := time.Now()
+	output, err := d.runner.Run(ctx, name, args...)
+	finishedAt := time.Now()
+
+	if logErr := d.writeLLMdCommandLog(stage, name, args, startedAt, finishedAt, commandExitCode(err), output); logErr != nil && err == nil {
+		return logErr
+	}
+	if err != nil {
+		output = strings.TrimSpace(output)
+		if output != "" {
+			return fmt.Errorf("%s failed: %w: %s", stage, err, output)
+		}
+		return fmt.Errorf("%s failed: %w", stage, err)
+	}
+	return nil
+}
+
+func (d *LLMdDeployer) captureLLMdCommand(ctx context.Context, stage string, name string, args ...string) (string, error) {
+	startedAt := time.Now()
+	output, err := d.runner.Run(ctx, name, args...)
+	finishedAt := time.Now()
+
+	if logErr := d.writeLLMdCommandLog(stage, name, args, startedAt, finishedAt, commandExitCode(err), output); logErr != nil && err == nil {
+		return "", logErr
+	}
+	if err != nil {
+		output = strings.TrimSpace(output)
+		if output != "" {
+			return output, fmt.Errorf("%s failed: %w: %s", stage, err, output)
+		}
+		return output, fmt.Errorf("%s failed: %w", stage, err)
+	}
+	return output, nil
+}
+
+func (d *LLMdDeployer) runLLMdCleanupCommand(ctx context.Context, stage string, name string, args ...string) error {
+	if d.runner == nil {
+		d.runner = execCommandRunner{}
+	}
+	if strings.TrimSpace(name) == "" {
+		return nil
+	}
+	if err := d.runLLMdCommand(ctx, stage, name, args...); err != nil {
+		fmt.Printf("Warning: LLM-d cleanup step %s failed: %v\n", stage, err)
+		return err
+	}
+	return nil
+}
+
+func (d *LLMdDeployer) runLLMdHelmCommand(ctx context.Context, stage string, args ...string) error {
+	name, commandArgs, err := d.llmdHelmCommand(args...)
+	if err != nil {
+		return err
+	}
+	return d.runLLMdCommand(ctx, stage, name, commandArgs...)
+}
+
+func (d *LLMdDeployer) captureLLMdHelmCommand(ctx context.Context, stage string, args ...string) (string, error) {
+	name, commandArgs, err := d.llmdHelmCommand(args...)
+	if err != nil {
+		return "", err
+	}
+	return d.captureLLMdCommand(ctx, stage, name, commandArgs...)
+}
+
+func (d *LLMdDeployer) runLLMdHelmCleanupCommand(ctx context.Context, stage string, args ...string) error {
+	if d.runner == nil {
+		d.runner = execCommandRunner{}
+	}
+	if err := d.runLLMdHelmCommand(ctx, stage, args...); err != nil {
+		fmt.Printf("Warning: LLM-d cleanup step %s failed: %v\n", stage, err)
+		return err
+	}
+	return nil
+}
+
+func (d *LLMdDeployer) llmdHelmCommand(args ...string) (string, []string, error) {
+	envArgs, err := d.llmdHelmEnvArgs()
+	if err != nil {
+		return "", nil, err
+	}
+	commandArgs := append(envArgs, "helm")
+	commandArgs = append(commandArgs, args...)
+	return "env", commandArgs, nil
+}
+
+func (d *LLMdDeployer) llmdHelmEnvArgs() ([]string, error) {
+	stateDir := filepath.Join(strings.TrimSpace(d.projectRoot), ".tmp", llmdHelmStateDirName)
+	if strings.TrimSpace(d.projectRoot) == "" {
+		return nil, fmt.Errorf("LLM-d deployer requires project root")
+	}
+	configDir := filepath.Join(stateDir, "config")
+	cacheDir := filepath.Join(stateDir, "cache")
+	dataDir := filepath.Join(stateDir, "data")
+	repositoryCacheDir := filepath.Join(cacheDir, "repository")
+	for _, dir := range []string{configDir, cacheDir, dataDir, repositoryCacheDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("failed to create LLM-d Helm state directory %s: %w", dir, err)
+		}
+	}
+	return []string{
+		"HELM_CONFIG_HOME=" + configDir,
+		"HELM_CACHE_HOME=" + cacheDir,
+		"HELM_DATA_HOME=" + dataDir,
+		"HELM_REPOSITORY_CONFIG=" + filepath.Join(configDir, "repositories.yaml"),
+		"HELM_REPOSITORY_CACHE=" + repositoryCacheDir,
+	}, nil
+}
+
+func (d *LLMdDeployer) writeLLMdCommandLog(stage string, name string, args []string, startedAt time.Time, finishedAt time.Time, exitCode int, output string) error {
+	if strings.TrimSpace(d.logDir) == "" {
+		return nil
+	}
+	logDir := filepath.Join(d.logDir, "commands")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create LLM-d command log directory: %w", err)
+	}
+
+	logPath := filepath.Join(logDir, fmt.Sprintf("%s.log", sanitizeDynamoCommandStage(stage)))
+	content := strings.Builder{}
+	content.WriteString("command: ")
+	content.WriteString(formatExecCommand(name, args...))
+	content.WriteString("\n")
+	content.WriteString("startedAt: ")
+	content.WriteString(startedAt.Format(time.RFC3339Nano))
+	content.WriteString("\n")
+	content.WriteString("finishedAt: ")
+	content.WriteString(finishedAt.Format(time.RFC3339Nano))
+	content.WriteString("\n")
+	content.WriteString(fmt.Sprintf("exitCode: %d\n", exitCode))
+	content.WriteString("\noutput:\n")
+	content.WriteString(output)
+	if output != "" && !strings.HasSuffix(output, "\n") {
+		content.WriteString("\n")
+	}
+	return os.WriteFile(logPath, []byte(content.String()), 0o644)
+}
+
+func trimStringSlice(values []string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			result = append(result, value)
+		}
+	}
+	return result
 }

--- a/brixbench/internal/deployers/llmd.go
+++ b/brixbench/internal/deployers/llmd.go
@@ -299,6 +299,7 @@ func (d *LLMdDeployer) installLLMdRouter(ctx context.Context) error {
 		"-n", d.namespace,
 		"--create-namespace",
 		"--version", llmdRouterChartVersion,
+		"--set", "router.monitoring.prometheus.auth.enabled=false",
 	}
 	for _, valuesFile := range d.controlPlanePaths {
 		args = append(args, "-f", valuesFile)

--- a/brixbench/internal/deployers/llmd.go
+++ b/brixbench/internal/deployers/llmd.go
@@ -33,7 +33,7 @@ const llmdRouterChart = "oci://ghcr.io/llm-d/charts/llm-d-router-standalone"
 const llmdRouterChartVersion = "v0.9.0"
 const llmdGAIEVersion = "v1.5.0"
 const llmdGAIEManifestURL = "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/v1-manifests.yaml"
-const llmdDefaultRepoPath = "/home/jinhyu.kim/workspace/Setup_Benchmark/llm-d"
+const llmdDefaultRepoPath = "../llm-d"
 const llmdReadinessTimeout = 10 * time.Minute
 const llmdReadinessPollInterval = 5 * time.Second
 const llmdHelmStateDirName = "llmd-helm"
@@ -80,6 +80,9 @@ func (d *LLMdDeployer) Initialize(ctx context.Context, config Config) error {
 	d.llmdRepoPath = strings.TrimSpace(os.Getenv("LLMD_REPO"))
 	if d.llmdRepoPath == "" {
 		d.llmdRepoPath = llmdDefaultRepoPath
+	}
+	if d.llmdRepoPath != "" && !filepath.IsAbs(d.llmdRepoPath) && d.projectRoot != "" {
+		d.llmdRepoPath = filepath.Clean(filepath.Join(d.projectRoot, d.llmdRepoPath))
 	}
 	if config.TestCase != nil {
 		d.version = strings.TrimSpace(config.TestCase.Version)

--- a/brixbench/internal/deployers/llmd_test.go
+++ b/brixbench/internal/deployers/llmd_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package deployers
 
 import (

--- a/brixbench/internal/deployers/llmd_test.go
+++ b/brixbench/internal/deployers/llmd_test.go
@@ -1,0 +1,33 @@
+package deployers
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInstallLLMdRouterDisablesEPPMetricsAuth(t *testing.T) {
+	runner := &fakeCommandRunner{}
+	deployer := &LLMdDeployer{
+		namespace:   LLMdBenchmarkNamespace,
+		projectRoot: t.TempDir(),
+		runner:      runner,
+	}
+
+	if err := deployer.installLLMdRouter(context.Background()); err != nil {
+		t.Fatalf("installLLMdRouter returned error: %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected one Helm command, got %d", len(runner.calls))
+	}
+	if runner.calls[0].name != "env" {
+		t.Fatalf("expected Helm command to run through env, got %q", runner.calls[0].name)
+	}
+
+	args := runner.calls[0].args
+	for index := 0; index < len(args)-1; index++ {
+		if args[index] == "--set" && args[index+1] == "router.monitoring.prometheus.auth.enabled=false" {
+			return
+		}
+	}
+	t.Fatalf("expected Helm args to disable EPP metrics auth, got %v", args)
+}

--- a/brixbench/internal/monitoring/podmonitor.go
+++ b/brixbench/internal/monitoring/podmonitor.go
@@ -167,6 +167,11 @@ func podMonitorManifests(config Config) []string {
 			dynamoFrontendPodMonitor(namespace),
 			dynamoKVBMPodMonitor(namespace),
 		}
+	case provider == "llmd" && engine == "vllm":
+		return []string{
+			llmdVLLMPodMonitor(namespace),
+			llmdEPPPodMonitor(namespace),
+		}
 	default:
 		return nil
 	}
@@ -274,5 +279,37 @@ func dynamoKVBMPodMonitor(namespace string) string {
   selector:
     matchLabels:
       nvidia.com/dynamo-component: VllmDecodeWorker
+`
+}
+
+func llmdVLLMPodMonitor(namespace string) string {
+	return podMonitorHeader("brixbench-llmd-vllm-metrics", namespace) + `  podMetricsEndpoints:
+  - interval: 15s
+    path: /metrics
+    port: modelserver
+    honorLabels: true
+    relabelings:
+    - action: replace
+      replacement: llmd-vllm
+      targetLabel: job
+  selector:
+    matchLabels:
+      llm-d.ai/guide: pd-disaggregation
+`
+}
+
+func llmdEPPPodMonitor(namespace string) string {
+	return podMonitorHeader("brixbench-llmd-epp-metrics", namespace) + `  podMetricsEndpoints:
+  - interval: 15s
+    path: /metrics
+    port: metrics
+    honorLabels: true
+    relabelings:
+    - action: replace
+      replacement: llmd-epp
+      targetLabel: job
+  selector:
+    matchLabels:
+      llm-d-router-gateway: llmd-brixbench-epp
 `
 }

--- a/brixbench/internal/monitoring/podmonitor_test.go
+++ b/brixbench/internal/monitoring/podmonitor_test.go
@@ -152,6 +152,32 @@ func TestDynamoPodMonitorManifests(t *testing.T) {
 	}
 }
 
+func TestLLMdPodMonitorManifests(t *testing.T) {
+	manifests := podMonitorManifests(Config{
+		Namespace: "brixbench-llmd",
+		Provider:  "llmd",
+		Engine:    "vllm",
+	})
+	if len(manifests) != 2 {
+		t.Fatalf("expected 2 manifests, got %d", len(manifests))
+	}
+	joined := strings.Join(manifests, "\n---\n")
+	for _, want := range []string{
+		"name: brixbench-llmd-vllm-metrics",
+		"port: modelserver",
+		"replacement: llmd-vllm",
+		"llm-d.ai/guide: pd-disaggregation",
+		"name: brixbench-llmd-epp-metrics",
+		"port: metrics",
+		"replacement: llmd-epp",
+		"llm-d-router-gateway: llmd-brixbench-epp",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected manifests to contain %q:\n%s", want, joined)
+		}
+	}
+}
+
 func TestEnsureAppliesPlainVLLMManifest(t *testing.T) {
 	var commands []recordedCommand
 	err := Ensure(context.Background(), Config{
@@ -178,6 +204,34 @@ func TestEnsureAppliesPlainVLLMManifest(t *testing.T) {
 	}
 	if !strings.Contains(commands[1].stdin, "brixbench-vllm-metrics") {
 		t.Fatalf("expected apply stdin to contain PodMonitor manifest, got:\n%s", commands[1].stdin)
+	}
+}
+
+func TestEnsureAppliesLLMdManifests(t *testing.T) {
+	var manifests []string
+	err := Ensure(context.Background(), Config{
+		Namespace: "brixbench-llmd",
+		Provider:  "llmd",
+		Engine:    "vllm",
+		Enabled:   true,
+		Runner: func(ctx context.Context, stdin string, args ...string) (string, error) {
+			if strings.Join(args, " ") == "apply -f -" {
+				manifests = append(manifests, stdin)
+			}
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected Ensure to succeed, got %v", err)
+	}
+	if len(manifests) != 2 {
+		t.Fatalf("expected 2 apply commands, got %d", len(manifests))
+	}
+	if !strings.Contains(manifests[0], "brixbench-llmd-vllm-metrics") {
+		t.Fatalf("expected first manifest to configure llm-d vLLM metrics:\n%s", manifests[0])
+	}
+	if !strings.Contains(manifests[1], "brixbench-llmd-epp-metrics") {
+		t.Fatalf("expected second manifest to configure llm-d EPP metrics:\n%s", manifests[1])
 	}
 }
 

--- a/brixbench/internal/resolver/aibrix_provider.go
+++ b/brixbench/internal/resolver/aibrix_provider.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resolver
 
 import (

--- a/brixbench/internal/resolver/aibrix_provider_test.go
+++ b/brixbench/internal/resolver/aibrix_provider_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resolver
 
 import (

--- a/brixbench/internal/resolver/dynamo_provider.go
+++ b/brixbench/internal/resolver/dynamo_provider.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resolver
 
 import (

--- a/brixbench/internal/resolver/dynamo_provider_test.go
+++ b/brixbench/internal/resolver/dynamo_provider_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resolver
 
 import (

--- a/brixbench/internal/resolver/llmd_provider.go
+++ b/brixbench/internal/resolver/llmd_provider.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resolver
 
 import (

--- a/brixbench/internal/resolver/llmd_provider.go
+++ b/brixbench/internal/resolver/llmd_provider.go
@@ -1,0 +1,71 @@
+package resolver
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var stableLLMdVersionPattern = regexp.MustCompile(`^v?[0-9]+\.[0-9]+\.[0-9]+$`)
+
+func validateLLMdSourceSelection(test *Test) error {
+	if strings.TrimSpace(test.Commit) != "" {
+		return fmt.Errorf("provider llmd only supports version, not commit, for %s", test.Name)
+	}
+	if strings.TrimSpace(test.LocalPath) != "" {
+		return fmt.Errorf("provider llmd only supports LLMD_REPO env override, not localPath, for %s", test.Name)
+	}
+	if strings.TrimSpace(test.Platform.ValuesFile) != "" {
+		return fmt.Errorf("provider llmd uses controlplane values files; platform.valuesFile is not supported for %s", test.Name)
+	}
+	if len(test.ControlPlane) == 0 {
+		return fmt.Errorf("provider llmd requires at least one controlplane values file for %s", test.Name)
+	}
+	if err := validateLLMdControlPlaneFiles(test); err != nil {
+		return err
+	}
+
+	normalizedVersion, err := normalizeLLMdVersion(test.Version)
+	if err != nil {
+		return fmt.Errorf("%w for %s", err, test.Name)
+	}
+	test.Version = normalizedVersion
+	return nil
+}
+
+func normalizeLLMdVersion(version string) (string, error) {
+	normalized := strings.TrimSpace(version)
+	if normalized == "" {
+		return "", fmt.Errorf("missing LLM-d version")
+	}
+	if !stableLLMdVersionPattern.MatchString(normalized) {
+		return "", fmt.Errorf("invalid LLM-d version %q: expected stable semver like v0.8.1", version)
+	}
+	if !strings.HasPrefix(normalized, "v") {
+		normalized = "v" + normalized
+	}
+	return normalized, nil
+}
+
+func validateLLMdControlPlaneFiles(test *Test) error {
+	for i, valuesFile := range test.ControlPlane {
+		valuesFile = strings.TrimSpace(valuesFile)
+		if valuesFile == "" {
+			return fmt.Errorf("provider llmd controlplane values file %d is empty for %s", i, test.Name)
+		}
+		test.ControlPlane[i] = valuesFile
+
+		info, err := os.Stat(valuesFile)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("provider llmd controlplane values file not found for %s: %s", test.Name, valuesFile)
+			}
+			return fmt.Errorf("failed to inspect provider llmd controlplane values file for %s: %w", test.Name, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("provider llmd controlplane values file must be a file for %s: %s", test.Name, valuesFile)
+		}
+	}
+	return nil
+}

--- a/brixbench/internal/resolver/llmd_provider_test.go
+++ b/brixbench/internal/resolver/llmd_provider_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resolver
 
 import (

--- a/brixbench/internal/resolver/llmd_provider_test.go
+++ b/brixbench/internal/resolver/llmd_provider_test.go
@@ -1,0 +1,151 @@
+package resolver
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateLLMdSourceSelection(t *testing.T) {
+	valuesFile := filepath.Join(t.TempDir(), "router-values.yaml")
+	if err := os.WriteFile(valuesFile, []byte("router: {}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write router values: %v", err)
+	}
+	test := Test{
+		Name:         "llmd",
+		Version:      "0.8.1",
+		ControlPlane: []string{" " + valuesFile + " "},
+	}
+
+	if err := validateLLMdSourceSelection(&test); err != nil {
+		t.Fatalf("validateLLMdSourceSelection returned error: %v", err)
+	}
+	if test.Version != "v0.8.1" {
+		t.Fatalf("expected normalized version v0.8.1, got %s", test.Version)
+	}
+	if test.ControlPlane[0] != valuesFile {
+		t.Fatalf("expected trimmed controlplane values file %s, got %s", valuesFile, test.ControlPlane[0])
+	}
+}
+
+func TestValidateLLMdSourceSelectionRejectsMissingVersion(t *testing.T) {
+	valuesFile := filepath.Join(t.TempDir(), "router-values.yaml")
+	if err := os.WriteFile(valuesFile, []byte("router: {}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write router values: %v", err)
+	}
+	test := Test{Name: "llmd", ControlPlane: []string{valuesFile}}
+
+	err := validateLLMdSourceSelection(&test)
+	if err == nil {
+		t.Fatalf("expected missing version error")
+	}
+	if !strings.Contains(err.Error(), "missing LLM-d version") {
+		t.Fatalf("expected missing version error, got %v", err)
+	}
+}
+
+func TestValidateLLMdSourceSelectionRejectsUnsupportedInputs(t *testing.T) {
+	valuesFile := filepath.Join(t.TempDir(), "router-values.yaml")
+	if err := os.WriteFile(valuesFile, []byte("router: {}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write router values: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		test Test
+		want string
+	}{
+		{
+			name: "commit",
+			test: Test{Name: "llmd", Version: "v0.8.1", Commit: "deadbeef", ControlPlane: []string{valuesFile}},
+			want: "not commit",
+		},
+		{
+			name: "localPath",
+			test: Test{Name: "llmd", Version: "v0.8.1", LocalPath: "~/llm-d", ControlPlane: []string{valuesFile}},
+			want: "not localPath",
+		},
+		{
+			name: "platform values",
+			test: Test{Name: "llmd", Version: "v0.8.1", ControlPlane: []string{valuesFile}, Platform: Platform{ValuesFile: "platform.yaml"}},
+			want: "platform.valuesFile is not supported",
+		},
+		{
+			name: "controlplane",
+			test: Test{Name: "llmd", Version: "v0.8.1"},
+			want: "requires at least one controlplane values file",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateLLMdSourceSelection(&tc.test)
+			if err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestValidateLLMdSourceSelectionRejectsInvalidControlPlaneFile(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		valuesFile string
+		want       string
+	}{
+		{
+			name:       "missing values file",
+			valuesFile: filepath.Join(t.TempDir(), "missing.yaml"),
+			want:       "controlplane values file not found",
+		},
+		{
+			name:       "empty values file path",
+			valuesFile: " ",
+			want:       "controlplane values file 0 is empty",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			test := Test{Name: "llmd", Version: "v0.8.1", ControlPlane: []string{tc.valuesFile}}
+
+			err := validateLLMdSourceSelection(&test)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestNormalizeLLMdVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "adds v prefix", input: "0.8.1", want: "v0.8.1"},
+		{name: "keeps v prefix", input: "v0.8.1", want: "v0.8.1"},
+		{name: "trims whitespace", input: "  v0.8.1  ", want: "v0.8.1"},
+		{name: "rejects prerelease", input: "v0.8.1-rc.1", wantErr: true},
+		{name: "rejects empty", input: "  ", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeLLMdVersion(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeLLMdVersion returned error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/brixbench/internal/resolver/provider_inputs.go
+++ b/brixbench/internal/resolver/provider_inputs.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resolver
 
 import (

--- a/brixbench/internal/resolver/provider_inputs.go
+++ b/brixbench/internal/resolver/provider_inputs.go
@@ -14,7 +14,7 @@ func validateProviderInputs(test *Test) error {
 	case "dynamo":
 		return validateDynamoSourceSelection(test)
 	case "llmd":
-		return fmt.Errorf("provider llmd is not implemented for %s", test.Name)
+		return validateLLMdSourceSelection(test)
 	default:
 		return fmt.Errorf("unknown provider %q for %s", test.ProviderName(), test.Name)
 	}

--- a/brixbench/internal/resolver/provider_inputs_test.go
+++ b/brixbench/internal/resolver/provider_inputs_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resolver
 
 import (

--- a/brixbench/internal/resolver/provider_inputs_test.go
+++ b/brixbench/internal/resolver/provider_inputs_test.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -47,16 +49,22 @@ func TestValidateProviderInputsRejectsNullProviderUnsupportedInputs(t *testing.T
 	}
 }
 
-func TestValidateProviderInputsRejectsLLMdProvider(t *testing.T) {
-	provider := "llmd"
-	test := Test{Name: "llmd", Provider: &provider}
-
-	err := validateProviderInputs(&test)
-	if err == nil {
-		t.Fatalf("expected llmd not implemented error")
+func TestValidateProviderInputsAcceptsLLMdProvider(t *testing.T) {
+	valuesFile := filepath.Join(t.TempDir(), "router-values.yaml")
+	if err := os.WriteFile(valuesFile, []byte("router: {}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write router values: %v", err)
 	}
-	if !strings.Contains(err.Error(), "provider llmd is not implemented") {
-		t.Fatalf("expected llmd not implemented error, got %v", err)
+	provider := "llmd"
+	test := Test{Name: "llmd", Provider: &provider, Version: "0.8.1", ControlPlane: []string{" " + valuesFile + " "}}
+
+	if err := validateProviderInputs(&test); err != nil {
+		t.Fatalf("validateProviderInputs returned error: %v", err)
+	}
+	if test.Version != "v0.8.1" {
+		t.Fatalf("expected normalized version v0.8.1, got %s", test.Version)
+	}
+	if test.ControlPlane[0] != valuesFile {
+		t.Fatalf("expected trimmed controlplane path %s, got %s", valuesFile, test.ControlPlane[0])
 	}
 }
 

--- a/brixbench/internal/resolver/resolver_test.go
+++ b/brixbench/internal/resolver/resolver_test.go
@@ -340,15 +340,22 @@ func TestResolveAcceptsExplicitNullProvider(t *testing.T) {
 	}
 }
 
-func TestResolveRejectsLLMdProvider(t *testing.T) {
+func TestResolveSupportsLLMdProvider(t *testing.T) {
 	tempDir, enginePath, benchmarkPath := createScenarioFixture(t)
 	scenarioPath := filepath.Join(tempDir, "scenario.yaml")
+	valuesPath := filepath.Join(tempDir, "router-values.yaml")
+	if err := os.WriteFile(valuesPath, []byte("router: {}\n"), 0644); err != nil {
+		t.Fatalf("failed to write router values file: %v", err)
+	}
 
 	scenarioYAML := []byte(
 		"Scenario: sample\n" +
 			"Tests:\n" +
 			"  - name: llmd\n" +
 			"    provider: llmd\n" +
+			"    version: 0.8.1\n" +
+			"    controlplane:\n" +
+			"      - " + valuesPath + "\n" +
 			"    engine:\n" +
 			"      type: vllm\n" +
 			"      manifest: " + enginePath + "\n" +
@@ -358,12 +365,15 @@ func TestResolveRejectsLLMdProvider(t *testing.T) {
 		t.Fatalf("failed to write scenario file: %v", err)
 	}
 
-	_, err := Resolve(scenarioPath)
-	if err == nil {
-		t.Fatalf("expected Resolve to reject llmd provider")
+	scenario, err := Resolve(scenarioPath)
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "provider llmd is not implemented") {
-		t.Fatalf("expected llmd not implemented error, got %v", err)
+	if scenario.Tests[0].ProviderName() != "llmd" {
+		t.Fatalf("expected provider llmd, got %s", scenario.Tests[0].ProviderName())
+	}
+	if scenario.Tests[0].Version != "v0.8.1" {
+		t.Fatalf("expected normalized version v0.8.1, got %s", scenario.Tests[0].Version)
 	}
 }
 


### PR DESCRIPTION
## Pull Request Description
This PR adds llm-d provider support to brixbench and enables llm-d routing smoke scenarios.

Changes include:
- llm-d provider resolution, deployment wiring, readiness, cleanup, and Qwen3-8B 4P4D smoke fixtures (public-release images).
- llm-d PodMonitor profiles for vLLM modelservers and the standalone router EPP, plus EPP metrics exposure for VMP scraping.
- Routing-policy docs and LLMD_REPO / relative ../llm-d default checkout path (no machine-absolute home path).
- Unit coverage for resolver/deployer/monitoring paths; remove the obsolete “llm-d not implemented” runner rejection test.
- Add missing Apache license headers for llm-d files and Dynamo/AIBrix leftovers so make licensecheck passes.

Stacked after #2469 (Dynamo). Out of scope here: TOS/CSV publish and multi-node compare fixtures (follow-up PRs).
