### PR TITLE
bugfix: add path /v1/responses for aibrix-reserved-router

### DIFF
--- a/dist/chart/templates/gateway-plugin/httproute.yaml
+++ b/dist/chart/templates/gateway-plugin/httproute.yaml
@@ -18,6 +18,9 @@ spec:
             value: /v1/chat/completions
         - path:
             type: PathPrefix
+            value: /v1/responses
+        - path:
+            type: PathPrefix
             value: /v1/completions
         - path:
             type: PathPrefix


### PR DESCRIPTION
## Pull Request Description
for new-added path /v1/responses, we need to add it in aibrix-gateway-plugin routers, otherwise we will receive an404 error

```
> User-Agent: curl/7.81.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 54
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< date: Mon, 10 Aug 2026 02:31:39 GMT
< connection: close
< content-length: 0
< 
* Closing connection 0
```
