### PR TITLE
fix(test): make SimpleQueue concurrency tests deterministic

### DIFF
--- a/pkg/plugins/gateway/queue/simple_queue_test.go
+++ b/pkg/plugins/gateway/queue/simple_queue_test.go
@@ -197,8 +197,6 @@ var _ = Describe("SimpleQueue", func() {
 			numWorkers := 10
 			const perWorker = 100
 
-			// queue = NewSimpleQueue[int](numWorkers * perWorker)
-
 			// Concurrent enqueues
 			wg.Add(numWorkers)
 			for i := 0; i < numWorkers; i++ {
@@ -212,8 +210,9 @@ var _ = Describe("SimpleQueue", func() {
 				}(i)
 			}
 
-			// Concurrent dequeues
-			seen := int32(0)
+			// Concurrent peeks. Nothing dequeues in this spec, so the queue
+			// only grows and Peek after a Len() > 0 check can never fail,
+			// regardless of goroutine scheduling.
 			numErrs := int32(0)
 			wg.Add(numWorkers)
 			for i := 0; i < numWorkers; i++ {
@@ -223,12 +222,9 @@ var _ = Describe("SimpleQueue", func() {
 						if queue.Len() > 0 {
 							_, err := queue.Peek(time.Now(), nil)
 							if err != nil {
-								// This is possible because there may be more dequeue calls than enqueue calls at some time.
 								atomic.AddInt32(&numErrs, 1)
-								continue
 							}
 							runtime.Gosched()
-							atomic.AddInt32(&seen, 1)
 						}
 					}
 				}(i)
@@ -238,36 +234,51 @@ var _ = Describe("SimpleQueue", func() {
 
 			// Verify all enqueued
 			Expect(queue.Len()).To(Equal(numWorkers * perWorker))
-			// Verify non duplicated dequeue object.
-			Expect(seen > 0).To(BeTrue())
 			Expect(numErrs).To(Equal(int32(0)))
+
+			// Deterministically verify peek() works on a non-empty queue:
+			// after wg.Wait() all enqueued items are present.
+			_, err := queue.Peek(time.Now(), nil)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should maintain consistency under load", func() {
 			const total = 1000
-			capacity := queue.Cap()
 			var wg sync.WaitGroup
 
+			enqOK := int32(0)
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				for i := 0; i < total; i++ {
-					// nolint: errcheck
-					queue.Enqueue(i, time.Now())
+					// Enqueue values starting at 1: the zero value is rejected
+					// with ErrZeroValueNotSupported.
+					if queue.Enqueue(i+1, time.Now()) == nil {
+						atomic.AddInt32(&enqOK, 1)
+					}
 				}
 			}()
 
+			deqOK := int32(0)
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				for i := 0; i < total; i++ {
-					// nolint: errcheck
-					queue.Dequeue(time.Now())
+					if _, err := queue.Dequeue(time.Now()); err == nil {
+						atomic.AddInt32(&deqOK, 1)
+					}
 				}
 			}()
 
-			Consistently(queue.Cap(), 1*time.Second).Should(Equal(capacity))
 			wg.Wait()
+
+			// Deterministic invariant: Len is derived from the cursors, and a
+			// successful Enqueue/Dequeue advances the enqueue/dequeue cursor
+			// exactly once while a failed one advances neither. This holds
+			// regardless of goroutine scheduling.
+			Expect(queue.Len()).To(Equal(int(atomic.LoadInt32(&enqOK) - atomic.LoadInt32(&deqOK))))
+			// SimpleQueue expands instead of rejecting, so every enqueue succeeds.
+			Expect(atomic.LoadInt32(&enqOK)).To(Equal(int32(total)))
 		})
 	})
 


### PR DESCRIPTION
## Summary

Two `Concurrency` specs in `simple_queue_test.go` asserted properties that depend on goroutine scheduling, making them flaky under load. This replaces those probabilistic assertions with deterministic invariants derived from the queue's cursor semantics.

## Problem

Both specs in `pkg/plugins/gateway/queue/simple_queue_test.go` failed intermittently:

**1. "should maintain consistency under load"**
```go
Consistently(queue.Cap(), 1*time.Second).Should(Equal(capacity))
```
- SimpleQueue is **designed to expand and never shrink** (`expandLocked` doubles capacity; there is no shrink path). When the producer goroutine gets ahead of the consumer, capacity legitimately grows, so the assertion fails under scheduling skew.
- The assertion also misuses `Consistently` (passes a value snapshot instead of a function).
- The producer loop started `Enqueue` at `i=0`, whose zero value is rejected by `ErrZeroValueNotSupported` — silently dropped via `// nolint: errcheck`, so only 999 items were actually enqueued.

**2. "should peek() consistent with len()"**
```go
Expect(seen > 0).To(BeTrue())
```
Asserts at least one concurrent `Peek` succeeded. Under scheduling skew the peek workers can run entirely before any enqueue, leaving `seen == 0`.

## Solution

No production code changes — only test assertions.

**Spec 1** → deterministic invariant from cursor semantics:
```go
Expect(queue.Len()).To(Equal(int(enqOK - deqOK)))
Expect(enqOK).To(Equal(int32(total)))
```
A successful `Enqueue`/`Dequeue` advances its cursor exactly once; a failed one (empty queue / zero value) advances neither. `Len()` is `enqueueCursor - dequeueCursor`, so `Len == successfulEnqueues - successfulDequeues` holds in any scheduling order. `Enqueue` now uses `i+1` to avoid the zero-value trap.

**Spec 2** → drop the probabilistic `seen > 0`; add a synchronous `Peek` after `wg.Wait()` (the queue is deterministically non-empty then), keeping the `numErrs == 0` invariant (this spec has no Dequeue, so the queue only grows).

## Why not change production

The capacity assertion asserted a property the data structure deliberately doesn't guarantee (no shrink). Expanding-under-load is correct behavior, verified by the existing `Expansion` specs. Fixing the test to assert a real invariant is the right move — adding a shrink path or capacity cap to satisfy the assertion would change production semantics for no benefit.

## Testing

| Check | Before | After |
|-------|--------|-------|
| per-process ×100 (no load) | — | 0 failures |
| per-process ×50 under CPU load | 1/50 failed (`seen > 0`) | 0/50 |
| `make lint-all` | pass | pass |
| `make test` | intermittent | pass |
| `make test-race-condition` | pass | pass |

Note: this file carries `//go:build !race`, so it is excluded from `-race` builds (pre-existing, unchanged).

## Impact

- Backward compatible (test-only)
- CI becomes more reliable for `pkg/plugins/gateway/queue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)