### PR TITLE
fix(test): use dynamic port in pd tests to avoid cross-package collisions

### DIFF
--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -109,8 +109,19 @@ func TestPDRouter_Route(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts := setupTestServer(t, tt.serverCode, tt.serverResp, tt.llmEngine)
+			ts, prefillPort := setupTestServer(t, tt.serverCode, tt.serverResp, tt.llmEngine)
 			defer ts.Close()
+
+			// Stamp the dynamic port onto each prefill pod so GetModelPortForPod
+			// resolves it instead of falling back to the default 8000.
+			for _, pod := range tt.readyPods {
+				if pod.Labels[PDRoleIdentifier] == "prefill" {
+					if pod.Labels == nil {
+						pod.Labels = map[string]string{}
+					}
+					pod.Labels[constants.ModelLabelPort] = prefillPort
+				}
+			}
 
 			ctx := types.NewRoutingContext(context.Background(), "test", "model", "message", "test-request", "user")
 			ctx.Engine = tt.llmEngine
@@ -1112,7 +1123,7 @@ func TestDoPrefillRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts := setupTestServer(t, tt.serverCode, tt.serverResp, tt.llmEngine)
+			ts, prefillPort := setupTestServer(t, tt.serverCode, tt.serverResp, tt.llmEngine)
 			defer ts.Close()
 
 			prefillPods := []*v1.Pod{
@@ -1120,6 +1131,9 @@ func TestDoPrefillRequest(t *testing.T) {
 				createPrefillPod("p2", tt.llmEngine),
 				createPrefillPod("p3", tt.llmEngine),
 				createPrefillPod("p4", tt.llmEngine),
+			}
+			for _, pod := range prefillPods {
+				pod.Labels[constants.ModelLabelPort] = prefillPort
 			}
 
 			routingCtx := createRoutingCtx()
@@ -1540,15 +1554,16 @@ func TestUpdateRoutingContextNIXLMode(t *testing.T) {
 
 func TestVLLMIntegrationWithTestServer(t *testing.T) {
 	// Integration test: verify vLLM prefill request extracts KV params from test server
-	ts := setupTestServer(t, http.StatusOK, "", VLLMEngine) // Empty resp means use default vLLM response
+	ts, prefillPort := setupTestServer(t, http.StatusOK, "", VLLMEngine) // Empty resp means use default vLLM response
 	defer ts.Close()
 
 	prefillPods := []*v1.Pod{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prefill-test",
 			Labels: map[string]string{
-				LLMEngineIdentifier: VLLMEngine,
-				PDRoleIdentifier:    "prefill",
+				LLMEngineIdentifier:      VLLMEngine,
+				PDRoleIdentifier:         "prefill",
+				constants.ModelLabelPort: prefillPort,
 			},
 		},
 		Status: v1.PodStatus{
@@ -1671,15 +1686,16 @@ func TestVLLMKVTransferProcessing(t *testing.T) {
 
 func TestTensorRTIntegrationWithTestServer(t *testing.T) {
 	// Integration test: verify TRT prefill request extracts disaggregated_params from test server
-	ts := setupTestServer(t, http.StatusOK, "", TensorRTLLM)
+	ts, prefillPort := setupTestServer(t, http.StatusOK, "", TensorRTLLM)
 	defer ts.Close()
 
 	prefillPods := []*v1.Pod{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prefill-trt",
 			Labels: map[string]string{
-				LLMEngineIdentifier: TensorRTLLM,
-				PDRoleIdentifier:    "prefill",
+				LLMEngineIdentifier:      TensorRTLLM,
+				PDRoleIdentifier:         "prefill",
+				constants.ModelLabelPort: prefillPort,
 			},
 		},
 		Status: v1.PodStatus{
@@ -1817,11 +1833,19 @@ func TestUpdateRoutingContextWithTRTDisaggParams(t *testing.T) {
 }
 
 // Common test utilities
-func setupTestServer(t *testing.T, code int, resp string, llmEngine string) *httptest.Server {
-	l, err := net.Listen("tcp", "127.0.0.1:8000")
+// setupTestServer starts an httptest server on an OS-assigned free port
+// (127.0.0.1:0) and returns the server along with that port (as a string).
+// Using a dynamic port instead of a hardcoded 127.0.0.1:8000 avoids
+// "address already in use" collisions with other packages' tests
+// (e.g. pkg/controller/modeladapter) when `go test ./...` runs package
+// binaries in parallel. Callers must set the returned port on the prefill
+// pod's constants.ModelLabelPort label so GetModelPortForPod resolves it.
+func setupTestServer(t *testing.T, code int, resp string, llmEngine string) (*httptest.Server, string) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
+	port := listenerPort(t, l)
 
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -1921,7 +1945,7 @@ func setupTestServer(t *testing.T, code int, resp string, llmEngine string) *htt
 	_ = ts.Listener.Close()
 	ts.Listener = l
 	ts.Start()
-	return ts
+	return ts, port
 }
 
 func TestLoadImbalanceSelectPrefillPod(t *testing.T) {


### PR DESCRIPTION
## Summary

Eliminate a flaky `address already in use` failure by switching `setupTestServer` in `pkg/plugins/gateway/algorithms` from a hardcoded `127.0.0.1:8000` to an OS-assigned free port, so it no longer collides with `pkg/controller/modeladapter`'s mock servers under `go test ./...` parallelism.

## Problem

`make test` (`go test ./...`) runs package test binaries in parallel. Two packages both bind `127.0.0.1:8000`:

- `pkg/plugins/gateway/algorithms/pd_disaggregation_test.go` — `setupTestServer`
- `pkg/controller/modeladapter/lora_client_test.go` — `mockServer` (ports are production constants `DefaultInferenceEnginePort`/`DefaultRuntimeAPIPort`, consumed by `BuildURLs`, so they cannot change)

When the binaries run concurrently, whichever binds second fails with `listen tcp 127.0.0.1:8000: bind: address already in use`.

Reproduced deterministically: the two packages together fail 5/5 rounds; `-p 1` (sequential) never fails — confirming package-level parallelism is the trigger, not any environment factor.

## Solution

Switch `setupTestServer` to listen on `127.0.0.1:0` (OS-assigned free port) and return the port. Each caller stamps the port onto its prefill pod via the `constants.ModelLabelPort` label, which `GetModelPortForPod` already reads (defaulting to 8000 when absent). This **reuses the dynamic-port pattern already present elsewhere in the same file** (e.g. `TestPDRouter_RouteDoesNotEmitAsyncPrefillSuccessBeforeHTTPCompletes`).

Why fix the pd side, not modeladapter: the pd port comes from a pod **label** (configurable in tests), whereas the modeladapter port is a **production constant** hardcoded in `BuildURLs`. So the pd side is the natural place to make dynamic.

This is cross-platform — `127.0.0.1:0` works on Linux, macOS, and Windows (an earlier attempt using a `127.0.0.11` loopback alias was correctly flagged as macOS-incompatible, since macOS only configures `127.0.0.1` on `lo0` by default).

Only test code changes; no production code, no assertions on the modeladapter side.

## Testing

| Check | Before | After |
|-------|--------|-------|
| Two packages concurrent ×5 | 5/5 FAIL (1–2 port collisions/round) | 5/5 PASS, 0 collisions |
| `go test ./pkg/plugins/gateway/algorithms/` | flaky | ok |
| `make lint-all` | pass | pass |
| `make test` | intermittent FAIL | pass |
| `make test-race-condition` | pass | pass |

## Impact

- Backward compatible (test-only)
- Cross-platform (Linux/macOS/Windows)
- CI becomes more reliable for these two packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)