### PR TITLE
[API] Batch: add adaptive AIMD ramp-up controls

### DIFF
--- a/apps/console/api/gen/console/v1/console.pb.go
+++ b/apps/console/api/gen/console/v1/console.pb.go
@@ -2209,13 +2209,15 @@ func (x *JobResourceRequest) GetProviderConfig() *structpb.Struct {
 // fields use proto3 presence so "unset" (fall back to env defaults) is
 // distinguishable from an explicit zero.
 type JobClientConfig struct {
-	state               protoimpl.MessageState `protogen:"open.v1"`
-	MaxConcurrency      *int32                 `protobuf:"varint,1,opt,name=max_concurrency,json=maxConcurrency,proto3,oneof" json:"max_concurrency,omitempty"`                // absolute in-flight cap, 1..1024
-	AdaptiveConcurrency *bool                  `protobuf:"varint,2,opt,name=adaptive_concurrency,json=adaptiveConcurrency,proto3,oneof" json:"adaptive_concurrency,omitempty"` // grow concurrency adaptively
-	AdaptiveMaxFactor   *float64               `protobuf:"fixed64,3,opt,name=adaptive_max_factor,json=adaptiveMaxFactor,proto3,oneof" json:"adaptive_max_factor,omitempty"`    // adaptive growth factor, >= 1
-	RetryPolicy         *JobClientRetryPolicy  `protobuf:"bytes,4,opt,name=retry_policy,json=retryPolicy,proto3" json:"retry_policy,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	state                    protoimpl.MessageState `protogen:"open.v1"`
+	MaxConcurrency           *int32                 `protobuf:"varint,1,opt,name=max_concurrency,json=maxConcurrency,proto3,oneof" json:"max_concurrency,omitempty"`                // absolute in-flight cap, 1..1024
+	AdaptiveConcurrency      *bool                  `protobuf:"varint,2,opt,name=adaptive_concurrency,json=adaptiveConcurrency,proto3,oneof" json:"adaptive_concurrency,omitempty"` // grow concurrency adaptively
+	AdaptiveMaxFactor        *float64               `protobuf:"fixed64,3,opt,name=adaptive_max_factor,json=adaptiveMaxFactor,proto3,oneof" json:"adaptive_max_factor,omitempty"`    // adaptive growth factor, >= 1
+	RetryPolicy              *JobClientRetryPolicy  `protobuf:"bytes,4,opt,name=retry_policy,json=retryPolicy,proto3" json:"retry_policy,omitempty"`
+	AdaptiveHealthyWindow    *int32                 `protobuf:"varint,5,opt,name=adaptive_healthy_window,json=adaptiveHealthyWindow,proto3,oneof" json:"adaptive_healthy_window,omitempty"`          // healthy completions per growth step, >= 1
+	AdaptiveAdditiveIncrease *int32                 `protobuf:"varint,6,opt,name=adaptive_additive_increase,json=adaptiveAdditiveIncrease,proto3,oneof" json:"adaptive_additive_increase,omitempty"` // minimum probe and post-probe growth step, >= 1
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *JobClientConfig) Reset() {
@@ -2274,6 +2276,20 @@ func (x *JobClientConfig) GetRetryPolicy() *JobClientRetryPolicy {
 		return x.RetryPolicy
 	}
 	return nil
+}
+
+func (x *JobClientConfig) GetAdaptiveHealthyWindow() int32 {
+	if x != nil && x.AdaptiveHealthyWindow != nil {
+		return *x.AdaptiveHealthyWindow
+	}
+	return 0
+}
+
+func (x *JobClientConfig) GetAdaptiveAdditiveIncrease() int32 {
+	if x != nil && x.AdaptiveAdditiveIncrease != nil {
+		return *x.AdaptiveAdditiveIncrease
+	}
+	return 0
 }
 
 type JobClientRetryPolicy struct {
@@ -5962,15 +5978,19 @@ const file_console_v1_console_proto_rawDesc = "" +
 	"max_tokensR\vtemperatureR\x05top_pR\x01n\"r\n" +
 	"\x12JobResourceRequest\x12\x1a\n" +
 	"\breplicas\x18\x01 \x01(\x05R\breplicas\x12@\n" +
-	"\x0fprovider_config\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x0eproviderConfig\"\xb6\x02\n" +
+	"\x0fprovider_config\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x0eproviderConfig\"\xf1\x03\n" +
 	"\x0fJobClientConfig\x12,\n" +
 	"\x0fmax_concurrency\x18\x01 \x01(\x05H\x00R\x0emaxConcurrency\x88\x01\x01\x126\n" +
 	"\x14adaptive_concurrency\x18\x02 \x01(\bH\x01R\x13adaptiveConcurrency\x88\x01\x01\x123\n" +
 	"\x13adaptive_max_factor\x18\x03 \x01(\x01H\x02R\x11adaptiveMaxFactor\x88\x01\x01\x12C\n" +
-	"\fretry_policy\x18\x04 \x01(\v2 .console.v1.JobClientRetryPolicyR\vretryPolicyB\x12\n" +
+	"\fretry_policy\x18\x04 \x01(\v2 .console.v1.JobClientRetryPolicyR\vretryPolicy\x12;\n" +
+	"\x17adaptive_healthy_window\x18\x05 \x01(\x05H\x03R\x15adaptiveHealthyWindow\x88\x01\x01\x12A\n" +
+	"\x1aadaptive_additive_increase\x18\x06 \x01(\x05H\x04R\x18adaptiveAdditiveIncrease\x88\x01\x01B\x12\n" +
 	"\x10_max_concurrencyB\x17\n" +
 	"\x15_adaptive_concurrencyB\x16\n" +
-	"\x14_adaptive_max_factor\"\xb5\x02\n" +
+	"\x14_adaptive_max_factorB\x1a\n" +
+	"\x18_adaptive_healthy_windowB\x1d\n" +
+	"\x1b_adaptive_additive_increase\"\xb5\x02\n" +
 	"\x14JobClientRetryPolicy\x12$\n" +
 	"\vmax_retries\x18\x01 \x01(\x05H\x00R\n" +
 	"maxRetries\x88\x01\x01\x121\n" +

--- a/apps/console/api/handler/job.go
+++ b/apps/console/api/handler/job.go
@@ -372,9 +372,11 @@ func toPlannerClientConfig(c *pb.JobClientConfig) *plannerapi.ClientConfig {
 		return nil
 	}
 	out := &plannerapi.ClientConfig{
-		MaxConcurrency:      c.MaxConcurrency,
-		AdaptiveConcurrency: c.AdaptiveConcurrency,
-		AdaptiveMaxFactor:   c.AdaptiveMaxFactor,
+		MaxConcurrency:           c.MaxConcurrency,
+		AdaptiveConcurrency:      c.AdaptiveConcurrency,
+		AdaptiveMaxFactor:        c.AdaptiveMaxFactor,
+		AdaptiveHealthyWindow:    c.AdaptiveHealthyWindow,
+		AdaptiveAdditiveIncrease: c.AdaptiveAdditiveIncrease,
 	}
 	if rp := c.RetryPolicy; rp != nil {
 		out.RetryPolicy = &plannerapi.ClientRetryPolicy{

--- a/apps/console/api/handler/job_test.go
+++ b/apps/console/api/handler/job_test.go
@@ -204,6 +204,26 @@ func TestCreateJobDefaultsCompletionWindowTo24h(t *testing.T) {
 	}
 }
 
+func TestToPlannerClientConfigForwardsAdaptiveRampControls(t *testing.T) {
+	healthyWindow := int32(8)
+	additiveIncrease := int32(2)
+
+	got := toPlannerClientConfig(&pb.JobClientConfig{
+		AdaptiveHealthyWindow:    &healthyWindow,
+		AdaptiveAdditiveIncrease: &additiveIncrease,
+	})
+
+	if got == nil {
+		t.Fatal("toPlannerClientConfig returned nil")
+	}
+	if got.AdaptiveHealthyWindow == nil || *got.AdaptiveHealthyWindow != healthyWindow {
+		t.Fatalf("adaptive healthy window = %v, want %d", got.AdaptiveHealthyWindow, healthyWindow)
+	}
+	if got.AdaptiveAdditiveIncrease == nil || *got.AdaptiveAdditiveIncrease != additiveIncrease {
+		t.Fatalf("adaptive additive increase = %v, want %d", got.AdaptiveAdditiveIncrease, additiveIncrease)
+	}
+}
+
 func TestCreateJobAcceptsMaxReplicas(t *testing.T) {
 	planner := &fakeJobPlanner{
 		job: plannerJobWithOwner("job-console-1", "owner@example.com"),

--- a/apps/console/api/planner/api/jobs.go
+++ b/apps/console/api/planner/api/jobs.go
@@ -75,10 +75,12 @@ type ResourceRequest struct {
 // field falls back to the metadata-service env defaults rather than overriding
 // with a zero value.
 type ClientConfig struct {
-	MaxConcurrency      *int32             `json:"max_concurrency,omitempty"`
-	AdaptiveConcurrency *bool              `json:"adaptive_concurrency,omitempty"`
-	AdaptiveMaxFactor   *float64           `json:"adaptive_max_factor,omitempty"`
-	RetryPolicy         *ClientRetryPolicy `json:"retry_policy,omitempty"`
+	MaxConcurrency           *int32             `json:"max_concurrency,omitempty"`
+	AdaptiveConcurrency      *bool              `json:"adaptive_concurrency,omitempty"`
+	AdaptiveMaxFactor        *float64           `json:"adaptive_max_factor,omitempty"`
+	AdaptiveHealthyWindow    *int32             `json:"adaptive_healthy_window,omitempty"`
+	AdaptiveAdditiveIncrease *int32             `json:"adaptive_additive_increase,omitempty"`
+	RetryPolicy              *ClientRetryPolicy `json:"retry_policy,omitempty"`
 }
 
 // ClientRetryPolicy mirrors the metadata-service aibrix.client.retry_policy block.

--- a/apps/console/api/planner/client/submission_test.go
+++ b/apps/console/api/planner/client/submission_test.go
@@ -30,14 +30,18 @@ func TestAIBrixExtraBodyClientSerialization(t *testing.T) {
 	maxConc := int32(256)
 	adaptive := true
 	factor := 8.0
+	healthyWindow := int32(4)
+	additiveIncrease := int32(2)
 	retries := int32(5)
 	baseDelay := 2.0
 
 	eb := AIBrixExtraBody{
 		Client: &plannerapi.ClientConfig{
-			MaxConcurrency:      &maxConc,
-			AdaptiveConcurrency: &adaptive,
-			AdaptiveMaxFactor:   &factor,
+			MaxConcurrency:           &maxConc,
+			AdaptiveConcurrency:      &adaptive,
+			AdaptiveMaxFactor:        &factor,
+			AdaptiveHealthyWindow:    &healthyWindow,
+			AdaptiveAdditiveIncrease: &additiveIncrease,
 			RetryPolicy: &plannerapi.ClientRetryPolicy{
 				MaxRetries:       &retries,
 				BaseDelaySeconds: &baseDelay,
@@ -57,7 +61,14 @@ func TestAIBrixExtraBodyClientSerialization(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	for _, key := range []string{"max_concurrency", "adaptive_concurrency", "adaptive_max_factor", "retry_policy"} {
+	for _, key := range []string{
+		"max_concurrency",
+		"adaptive_concurrency",
+		"adaptive_max_factor",
+		"adaptive_healthy_window",
+		"adaptive_additive_increase",
+		"retry_policy",
+	} {
 		if _, ok := decoded.Client[key]; !ok {
 			t.Errorf("expected aibrix.client.%s in %s", key, raw)
 		}

--- a/apps/console/api/proto/console/v1/console.proto
+++ b/apps/console/api/proto/console/v1/console.proto
@@ -363,10 +363,12 @@ message JobResourceRequest {
 // fields use proto3 presence so "unset" (fall back to env defaults) is
 // distinguishable from an explicit zero.
 message JobClientConfig {
-  optional int32 max_concurrency = 1;       // absolute in-flight cap, 1..1024
-  optional bool adaptive_concurrency = 2;   // grow concurrency adaptively
-  optional double adaptive_max_factor = 3;  // adaptive growth factor, >= 1
+  optional int32 max_concurrency = 1;             // absolute in-flight cap, 1..1024
+  optional bool adaptive_concurrency = 2;         // grow concurrency adaptively
+  optional double adaptive_max_factor = 3;        // adaptive growth factor, >= 1
   JobClientRetryPolicy retry_policy = 4;
+  optional int32 adaptive_healthy_window = 5;     // healthy completions per growth step, >= 1
+  optional int32 adaptive_additive_increase = 6;  // minimum probe and post-probe growth step, >= 1
 }
 
 message JobClientRetryPolicy {
@@ -546,6 +548,8 @@ message CreateModelRequest {
 //                   "max_concurrency": 1024,         # optional job-global cap, 1..1024
 //                   "adaptive_concurrency": true,    # optional
 //                   "adaptive_max_factor": 16,       # optional, >= 1
+//                   "adaptive_healthy_window": 8,     # optional, >= 1
+//                   "adaptive_additive_increase": 1,  # optional, >= 1
 //                   "retry_policy": {                # optional
 //                       "max_retries": 5,            # optional, >= 0
 //                       "base_delay_seconds": 2,     # optional, >= 0
@@ -584,7 +588,7 @@ message CreateModelRequest {
 //     telemetry/logging interval, QPS, request timeout, or fine-grained adaptive
 //     controller internals.
 //   - client.max_concurrency is an absolute job-global in-flight cap, hard
-//     limited to 256 (requests above are rejected). When adaptive_concurrency
+//     limited to 1024 (requests above are rejected). When adaptive_concurrency
 //     is true, it caps adaptive growth. When adaptive_concurrency is false, it
 //     is the fixed concurrency. If omitted, adaptive jobs keep the
 //     source.capacity * adaptive_max_factor upper bound, and fixed jobs use

--- a/apps/console/web/src/utils/api.ts
+++ b/apps/console/web/src/utils/api.ts
@@ -104,6 +104,8 @@ export interface JobClientConfig {
   maxConcurrency?: number;       // absolute in-flight cap, 1..1024
   adaptiveConcurrency?: boolean; // grow concurrency adaptively
   adaptiveMaxFactor?: number;    // adaptive growth factor, >= 1
+  adaptiveHealthyWindow?: number; // healthy completions per growth step, >= 1
+  adaptiveAdditiveIncrease?: number; // minimum probe and post-probe growth step, >= 1
   retryPolicy?: JobClientRetryPolicy;
 }
 

--- a/docs/source/features/batch-model-deployment-templates.rst
+++ b/docs/source/features/batch-model-deployment-templates.rst
@@ -312,6 +312,8 @@ The MDS API accepts this AIBrix extension block:
          "max_concurrency": 256,
          "adaptive_concurrency": true,
          "adaptive_max_factor": 16,
+         "adaptive_healthy_window": 2,
+         "adaptive_additive_increase": 4,
          "retry_policy": {
            "max_retries": 5,
            "base_delay_seconds": 2,
@@ -323,13 +325,22 @@ The MDS API accepts this AIBrix extension block:
    }
 
 ``client`` controls per-job smart-client behavior. ``max_concurrency`` is an
-absolute job-global in-flight cap, hard limited to 256 (requests above are
+absolute job-global in-flight cap, hard limited to 1024 (requests above are
 rejected). If adaptive concurrency is enabled, the cap limits adaptive growth;
 if adaptive concurrency is disabled, it becomes the fixed concurrency. Omitted
 fields fall back to metadata-service environment
-defaults and then built-in defaults. This public block intentionally does not
-expose telemetry interval, QPS, request timeout, or fine-grained adaptive
-controller internals.
+defaults and then built-in defaults. ``adaptive_healthy_window`` is the number
+of healthy completions required for each growth step (default 8).
+During initial capacity probing, the controller increases by the greater of
+``adaptive_additive_increase`` and 25% of the current limit. After the first
+overload or latency-driven decrease, probing ends permanently and the
+controller uses ``adaptive_additive_increase`` as the fixed AIMD
+congestion-avoidance step (default 1). Smaller windows and larger increases
+ramp up faster but can overshoot backend capacity. Operators can set their
+process-wide fallbacks with
+``AIBRIX_BATCH_ADAPTIVE_HEALTHY_WINDOW`` and
+``AIBRIX_BATCH_ADAPTIVE_ADDITIVE_INCREASE``. Other fine-grained adaptive
+controller internals remain private.
 
 The known upstream runtime targets are:
 

--- a/python/aibrix/aibrix/batch/client/concurrency.py
+++ b/python/aibrix/aibrix/batch/client/concurrency.py
@@ -21,7 +21,7 @@ or job-progress dependency.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from math import floor
+from math import ceil, floor
 from time import monotonic
 from typing import Any, Optional, Protocol, runtime_checkable
 
@@ -29,6 +29,9 @@ from aibrix.batch.client.errors import InferenceError
 
 _OVERLOAD_STATUSES = {408, 429, 500, 502, 503, 504}
 _CLIENT_ERROR_STATUSES = {400, 401, 403, 404, 422}
+DEFAULT_ADAPTIVE_HEALTHY_WINDOW = 8
+DEFAULT_ADAPTIVE_ADDITIVE_INCREASE = 1
+_PROBE_INCREASE_RATIO = 0.25
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,11 +82,16 @@ class LLMAdaptiveConcurrencySettings:
     Absolute targets are optional because many backends do not expose TTFT/TPOT
     yet. When absent, the controller still reacts to overload errors and can use
     EWMA-relative TTFT/TPOT slowdowns once those metrics are present.
+
+    ``healthy_window`` is the number of healthy completions required for each
+    growth step. During initial probing, that step is the greater of
+    ``additive_increase`` and 25% of the current limit. The first decrease ends
+    probing permanently, after which ``additive_increase`` is the fixed step.
     """
 
     min_limit: int = 1
-    healthy_window: int = 8
-    additive_increase: int = 1
+    healthy_window: int = DEFAULT_ADAPTIVE_HEALTHY_WINDOW
+    additive_increase: int = DEFAULT_ADAPTIVE_ADDITIVE_INCREASE
     overload_decrease_factor: float = 0.9
     overload_error_rate_threshold: float = 0.1
     slow_decrease_factor: float = 0.8
@@ -128,6 +136,8 @@ class LLMAdaptiveConcurrencySettings:
 class LLMAdaptiveConcurrencyController:
     """Windowed AIMD controller for LLM serving backends.
 
+    Capacity probing uses bounded proportional increases until the first
+    decrease, then switches to additive congestion avoidance.
     Capacity errors are evaluated once per current-limit sample window so a
     burst of failures from the same in-flight cohort causes at most one
     decrease.
@@ -145,6 +155,7 @@ class LLMAdaptiveConcurrencyController:
         self._limit = min(
             max(int(initial_limit), self._settings.min_limit), self._max_limit
         )
+        self._probing = True
         self._healthy = 0
         self._ttft_ewma: Optional[float] = None
         self._tpot_ewma: Optional[float] = None
@@ -195,9 +206,7 @@ class LLMAdaptiveConcurrencyController:
         self._healthy += 1
         if self._healthy >= self._settings.healthy_window:
             self._healthy = 0
-            self._limit = min(
-                self._max_limit, self._limit + self._settings.additive_increase
-            )
+            self._increase()
 
     def _is_capacity_error(self, outcome: ConcurrencyOutcome) -> bool:
         if outcome.success:
@@ -282,11 +291,18 @@ class LLMAdaptiveConcurrencyController:
         return alpha * value + (1 - alpha) * current
 
     def _decrease(self, factor: float) -> None:
+        self._probing = False
         self._healthy = 0
         next_limit = max(self._settings.min_limit, floor(self._limit * factor))
         if next_limit >= self._limit and self._limit > self._settings.min_limit:
             next_limit = self._limit - 1
         self._limit = next_limit
+
+    def _increase(self) -> None:
+        increase = self._settings.additive_increase
+        if self._probing:
+            increase = max(increase, ceil(self._limit * _PROBE_INCREASE_RATIO))
+        self._limit = min(self._max_limit, self._limit + increase)
 
     def _observe_overload_window(self, capacity_error: bool) -> Optional[int]:
         if self._overload_samples == 0:

--- a/python/aibrix/aibrix/batch/client/engine.py
+++ b/python/aibrix/aibrix/batch/client/engine.py
@@ -37,9 +37,12 @@ from typing import (
 
 from aibrix.batch.client.channel import InferenceRequest, Response
 from aibrix.batch.client.concurrency import (
+    DEFAULT_ADAPTIVE_ADDITIVE_INCREASE,
+    DEFAULT_ADAPTIVE_HEALTHY_WINDOW,
     ConcurrencyController,
     FixedConcurrencyController,
     LLMAdaptiveConcurrencyController,
+    LLMAdaptiveConcurrencySettings,
     concurrency_outcome_from_result,
 )
 from aibrix.batch.client.errors import InferenceError, InferenceErrorCode
@@ -212,6 +215,8 @@ class DispatchEngine:
         adaptive_concurrency: bool = False,
         adaptive_max_factor: float = 1.0,
         adaptive_max_concurrency: Optional[int] = None,
+        adaptive_healthy_window: int = DEFAULT_ADAPTIVE_HEALTHY_WINDOW,
+        adaptive_additive_increase: int = DEFAULT_ADAPTIVE_ADDITIVE_INCREASE,
         concurrency_controller: Optional[ConcurrencyController] = None,
         stats: Optional[DispatchStats] = None,
     ) -> None:
@@ -228,6 +233,8 @@ class DispatchEngine:
                 adaptive_concurrency=adaptive_concurrency,
                 adaptive_max_factor=adaptive_max_factor,
                 adaptive_max_concurrency=adaptive_max_concurrency,
+                adaptive_healthy_window=adaptive_healthy_window,
+                adaptive_additive_increase=adaptive_additive_increase,
                 concurrency_controller=concurrency_controller,
             )
         )
@@ -330,6 +337,8 @@ class DispatchEngine:
         adaptive_concurrency: bool,
         adaptive_max_factor: float,
         adaptive_max_concurrency: Optional[int],
+        adaptive_healthy_window: int,
+        adaptive_additive_increase: int,
         concurrency_controller: Optional[ConcurrencyController],
     ) -> ConcurrencyController:
         if concurrency_controller is not None:
@@ -344,6 +353,10 @@ class DispatchEngine:
             return LLMAdaptiveConcurrencyController(
                 initial_limit=min(limit, max_limit),
                 max_limit=max_limit,
+                settings=LLMAdaptiveConcurrencySettings(
+                    healthy_window=adaptive_healthy_window,
+                    additive_increase=adaptive_additive_increase,
+                ),
             )
         return FixedConcurrencyController(limit)
 

--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -49,6 +49,10 @@ from aibrix.batch.client import (
     InferenceRequest,
     RetryConfig,
 )
+from aibrix.batch.client.concurrency import (
+    DEFAULT_ADAPTIVE_ADDITIVE_INCREASE,
+    DEFAULT_ADAPTIVE_HEALTHY_WINDOW,
+)
 from aibrix.batch.job_driver.driver import TerminateResult
 from aibrix.batch.job_driver.error_injection import (
     ACTION_INTERRUPT_RUNTIME,
@@ -83,6 +87,8 @@ from aibrix.metadata.core.metrics import Emitter, T, metrics_names
 logger = init_logger(__name__)
 
 _ADAPTIVE_MAX_FACTOR_ENV = "AIBRIX_BATCH_ADAPTIVE_MAX_FACTOR"
+_ADAPTIVE_HEALTHY_WINDOW_ENV = "AIBRIX_BATCH_ADAPTIVE_HEALTHY_WINDOW"
+_ADAPTIVE_ADDITIVE_INCREASE_ENV = "AIBRIX_BATCH_ADAPTIVE_ADDITIVE_INCREASE"
 _TELEMETRY_INTERVAL_ENV = "AIBRIX_BATCH_TELEMETRY_INTERVAL_SECONDS"
 _INFERENCE_MAX_RETRIES_ENV = "AIBRIX_BATCH_INFERENCE_MAX_RETRIES"
 _NO_ENDPOINT_MAX_RETRIES_ENV = "AIBRIX_BATCH_NO_ENDPOINT_MAX_RETRIES"
@@ -104,6 +110,26 @@ def _adaptive_max_factor() -> float:
     return max(
         _float_env(_ADAPTIVE_MAX_FACTOR_ENV, _DEFAULT_ADAPTIVE_MAX_FACTOR),
         1.0,
+    )
+
+
+def _adaptive_healthy_window() -> int:
+    return max(
+        _int_env(
+            _ADAPTIVE_HEALTHY_WINDOW_ENV,
+            DEFAULT_ADAPTIVE_HEALTHY_WINDOW,
+        ),
+        1,
+    )
+
+
+def _adaptive_additive_increase() -> int:
+    return max(
+        _int_env(
+            _ADAPTIVE_ADDITIVE_INCREASE_ENV,
+            DEFAULT_ADAPTIVE_ADDITIVE_INCREASE,
+        ),
+        1,
     )
 
 
@@ -893,10 +919,22 @@ class BaseJobDriver:
             if client is not None and client.adaptive_max_factor is not None
             else _adaptive_max_factor()
         )
+        adaptive_healthy_window = (
+            client.adaptive_healthy_window
+            if client is not None and client.adaptive_healthy_window is not None
+            else _adaptive_healthy_window()
+        )
+        adaptive_additive_increase = (
+            client.adaptive_additive_increase
+            if client is not None and client.adaptive_additive_increase is not None
+            else _adaptive_additive_increase()
+        )
         max_concurrency = client.max_concurrency if client is not None else None
         kwargs: Dict[str, Any] = {
             "adaptive_concurrency": adaptive,
             "adaptive_max_factor": adaptive_max_factor,
+            "adaptive_healthy_window": adaptive_healthy_window,
+            "adaptive_additive_increase": adaptive_additive_increase,
         }
         if max_concurrency is not None:
             if adaptive:

--- a/python/aibrix/aibrix/batch/job_entity/aibrix_metadata.py
+++ b/python/aibrix/aibrix/batch/job_entity/aibrix_metadata.py
@@ -97,6 +97,8 @@ class ClientConfig(_Strict):
     )
     adaptive_concurrency: Optional[bool] = None
     adaptive_max_factor: Optional[float] = Field(default=None, ge=1)
+    adaptive_healthy_window: Optional[int] = Field(default=None, ge=1)
+    adaptive_additive_increase: Optional[int] = Field(default=None, ge=1)
     retry_policy: Optional[ClientRetryPolicy] = None
 
 

--- a/python/aibrix/aibrix/metadata/api/v1/batch.py
+++ b/python/aibrix/aibrix/metadata/api/v1/batch.py
@@ -149,6 +149,8 @@ class AibrixExtension(BaseModel):
                         "max_concurrency": 1024,
                         "adaptive_concurrency": True,
                         "adaptive_max_factor": 16,
+                        "adaptive_healthy_window": 8,
+                        "adaptive_additive_increase": 1,
                         "retry_policy": {
                             "max_retries": 5,
                             "base_delay_seconds": 2,

--- a/python/aibrix/tests/batch/job_driver/test_base_job_driver_concurrent.py
+++ b/python/aibrix/tests/batch/job_driver/test_base_job_driver_concurrent.py
@@ -188,6 +188,8 @@ def test_dispatch_kwargs_preserve_adaptive_capacity_factor_when_cap_absent(
     monkeypatch,
 ):
     monkeypatch.setenv("AIBRIX_BATCH_ADAPTIVE_MAX_FACTOR", "12")
+    monkeypatch.setenv("AIBRIX_BATCH_ADAPTIVE_HEALTHY_WINDOW", "2")
+    monkeypatch.setenv("AIBRIX_BATCH_ADAPTIVE_ADDITIVE_INCREASE", "4")
     job = _make_job(total=1)
     driver = BaseJobDriver(
         InfrastructureContext(),
@@ -200,16 +202,44 @@ def test_dispatch_kwargs_preserve_adaptive_capacity_factor_when_cap_absent(
     assert kwargs == {
         "adaptive_concurrency": True,
         "adaptive_max_factor": 12.0,
+        "adaptive_healthy_window": 2,
+        "adaptive_additive_increase": 4,
     }
 
 
-def test_dispatch_kwargs_use_fixed_max_concurrency_when_adaptive_disabled():
+def test_adaptive_ramp_env_clamps_nonpositive_and_defaults_invalid(monkeypatch):
+    from aibrix.batch.job_driver import base as base_module
+
+    cases = (
+        (
+            base_module._ADAPTIVE_HEALTHY_WINDOW_ENV,
+            base_module._adaptive_healthy_window,
+            base_module.DEFAULT_ADAPTIVE_HEALTHY_WINDOW,
+        ),
+        (
+            base_module._ADAPTIVE_ADDITIVE_INCREASE_ENV,
+            base_module._adaptive_additive_increase,
+            base_module.DEFAULT_ADAPTIVE_ADDITIVE_INCREASE,
+        ),
+    )
+    for env_name, reader, default in cases:
+        monkeypatch.setenv(env_name, "0")
+        assert reader() == 1
+        monkeypatch.setenv(env_name, "not-an-int")
+        assert reader() == default
+
+
+def test_dispatch_kwargs_prefer_job_client_when_adaptive_disabled(monkeypatch):
+    monkeypatch.setenv("AIBRIX_BATCH_ADAPTIVE_HEALTHY_WINDOW", "2")
+    monkeypatch.setenv("AIBRIX_BATCH_ADAPTIVE_ADDITIVE_INCREASE", "4")
     job = _make_job(total=1)
     job.spec.aibrix = AibrixMetadata(
         client={
             "max_concurrency": 64,
             "adaptive_concurrency": False,
             "adaptive_max_factor": 16,
+            "adaptive_healthy_window": 3,
+            "adaptive_additive_increase": 8,
         }
     )
     driver = BaseJobDriver(
@@ -223,6 +253,8 @@ def test_dispatch_kwargs_use_fixed_max_concurrency_when_adaptive_disabled():
     assert kwargs == {
         "adaptive_concurrency": False,
         "adaptive_max_factor": 16,
+        "adaptive_healthy_window": 3,
+        "adaptive_additive_increase": 8,
         "max_concurrency": 64,
     }
 
@@ -332,6 +364,8 @@ async def test_execute_worker_passes_client_concurrency_as_absolute_adaptive_cap
             "max_concurrency": 64,
             "adaptive_concurrency": True,
             "adaptive_max_factor": 16,
+            "adaptive_healthy_window": 2,
+            "adaptive_additive_increase": 4,
         }
     )
     driver = BaseJobDriver(
@@ -353,6 +387,8 @@ async def test_execute_worker_passes_client_concurrency_as_absolute_adaptive_cap
     assert engine.run_kwargs["adaptive_concurrency"] is True
     assert engine.run_kwargs["adaptive_max_concurrency"] == 64
     assert engine.run_kwargs["adaptive_max_factor"] == 16
+    assert engine.run_kwargs["adaptive_healthy_window"] == 2
+    assert engine.run_kwargs["adaptive_additive_increase"] == 4
     assert "max_concurrency" not in engine.run_kwargs
 
 

--- a/python/aibrix/tests/batch/test_batch_endpoints.py
+++ b/python/aibrix/tests/batch/test_batch_endpoints.py
@@ -354,6 +354,8 @@ def test_batch_spec_accepts_client_config():
                     "max_concurrency": MAX_CLIENT_CONCURRENCY,
                     "adaptive_concurrency": True,
                     "adaptive_max_factor": 16,
+                    "adaptive_healthy_window": 2,
+                    "adaptive_additive_increase": 4,
                     "retry_policy": {
                         "max_retries": 5,
                         "base_delay_seconds": 2,
@@ -372,6 +374,8 @@ def test_batch_spec_accepts_client_config():
     assert batch_job_spec.aibrix.client.max_concurrency == MAX_CLIENT_CONCURRENCY
     assert batch_job_spec.aibrix.client.adaptive_concurrency is True
     assert batch_job_spec.aibrix.client.adaptive_max_factor == 16
+    assert batch_job_spec.aibrix.client.adaptive_healthy_window == 2
+    assert batch_job_spec.aibrix.client.adaptive_additive_increase == 4
     retry = batch_job_spec.aibrix.client.retry_policy
     assert retry is not None
     assert retry.max_retries == 5
@@ -386,6 +390,8 @@ def test_batch_spec_accepts_client_config():
         {"max_concurrency": 0},
         {"max_concurrency": MAX_CLIENT_CONCURRENCY + 1},
         {"adaptive_max_factor": 0.5},
+        {"adaptive_healthy_window": 0},
+        {"adaptive_additive_increase": 0},
         {"retry_policy": {"max_retries": -1}},
         {"retry_policy": {"base_delay_seconds": -0.1}},
     ],

--- a/python/aibrix/tests/batch/test_concurrency_controller.py
+++ b/python/aibrix/tests/batch/test_concurrency_controller.py
@@ -57,7 +57,7 @@ def test_llm_controller_reduces_once_per_overloaded_sample_window():
     assert controller.limit() == 103
 
 
-def test_llm_controller_recovers_quickly_after_small_decrease():
+def test_llm_controller_uses_additive_increase_after_overload():
     controller = LLMAdaptiveConcurrencyController(
         initial_limit=128,
         max_limit=128,
@@ -69,9 +69,59 @@ def test_llm_controller_recovers_quickly_after_small_decrease():
         controller.on_complete(outcome)
     assert controller.limit() == 115
 
-    for _ in range(104):
+    for _ in range(7):
+        controller.on_complete(healthy)
+    assert controller.limit() == 115
+
+    controller.on_complete(healthy)
+    assert controller.limit() == 116
+
+    for _ in range(96):
         controller.on_complete(healthy)
     assert controller.limit() == 128
+
+
+def test_llm_controller_adapts_probe_increase_to_current_limit():
+    settings = LLMAdaptiveConcurrencySettings(healthy_window=2)
+    controller = LLMAdaptiveConcurrencyController(
+        initial_limit=4,
+        max_limit=64,
+        settings=settings,
+    )
+    healthy = ConcurrencyOutcome(success=True)
+
+    controller.on_complete(healthy)
+    assert controller.limit() == 4
+
+    controller.on_complete(healthy)
+    assert controller.limit() == 5
+
+    for _ in range(2):
+        controller.on_complete(healthy)
+    assert controller.limit() == 7
+
+
+def test_llm_controller_uses_configured_increase_after_decrease():
+    settings = LLMAdaptiveConcurrencySettings(
+        healthy_window=2,
+        additive_increase=4,
+        overload_decrease_factor=0.5,
+    )
+    controller = LLMAdaptiveConcurrencyController(
+        initial_limit=8,
+        max_limit=16,
+        settings=settings,
+    )
+    overload = ConcurrencyOutcome(success=False, status_code=503, retryable=True)
+    healthy = ConcurrencyOutcome(success=True)
+
+    for _ in range(8):
+        controller.on_complete(overload)
+    assert controller.limit() == 4
+
+    for _ in range(2):
+        controller.on_complete(healthy)
+    assert controller.limit() == 8
 
 
 def test_llm_controller_honors_configured_min_limit():

--- a/python/aibrix/tests/batch/test_dispatch_engine.py
+++ b/python/aibrix/tests/batch/test_dispatch_engine.py
@@ -799,6 +799,28 @@ async def test_adaptive_concurrency_respects_absolute_max_cap():
 
 
 @pytest.mark.asyncio
+async def test_adaptive_concurrency_uses_configured_ramp_up():
+    source = _FakeSource([_FakeChannel("a")])
+    engine = DispatchEngine(source, max_retries=0)
+    controller = await engine._resolve_concurrency_controller(
+        max_concurrency=None,
+        adaptive_concurrency=True,
+        adaptive_max_factor=1,
+        adaptive_max_concurrency=16,
+        adaptive_healthy_window=2,
+        adaptive_additive_increase=4,
+        concurrency_controller=None,
+    )
+    healthy = ConcurrencyOutcome(success=True)
+
+    controller.on_complete(healthy)
+    assert controller.limit() == 1
+
+    controller.on_complete(healthy)
+    assert controller.limit() == 5
+
+
+@pytest.mark.asyncio
 async def test_adaptive_concurrency_can_decrease_below_source_capacity():
     source = _FakeSource([_FakeChannel("a"), _FakeChannel("b")])
     engine = DispatchEngine(source, max_retries=0)
@@ -807,6 +829,8 @@ async def test_adaptive_concurrency_can_decrease_below_source_capacity():
         adaptive_concurrency=True,
         adaptive_max_factor=1,
         adaptive_max_concurrency=32,
+        adaptive_healthy_window=8,
+        adaptive_additive_increase=1,
         concurrency_controller=None,
     )
     overload = ConcurrencyOutcome(success=False, status_code=503, retryable=True)

--- a/python/aibrix/tests/batch/test_job_entity.py
+++ b/python/aibrix/tests/batch/test_job_entity.py
@@ -277,6 +277,8 @@ class TestBatchJobEntityCreation:
                     "request_timeout_seconds": 45,
                     "adaptive_concurrency": True,
                     "adaptive_max_factor": 16,
+                    "adaptive_healthy_window": 2,
+                    "adaptive_additive_increase": 4,
                     "retry_policy": {
                         "max_retries": 5,
                         "base_delay_seconds": 2,
@@ -295,6 +297,8 @@ class TestBatchJobEntityCreation:
         assert restored is not None
         assert restored.client is not None
         assert restored.client.request_timeout_seconds == 45
+        assert restored.client.adaptive_healthy_window == 2
+        assert restored.client.adaptive_additive_increase == 4
         assert restored.client.retry_policy is not None
         assert restored.client.retry_policy.base_delay_seconds == 2
 


### PR DESCRIPTION
## Pull Request Description
This PR makes the two batch-client AIMD ramp-up controls configurable and adapts their effective behavior without changing the surrounding smart-client design.

- expose `adaptive_healthy_window` and `adaptive_additive_increase` through per-job client config and process-level environment fallbacks
- use a bounded 25% proportional increase while initially probing capacity
- switch permanently to the configured additive step after the first overload- or latency-driven decrease
- preserve the existing max limit, overload detection, multiplicative decrease, backoff, routing, and dispatch behavior

## Testing
- `poetry run pytest ...` (194 passed)
- `poetry run ruff check ...`
- `poetry run ruff format --check ...`

## Related Issues
Resolves: N/A