### PR TITLE
[Bug] Drop hardcoded namespace from envoy sidecar ConfigMap

### DIFF
--- a/dist/chart/templates/gateway-instance/envoy_config.yaml
+++ b/dist/chart/templates/gateway-instance/envoy_config.yaml
@@ -9,7 +9,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "aibrix.fullname" . }}-envoy-config
-  namespace: aibrix-system
 data:
   envoy.yaml: |
     admin:


### PR DESCRIPTION
The `envoy-config` ConfigMap had `namespace: aibrix-system` hardcoded, causing it to always deploy into that namespace regardless of the Helm release namespace. Removing it lets the resource follow the release namespace like all other chart resources.

## Related Issues
N/A