### PR TITLE
[Docs][CI] Enable EnvoyPatchPolicy via helm --set

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install Envoy Gateway
         run: |
-          helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace --wait
+          helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace --wait --set config.envoyGateway.extensionApis.enableEnvoyPatchPolicy=true
       
       - name: Install Kuberay operator
         run: |

--- a/docs/source/getting_started/installation/installation.rst
+++ b/docs/source/getting_started/installation/installation.rst
@@ -43,7 +43,9 @@ Prerequisites
 .. code:: bash
 
     # Install envoy-gateway, this is not aibrix component. you can also use helm package to install it.
-    helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.2.8 -n envoy-gateway-system --create-namespace --set config.envoyGateway.extensionApis.enableEnvoyPatchPolicy=true
+    helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.2.8 -n envoy-gateway-system \
+    --create-namespace \
+    --set config.envoyGateway.extensionApis.enableEnvoyPatchPolicy=true
 
 .. note::
     If you are experiencing network issues with `docker.io`, you can install the helm chart from the code repo https://github.com/envoyproxy/gateway/tree/main/charts/gateway-helm instead.

--- a/docs/source/getting_started/installation/installation.rst
+++ b/docs/source/getting_started/installation/installation.rst
@@ -43,26 +43,7 @@ Prerequisites
 .. code:: bash
 
     # Install envoy-gateway, this is not aibrix component. you can also use helm package to install it.
-    helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.2.8 -n envoy-gateway-system --create-namespace
-
-    # patch the configuration to enable EnvoyPatchPolicy, this is super important!
-    kubectl apply -f - <<EOF
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: envoy-gateway-config
-      namespace: envoy-gateway-system
-    data:
-      envoy-gateway.yaml: |
-        apiVersion: gateway.envoyproxy.io/v1alpha1
-        kind: EnvoyGateway
-        provider:
-          type: Kubernetes
-        gateway:
-          controllerName: gateway.envoyproxy.io/gatewayclass-controller
-        extensionApis:
-          enableEnvoyPatchPolicy: true
-    EOF
+    helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.2.8 -n envoy-gateway-system --create-namespace --set config.envoyGateway.extensionApis.enableEnvoyPatchPolicy=true
 
 .. note::
     If you are experiencing network issues with `docker.io`, you can install the helm chart from the code repo https://github.com/envoyproxy/gateway/tree/main/charts/gateway-helm instead.


### PR DESCRIPTION
## Pull Request Description
The manual `kubectl apply` ConfigMap patch to enable `EnvoyPatchPolicy` can be achieved with a single Helm `--set` flag instead. This is cleaner for users deploying via tools like Flux/Argo, where an out-of-band kubectl patch doesn't fit the declarative workflow. Also updated `chart-ci.yml` to match.

## Related Issues
Resolves: #N/A

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>