### PR TITLE
feat(gateway-plugin): add lockedRoutingStrategy to pin per-model routing strategy

### DIFF
--- a/docs/source/features/gateway-plugins.rst
+++ b/docs/source/features/gateway-plugins.rst
@@ -542,9 +542,35 @@ Add the ``model.aibrix.ai/config`` annotation to the pod template of your ``Depl
           }
         }
 
+Optionally pin a single routing strategy model-wide so it cannot be overridden at
+request time (see Routing strategy priority below). ``lockedRoutingStrategy`` only
+locks the strategy: the remaining per-profile knobs (``requestsPerSecond``,
+``routingConfig``) still follow the profile selected by ``config-profile``:
+
+.. code-block:: yaml
+
+    annotations:
+      model.aibrix.ai/config: |
+        {
+          "lockedRoutingStrategy": "pd",
+          "defaultProfile": "default",
+          "profiles": {
+            "default": {
+              "routingStrategy": "pd"
+            },
+            "batch": {
+              "routingStrategy": "random",
+              "requestsPerSecond": 50
+            }
+          }
+        }
+
 **Selecting a profile at request time**
 
-Add the ``config-profile`` header. If the header is absent, the ``defaultProfile`` is used:
+Two request headers drive the config at request time:
+
+* ``config-profile`` selects a named profile; when absent, ``defaultProfile`` (or ``"default"``) is used.
+* ``routing-strategy`` overrides the selected profile's ``routingStrategy``, unless ``lockedRoutingStrategy`` is set (see Routing strategy priority below).
 
 .. code-block:: bash
 
@@ -553,6 +579,21 @@ Add the ``config-profile`` header. If the header is absent, the ``defaultProfile
       -H "config-profile: batch" \
       -H "Content-Type: application/json" \
       -d '{"model": "my-model", "messages": [{"role": "user", "content": "Summarize..."}]}'
+
+**Top-level fields**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Field
+     - Description
+   * - ``lockedRoutingStrategy``
+     - Pins a single routing strategy model-wide. When set, it takes precedence over the ``routing-strategy`` header, the per-profile ``routingStrategy`` and the ``ROUTING_ALGORITHM`` env. The remaining per-profile knobs (``requestsPerSecond``, ``routingConfig``) are still applied normally.
+   * - ``defaultProfile``
+     - Profile name used when no ``config-profile`` header is sent. Falls back to ``"default"`` when omitted.
+   * - ``profiles``
+     - Map of named profiles, each carrying the per-profile fields below.
 
 **Profile fields**
 
@@ -571,11 +612,12 @@ Add the ``config-profile`` header. If the header is absent, the ``defaultProfile
 
 **Routing strategy priority** (highest to lowest):
 
-1. ``routing-strategy`` request header — always wins, even if a profile is active.
-2. ``routingStrategy`` from the resolved config profile.
-3. ``ROUTING_ALGORITHM`` environment variable on the gateway plugin.
+1. ``lockedRoutingStrategy`` pinned model-wide in the config — always wins when set, even over the ``routing-strategy`` header.
+2. ``routing-strategy`` request header.
+3. ``routingStrategy`` from the resolved config profile.
+4. ``ROUTING_ALGORITHM`` environment variable on the gateway plugin.
 
-**Backward compatibility**: if a pod has no ``model.aibrix.ai/config`` annotation, the gateway falls back to the ``model.aibrix.ai/routing-strategy`` pod label and the ``ROUTING_ALGORITHM`` env. No migration is required for existing deployments.
+**Backward compatibility**: if a pod has no ``model.aibrix.ai/config`` annotation, the gateway falls back to the ``routing-strategy`` request header and then the ``ROUTING_ALGORITHM`` env (steps 2 and 4 above). No migration is required for existing deployments.
 
 .. _prometheus-api-access:
 

--- a/docs/source/features/pd-disaggregation.rst
+++ b/docs/source/features/pd-disaggregation.rst
@@ -184,6 +184,21 @@ To make ``pd`` the default for a model, add the config annotation to the pod tem
           }
         }
 
+To prevent clients from overriding ``pd`` with a ``routing-strategy`` header (e.g.
+``random``), pin it model-wide with ``lockedRoutingStrategy``:
+
+.. code-block:: yaml
+
+    annotations:
+      model.aibrix.ai/config: |
+        {
+          "lockedRoutingStrategy": "pd",
+          "defaultProfile": "default",
+          "profiles": {
+            "default": { "routingStrategy": "pd" }
+          }
+        }
+
 
 Step 3 — Add Standard Inference Pods (Optional)
 -------------------------------------------------

--- a/pkg/plugins/gateway/configprofiles/configprofiles.go
+++ b/pkg/plugins/gateway/configprofiles/configprofiles.go
@@ -44,8 +44,12 @@ type ModelConfigProfile struct {
 
 // ModelConfigProfiles is the root JSON structure from model.aibrix.ai/config.
 type ModelConfigProfiles struct {
-	DefaultProfile string                        `json:"defaultProfile"`
-	Profiles       map[string]ModelConfigProfile `json:"profiles"`
+	// LockedRoutingStrategy, when set, pins the routing strategy model-wide.
+	// It takes precedence over the routing-strategy request header, the per-profile
+	// routingStrategy and the ROUTING_ALGORITHM environment variable.
+	LockedRoutingStrategy string                        `json:"lockedRoutingStrategy,omitempty"`
+	DefaultProfile        string                        `json:"defaultProfile"`
+	Profiles              map[string]ModelConfigProfile `json:"profiles"`
 }
 
 // GetProfile returns the profile for the given name, or the default profile.
@@ -67,20 +71,37 @@ func (c *ModelConfigProfiles) GetProfile(name string) *ModelConfigProfile {
 	return nil
 }
 
-// ResolveProfile resolves the model config from pods (annotation),
-// then returns the profile selected by headerProfile (from config-profile).
-// configMapGetter can be nil; it is checked first when provided.
-func ResolveProfile(pods []*v1.Pod, headerProfile string) *ModelConfigProfile {
-	for _, pod := range pods {
-		if p := ResolveProfileFromPod(pod, headerProfile); p != nil {
-			return p
-		}
+// ResolveProfileFromPod resolves the model config from a single pod annotation and
+// returns the selected profile. The profile is selected by headerProfile; an empty
+// headerProfile falls back to the default profile. Returns nil when the pod has no
+// config annotation, the config is invalid, or no selectable profile exists.
+func ResolveProfileFromPod(pod *v1.Pod, headerProfile string) *ModelConfigProfile {
+	cfg := parseConfigFromPod(pod)
+	if cfg == nil {
+		return nil
 	}
-	return nil
+	return cfg.GetProfile(headerProfile)
 }
 
-// ResolveProfileFromPod resolves the model config from a single pod annotation and returns the selected profile.
-func ResolveProfileFromPod(pod *v1.Pod, headerProfile string) *ModelConfigProfile {
+// ResolveConfig resolves the model config from the first pod carrying a
+// model.aibrix.ai/config annotation. It returns the profile selected by
+// headerProfile (nil when no selectable profile exists) together with the
+// model-wide locked routing strategy ("" when unset). The locked strategy applies
+// even when no profile resolves.
+func ResolveConfig(pods []*v1.Pod, headerProfile string) (*ModelConfigProfile, string) {
+	for _, pod := range pods {
+		cfg := parseConfigFromPod(pod)
+		if cfg == nil {
+			continue
+		}
+		return cfg.GetProfile(headerProfile), cfg.LockedRoutingStrategy
+	}
+	return nil, ""
+}
+
+// parseConfigFromPod parses the model config from a single pod annotation.
+// Returns nil when the pod is nil, has no config annotation, or the config is invalid.
+func parseConfigFromPod(pod *v1.Pod) *ModelConfigProfiles {
 	if pod == nil {
 		return nil
 	}
@@ -93,10 +114,7 @@ func ResolveProfileFromPod(pod *v1.Pod, headerProfile string) *ModelConfigProfil
 		klog.V(4).InfoS("failed to parse model config from pod annotation", "pod", pod.Name, "err", err)
 		return nil
 	}
-	if headerProfile == "" {
-		return cfg.GetProfile("")
-	}
-	return cfg.GetProfile(headerProfile)
+	return cfg
 }
 
 // ParseModelConfig parses the JSON from annotation data.

--- a/pkg/plugins/gateway/configprofiles/configprofiles_test.go
+++ b/pkg/plugins/gateway/configprofiles/configprofiles_test.go
@@ -206,47 +206,63 @@ func TestParseModelConfigWithoutRoutingConfig(t *testing.T) {
 	}
 }
 
-func TestResolveProfile(t *testing.T) {
-	configJSON := `{"defaultProfile":"pd","profiles":{"default":{"routingStrategy":"random","routingConfig":{"promptLenBucketMinLength":0,"promptLenBucketMaxLength":4096}},"pd":{"routingStrategy":"pd","routingConfig":{"promptLenBucketMinLength":0,"promptLenBucketMaxLength":2048}}}}`
-
+func TestResolveConfig(t *testing.T) {
 	podWithAnno := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "pod1",
 			Namespace:   "default",
-			Annotations: map[string]string{constants.ModelAnnoConfig: configJSON},
+			Annotations: map[string]string{constants.ModelAnnoConfig: `{"defaultProfile":"pd","profiles":{"default":{"routingStrategy":"random"},"pd":{"routingStrategy":"pd"}}}`},
 		},
 	}
-	podNoAnno := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "default"},
+	podWithLock := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pod2",
+			Namespace:   "default",
+			Annotations: map[string]string{constants.ModelAnnoConfig: `{"lockedRoutingStrategy":"pd","profiles":{"burst":{"routingStrategy":"random"}}}`},
+		},
 	}
+	podWithBoth := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pod3",
+			Namespace:   "default",
+			Annotations: map[string]string{constants.ModelAnnoConfig: `{"lockedRoutingStrategy":"pd","defaultProfile":"default","profiles":{"default":{"routingStrategy":"random"}}}`},
+		},
+	}
+	podNoAnno := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod4", Namespace: "default"}}
+	podInvalid := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod5", Namespace: "default", Annotations: map[string]string{constants.ModelAnnoConfig: `{`}}}
 
 	tests := []struct {
 		name          string
 		pods          []*v1.Pod
 		headerProfile string
 		wantProfile   string
+		wantLocked    string
 	}{
-		{"no pods", nil, "", ""},
-		{"pods without anno", []*v1.Pod{podNoAnno}, "", ""},
-		{"pods with anno, no header", []*v1.Pod{podWithAnno}, "", "pd"},
-		{"pods with anno, header pd", []*v1.Pod{podWithAnno}, "pd", "pd"},
-		{"pods with anno, header default", []*v1.Pod{podWithAnno}, "default", "random"},
+		{"no pods", nil, "", "", ""},
+		{"pod without annotation", []*v1.Pod{podNoAnno}, "", "", ""},
+		{"profile only", []*v1.Pod{podWithAnno}, "", "pd", ""},
+		{"profile selected by header", []*v1.Pod{podWithAnno}, "default", "random", ""},
+		{"lock without resolvable profile", []*v1.Pod{podWithLock}, "", "", "pd"},
+		{"profile and lock together", []*v1.Pod{podWithBoth}, "", "random", "pd"},
+		{"invalid config skipped", []*v1.Pod{podInvalid, podWithAnno}, "", "pd", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := ResolveProfile(tt.pods, tt.headerProfile)
+			profile, locked := ResolveConfig(tt.pods, tt.headerProfile)
 			if tt.wantProfile == "" {
-				if p != nil {
-					t.Errorf("ResolveProfile() = %v, want nil", p)
+				if profile != nil {
+					t.Errorf("ResolveConfig() profile = %v, want nil", profile)
 				}
-				return
+			} else {
+				if profile == nil {
+					t.Fatalf("ResolveConfig() profile = nil, want routingStrategy=%s", tt.wantProfile)
+				}
+				if profile.RoutingStrategy != tt.wantProfile {
+					t.Errorf("ResolveConfig().profile.RoutingStrategy = %s, want %s", profile.RoutingStrategy, tt.wantProfile)
+				}
 			}
-			if p == nil {
-				t.Errorf("ResolveProfile() = nil, want profile with routingStrategy=%s", tt.wantProfile)
-				return
-			}
-			if p.RoutingStrategy != tt.wantProfile {
-				t.Errorf("ResolveProfile().RoutingStrategy = %s, want %s", p.RoutingStrategy, tt.wantProfile)
+			if locked != tt.wantLocked {
+				t.Errorf("ResolveConfig() locked = %q, want %q", locked, tt.wantLocked)
 			}
 		})
 	}

--- a/pkg/plugins/gateway/gateway_req_body_test.go
+++ b/pkg/plugins/gateway/gateway_req_body_test.go
@@ -797,17 +797,11 @@ func responseHeader(response *extProcPb.ProcessingResponse, key string) string {
 }
 
 func TestHandleRequestBody_ModelRPSNotConsumedOnRoutingFailure(t *testing.T) {
-	routingalgorithms.Init()
-
 	mockCache := &MockCache{Cache: cache.NewForTest()}
 	mockRouter := new(mockRouter)
 	mockModelRL := &mockRateLimiter{}
 
-	mockRouterProvider := func() (types.Router, error) {
-		return mockRouter, nil
-	}
-	routingalgorithms.Register(TestRouterAlgorithm, mockRouterProvider)
-	routingalgorithms.Init()
+	registerTestRouter(mockRouter)
 
 	// Config profile enables model RPS checks.
 	profileJSON := `{"defaultProfile":"rps-limited","profiles":{"rps-limited":{"requestsPerSecond":5}}}`
@@ -877,4 +871,146 @@ func TestHandleRequestBody_ModelRPSNotConsumedOnRoutingFailure(t *testing.T) {
 	mockCache.AssertExpectations(t)
 	mockRouter.AssertExpectations(t)
 	mockModelRL.AssertExpectations(t)
+}
+
+// registerTestRouter registers the shared TestRouterAlgorithm mock router so a
+// request can be routed with it. Idempotent across tests.
+func registerTestRouter(mockRouter *mockRouter) {
+	mockRouterProvider := func() (types.Router, error) {
+		return mockRouter, nil
+	}
+	routingalgorithms.Register(TestRouterAlgorithm, mockRouterProvider)
+	routingalgorithms.Init()
+}
+
+// routingStrategyHeaderFromResponse reads the routing-strategy from the
+// request-header mutation that HandleRequestBody sets on the upstream request.
+// The gateway propagates the resolved strategy to the backend via a request-header
+// mutation (not an HTTP response header), which is why it is read from RequestBody.
+func routingStrategyHeaderFromResponse(resp *extProcPb.ProcessingResponse) string {
+	headers := resp.GetRequestBody().GetResponse().GetHeaderMutation().GetSetHeaders()
+	for _, h := range headers {
+		if h.Header.Key == HeaderRoutingStrategy {
+			return string(h.Header.RawValue)
+		}
+	}
+	return ""
+}
+
+// configProfilePods builds two ready pods carrying the given model.aibrix.ai/config
+// annotation. Two pods are used so selectTargetPod goes through the routing
+// algorithm instead of the single-pod shortcut.
+func configProfilePods(anno string) []*v1.Pod {
+	return []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "pod-a",
+				Namespace:   "default",
+				Annotations: map[string]string{constants.ModelAnnoConfig: anno},
+			},
+			Status: v1.PodStatus{
+				PodIP:      "1.2.3.4",
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "pod-b",
+				Namespace:   "default",
+				Annotations: map[string]string{constants.ModelAnnoConfig: anno},
+			},
+			Status: v1.PodStatus{
+				PodIP:      "4.5.6.7",
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			},
+		},
+	}
+}
+
+// TestHandleRequestBody_LockedRoutingStrategy verifies the routing-strategy
+// precedence chain end to end: a model-wide lockedRoutingStrategy wins over the
+// routing-strategy header; an invalid locked value is rejected; and the header
+// still wins over the profile when no lock is set.
+func TestHandleRequestBody_LockedRoutingStrategy(t *testing.T) {
+	tests := []struct {
+		name         string
+		profileJSON  string
+		headerValue  string
+		wantStrategy string // expected routing-strategy response header; empty when routing is expected to fail
+		wantStatus   envoyTypePb.StatusCode
+	}{
+		{
+			name:         "locked strategy wins over header",
+			profileJSON:  `{"lockedRoutingStrategy":"test-router","defaultProfile":"default","profiles":{"default":{"routingStrategy":"least-request"}}}`,
+			headerValue:  "least-request",
+			wantStrategy: "test-router",
+			wantStatus:   envoyTypePb.StatusCode_OK,
+		},
+		{
+			name:         "locked strategy applies without a resolvable profile",
+			profileJSON:  `{"lockedRoutingStrategy":"test-router","profiles":{"burst":{"routingStrategy":"least-request"}}}`,
+			headerValue:  "least-request",
+			wantStrategy: "test-router",
+			wantStatus:   envoyTypePb.StatusCode_OK,
+		},
+		{
+			name:        "invalid locked strategy is rejected",
+			profileJSON: `{"lockedRoutingStrategy":"invalid-strategy","profiles":{"default":{"routingStrategy":"test-router"}}}`,
+			headerValue: string(TestRouterAlgorithm),
+			wantStatus:  envoyTypePb.StatusCode_BadRequest,
+		},
+		{
+			name:         "header wins without a locked strategy",
+			profileJSON:  `{"profiles":{"default":{"routingStrategy":"least-request"}}}`,
+			headerValue:  string(TestRouterAlgorithm),
+			wantStrategy: "test-router",
+			wantStatus:   envoyTypePb.StatusCode_OK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCache := &MockCache{Cache: cache.NewForTest()}
+			mockRouter := new(mockRouter)
+			registerTestRouter(mockRouter)
+
+			podList := &utils.PodArray{Pods: configProfilePods(tt.profileJSON)}
+
+			mockCache.On("HasModel", "test-model").Return(true)
+			mockCache.On("ListPodsByModel", "test-model").Return(podList, nil)
+			if tt.wantStatus == envoyTypePb.StatusCode_OK {
+				mockCache.On("AddRequestCount", mock.Anything, mock.Anything, "test-model").Return(int64(1))
+				mockRouter.On("Route", mock.Anything, mock.Anything).Return("1.2.3.4:8000", nil).Once()
+			}
+
+			server := &Server{cache: mockCache}
+
+			req := &extProcPb.ProcessingRequest{
+				Request: &extProcPb.ProcessingRequest_RequestBody{
+					RequestBody: &extProcPb.HttpBody{
+						Body: []byte(`{"model":"test-model","messages":[{"role":"user","content":"test"}]}`),
+					},
+				},
+			}
+
+			routingCtx := types.NewRoutingContext(context.Background(), "", "", "", "test-request-id", "test-user")
+			routingCtx.ReqPath = PathChatCompletions
+			routingCtx.ReqHeaders[HeaderRoutingStrategy] = tt.headerValue
+
+			resp, _, _, term := server.HandleRequestBody(context.Background(), routingCtx, "test-request-id", req, utils.User{Name: "test-user"})
+
+			require.NotNil(t, resp)
+			if tt.wantStatus == envoyTypePb.StatusCode_OK {
+				assert.Nil(t, resp.GetImmediateResponse(), "successful routing should not return an immediate response")
+				assert.Equal(t, tt.wantStrategy, routingStrategyHeaderFromResponse(resp))
+				mockRouter.AssertCalled(t, "Route", mock.Anything, mock.Anything)
+			} else {
+				assert.Equal(t, tt.wantStatus, resp.GetImmediateResponse().GetStatus().GetCode())
+				assert.Equal(t, int64(0), term)
+				mockRouter.AssertNotCalled(t, "Route", mock.Anything, mock.Anything)
+			}
+			mockCache.AssertExpectations(t)
+			mockRouter.AssertExpectations(t)
+		})
+	}
 }

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -648,42 +648,58 @@ func validateStreamOptions(requestID string, user utils.User, stream *bool, stre
 	return nil
 }
 
-// applyConfigProfile resolves the model config from pod annotation (model.aibrix.ai/config)
-// and applies the selected profile: sets ConfigProfile on routingCtx.
-// - If the client provides config-profile, use that profile name.
-// - If not provided or not found, fall back to defaultProfile (or "default") in the JSON.
+// applyConfigProfile resolves the model config from the pod annotation
+// (model.aibrix.ai/config) and applies the selected profile plus the model-wide
+// locked routing strategy onto routingCtx.ConfigProfile.
+//   - The profile is selected by the config-profile header, falling back to
+//     defaultProfile (or "default") in the JSON.
+//   - lockedRoutingStrategy (top-level) is applied even when no profile resolves, so a
+//     model-wide lock cannot be bypassed by selecting a profile or sending a header.
 func applyConfigProfile(routingCtx *types.RoutingContext, pods []*v1.Pod) {
-	headerProfile := routingCtx.ReqConfigProfile
-	profile := configprofiles.ResolveProfile(pods, headerProfile)
-	if profile == nil {
+	profile, locked := configprofiles.ResolveConfig(pods, routingCtx.ReqConfigProfile)
+	if profile == nil && locked == "" {
 		return
 	}
-	routingCtx.ConfigProfile = &types.ResolvedConfigProfile{
-		RoutingStrategy:   profile.RoutingStrategy,
-		RoutingConfig:     profile.RoutingConfig,
-		RequestsPerSecond: profile.RequestsPerSecond,
+	cp := &types.ResolvedConfigProfile{LockedRoutingStrategy: locked}
+	if profile != nil {
+		cp.RoutingStrategy = profile.RoutingStrategy
+		cp.RoutingConfig = profile.RoutingConfig
+		cp.RequestsPerSecond = profile.RequestsPerSecond
 	}
+	routingCtx.ConfigProfile = cp
 }
 
 var defaultRoutingStrategy, defaultRoutingStrategyEnabled = utils.LookupEnv(EnvRoutingAlgorithm)
 
-// deriveRoutingStrategyFromContext retrieves routing strategy from headers or resolved profile, falling back to env defaults.
+// deriveRoutingStrategyFromContext retrieves routing strategy with the following
+// precedence (highest first):
+//  1. lockedRoutingStrategy pinned model-wide in the model config
+//  2. routing-strategy request header
+//  3. routingStrategy from the resolved config profile
+//  4. ROUTING_ALGORITHM environment variable
 func deriveRoutingStrategyFromContext(routingCtx *types.RoutingContext) (string, bool) {
+	if routingCtx == nil {
+		return defaultRoutingStrategy, defaultRoutingStrategyEnabled
+	}
+
+	// Check locked routing strategy from model config (top-level, model-wide).
+	if cp := routingCtx.ConfigProfile; cp != nil {
+		if s := strings.TrimSpace(cp.LockedRoutingStrategy); s != "" {
+			return s, true
+		}
+	}
 	// Check request headers (case-insensitive key match)
-	if routingCtx != nil && routingCtx.ReqHeaders != nil {
-		for k, v := range routingCtx.ReqHeaders {
-			if strings.EqualFold(k, HeaderRoutingStrategy) {
-				if strings.TrimSpace(v) != "" {
-					return v, true
-				}
-				break
+	for k, v := range routingCtx.ReqHeaders {
+		if strings.EqualFold(k, HeaderRoutingStrategy) {
+			if s := strings.TrimSpace(v); s != "" {
+				return s, true
 			}
+			break
 		}
 	}
 	// Fallback to resolved profile on routing context
-	if routingCtx != nil && routingCtx.ConfigProfile != nil {
-		s := strings.TrimSpace(routingCtx.ConfigProfile.RoutingStrategy)
-		if s != "" {
+	if cp := routingCtx.ConfigProfile; cp != nil {
+		if s := strings.TrimSpace(cp.RoutingStrategy); s != "" {
 			return s, true
 		}
 	}

--- a/pkg/plugins/gateway/util_test.go
+++ b/pkg/plugins/gateway/util_test.go
@@ -26,6 +26,7 @@ import (
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -1425,6 +1426,60 @@ func TestFieldsToAttributes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, fieldsToAttributes(tt.fields))
+		})
+	}
+}
+
+func TestDeriveRoutingStrategyFromContext(t *testing.T) {
+	// lockedRoutingStrategy (model-wide) always wins over header and profile.
+	lockedCtx := &types.RoutingContext{
+		ConfigProfile: &types.ResolvedConfigProfile{
+			LockedRoutingStrategy: "pd",
+			RoutingStrategy:       "random",
+		},
+		ReqHeaders: map[string]string{HeaderRoutingStrategy: "throughput"},
+	}
+
+	// Header wins over profile strategy.
+	headerCtx := &types.RoutingContext{
+		ConfigProfile: &types.ResolvedConfigProfile{RoutingStrategy: "random"},
+		ReqHeaders:    map[string]string{HeaderRoutingStrategy: "throughput"},
+	}
+
+	// Profile strategy is used when no header is present.
+	profileCtx := &types.RoutingContext{
+		ConfigProfile: &types.ResolvedConfigProfile{RoutingStrategy: "least-request"},
+		ReqHeaders:    map[string]string{},
+	}
+
+	// Case-insensitive header key match.
+	headerCaseCtx := &types.RoutingContext{
+		ConfigProfile: &types.ResolvedConfigProfile{RoutingStrategy: "random"},
+		ReqHeaders:    map[string]string{"Routing-Strategy": "pd"},
+	}
+
+	// Nothing set: falls back to environment default.
+	emptyCtx := &types.RoutingContext{ReqHeaders: map[string]string{}}
+
+	tests := []struct {
+		name   string
+		ctx    *types.RoutingContext
+		want   string
+		wantOK bool
+	}{
+		{"locked strategy wins over header and profile", lockedCtx, "pd", true},
+		{"header wins over profile strategy", headerCtx, "throughput", true},
+		{"profile strategy used when header absent", profileCtx, "least-request", true},
+		{"case-insensitive header key", headerCaseCtx, "pd", true},
+		{"falls back to env when nothing set", emptyCtx, defaultRoutingStrategy, defaultRoutingStrategyEnabled},
+		{"nil context falls back to env", nil, defaultRoutingStrategy, defaultRoutingStrategyEnabled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := deriveRoutingStrategyFromContext(tt.ctx)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantOK, ok)
 		})
 	}
 }

--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -47,9 +47,13 @@ type RequestFeatures []float64
 // Populated from model.aibrix.ai/config annotation based on config-profile header or defaultProfile.
 // Nil when no config is present;
 type ResolvedConfigProfile struct {
-	RoutingStrategy   string
-	RoutingConfig     json.RawMessage
-	RequestsPerSecond int64
+	// LockedRoutingStrategy pins the routing strategy model-wide when set.
+	// It takes precedence over the routing-strategy request header, the profile
+	// RoutingStrategy and the ROUTING_ALGORITHM environment variable.
+	LockedRoutingStrategy string
+	RoutingStrategy       string
+	RoutingConfig         json.RawMessage
+	RequestsPerSecond     int64
 }
 
 // RoutingAlgorithm defines the routing algorithms

--- a/test/e2e/routing_config_profile_test.go
+++ b/test/e2e/routing_config_profile_test.go
@@ -36,7 +36,7 @@ import (
 //   - defaultProfile: "least-request"
 //   - profiles: "least-request" (routingStrategy: least-request), "throughput" (routingStrategy: throughput)
 //
-// The gateway resolves config-profile header -> ResolveProfile -> deriveRoutingStrategyFromContext
+// The gateway resolves config-profile header -> ResolveConfig -> deriveRoutingStrategyFromContext
 // and sets routing-strategy in the response headers.
 func TestConfigProfileRoutingStrategy(t *testing.T) {
 	msg := "config-profile routing test message"


### PR DESCRIPTION
## Summary

Add `lockedRoutingStrategy` to the `model.aibrix.ai/config` annotation so admins can pin a routing strategy model-wide and prevent clients from overriding it via the `routing-strategy` request header.

### New resolution priority (highest → lowest)

1. `lockedRoutingStrategy` (top-level) — always wins when set
2. `routing-strategy` request header
3. `routingStrategy` from the resolved config profile
4. `ROUTING_ALGORITHM` environment variable

Behavior is unchanged when `lockedRoutingStrategy` is unset.

### Usage

```yaml
annotations:
  model.aibrix.ai/config: |
    {
      "lockedRoutingStrategy": "pd",
      "defaultProfile": "default",
      "profiles": {
        "default": { "routingStrategy": "pd" },
        "batch":   { "routingStrategy": "random", "requestsPerSecond": 50 }
      }
    }
```

Profile selection via `config-profile` stays alive — the lock only pins `routingStrategy`. The `batch` profile above can still tune `requestsPerSecond`; its `routingStrategy` is simply ignored while the lock is set.

### Use cases

- **Pin PD for disaggregated deployments** — a model served with separate prefill/decode pools must always go through `pd`. Clients sending `routing-strategy: random` can no longer break the prefill/decode split.
- **Per-model strategy on mixed clusters** — when a cluster mixes PD and non-PD models, each model pins its own strategy via its own annotation, independently of the global `ROUTING_ALGORITHM`.
- **Predictable routing for SLO/audit** — latency-sensitive models can be locked to `slo` / `least-latency` / `prefix-cache` so routing stays auditable.

## Changes

- `pkg/plugins/gateway/configprofiles/configprofiles.go`: add `LockedRoutingStrategy` to `ModelConfigProfiles`; split `ResolveProfile` into `ResolveConfig` (returns profile + locked strategy) and keep `ResolveProfileFromPod` for callers that only need the profile.
- `pkg/types/router_context.go`: add `LockedRoutingStrategy` to `ResolvedConfigProfile`.
- `pkg/plugins/gateway/util.go`: propagate the locked strategy in `applyConfigProfile`; check it first in `deriveRoutingStrategyFromContext`.
- Tests: unit tests for `ResolveConfig` and `deriveRoutingStrategyFromContext`, plus four integration tests covering lock-wins-over-header, lock-without-resolvable-profile, invalid-lock-returns-400, and a regression check that the header still wins when no lock is set.
- Docs: `gateway-plugins.rst` (field reference, priority table, example) and `pd-disaggregation.rst` (how to pin `pd`).

## Non-goals / Limitations

- **Backend compatibility is not validated.** The lock bypasses the per-request override, so the admin must ensure the pinned strategy matches the deployment: `pd` requires disaggregated prefill/decode pools; cache-aware strategies depend on the engine exposing prefix-cache state. Forcing an unsupported strategy will fail or degrade routing.
- **An invalid `lockedRoutingStrategy` returns 400 for every request** rather than silently falling back. This is intentional (fail loud over silently routing somewhere unintended), but a typo in the annotation makes the model unavailable until corrected.
- **Models without the annotation are unaffected.** Existing deployments need no migration.
- **`pd_disaggregation.go` keeps using `ResolveProfileFromPod`** (not `ResolveConfig`) because PD routing-config resolution happens inside the algorithm, after the locked strategy has already been enforced upstream in `deriveRoutingStrategyFromContext`.