### PR TITLE
[API] Add Kubernetes ModelAdapter management to Console

### DIFF
--- a/apps/console/api/deployment/provider/kubernetes.go
+++ b/apps/console/api/deployment/provider/kubernetes.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vllm-project/aibrix/apps/console/api/config"
 	deploymentstatus "github.com/vllm-project/aibrix/apps/console/api/deployment/status"
 	pb "github.com/vllm-project/aibrix/apps/console/api/gen/console/v1"
+	aibrixclient "github.com/vllm-project/aibrix/pkg/client/clientset/versioned"
 	"github.com/vllm-project/aibrix/pkg/constants"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -87,11 +88,26 @@ type KubernetesClientProvider interface {
 	Client() (kubernetes.Interface, string, error)
 }
 
+// ModelClientProvider resolves the AIBrix typed client against the same
+// cluster and namespace as the core Kubernetes client.
+type ModelClientProvider interface {
+	ModelClient() (aibrixclient.Interface, string, error)
+}
+
+// ClusterClientProvider exposes both clientsets backed by one Kubernetes
+// configuration.
+type ClusterClientProvider interface {
+	KubernetesClientProvider
+	ModelClientProvider
+}
+
 type kubeconfigClientProvider struct {
-	cfg             config.KubernetesProviderConfig
-	mu              sync.Mutex
-	cachedClientset kubernetes.Interface
-	cachedNamespace string
+	cfg                  config.KubernetesProviderConfig
+	mu                   sync.Mutex
+	cachedRESTConfig     *rest.Config
+	cachedClientset      kubernetes.Interface
+	cachedModelClientset aibrixclient.Interface
+	cachedNamespace      string
 }
 
 type kubernetesDeploymentProvider struct {
@@ -102,9 +118,10 @@ type kubernetesDeploymentProvider struct {
 var (
 	_ DeploymentProvider       = (*kubernetesDeploymentProvider)(nil)
 	_ KubernetesClientProvider = (*kubeconfigClientProvider)(nil)
+	_ ModelClientProvider      = (*kubeconfigClientProvider)(nil)
 )
 
-func NewKubernetesClientProvider(cfg config.KubernetesProviderConfig) KubernetesClientProvider {
+func NewKubernetesClientProvider(cfg config.KubernetesProviderConfig) ClusterClientProvider {
 	return &kubeconfigClientProvider{cfg: cfg}
 }
 
@@ -515,6 +532,44 @@ func (p *kubeconfigClientProvider) Client() (kubernetes.Interface, string, error
 		return p.cachedClientset, p.cachedNamespace, nil
 	}
 
+	restConfig, namespace, err := p.restConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, "", status.Errorf(codes.Internal, "create kubernetes client: %v", err)
+	}
+	p.cachedClientset = clientset
+	return clientset, namespace, nil
+}
+
+func (p *kubeconfigClientProvider) ModelClient() (aibrixclient.Interface, string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cachedModelClientset != nil {
+		return p.cachedModelClientset, p.cachedNamespace, nil
+	}
+
+	restConfig, namespace, err := p.restConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	clientset, err := aibrixclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, "", status.Errorf(codes.Internal, "create AIBrix client: %v", err)
+	}
+	p.cachedModelClientset = clientset
+	return clientset, namespace, nil
+}
+
+// restConfig must be called while p.mu is held.
+func (p *kubeconfigClientProvider) restConfig() (*rest.Config, string, error) {
+	if p.cachedRESTConfig != nil {
+		return p.cachedRESTConfig, p.cachedNamespace, nil
+	}
+
 	namespace := defaultKubernetesNamespace
 	if p.cfg.Namespace != "" {
 		namespace = p.cfg.Namespace
@@ -549,13 +604,9 @@ func (p *kubeconfigClientProvider) Client() (kubernetes.Interface, string, error
 		}
 	}
 
-	clientset, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, "", status.Errorf(codes.Internal, "create kubernetes client: %v", err)
-	}
-	p.cachedClientset = clientset
+	p.cachedRESTConfig = restConfig
 	p.cachedNamespace = namespace
-	return clientset, namespace, nil
+	return restConfig, namespace, nil
 }
 
 func validateDeploymentSizing(spec *pb.ModelDeploymentTemplateSpec, req *pb.CreateDeploymentRequest) error {

--- a/apps/console/api/handler/modeladapter.go
+++ b/apps/console/api/handler/modeladapter.go
@@ -1,0 +1,781 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	modelv1alpha1 "github.com/vllm-project/aibrix/api/model/v1alpha1"
+	"github.com/vllm-project/aibrix/apps/console/api/middleware"
+	aibrixclient "github.com/vllm-project/aibrix/pkg/client/clientset/versioned"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/utils"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	modelAdapterAPIPath             = "/api/v1/model-adapters"
+	modelAdapterTargetAPIPath       = "/api/v1/model-adapter-targets"
+	modelAdapterAPIVersion          = "model.aibrix.ai/v1alpha1"
+	deploymentAPIVersion            = "apps/v1"
+	defaultModelAdapterScheduler    = "default"
+	defaultModelServingPort         = int32(8000)
+	placementAll                    = "all"
+	placementSingle                 = "single"
+	targetDeploymentAnnotation      = "console.aibrix.ai/target-deployment"
+	modelAdapterManagedByLabel      = "app.kubernetes.io/managed-by"
+	modelAdapterManagedByLabelValue = "aibrix-console"
+	modelSourceEnvName              = "AIBRIX_MODEL_SOURCE_URI"
+	engineTypeEnvName               = "AIBRIX_ENGINE_TYPE"
+	modelAdapterAdminRole           = "admin"
+	modelAdapterVLLMEngine          = "vllm"
+	modelAdapterSGLangEngine        = "sglang"
+)
+
+type modelAdapterClientProvider interface {
+	Client() (kubernetes.Interface, string, error)
+	ModelClient() (aibrixclient.Interface, string, error)
+}
+
+// ModelAdapterHandler exposes the open-source ModelAdapter workflow as a
+// narrow REST BFF over Kubernetes.
+type ModelAdapterHandler struct {
+	clients modelAdapterClientProvider
+}
+
+type createModelAdapterRequest struct {
+	Name           string `json:"name"`
+	ArtifactURL    string `json:"artifact_url"`
+	DeploymentName string `json:"deployment_name"`
+	Placement      string `json:"placement"`
+}
+
+type modelAdapterResponse struct {
+	Name            string              `json:"name"`
+	Namespace       string              `json:"namespace"`
+	APIVersion      string              `json:"api_version"`
+	ArtifactURL     string              `json:"artifact_url"`
+	BaseModel       string              `json:"base_model"`
+	SchedulerName   string              `json:"scheduler_name"`
+	Placement       string              `json:"placement"`
+	Phase           string              `json:"phase"`
+	ReadyReplicas   int32               `json:"ready_replicas"`
+	DesiredReplicas int32               `json:"desired_replicas"`
+	Candidates      int32               `json:"candidates"`
+	CreatedAt       string              `json:"created_at"`
+	PodSelector     string              `json:"pod_selector"`
+	Target          *modelAdapterTarget `json:"target,omitempty"`
+	Instances       []boundPod          `json:"instances"`
+}
+
+type modelAdapterTarget struct {
+	Name            string `json:"name"`
+	Namespace       string `json:"namespace"`
+	Kind            string `json:"kind"`
+	APIVersion      string `json:"api_version"`
+	BaseModel       string `json:"base_model"`
+	Engine          string `json:"engine"`
+	Port            int32  `json:"port"`
+	ReadyReplicas   int32  `json:"ready_replicas"`
+	DesiredReplicas int32  `json:"desired_replicas"`
+	Selector        string `json:"selector"`
+	UpdateStrategy  string `json:"update_strategy"`
+	CreatedAt       string `json:"created_at"`
+}
+
+type boundPod struct {
+	Name      string `json:"name"`
+	Ready     string `json:"ready"`
+	Status    string `json:"status"`
+	Restarts  int32  `json:"restarts"`
+	CreatedAt string `json:"created_at"`
+	PodIP     string `json:"pod_ip"`
+	Node      string `json:"node"`
+}
+
+type listModelAdaptersResponse struct {
+	ModelAdapters []modelAdapterResponse `json:"model_adapters"`
+}
+
+type listModelAdapterTargetsResponse struct {
+	Targets []modelAdapterTarget `json:"targets"`
+}
+
+type modelAdapterErrorResponse struct {
+	Error string `json:"error"`
+}
+
+func NewModelAdapterHandler(clients modelAdapterClientProvider) *ModelAdapterHandler {
+	return &ModelAdapterHandler{clients: clients}
+}
+
+func (h *ModelAdapterHandler) RegisterRoutes(mux *runtime.ServeMux) error {
+	routes := []struct {
+		method  string
+		path    string
+		handler runtime.HandlerFunc
+	}{
+		{http.MethodGet, modelAdapterAPIPath, h.handleList},
+		{http.MethodPost, modelAdapterAPIPath, h.handleCreate},
+		{http.MethodGet, modelAdapterAPIPath + "/{name}", h.handleGet},
+		{http.MethodDelete, modelAdapterAPIPath + "/{name}", h.handleDelete},
+		{http.MethodGet, modelAdapterTargetAPIPath, h.handleListTargets},
+	}
+	for _, route := range routes {
+		if err := mux.HandlePath(route.method, route.path, route.handler); err != nil {
+			return fmt.Errorf("register %s %s: %w", route.method, route.path, err)
+		}
+	}
+	return nil
+}
+
+func (h *ModelAdapterHandler) handleList(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+	kubeClient, modelClient, namespace, err := h.resolveClients()
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+
+	adapters, err := modelClient.ModelV1alpha1().ModelAdapters(namespace).List(r.Context(), metav1.ListOptions{})
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+	deployments, err := kubeClient.AppsV1().Deployments(namespace).List(r.Context(), metav1.ListOptions{})
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+	pods, err := kubeClient.CoreV1().Pods(namespace).List(r.Context(), metav1.ListOptions{})
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+
+	sort.Slice(adapters.Items, func(i, j int) bool {
+		if adapters.Items[i].CreationTimestamp.Equal(&adapters.Items[j].CreationTimestamp) {
+			return adapters.Items[i].Name < adapters.Items[j].Name
+		}
+		return adapters.Items[i].CreationTimestamp.After(adapters.Items[j].CreationTimestamp.Time)
+	})
+	podsByName := indexPods(pods.Items)
+	response := listModelAdaptersResponse{
+		ModelAdapters: make([]modelAdapterResponse, 0, len(adapters.Items)),
+	}
+	for i := range adapters.Items {
+		response.ModelAdapters = append(
+			response.ModelAdapters,
+			buildModelAdapterResponse(&adapters.Items[i], deployments.Items, podsByName),
+		)
+	}
+	writeModelAdapterJSON(w, http.StatusOK, response)
+}
+
+func (h *ModelAdapterHandler) handleGet(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+	kubeClient, modelClient, namespace, err := h.resolveClients()
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+
+	adapter, err := modelClient.ModelV1alpha1().ModelAdapters(namespace).Get(
+		r.Context(),
+		pathParams["name"],
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+	deployments, err := kubeClient.AppsV1().Deployments(namespace).List(r.Context(), metav1.ListOptions{})
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+	podsByName := make(map[string]*corev1.Pod, len(adapter.Status.Instances))
+	for _, name := range adapter.Status.Instances {
+		pod, err := kubeClient.CoreV1().Pods(namespace).Get(r.Context(), name, metav1.GetOptions{})
+		if err == nil {
+			podsByName[name] = pod
+		} else if !apierrors.IsNotFound(err) {
+			writeModelAdapterError(w, err)
+			return
+		}
+	}
+
+	writeModelAdapterJSON(
+		w,
+		http.StatusOK,
+		buildModelAdapterResponse(adapter, deployments.Items, podsByName),
+	)
+}
+
+func (h *ModelAdapterHandler) handleCreate(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+	if err := requireModelAdapterAdmin(r.Context()); err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+
+	var request createModelAdapterRequest
+	if err := decodeModelAdapterRequest(r, &request); err != nil {
+		writeModelAdapterJSON(w, http.StatusBadRequest, modelAdapterErrorResponse{Error: err.Error()})
+		return
+	}
+	if err := validateCreateModelAdapterRequest(&request); err != nil {
+		writeModelAdapterJSON(w, http.StatusBadRequest, modelAdapterErrorResponse{Error: err.Error()})
+		return
+	}
+
+	kubeClient, modelClient, namespace, err := h.resolveClients()
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+	deployment, err := kubeClient.AppsV1().Deployments(namespace).Get(
+		r.Context(),
+		request.DeploymentName,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+	if !isModelAdapterTarget(deployment) {
+		writeModelAdapterJSON(w, http.StatusBadRequest, modelAdapterErrorResponse{
+			Error: "deployment is not compatible with the ModelAdapter controller",
+		})
+		return
+	}
+
+	baseModel := modelAdapterBaseModel(deployment)
+	adapter := &modelv1alpha1.ModelAdapter{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: modelAdapterAPIVersion,
+			Kind:       "ModelAdapter",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      request.Name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.ModelLabelName:   request.Name,
+				constants.ModelLabelPort:   strconv.Itoa(int(deploymentPort(deployment))),
+				modelAdapterManagedByLabel: modelAdapterManagedByLabelValue,
+			},
+			Annotations: map[string]string{
+				targetDeploymentAnnotation: deployment.Name,
+			},
+		},
+		Spec: modelv1alpha1.ModelAdapterSpec{
+			BaseModel:     ptr.To(baseModel),
+			PodSelector:   deployment.Spec.Selector.DeepCopy(),
+			SchedulerName: defaultModelAdapterScheduler,
+			ArtifactURL:   request.ArtifactURL,
+		},
+	}
+	if request.Placement == placementSingle {
+		adapter.Spec.Replicas = ptr.To[int32](1)
+	}
+
+	created, err := modelClient.ModelV1alpha1().ModelAdapters(namespace).Create(
+		r.Context(),
+		adapter,
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+	writeModelAdapterJSON(
+		w,
+		http.StatusCreated,
+		buildModelAdapterResponse(created, []appsv1.Deployment{*deployment}, nil),
+	)
+}
+
+func (h *ModelAdapterHandler) handleDelete(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+	if err := requireModelAdapterAdmin(r.Context()); err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+
+	if h.clients == nil {
+		writeModelAdapterJSON(w, http.StatusServiceUnavailable, modelAdapterErrorResponse{
+			Error: "Kubernetes clients are not configured",
+		})
+		return
+	}
+	modelClient, namespace, err := h.clients.ModelClient()
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+	if modelClient == nil {
+		writeModelAdapterJSON(w, http.StatusServiceUnavailable, modelAdapterErrorResponse{
+			Error: "AIBrix client is not configured",
+		})
+		return
+	}
+	if err := modelClient.ModelV1alpha1().ModelAdapters(namespace).Delete(
+		r.Context(),
+		pathParams["name"],
+		metav1.DeleteOptions{},
+	); err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *ModelAdapterHandler) handleListTargets(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+	if h.clients == nil {
+		writeModelAdapterJSON(w, http.StatusServiceUnavailable, modelAdapterErrorResponse{
+			Error: "Kubernetes clients are not configured",
+		})
+		return
+	}
+	kubeClient, namespace, err := h.clients.Client()
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+	if kubeClient == nil {
+		writeModelAdapterJSON(w, http.StatusServiceUnavailable, modelAdapterErrorResponse{
+			Error: "Kubernetes client is not configured",
+		})
+		return
+	}
+	deployments, err := kubeClient.AppsV1().Deployments(namespace).List(r.Context(), metav1.ListOptions{})
+	if err != nil {
+		writeModelAdapterError(w, err)
+		return
+	}
+
+	response := listModelAdapterTargetsResponse{Targets: make([]modelAdapterTarget, 0, len(deployments.Items))}
+	for i := range deployments.Items {
+		if isModelAdapterTarget(&deployments.Items[i]) {
+			response.Targets = append(response.Targets, buildModelAdapterTarget(&deployments.Items[i]))
+		}
+	}
+	sort.Slice(response.Targets, func(i, j int) bool {
+		return response.Targets[i].Name < response.Targets[j].Name
+	})
+	writeModelAdapterJSON(w, http.StatusOK, response)
+}
+
+func requireModelAdapterAdmin(ctx context.Context) error {
+	user := middleware.GetUser(ctx)
+	if user == nil {
+		return grpcstatus.Error(codes.Unauthenticated, "authentication is required")
+	}
+	if !strings.EqualFold(strings.TrimSpace(user.Role), modelAdapterAdminRole) {
+		return grpcstatus.Error(codes.PermissionDenied, "admin role is required to manage ModelAdapters")
+	}
+	return nil
+}
+
+func (h *ModelAdapterHandler) resolveClients() (kubernetes.Interface, aibrixclient.Interface, string, error) {
+	if h.clients == nil {
+		return nil, nil, "", grpcstatus.Error(codes.Unavailable, "Kubernetes clients are not configured")
+	}
+	kubeClient, namespace, err := h.clients.Client()
+	if err != nil {
+		return nil, nil, "", err
+	}
+	modelClient, modelNamespace, err := h.clients.ModelClient()
+	if err != nil {
+		return nil, nil, "", err
+	}
+	if kubeClient == nil || modelClient == nil {
+		return nil, nil, "", grpcstatus.Error(codes.Unavailable, "Kubernetes clients are not configured")
+	}
+	if namespace != modelNamespace {
+		return nil, nil, "", grpcstatus.Error(codes.Internal, "Kubernetes client namespaces do not match")
+	}
+	return kubeClient, modelClient, namespace, nil
+}
+
+func decodeModelAdapterRequest(r *http.Request, request *createModelAdapterRequest) error {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(request); err != nil {
+		return fmt.Errorf("invalid request body: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("request body must contain one JSON object")
+	}
+	request.Name = strings.TrimSpace(request.Name)
+	request.ArtifactURL = strings.TrimSpace(request.ArtifactURL)
+	request.DeploymentName = strings.TrimSpace(request.DeploymentName)
+	request.Placement = strings.TrimSpace(request.Placement)
+	return nil
+}
+
+func validateCreateModelAdapterRequest(request *createModelAdapterRequest) error {
+	if errors := validation.IsDNS1123Subdomain(request.Name); len(errors) > 0 {
+		return fmt.Errorf("name must be a valid Kubernetes DNS subdomain: %s", strings.Join(errors, ", "))
+	}
+	if errors := validation.IsValidLabelValue(request.Name); len(errors) > 0 {
+		return fmt.Errorf("name must be a valid Kubernetes label value: %s", strings.Join(errors, ", "))
+	}
+	if request.DeploymentName == "" {
+		return fmt.Errorf("deployment_name is required")
+	}
+	if request.Placement != placementAll && request.Placement != placementSingle {
+		return fmt.Errorf("placement must be %q or %q", placementAll, placementSingle)
+	}
+	if request.ArtifactURL == "" {
+		return fmt.Errorf("artifact_url is required")
+	}
+	if _, err := url.ParseRequestURI(request.ArtifactURL); err != nil {
+		return fmt.Errorf("artifact_url is invalid: %w", err)
+	}
+	if err := utils.ValidateArtifactURL(request.ArtifactURL); err != nil {
+		return fmt.Errorf("artifact_url uses an unsupported scheme: %w", err)
+	}
+	return nil
+}
+
+func buildModelAdapterResponse(
+	adapter *modelv1alpha1.ModelAdapter,
+	deployments []appsv1.Deployment,
+	podsByName map[string]*corev1.Pod,
+) modelAdapterResponse {
+	baseModel := ""
+	if adapter.Spec.BaseModel != nil {
+		baseModel = *adapter.Spec.BaseModel
+	}
+	placement := placementAll
+	if adapter.Spec.Replicas != nil {
+		placement = placementSingle
+	}
+	phase := string(adapter.Status.Phase)
+	if phase == "" {
+		phase = string(modelv1alpha1.ModelAdapterPending)
+	}
+
+	response := modelAdapterResponse{
+		Name:            adapter.Name,
+		Namespace:       adapter.Namespace,
+		APIVersion:      modelAdapterAPIVersion,
+		ArtifactURL:     adapter.Spec.ArtifactURL,
+		BaseModel:       baseModel,
+		SchedulerName:   adapter.Spec.SchedulerName,
+		Placement:       placement,
+		Phase:           phase,
+		ReadyReplicas:   adapter.Status.ReadyReplicas,
+		DesiredReplicas: adapter.Status.DesiredReplicas,
+		Candidates:      adapter.Status.Candidates,
+		CreatedAt:       formatKubernetesTime(adapter.CreationTimestamp),
+		PodSelector:     formatLabelSelector(adapter.Spec.PodSelector),
+		Instances:       make([]boundPod, 0, len(adapter.Status.Instances)),
+	}
+	if target := findTargetDeployment(adapter, deployments); target != nil {
+		targetResponse := buildModelAdapterTarget(target)
+		response.Target = &targetResponse
+		response.BaseModel = targetResponse.BaseModel
+	}
+	for _, name := range adapter.Status.Instances {
+		response.Instances = append(response.Instances, buildBoundPod(name, podsByName[name]))
+	}
+	return response
+}
+
+func buildModelAdapterTarget(deployment *appsv1.Deployment) modelAdapterTarget {
+	desiredReplicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		desiredReplicas = *deployment.Spec.Replicas
+	}
+	return modelAdapterTarget{
+		Name:            deployment.Name,
+		Namespace:       deployment.Namespace,
+		Kind:            "Deployment",
+		APIVersion:      deploymentAPIVersion,
+		BaseModel:       deploymentBaseModel(deployment),
+		Engine:          deploymentEngine(deployment),
+		Port:            deploymentPort(deployment),
+		ReadyReplicas:   deployment.Status.ReadyReplicas,
+		DesiredReplicas: desiredReplicas,
+		Selector:        formatLabelSelector(deployment.Spec.Selector),
+		UpdateStrategy:  string(deployment.Spec.Strategy.Type),
+		CreatedAt:       formatKubernetesTime(deployment.CreationTimestamp),
+	}
+}
+
+func findTargetDeployment(
+	adapter *modelv1alpha1.ModelAdapter,
+	deployments []appsv1.Deployment,
+) *appsv1.Deployment {
+	targetName := adapter.Annotations[targetDeploymentAnnotation]
+	if targetName != "" {
+		for i := range deployments {
+			if deployments[i].Name == targetName {
+				return &deployments[i]
+			}
+		}
+	}
+	selector, err := metav1.LabelSelectorAsSelector(adapter.Spec.PodSelector)
+	if err != nil || selector.Empty() {
+		return nil
+	}
+	for i := range deployments {
+		if selector.Matches(labels.Set(deployments[i].Spec.Template.Labels)) {
+			return &deployments[i]
+		}
+	}
+	return nil
+}
+
+func isModelAdapterTarget(deployment *appsv1.Deployment) bool {
+	if deployment == nil || deployment.Spec.Selector == nil {
+		return false
+	}
+	if deployment.DeletionTimestamp != nil ||
+		len(deployment.Spec.Selector.MatchLabels) == 0 ||
+		len(deployment.Spec.Selector.MatchExpressions) > 0 {
+		return false
+	}
+	if !hasExplicitBaseModel(deployment) {
+		return false
+	}
+	engine := strings.ToLower(strings.TrimSpace(deploymentEngine(deployment)))
+	if engine != modelAdapterVLLMEngine && engine != modelAdapterSGLangEngine {
+		return false
+	}
+	if deploymentPort(deployment) != defaultModelServingPort {
+		return false
+	}
+	return modelAdapterEnabled(deployment) || hasExplicitEngine(deployment)
+}
+
+func hasExplicitBaseModel(deployment *appsv1.Deployment) bool {
+	if _, ok := constants.ModelNameFromMetadata(
+		deployment.Spec.Template.Labels,
+		deployment.Spec.Template.Annotations,
+	); ok {
+		return true
+	}
+	if _, ok := constants.ModelNameFromMetadata(deployment.Labels, deployment.Annotations); ok {
+		return true
+	}
+	return deploymentContainerEnv(deployment, modelSourceEnvName) != ""
+}
+
+func hasExplicitEngine(deployment *appsv1.Deployment) bool {
+	return deployment.Spec.Template.Labels[constants.ModelLabelEngine] != "" ||
+		deployment.Labels[constants.ModelLabelEngine] != "" ||
+		deploymentContainerEnv(deployment, engineTypeEnvName) != ""
+}
+
+func modelAdapterEnabled(deployment *appsv1.Deployment) bool {
+	return strings.EqualFold(
+		deployment.Spec.Template.Labels[constants.ModelLabelAdapterEnabled],
+		"true",
+	) || strings.EqualFold(
+		deployment.Labels[constants.ModelLabelAdapterEnabled],
+		"true",
+	)
+}
+
+func deploymentBaseModel(deployment *appsv1.Deployment) string {
+	if value, ok := constants.ModelNameFromMetadata(
+		deployment.Spec.Template.Labels,
+		deployment.Spec.Template.Annotations,
+	); ok {
+		return value
+	}
+	if value, ok := constants.ModelNameFromMetadata(deployment.Labels, deployment.Annotations); ok {
+		return value
+	}
+	if value := deploymentContainerEnv(deployment, modelSourceEnvName); value != "" {
+		return value
+	}
+	return deployment.Name
+}
+
+func modelAdapterBaseModel(deployment *appsv1.Deployment) string {
+	baseModel := deploymentBaseModel(deployment)
+	if len(validation.IsValidLabelValue(baseModel)) == 0 {
+		return baseModel
+	}
+	// The controller projects spec.baseModel into a Service label. Model URIs
+	// commonly contain slashes, so use the stable workload name when the
+	// display identifier cannot be represented as a Kubernetes label value.
+	return deployment.Name
+}
+
+func deploymentEngine(deployment *appsv1.Deployment) string {
+	if value := deployment.Spec.Template.Labels[constants.ModelLabelEngine]; value != "" {
+		return value
+	}
+	if value := deployment.Labels[constants.ModelLabelEngine]; value != "" {
+		return value
+	}
+	if value := deploymentContainerEnv(deployment, engineTypeEnvName); value != "" {
+		return value
+	}
+	return modelAdapterVLLMEngine
+}
+
+func deploymentContainerEnv(deployment *appsv1.Deployment, name string) string {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		for _, env := range container.Env {
+			if env.Name == name {
+				return env.Value
+			}
+		}
+	}
+	return ""
+}
+
+func deploymentPort(deployment *appsv1.Deployment) int32 {
+	for _, source := range []map[string]string{deployment.Spec.Template.Labels, deployment.Labels} {
+		if value := source[constants.ModelLabelPort]; value != "" {
+			if port, err := strconv.ParseInt(value, 10, 32); err == nil && port > 0 && port <= 65535 {
+				return int32(port)
+			}
+		}
+	}
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.Name == "http" && port.ContainerPort > 0 {
+				return port.ContainerPort
+			}
+		}
+	}
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.ContainerPort > 0 {
+				return port.ContainerPort
+			}
+		}
+	}
+	return defaultModelServingPort
+}
+
+func indexPods(pods []corev1.Pod) map[string]*corev1.Pod {
+	result := make(map[string]*corev1.Pod, len(pods))
+	for i := range pods {
+		result[pods[i].Name] = &pods[i]
+	}
+	return result
+}
+
+func buildBoundPod(name string, pod *corev1.Pod) boundPod {
+	if pod == nil {
+		return boundPod{Name: name, Status: "Unknown", Ready: "0/0"}
+	}
+	readyContainers := 0
+	restarts := int32(0)
+	for _, container := range pod.Status.ContainerStatuses {
+		if container.Ready {
+			readyContainers++
+		}
+		restarts += container.RestartCount
+	}
+	return boundPod{
+		Name:      pod.Name,
+		Ready:     fmt.Sprintf("%d/%d", readyContainers, len(pod.Spec.Containers)),
+		Status:    string(pod.Status.Phase),
+		Restarts:  restarts,
+		CreatedAt: formatKubernetesTime(pod.CreationTimestamp),
+		PodIP:     pod.Status.PodIP,
+		Node:      pod.Spec.NodeName,
+	}
+}
+
+func formatLabelSelector(selector *metav1.LabelSelector) string {
+	if selector == nil {
+		return ""
+	}
+	parsed, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return ""
+	}
+	return parsed.String()
+}
+
+func formatKubernetesTime(value metav1.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func writeModelAdapterJSON(w http.ResponseWriter, statusCode int, value interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if statusCode == http.StatusNoContent {
+		return
+	}
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		klog.Errorf("write ModelAdapter response: %v", err)
+	}
+}
+
+func writeModelAdapterError(w http.ResponseWriter, err error) {
+	statusCode := http.StatusInternalServerError
+	switch {
+	case apierrors.IsNotFound(err):
+		statusCode = http.StatusNotFound
+	case apierrors.IsAlreadyExists(err):
+		statusCode = http.StatusConflict
+	case apierrors.IsInvalid(err), apierrors.IsBadRequest(err):
+		statusCode = http.StatusBadRequest
+	case apierrors.IsForbidden(err):
+		statusCode = http.StatusForbidden
+	case apierrors.IsUnauthorized(err):
+		statusCode = http.StatusUnauthorized
+	default:
+		switch grpcstatus.Code(err) {
+		case codes.InvalidArgument:
+			statusCode = http.StatusBadRequest
+		case codes.NotFound:
+			statusCode = http.StatusNotFound
+		case codes.AlreadyExists:
+			statusCode = http.StatusConflict
+		case codes.PermissionDenied:
+			statusCode = http.StatusForbidden
+		case codes.Unauthenticated:
+			statusCode = http.StatusUnauthorized
+		case codes.FailedPrecondition:
+			statusCode = http.StatusPreconditionFailed
+		case codes.Unavailable:
+			statusCode = http.StatusServiceUnavailable
+		}
+	}
+	writeModelAdapterJSON(w, statusCode, modelAdapterErrorResponse{Error: err.Error()})
+}

--- a/apps/console/api/handler/modeladapter_test.go
+++ b/apps/console/api/handler/modeladapter_test.go
@@ -1,0 +1,438 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	modelv1alpha1 "github.com/vllm-project/aibrix/api/model/v1alpha1"
+	"github.com/vllm-project/aibrix/apps/console/api/middleware"
+	aibrixclient "github.com/vllm-project/aibrix/pkg/client/clientset/versioned"
+	aibrixfake "github.com/vllm-project/aibrix/pkg/client/clientset/versioned/fake"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+)
+
+const modelAdapterTestNamespace = "model-serving"
+
+type staticModelAdapterClientProvider struct {
+	kubeClient  kubernetes.Interface
+	modelClient aibrixclient.Interface
+	namespace   string
+}
+
+type modelAdapterLifecycleFixture struct {
+	deployment  *appsv1.Deployment
+	pod         *corev1.Pod
+	kubeClient  kubernetes.Interface
+	modelClient aibrixclient.Interface
+	mux         *runtime.ServeMux
+}
+
+func (p staticModelAdapterClientProvider) Client() (kubernetes.Interface, string, error) {
+	return p.kubeClient, p.namespace, nil
+}
+
+func (p staticModelAdapterClientProvider) ModelClient() (aibrixclient.Interface, string, error) {
+	return p.modelClient, p.namespace, nil
+}
+
+func TestModelAdapterHandlerLifecycle(t *testing.T) {
+	fixture := newModelAdapterLifecycleFixture(t)
+	fixture.assertTargets(t)
+	created := fixture.createAdapter(t)
+	fixture.assertAdapterStatus(t, created)
+	fixture.deleteAdapter(t, created)
+}
+
+func newModelAdapterLifecycleFixture(t *testing.T) *modelAdapterLifecycleFixture {
+	t.Helper()
+	now := metav1.NewTime(time.Now().UTC().Add(-time.Minute))
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "qwen-serving",
+			Namespace:         modelAdapterTestNamespace,
+			CreationTimestamp: now,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To[int32](2),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "qwen-serving"},
+			},
+			Strategy: appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":                    "qwen-serving",
+						constants.ModelLabelName: "Qwen/Qwen2.5-7B",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "engine",
+						Image: "example/vllm:latest",
+						Env: []corev1.EnvVar{{
+							Name:  engineTypeEnvName,
+							Value: "vllm",
+						}},
+						Ports: []corev1.ContainerPort{{
+							Name:          "http",
+							ContainerPort: 8000,
+						}},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 2},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "qwen-serving-abc",
+			Namespace:         modelAdapterTestNamespace,
+			CreationTimestamp: now,
+			Labels:            map[string]string{"app": "qwen-serving"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   "kind-worker",
+			Containers: []corev1.Container{{Name: "engine"}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "10.244.1.10",
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         "engine",
+				Ready:        true,
+				RestartCount: 1,
+				Image:        "example/vllm:latest",
+				ImageID:      "example/vllm@sha256:test",
+			}},
+		},
+	}
+
+	kubeClient := kubernetesfake.NewSimpleClientset(deployment, pod)
+	modelClient := aibrixfake.NewSimpleClientset()
+	handler := NewModelAdapterHandler(staticModelAdapterClientProvider{
+		kubeClient:  kubeClient,
+		modelClient: modelClient,
+		namespace:   modelAdapterTestNamespace,
+	})
+	mux := runtime.NewServeMux()
+	if err := handler.RegisterRoutes(mux); err != nil {
+		t.Fatalf("RegisterRoutes() error = %v", err)
+	}
+
+	return &modelAdapterLifecycleFixture{
+		deployment:  deployment,
+		pod:         pod,
+		kubeClient:  kubeClient,
+		modelClient: modelClient,
+		mux:         mux,
+	}
+}
+
+func (f *modelAdapterLifecycleFixture) assertTargets(t *testing.T) {
+	t.Helper()
+	targetsRecorder := serveModelAdapterRequest(t, f.mux, http.MethodGet, modelAdapterTargetAPIPath, nil)
+	if targetsRecorder.Code != http.StatusOK {
+		t.Fatalf("list targets status = %d, body = %s", targetsRecorder.Code, targetsRecorder.Body.String())
+	}
+	var targets listModelAdapterTargetsResponse
+	if err := json.Unmarshal(targetsRecorder.Body.Bytes(), &targets); err != nil {
+		t.Fatalf("decode targets: %v", err)
+	}
+	if len(targets.Targets) != 1 || targets.Targets[0].Name != f.deployment.Name {
+		t.Fatalf("targets = %#v", targets.Targets)
+	}
+	if targets.Targets[0].BaseModel != "Qwen/Qwen2.5-7B" || targets.Targets[0].ReadyReplicas != 2 {
+		t.Fatalf("target details = %#v", targets.Targets[0])
+	}
+}
+
+func (f *modelAdapterLifecycleFixture) createAdapter(t *testing.T) *modelv1alpha1.ModelAdapter {
+	t.Helper()
+	createBody := []byte(`{
+		"name":"sql-assistant",
+		"artifact_url":"huggingface://example/sql-assistant",
+		"deployment_name":"qwen-serving",
+		"placement":"all"
+	}`)
+	createRecorder := serveModelAdapterRequest(t, f.mux, http.MethodPost, modelAdapterAPIPath, createBody)
+	if createRecorder.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, body = %s", createRecorder.Code, createRecorder.Body.String())
+	}
+
+	created, err := f.modelClient.ModelV1alpha1().ModelAdapters(modelAdapterTestNamespace).Get(
+		context.Background(),
+		"sql-assistant",
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		t.Fatalf("get created ModelAdapter: %v", err)
+	}
+	if created.Spec.Replicas != nil {
+		t.Fatalf("replicas = %v, want nil for all-pods placement", *created.Spec.Replicas)
+	}
+	if created.Spec.BaseModel == nil || *created.Spec.BaseModel != f.deployment.Name {
+		t.Fatalf("base model = %v", created.Spec.BaseModel)
+	}
+	if created.Spec.PodSelector.MatchLabels["app"] != "qwen-serving" {
+		t.Fatalf("pod selector = %#v", created.Spec.PodSelector)
+	}
+	if created.Labels[constants.ModelLabelName] != created.Name ||
+		created.Annotations[targetDeploymentAnnotation] != f.deployment.Name {
+		t.Fatalf("metadata = labels %#v, annotations %#v", created.Labels, created.Annotations)
+	}
+	return created
+}
+
+func (f *modelAdapterLifecycleFixture) assertAdapterStatus(
+	t *testing.T,
+	created *modelv1alpha1.ModelAdapter,
+) {
+	t.Helper()
+	created.Status = modelv1alpha1.ModelAdapterStatus{
+		Phase:           modelv1alpha1.ModelAdapterRunning,
+		Candidates:      2,
+		ReadyReplicas:   1,
+		DesiredReplicas: 2,
+		Instances:       []string{f.pod.Name},
+	}
+	if _, err := f.modelClient.ModelV1alpha1().ModelAdapters(modelAdapterTestNamespace).UpdateStatus(
+		context.Background(),
+		created,
+		metav1.UpdateOptions{},
+	); err != nil {
+		t.Fatalf("UpdateStatus() error = %v", err)
+	}
+
+	getRecorder := serveModelAdapterRequest(
+		t,
+		f.mux,
+		http.MethodGet,
+		modelAdapterAPIPath+"/sql-assistant",
+		nil,
+	)
+	if getRecorder.Code != http.StatusOK {
+		t.Fatalf("get status = %d, body = %s", getRecorder.Code, getRecorder.Body.String())
+	}
+	var detail modelAdapterResponse
+	if err := json.Unmarshal(getRecorder.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode detail: %v", err)
+	}
+	if detail.Phase != "Running" || detail.Target == nil || detail.Target.Name != f.deployment.Name {
+		t.Fatalf("detail = %#v", detail)
+	}
+	if detail.BaseModel != "Qwen/Qwen2.5-7B" {
+		t.Fatalf("display base model = %q", detail.BaseModel)
+	}
+	if len(detail.Instances) != 1 || detail.Instances[0].Ready != "1/1" ||
+		detail.Instances[0].PodIP != f.pod.Status.PodIP {
+		t.Fatalf("instances = %#v", detail.Instances)
+	}
+
+	listRecorder := serveModelAdapterRequest(t, f.mux, http.MethodGet, modelAdapterAPIPath, nil)
+	if listRecorder.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body = %s", listRecorder.Code, listRecorder.Body.String())
+	}
+	var list listModelAdaptersResponse
+	if err := json.Unmarshal(listRecorder.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list.ModelAdapters) != 1 || list.ModelAdapters[0].Name != created.Name {
+		t.Fatalf("list = %#v", list.ModelAdapters)
+	}
+}
+
+func (f *modelAdapterLifecycleFixture) deleteAdapter(
+	t *testing.T,
+	created *modelv1alpha1.ModelAdapter,
+) {
+	t.Helper()
+	deleteRecorder := serveModelAdapterRequest(
+		t,
+		f.mux,
+		http.MethodDelete,
+		modelAdapterAPIPath+"/sql-assistant",
+		nil,
+	)
+	if deleteRecorder.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d, body = %s", deleteRecorder.Code, deleteRecorder.Body.String())
+	}
+	if _, err := f.kubeClient.AppsV1().Deployments(modelAdapterTestNamespace).Get(
+		context.Background(),
+		f.deployment.Name,
+		metav1.GetOptions{},
+	); err != nil {
+		t.Fatalf("base deployment was changed by adapter delete: %v", err)
+	}
+	if _, err := f.modelClient.ModelV1alpha1().ModelAdapters(modelAdapterTestNamespace).Get(
+		context.Background(),
+		created.Name,
+		metav1.GetOptions{},
+	); err == nil || !apierrors.IsNotFound(err) {
+		t.Fatalf("get deleted ModelAdapter error = %v, want NotFound", err)
+	}
+}
+
+func TestModelAdapterHandlerRequiresAdminForMutations(t *testing.T) {
+	handler := NewModelAdapterHandler(staticModelAdapterClientProvider{
+		kubeClient:  kubernetesfake.NewSimpleClientset(),
+		modelClient: aibrixfake.NewSimpleClientset(),
+		namespace:   modelAdapterTestNamespace,
+	})
+	mux := runtime.NewServeMux()
+	if err := handler.RegisterRoutes(mux); err != nil {
+		t.Fatalf("RegisterRoutes() error = %v", err)
+	}
+
+	body := []byte(`{
+		"name":"sql-assistant",
+		"artifact_url":"huggingface://example/sql-assistant",
+		"deployment_name":"qwen-serving",
+		"placement":"all"
+	}`)
+	viewerCreate := serveModelAdapterRequestAsRole(
+		t, mux, http.MethodPost, modelAdapterAPIPath, body, "viewer",
+	)
+	if viewerCreate.Code != http.StatusForbidden {
+		t.Fatalf("viewer create status = %d, want %d", viewerCreate.Code, http.StatusForbidden)
+	}
+	viewerDelete := serveModelAdapterRequestAsRole(
+		t, mux, http.MethodDelete, modelAdapterAPIPath+"/sql-assistant", nil, "viewer",
+	)
+	if viewerDelete.Code != http.StatusForbidden {
+		t.Fatalf("viewer delete status = %d, want %d", viewerDelete.Code, http.StatusForbidden)
+	}
+	unauthenticated := serveModelAdapterRequestAsRole(
+		t, mux, http.MethodDelete, modelAdapterAPIPath+"/sql-assistant", nil, "",
+	)
+	if unauthenticated.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want %d", unauthenticated.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestIsModelAdapterTarget(t *testing.T) {
+	base := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "model"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+					constants.ModelLabelName:   "base-model",
+					constants.ModelLabelEngine: modelAdapterVLLMEngine,
+				}},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Ports: []corev1.ContainerPort{{
+						Name:          "http",
+						ContainerPort: defaultModelServingPort,
+					}},
+				}}},
+			},
+		},
+	}
+
+	if !isModelAdapterTarget(base) {
+		t.Fatal("expected explicitly configured vLLM Deployment to be compatible")
+	}
+
+	unrelated := base.DeepCopy()
+	unrelated.Spec.Template.Labels = map[string]string{}
+	if isModelAdapterTarget(unrelated) {
+		t.Fatal("unrelated Deployment was accepted as a ModelAdapter target")
+	}
+
+	unsupportedEngine := base.DeepCopy()
+	unsupportedEngine.Spec.Template.Labels[constants.ModelLabelEngine] = "trtllm"
+	if isModelAdapterTarget(unsupportedEngine) {
+		t.Fatal("unsupported engine was accepted as a ModelAdapter target")
+	}
+
+	unsupportedPort := base.DeepCopy()
+	unsupportedPort.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = 9000
+	if isModelAdapterTarget(unsupportedPort) {
+		t.Fatal("non-8000 engine port was accepted as a ModelAdapter target")
+	}
+}
+
+func TestModelAdapterHandlerRejectsUnsupportedArtifactScheme(t *testing.T) {
+	kubeClient := kubernetesfake.NewSimpleClientset()
+	modelClient := aibrixfake.NewSimpleClientset()
+	handler := NewModelAdapterHandler(staticModelAdapterClientProvider{
+		kubeClient:  kubeClient,
+		modelClient: modelClient,
+		namespace:   modelAdapterTestNamespace,
+	})
+	mux := runtime.NewServeMux()
+	if err := handler.RegisterRoutes(mux); err != nil {
+		t.Fatalf("RegisterRoutes() error = %v", err)
+	}
+
+	body := []byte(`{
+		"name":"sql-assistant",
+		"artifact_url":"hdfs://model-store/lora/sql-assistant",
+		"deployment_name":"qwen-serving",
+		"placement":"single"
+	}`)
+	recorder := serveModelAdapterRequest(t, mux, http.MethodPost, modelAdapterAPIPath, body)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func serveModelAdapterRequest(
+	t *testing.T,
+	mux http.Handler,
+	method string,
+	path string,
+	body []byte,
+) *httptest.ResponseRecorder {
+	return serveModelAdapterRequestAsRole(t, mux, method, path, body, modelAdapterAdminRole)
+}
+
+func serveModelAdapterRequestAsRole(
+	t *testing.T,
+	mux http.Handler,
+	method string,
+	path string,
+	body []byte,
+	role string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(method, path, bytes.NewReader(body))
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	if role != "" {
+		user := &middleware.UserInfo{ID: "test-user", Role: role}
+		request = request.WithContext(context.WithValue(request.Context(), middleware.UserContextKey, user))
+	}
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, request)
+	return recorder
+}

--- a/apps/console/api/server/server.go
+++ b/apps/console/api/server/server.go
@@ -59,6 +59,7 @@ type Server struct {
 	planner        plannerapi.Planner
 	injector       error_injection.Injector
 	metricsHandler http.Handler
+	clusterClients provider.ClusterClientProvider
 }
 
 // New creates a new console Server from configuration.
@@ -130,6 +131,7 @@ func New(cfg *config.Config) *Server {
 		auth:           auth,
 		injector:       injector,
 		metricsHandler: metricsHandler,
+		clusterClients: provider.NewKubernetesClientProvider(cfg.KubernetesProvider),
 	}
 }
 
@@ -160,7 +162,7 @@ func (s *Server) StartGRPC(addr string) error {
 	}
 	deploymentProviders := provider.NewRegistry(
 		provider.NewKubernetesDeploymentProvider(
-			provider.NewKubernetesClientProvider(s.cfg.KubernetesProvider),
+			s.clusterClients,
 			s.cfg.KubernetesWorkload,
 		),
 	)
@@ -235,6 +237,12 @@ func (s *Server) StartHTTP(httpAddr, grpcAddr string) error {
 	// Register file proxy routes
 	fileHandler := handler.NewFileHandler(s.cfg.MetadataServiceURL, s.injector, s.store)
 	fileHandler.RegisterRoutes(mux)
+
+	// Register the Kubernetes-backed ModelAdapter BFF.
+	modelAdapterHandler := handler.NewModelAdapterHandler(s.clusterClients)
+	if err := modelAdapterHandler.RegisterRoutes(mux); err != nil {
+		return err
+	}
 
 	// Register auth routes
 	s.auth.RegisterAuthRoutes(mux)

--- a/apps/console/web/src/App.tsx
+++ b/apps/console/web/src/App.tsx
@@ -24,6 +24,9 @@ import { Playground } from './components/Playground';
 import { Deployments } from './components/Deployments';
 import { CreateDeployment } from './components/CreateDeployment';
 import { DeploymentDetail } from './components/DeploymentDetail';
+import { LoraAdapters } from './components/LoraAdapters';
+import { CreateLoraAdapter } from './components/CreateLoraAdapter';
+import { LoraAdapterDetail } from './components/LoraAdapterDetail';
 import { ApiKeysPage } from './components/settings/ApiKeysPage';
 import { SecretsPage } from './components/settings/SecretsPage';
 import { Toast } from './components/settings/Toast';
@@ -151,6 +154,38 @@ function DeploymentDetailRoute() {
   );
 }
 
+function LoraAdaptersRoute() {
+  const navigate = useNavigate();
+  return (
+    <LoraAdapters
+      onSelectAdapter={(name) => navigate(`/lora/${name}`)}
+      onCreateAdapter={() => navigate('/lora/new')}
+    />
+  );
+}
+
+function CreateLoraAdapterRoute() {
+  const navigate = useNavigate();
+  return (
+    <CreateLoraAdapter
+      onBack={() => navigate('/lora')}
+      onCreated={(name) => navigate(`/lora/${name}`)}
+    />
+  );
+}
+
+function LoraAdapterDetailRoute() {
+  const { adapterName } = useParams<{ adapterName: string }>();
+  const navigate = useNavigate();
+  if (!adapterName) return <Navigate to="/lora" replace />;
+  return (
+    <LoraAdapterDetail
+      adapterName={adapterName}
+      onBack={() => navigate('/lora')}
+    />
+  );
+}
+
 function ComingSoon({ title, description, features }: {
   title: string;
   description: string;
@@ -209,21 +244,6 @@ function PlaygroundComingSoon() {
         'Chat with any registered model in real time',
         'Tune sampling parameters and system prompts on the fly',
         'Compare responses side by side across models',
-      ]}
-    />
-  );
-}
-
-function LoraComingSoon() {
-  return (
-    <ComingSoon
-      title="LoRA Adapters"
-      description="Deploy lightweight LoRA adapters on top of existing base model deployments. Fine-tune model behavior without the cost of full model training or separate deployments."
-      features={[
-        'Select an existing deployment as the base model',
-        'Upload and manage LoRA adapter weights',
-        'Hot-swap adapters without restarting the deployment',
-        'Monitor adapter-specific performance metrics',
       ]}
     />
   );
@@ -318,7 +338,9 @@ export default function App() {
               path="/deployments/:deploymentId"
               element={features.deployments ? <DeploymentDetailRoute /> : <Navigate to="/deployments" replace />}
             />
-            <Route path="/lora" element={<LoraComingSoon />} />
+            <Route path="/lora" element={<LoraAdaptersRoute />} />
+            <Route path="/lora/new" element={<CreateLoraAdapterRoute />} />
+            <Route path="/lora/:adapterName" element={<LoraAdapterDetailRoute />} />
 
             <Route path="/settings" element={<Navigate to="/settings/api-keys" replace />} />
             <Route path="/settings/api-keys" element={<SettingsRoute tab="api-keys" showToast={showToast} />} />

--- a/apps/console/web/src/components/CreateLoraAdapter.tsx
+++ b/apps/console/web/src/components/CreateLoraAdapter.tsx
@@ -1,0 +1,396 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
+import {
+  Check,
+  ChevronLeft,
+  LoaderCircle,
+  Plus,
+} from 'lucide-react';
+import {
+  createModelAdapter,
+  listModelAdapterTargets,
+} from '../utils/api';
+import type {
+  ModelAdapter,
+  ModelAdapterPlacement,
+  ModelAdapterTarget,
+} from '../utils/api';
+
+interface CreateLoraAdapterProps {
+  onBack: () => void;
+  onCreated: (name: string) => void;
+}
+
+const modelAdapterNamePattern = /^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/;
+const modelAdapterNameMaxLength = 63;
+
+export function CreateLoraAdapter({ onBack, onCreated }: CreateLoraAdapterProps) {
+  const [name, setName] = useState('');
+  const [artifactUrl, setArtifactUrl] = useState('');
+  const [targets, setTargets] = useState<ModelAdapterTarget[]>([]);
+  const [selectedTargetName, setSelectedTargetName] = useState('');
+  const [placement, setPlacement] = useState<ModelAdapterPlacement>('all');
+  const [loadingTargets, setLoadingTargets] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [artifactError, setArtifactError] = useState<string | null>(null);
+  const [createdAdapter, setCreatedAdapter] = useState<ModelAdapter | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listModelAdapterTargets()
+      .then((items) => {
+        if (cancelled) return;
+        setTargets(items);
+        setSelectedTargetName(items[0]?.name ?? '');
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to discover Kubernetes deployments.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingTargets(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selectedTarget = useMemo(
+    () => targets.find((target) => target.name === selectedTargetName) ?? null,
+    [selectedTargetName, targets],
+  );
+
+  const targetPods = selectedTarget
+    ? placement === 'all'
+      ? selectedTarget.readyReplicas
+      : Math.min(1, selectedTarget.readyReplicas)
+    : 0;
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (submitting) return;
+
+    const normalizedName = name.trim();
+    const normalizedArtifactUrl = artifactUrl.trim();
+    const nextNameError = !normalizedName ||
+      normalizedName.length > modelAdapterNameMaxLength ||
+      !modelAdapterNamePattern.test(normalizedName)
+      ? 'Use lowercase letters, numbers, dots, and hyphens.'
+      : null;
+    const nextArtifactError = normalizedArtifactUrl
+      ? null
+      : 'Enter a supported LoRA artifact URL.';
+    setNameError(nextNameError);
+    setArtifactError(nextArtifactError);
+    if (nextNameError || nextArtifactError || !selectedTarget) return;
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const adapter = await createModelAdapter({
+        name: normalizedName,
+        artifactUrl: normalizedArtifactUrl,
+        deploymentName: selectedTarget.name,
+        placement,
+      });
+      setCreatedAdapter(adapter);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create ModelAdapter.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="mx-auto w-full max-w-6xl p-8">
+        <button
+          type="button"
+          onClick={onBack}
+          className="mb-4 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-900"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          LoRA deployments
+        </button>
+
+        <div className="mb-6">
+          <div className="mb-1 text-xs font-semibold uppercase tracking-widest text-teal-700">
+            Create ModelAdapter
+          </div>
+          <h1 className="mb-1 text-3xl font-semibold tracking-tight text-gray-900">
+            Deploy a LoRA adapter
+          </h1>
+          <p className="text-sm text-gray-500">
+            Provide the adapter artifact and select the existing Kubernetes deployment that will load it.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="grid grid-cols-1 items-start gap-6 xl:grid-cols-3">
+          <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm xl:col-span-2">
+            {error && (
+              <div className="mb-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                {error}
+              </div>
+            )}
+
+            <div className="border-b border-gray-100 pb-6">
+              <div className="mb-5">
+                <h2 className="mb-1 text-lg font-semibold text-gray-900">Adapter</h2>
+                <p className="text-sm text-gray-500">
+                  Only the public model ID and artifact URL are required.
+                </p>
+              </div>
+              <div className="mb-5">
+                <label className="mb-2 block text-sm font-medium text-gray-700">
+                  LoRA model ID <span className="text-red-600">*</span>
+                </label>
+                <input
+                  value={name}
+                  maxLength={modelAdapterNameMaxLength}
+                  onChange={(event) => {
+                    setName(event.target.value);
+                    setNameError(null);
+                  }}
+                  placeholder="sql-assistant"
+                  className={`w-full rounded-lg border px-4 py-2.5 text-sm focus:outline-none focus:ring-2 ${
+                    nameError
+                      ? 'border-red-300 focus:ring-red-200'
+                      : 'border-gray-200 focus:border-teal-500 focus:ring-teal-500/20'
+                  }`}
+                />
+                <p className="mt-2 text-xs text-gray-400">
+                  This becomes the ModelAdapter name and inference model ID.
+                </p>
+                {nameError && <p className="mt-1 text-xs text-red-600">{nameError}</p>}
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium text-gray-700">
+                  LoRA artifact URL <span className="text-red-600">*</span>
+                </label>
+                <input
+                  value={artifactUrl}
+                  onChange={(event) => {
+                    setArtifactUrl(event.target.value);
+                    setArtifactError(null);
+                  }}
+                  placeholder="huggingface://organization/adapter"
+                  className={`w-full rounded-lg border px-4 py-2.5 text-sm focus:outline-none focus:ring-2 ${
+                    artifactError
+                      ? 'border-red-300 focus:ring-red-200'
+                      : 'border-gray-200 focus:border-teal-500 focus:ring-teal-500/20'
+                  }`}
+                />
+                <p className="mt-2 text-xs text-gray-400">
+                  Use a controller-supported URL such as huggingface://, s3://, gcs://, tos://, or an absolute mounted path.
+                </p>
+                {artifactError && <p className="mt-1 text-xs text-red-600">{artifactError}</p>}
+              </div>
+            </div>
+
+            <div className="border-b border-gray-100 py-6">
+              <div className="mb-5">
+                <h2 className="mb-1 text-lg font-semibold text-gray-900">Base model deployment</h2>
+                <p className="text-sm text-gray-500">
+                  Select an existing Kubernetes Deployment. AIBrix does not create the base workload in this workflow.
+                </p>
+              </div>
+
+              {loadingTargets ? (
+                <div className="rounded-lg border border-gray-200 px-4 py-8 text-center text-sm text-gray-400">
+                  Discovering Kubernetes deployments...
+                </div>
+              ) : targets.length === 0 ? (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-4 text-sm text-amber-700">
+                  No compatible Kubernetes Deployments were found in the configured namespace.
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {targets.map((target) => {
+                    const selected = target.name === selectedTargetName;
+                    return (
+                      <button
+                        key={target.name}
+                        type="button"
+                        onClick={() => setSelectedTargetName(target.name)}
+                        className={`w-full rounded-lg border p-4 text-left transition-colors ${
+                          selected
+                            ? 'border-teal-400 bg-teal-50/60 ring-2 ring-teal-100'
+                            : 'border-gray-200 hover:border-teal-200'
+                        }`}
+                      >
+                        <div className="flex items-start gap-3">
+                          <span className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
+                            selected ? 'border-teal-700' : 'border-gray-300'
+                          }`}>
+                            {selected && <span className="h-2 w-2 rounded-full bg-teal-700" />}
+                          </span>
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-sm font-semibold text-gray-900">
+                              {target.name}
+                            </div>
+                            <div className="mt-1 truncate text-xs text-gray-500">
+                              {target.baseModel} · {target.engine}
+                            </div>
+                          </div>
+                          <span className="rounded-md border border-gray-200 bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600">
+                            {target.kind}
+                          </span>
+                        </div>
+                        <div className="ml-7 mt-3 flex gap-5 border-t border-gray-100 pt-3 text-xs text-gray-500">
+                          <span>{target.readyReplicas}/{target.desiredReplicas} ready</span>
+                          <span>{target.apiVersion}</span>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <div className="pt-6">
+              <div className="mb-5">
+                <h2 className="mb-1 text-lg font-semibold text-gray-900">Placement</h2>
+                <p className="text-sm text-gray-500">
+                  This maps directly to ModelAdapter <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">spec.replicas</code>.
+                </p>
+              </div>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <PlacementOption
+                  selected={placement === 'all'}
+                  title="All matching Pods"
+                  description={`Omit replicas. Load onto all ${selectedTarget?.readyReplicas ?? 0} healthy Pods and follow deployment scale-out.`}
+                  onClick={() => setPlacement('all')}
+                />
+                <PlacementOption
+                  selected={placement === 'single'}
+                  title="Single Pod"
+                  description="Set replicas to 1 and let the ModelAdapter scheduler select one Pod."
+                  onClick={() => setPlacement('single')}
+                />
+              </div>
+            </div>
+
+            <div className="mt-6 flex justify-end gap-3 border-t border-gray-100 pt-5">
+              <button
+                type="button"
+                onClick={onBack}
+                className="rounded-lg border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !selectedTarget}
+                className="inline-flex items-center gap-2 rounded-lg bg-teal-700 px-4 py-2.5 text-sm font-medium text-white hover:bg-teal-800 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {submitting ? (
+                  <LoaderCircle className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Plus className="h-4 w-4" />
+                )}
+                Create ModelAdapter
+              </button>
+            </div>
+          </section>
+
+          <aside className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-4 text-base font-semibold text-gray-900">ModelAdapter preview</h2>
+            <PreviewRow label="Name" value={name || '-'} />
+            <PreviewRow label="Artifact URL" value={artifactUrl || '-'} />
+            <PreviewRow label="Base model" value={selectedTarget?.baseModel || '-'} />
+            <PreviewRow
+              label="Base deployment"
+              value={selectedTarget ? `Deployment / ${selectedTarget.name}` : '-'}
+            />
+            <PreviewRow label="Target Pods" value={String(targetPods)} />
+            <div className="mt-4 rounded-lg border border-teal-200 bg-teal-50 px-3 py-3 text-xs leading-relaxed text-teal-800">
+              The UI derives <strong>baseModel</strong>, <strong>podSelector</strong>, and runtime targets from the selected Kubernetes Deployment.
+            </div>
+          </aside>
+        </form>
+      </div>
+
+      {(submitting || createdAdapter) && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-6 backdrop-blur-sm">
+          <div className="w-full max-w-md overflow-hidden rounded-xl border border-gray-200 bg-white shadow-2xl">
+            <div className="flex items-center gap-4 p-6">
+              {createdAdapter ? (
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-green-600 text-white">
+                  <Check className="h-5 w-5" />
+                </span>
+              ) : (
+                <LoaderCircle className="h-9 w-9 shrink-0 animate-spin text-teal-700" />
+              )}
+              <div>
+                <div className="font-semibold text-gray-900">
+                  {createdAdapter ? 'ModelAdapter created' : 'Creating ModelAdapter'}
+                </div>
+                <div className="mt-1 text-sm text-gray-500">
+                  {createdAdapter
+                    ? `${createdAdapter.name} is ${createdAdapter.phase.toLowerCase()} on ${selectedTarget?.name}.`
+                    : `Submitting ${name || 'the requested adapter'} to Kubernetes.`}
+                </div>
+              </div>
+            </div>
+            <div className="flex justify-end border-t border-gray-100 bg-gray-50 px-5 py-3">
+              <button
+                type="button"
+                disabled={!createdAdapter}
+                onClick={() => createdAdapter && onCreated(createdAdapter.name)}
+                className="rounded-lg bg-teal-700 px-4 py-2 text-sm font-medium text-white hover:bg-teal-800 disabled:opacity-50"
+              >
+                View ModelAdapter
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function PlacementOption({
+  selected,
+  title,
+  description,
+  onClick,
+}: {
+  selected: boolean;
+  title: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`min-h-24 rounded-lg border p-4 text-left ${
+        selected
+          ? 'border-teal-400 bg-teal-50/60 ring-2 ring-teal-100'
+          : 'border-gray-200 hover:border-teal-200'
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        <span className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
+          selected ? 'border-teal-700' : 'border-gray-300'
+        }`}>
+          {selected && <span className="h-2 w-2 rounded-full bg-teal-700" />}
+        </span>
+        <span className="text-sm font-semibold text-gray-900">{title}</span>
+      </div>
+      <p className="ml-7 mt-2 text-xs leading-relaxed text-gray-500">{description}</p>
+    </button>
+  );
+}
+
+function PreviewRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[7rem_minmax(0,1fr)] gap-2 border-b border-gray-100 py-3 text-xs last:border-0">
+      <span className="text-gray-400">{label}</span>
+      <span className="truncate font-medium text-gray-700">{value}</span>
+    </div>
+  );
+}

--- a/apps/console/web/src/components/LoraAdapterDetail.tsx
+++ b/apps/console/web/src/components/LoraAdapterDetail.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useState } from 'react';
+import {
+  ChevronLeft,
+  Copy,
+  Link,
+  Server,
+} from 'lucide-react';
+import {
+  APIError,
+  deleteModelAdapter,
+  getModelAdapter,
+} from '../utils/api';
+import type { ModelAdapter } from '../utils/api';
+import { copyToClipboard } from '../utils/clipboard';
+import {
+  formatResourceAge,
+  MODEL_ADAPTER_REFRESH_INTERVAL_MS,
+  ModelAdapterPhase,
+} from './LoraShared';
+
+interface LoraAdapterDetailProps {
+  adapterName: string;
+  onBack: () => void;
+}
+
+export function LoraAdapterDetail({ adapterName, onBack }: LoraAdapterDetailProps) {
+  const [adapter, setAdapter] = useState<ModelAdapter | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    let requestInFlight = false;
+    let initialLoad = true;
+
+    const refresh = async () => {
+      if (requestInFlight) return;
+      requestInFlight = true;
+      try {
+        const result = await getModelAdapter(adapterName);
+        if (active) {
+          setAdapter(result);
+          setError(null);
+        }
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : 'Failed to load ModelAdapter.');
+          if (err instanceof APIError && err.status === 404) {
+            setAdapter(null);
+          }
+        }
+      } finally {
+        requestInFlight = false;
+        if (active && initialLoad) {
+          initialLoad = false;
+          setLoading(false);
+        }
+      }
+    };
+
+    void refresh();
+    const interval = window.setInterval(() => {
+      void refresh();
+    }, MODEL_ADAPTER_REFRESH_INTERVAL_MS);
+
+    return () => {
+      active = false;
+      window.clearInterval(interval);
+    };
+  }, [adapterName]);
+
+  const showToast = (message: string) => {
+    setToast(message);
+    window.setTimeout(() => setToast(null), 1800);
+  };
+
+  const copyValue = async (value: string, message: string) => {
+    await copyToClipboard(value);
+    showToast(message);
+  };
+
+  const handleDelete = async () => {
+    if (!adapter || deleting) return;
+    if (!window.confirm(`Delete ModelAdapter "${adapter.name}"? This will unload it from all running instances.`)) {
+      return;
+    }
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteModelAdapter(adapter.name);
+      onBack();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete ModelAdapter.');
+      setDeleting(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="p-8 text-sm text-gray-400">Loading ModelAdapter...</div>;
+  }
+  if (!adapter) {
+    return (
+      <div className="p-8">
+        <button type="button" onClick={onBack} className="mb-4 text-sm text-teal-700">
+          Back to LoRA deployments
+        </button>
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error || 'ModelAdapter not found.'}
+        </div>
+      </div>
+    );
+  }
+
+  const target = adapter.target;
+
+  return (
+    <div className="mx-auto w-full max-w-6xl p-8">
+      <button
+        type="button"
+        onClick={onBack}
+        className="mb-4 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-900"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        LoRA deployments
+      </button>
+
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <div className="mb-1 text-xs font-semibold uppercase tracking-widest text-teal-700">
+            ModelAdapter
+          </div>
+          <div className="mb-1 flex items-center gap-3">
+            <h1 className="text-3xl font-semibold tracking-tight text-gray-900">
+              {adapter.name}
+            </h1>
+            <ModelAdapterPhase phase={adapter.phase} />
+          </div>
+          <p className="text-sm text-gray-500">
+            LoRA adapter attached to base model <strong className="text-gray-700">{adapter.baseModel}</strong>.
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => copyValue(adapter.name, 'Model ID copied')}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            <Copy className="h-4 w-4" />
+            Copy model ID
+          </button>
+          <button
+            type="button"
+            disabled={deleting}
+            onClick={handleDelete}
+            className="rounded-lg border border-red-200 bg-white px-4 py-2.5 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50"
+          >
+            {deleting ? 'Deleting...' : 'Delete'}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="mb-5 grid overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm sm:grid-cols-5">
+        <Stat label="Phase" value={adapter.phase} />
+        <Stat label="Ready" value={String(adapter.readyReplicas)} />
+        <Stat label="Desired" value={String(adapter.desiredReplicas)} />
+        <Stat label="Candidates" value={String(adapter.candidates)} />
+        <Stat label="Age" value={formatResourceAge(adapter.createdAt)} last />
+      </div>
+
+      <div className="grid items-start gap-5 xl:grid-cols-[minmax(0,1.55fr)_minmax(18rem,0.8fr)]">
+        <div className="space-y-5">
+          <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <CardHeader title="ModelAdapter configuration" code="spec" />
+            <PropertyGrid
+              items={[
+                ['Base model', adapter.baseModel || '-'],
+                ['Replicas', adapter.placement === 'all' ? 'All matching Pods' : '1'],
+                ['Pod selector', adapter.podSelector || '-', true],
+                ['Scheduler', adapter.schedulerName || 'default'],
+              ]}
+            />
+          </section>
+
+          <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="font-semibold text-gray-900">Base model deployment</h2>
+              <span className="rounded-md border border-teal-100 bg-teal-50 px-2 py-1 text-xs font-medium text-teal-700">
+                Kubernetes
+              </span>
+            </div>
+            {target ? (
+              <>
+                <div className="mb-4 flex items-start gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white text-teal-700">
+                    <Server className="h-4 w-4" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-semibold text-gray-900">
+                      {target.name}
+                    </div>
+                    <div className="mt-1 truncate text-xs text-gray-500">
+                      {target.baseModel} · {target.engine}
+                    </div>
+                  </div>
+                  <span className="rounded-md border border-gray-200 bg-white px-2 py-1 text-xs text-gray-600">
+                    {target.kind}
+                  </span>
+                  <span className="rounded-full bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700">
+                    {target.readyReplicas > 0 ? 'Ready' : 'Pending'}
+                  </span>
+                </div>
+                <PropertyGrid
+                  items={[
+                    ['Resource type', target.kind],
+                    ['API version', target.apiVersion],
+                    ['Ready replicas', `${target.readyReplicas} / ${target.desiredReplicas}`],
+                    ['Update strategy', target.updateStrategy || '-'],
+                    ['Engine', target.engine],
+                    ['Namespace', target.namespace],
+                  ]}
+                />
+              </>
+            ) : (
+              <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+                The referenced Deployment is no longer available.
+              </div>
+            )}
+          </section>
+        </div>
+
+        <aside className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+          <CardHeader title="LoRA artifact" code="spec.artifactURL" />
+          <button
+            type="button"
+            onClick={() => copyValue(adapter.artifactUrl, 'Artifact URL copied')}
+            className="flex w-full items-start gap-2 rounded-lg border border-teal-200 bg-teal-50 px-3 py-3 text-left font-mono text-xs leading-relaxed text-teal-800 hover:bg-teal-100/60"
+          >
+            <Link className="mt-0.5 h-4 w-4 shrink-0" />
+            <span className="break-all">{adapter.artifactUrl}</span>
+          </button>
+          <p className="mt-3 text-xs leading-relaxed text-gray-400">
+            The ModelAdapter controller loads adapter weights from this artifact URL.
+          </p>
+        </aside>
+      </div>
+
+      <section className="mt-5 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+          <h2 className="font-semibold text-gray-900">Bound Pods</h2>
+          <span className="rounded bg-gray-100 px-2 py-1 font-mono text-xs text-gray-500">
+            status.instances · {adapter.instances.length} pods
+          </span>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead className="border-b border-gray-200 bg-gray-50">
+              <tr>
+                {['Name', 'Ready', 'Status', 'Restarts', 'Age', 'Pod IP', 'Node'].map((label) => (
+                  <th
+                    key={label}
+                    className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500"
+                  >
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {adapter.instances.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-400">
+                    No Pods are currently bound.
+                  </td>
+                </tr>
+              ) : (
+                adapter.instances.map((pod) => (
+                  <tr key={pod.name}>
+                    <td className="px-4 py-3 font-mono text-xs text-gray-700">{pod.name}</td>
+                    <td className="px-4 py-3 text-sm text-gray-600">{pod.ready}</td>
+                    <td className="px-4 py-3 text-sm font-medium text-green-700">{pod.status}</td>
+                    <td className="px-4 py-3 text-sm text-gray-600">{pod.restarts}</td>
+                    <td className="px-4 py-3 text-sm text-gray-600">{formatResourceAge(pod.createdAt)}</td>
+                    <td className="px-4 py-3 font-mono text-xs text-gray-600">{pod.podIp || '-'}</td>
+                    <td className="px-4 py-3 font-mono text-xs text-gray-600">{pod.node || '-'}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {toast && (
+        <div className="fixed bottom-6 right-6 rounded-lg bg-slate-900 px-4 py-3 text-sm text-white shadow-xl">
+          {toast}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, last = false }: { label: string; value: string; last?: boolean }) {
+  return (
+    <div className={`px-4 py-3 ${last ? '' : 'border-r border-gray-200'}`}>
+      <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-gray-400">{label}</div>
+      <div className="truncate text-sm font-semibold text-gray-800">{value}</div>
+    </div>
+  );
+}
+
+function CardHeader({ title, code }: { title: string; code: string }) {
+  return (
+    <div className="mb-4 flex items-center justify-between">
+      <h2 className="font-semibold text-gray-900">{title}</h2>
+      <span className="rounded bg-gray-100 px-2 py-1 font-mono text-xs text-gray-500">{code}</span>
+    </div>
+  );
+}
+
+function PropertyGrid({ items }: { items: Array<[string, string, boolean?]> }) {
+  return (
+    <div className="grid overflow-hidden rounded-lg border border-gray-200 sm:grid-cols-2">
+      {items.map(([label, value, code], index) => (
+        <div
+          key={label}
+          className={`min-w-0 p-3 ${
+            index % 2 === 0 ? 'border-r border-gray-200' : ''
+          } ${index < items.length - 2 ? 'border-b border-gray-200' : ''}`}
+        >
+          <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-gray-400">
+            {label}
+          </div>
+          <div className={`truncate text-sm font-medium text-gray-700 ${code ? 'font-mono text-xs' : ''}`}>
+            {value}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/console/web/src/components/LoraAdapters.tsx
+++ b/apps/console/web/src/components/LoraAdapters.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronRight, Plus, Search } from 'lucide-react';
+import { listModelAdapters } from '../utils/api';
+import type { ModelAdapter } from '../utils/api';
+import {
+  formatResourceAge,
+  MODEL_ADAPTER_REFRESH_INTERVAL_MS,
+  ModelAdapterIcon,
+  ModelAdapterPhase,
+} from './LoraShared';
+
+interface LoraAdaptersProps {
+  onSelectAdapter: (name: string) => void;
+  onCreateAdapter: () => void;
+}
+
+export function LoraAdapters({ onSelectAdapter, onCreateAdapter }: LoraAdaptersProps) {
+  const [adapters, setAdapters] = useState<ModelAdapter[]>([]);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    let requestInFlight = false;
+    let initialLoad = true;
+
+    const refresh = async () => {
+      if (requestInFlight) return;
+      requestInFlight = true;
+      try {
+        const items = await listModelAdapters();
+        if (active) {
+          setAdapters(items);
+          setError(null);
+        }
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : 'Failed to load ModelAdapters.');
+        }
+      } finally {
+        requestInFlight = false;
+        if (active && initialLoad) {
+          initialLoad = false;
+          setLoading(false);
+        }
+      }
+    };
+
+    void refresh();
+    const interval = window.setInterval(() => {
+      void refresh();
+    }, MODEL_ADAPTER_REFRESH_INTERVAL_MS);
+
+    return () => {
+      active = false;
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  const filteredAdapters = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return adapters;
+    return adapters.filter((adapter) => (
+      `${adapter.name} ${adapter.baseModel} ${adapter.target?.name ?? ''}`
+        .toLowerCase()
+        .includes(query)
+    ));
+  }, [adapters, search]);
+
+  return (
+    <div className="mx-auto w-full max-w-6xl p-8">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <div className="mb-1 text-xs font-semibold uppercase tracking-widest text-teal-700">
+            Model adapters
+          </div>
+          <h1 className="mb-1 text-3xl font-semibold tracking-tight text-gray-900">
+            LoRA deployments
+          </h1>
+          <p className="text-sm text-gray-500">
+            Manage ModelAdapter resources and the base model deployments they attach to.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onCreateAdapter}
+          className="inline-flex items-center gap-2 rounded-lg bg-teal-700 px-4 py-2.5 text-sm font-medium text-white shadow-sm hover:bg-teal-800"
+        >
+          <Plus className="h-4 w-4" />
+          Deploy LoRA
+        </button>
+      </div>
+
+      <div className="relative mb-4">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search ModelAdapter or base model deployment"
+          className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/20"
+        />
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="overflow-x-auto">
+          <table className="w-full table-fixed">
+            <colgroup>
+              <col className="w-[26%]" />
+              <col className="w-[19%]" />
+              <col className="w-[25%]" />
+              <col className="w-[10%]" />
+              <col className="w-[12%]" />
+              <col className="w-[6%]" />
+              <col className="w-[2%]" />
+            </colgroup>
+            <thead className="border-b border-gray-200 bg-gray-50">
+              <tr>
+                {['ModelAdapter', 'Base model', 'Base model deployment', 'Ready', 'Phase', 'Age', ''].map((label) => (
+                  <th
+                    key={label}
+                    className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500"
+                  >
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {loading ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-10 text-center text-sm text-gray-400">
+                    Loading ModelAdapters...
+                  </td>
+                </tr>
+              ) : filteredAdapters.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-10 text-center text-sm text-gray-400">
+                    No matching ModelAdapters.
+                  </td>
+                </tr>
+              ) : (
+                filteredAdapters.map((adapter) => (
+                  <tr
+                    key={adapter.name}
+                    onClick={() => onSelectAdapter(adapter.name)}
+                    className="cursor-pointer transition-colors hover:bg-gray-50"
+                  >
+                    <td className="px-4 py-4">
+                      <div className="flex min-w-0 items-center gap-3">
+                        <ModelAdapterIcon />
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium text-gray-900">
+                            {adapter.name}
+                          </div>
+                          <div className="truncate font-mono text-xs text-gray-400">
+                            {adapter.apiVersion}
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="truncate px-4 py-4 text-sm text-gray-700">
+                      {adapter.baseModel || '-'}
+                    </td>
+                    <td className="px-4 py-4">
+                      <div className="truncate text-sm font-medium text-gray-800">
+                        {adapter.target?.name || 'Unavailable'}
+                      </div>
+                      <div className="truncate font-mono text-xs text-gray-400">
+                        {adapter.target ? `${adapter.target.kind} · Kubernetes` : '-'}
+                      </div>
+                    </td>
+                    <td className="px-4 py-4 text-sm font-medium text-gray-700">
+                      {adapter.readyReplicas}
+                      <span className="font-normal text-gray-400">
+                        {' '}/ {adapter.desiredReplicas}
+                      </span>
+                    </td>
+                    <td className="px-4 py-4">
+                      <ModelAdapterPhase phase={adapter.phase} />
+                    </td>
+                    <td className="px-4 py-4 text-sm text-gray-500">
+                      {formatResourceAge(adapter.createdAt)}
+                    </td>
+                    <td className="px-2 py-4 text-gray-400">
+                      <ChevronRight className="h-4 w-4" />
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/web/src/components/LoraShared.tsx
+++ b/apps/console/web/src/components/LoraShared.tsx
@@ -1,0 +1,37 @@
+import { Layers } from 'lucide-react';
+
+export const MODEL_ADAPTER_REFRESH_INTERVAL_MS = 5000;
+
+export function formatResourceAge(createdAt?: string): string {
+  if (!createdAt) return '-';
+  const created = new Date(createdAt).getTime();
+  if (!Number.isFinite(created)) return '-';
+  const seconds = Math.max(0, Math.floor((Date.now() - created) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+export function ModelAdapterIcon() {
+  return (
+    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-teal-100 bg-teal-50 text-teal-700">
+      <Layers className="h-4 w-4" />
+    </span>
+  );
+}
+
+export function ModelAdapterPhase({ phase }: { phase: string }) {
+  const normalized = phase || 'Pending';
+  const className = normalized === 'Running'
+    ? 'bg-green-50 text-green-700'
+    : normalized === 'Failed'
+      ? 'bg-red-50 text-red-700'
+      : 'bg-amber-50 text-amber-700';
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ${className}`}>
+      <span className="h-1.5 w-1.5 rounded-full bg-current" />
+      {normalized}
+    </span>
+  );
+}

--- a/apps/console/web/src/utils/api.test.ts
+++ b/apps/console/web/src/utils/api.test.ts
@@ -87,4 +87,18 @@ describe('api helpers', () => {
       },
     });
   });
+
+  it('serializes ModelAdapter creation without exposing the Kubernetes CRD', () => {
+    expect(camelToSnake({
+      name: 'sql-assistant',
+      artifactUrl: 'huggingface://example/sql-assistant',
+      deploymentName: 'qwen-serving',
+      placement: 'all',
+    })).toEqual({
+      name: 'sql-assistant',
+      artifact_url: 'huggingface://example/sql-assistant',
+      deployment_name: 'qwen-serving',
+      placement: 'all',
+    });
+  });
 });

--- a/apps/console/web/src/utils/api.ts
+++ b/apps/console/web/src/utils/api.ts
@@ -145,6 +145,58 @@ export interface DeploymentOverrides {
   engineArgs?: Record<string, string>;
 }
 
+export type ModelAdapterPlacement = 'all' | 'single';
+
+export interface ModelAdapterTarget {
+  name: string;
+  namespace: string;
+  kind: 'Deployment';
+  apiVersion: string;
+  baseModel: string;
+  engine: string;
+  port: number;
+  readyReplicas: number;
+  desiredReplicas: number;
+  selector: string;
+  updateStrategy: string;
+  createdAt: string;
+}
+
+export interface ModelAdapterPod {
+  name: string;
+  ready: string;
+  status: string;
+  restarts: number;
+  createdAt: string;
+  podIp: string;
+  node: string;
+}
+
+export interface ModelAdapter {
+  name: string;
+  namespace: string;
+  apiVersion: string;
+  artifactUrl: string;
+  baseModel: string;
+  schedulerName: string;
+  placement: ModelAdapterPlacement;
+  phase: string;
+  readyReplicas: number;
+  desiredReplicas: number;
+  candidates: number;
+  createdAt: string;
+  podSelector: string;
+  target?: ModelAdapterTarget;
+  instances: ModelAdapterPod[];
+}
+
+export interface CreateModelAdapterRequest {
+  name: string;
+  artifactUrl: string;
+  deploymentName: string;
+  placement: ModelAdapterPlacement;
+}
+
 // --- Model Deployment Templates ---
 //
 // Mirrors apps/console/api/proto/console/v1/console.proto. The proto comment
@@ -371,7 +423,7 @@ export function camelToSnake<T>(data: unknown): T {
 
 // --- Fetch helper ---
 
-class APIError extends Error {
+export class APIError extends Error {
   status: number;
 
   constructor(message: string, status: number) {
@@ -519,6 +571,37 @@ export async function deleteDeployment(id: string): Promise<void> {
   return apiFetch<void>(`/api/v1/deployments/${encodeURIComponent(id)}`, {
     method: 'DELETE',
   });
+}
+
+// --- ModelAdapters ---
+
+export async function listModelAdapters(): Promise<ModelAdapter[]> {
+  const data = await apiFetch<{ modelAdapters: ModelAdapter[] }>('/api/v1/model-adapters');
+  return data.modelAdapters || [];
+}
+
+export async function getModelAdapter(name: string): Promise<ModelAdapter> {
+  return apiFetch<ModelAdapter>(`/api/v1/model-adapters/${encodeURIComponent(name)}`);
+}
+
+export async function createModelAdapter(
+  request: CreateModelAdapterRequest,
+): Promise<ModelAdapter> {
+  return apiFetch<ModelAdapter>('/api/v1/model-adapters', {
+    method: 'POST',
+    body: JSON.stringify(camelToSnake(request)),
+  });
+}
+
+export async function deleteModelAdapter(name: string): Promise<void> {
+  return apiFetch<void>(`/api/v1/model-adapters/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function listModelAdapterTargets(): Promise<ModelAdapterTarget[]> {
+  const data = await apiFetch<{ targets: ModelAdapterTarget[] }>('/api/v1/model-adapter-targets');
+  return data.targets || [];
 }
 
 // --- Models ---


### PR DESCRIPTION
## Pull Request Description

Add open-source Kubernetes ModelAdapter management to AIBrix Console.

### Changes

- Add a Kubernetes-backed ModelAdapter REST BFF.
- Reuse the Deployment provider's kubeconfig, context, namespace, and cached REST configuration.
- Discover compatible `vllm` and `sglang` Deployments as LoRA targets.
- Derive `baseModel`, `podSelector`, engine, port, and placement server-side.
- Add ModelAdapter list, create, detail, bound-Pod status, periodic refresh, and delete UI.
- Preserve the base Deployment when deleting a ModelAdapter.
- Keep ModelAdapter CRD and controller APIs unchanged.
- Restrict ModelAdapter mutations to Console admins.

tested in local envs,

the lora list:
<img width="2854" height="1154" alt="image" src="https://github.com/user-attachments/assets/cf1f6b6a-3daf-4b7d-8948-6e2e4fea23eb" />

the lora detail

<img width="2792" height="1788" alt="image" src="https://github.com/user-attachments/assets/dcdea9e2-6e83-4e96-85d6-8f554df2ef55" />


## Submission Checklist

- [x] PR title includes an appropriate prefix.
- [x] Changes are clearly explained.
- [x] New and existing tests pass.
- [x] Code follows existing Console and Kubernetes provider patterns.
- [x] No CRD or unrelated configuration changes are included.
- [x] End-to-end kind validation completed.
