### PR TITLE
[Misc] Batch: Improve batch error context

### DIFF
--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -566,7 +566,17 @@ class BaseJobDriver:
             job_id=job_id,
             error_code=error.code,
             error=error.message,
+            line=error.line,
+            param=error.param,
         )  # type: ignore[call-arg]
+
+    @staticmethod
+    def _simplified_input_param(request_input: dict[str, Any]) -> Optional[str]:
+        """Return a sanitized request identifier for persisted batch errors."""
+        custom_id = request_input.get("custom_id")
+        if isinstance(custom_id, str) and custom_id.strip():
+            return f"custom_id={custom_id.strip()}"
+        return None
 
     def _log_completed(self, job: BatchJob) -> None:
         logger.debug(
@@ -900,8 +910,8 @@ class BaseJobDriver:
     ) -> tuple[int, bool]:
         """Execute one request and persist its output record."""
         request_id = request_input.pop("_request_index")
-        input_line_no = request_input.pop("_input_line_no", request_id)
-        input_line_data = request_input.pop("_input_line_data", None)
+        input_line_no = request_id
+        input_line_data = self._simplified_input_param(request_input)
         self._accumulate_dispatched_request(job.job_id, request_id)
         custom_id = request_input.get("custom_id", "")
 
@@ -1264,8 +1274,8 @@ class BaseJobDriver:
                         return
 
                     request_id = request_input.pop("_request_index", -1)
-                    input_line_no = request_input.pop("_input_line_no", request_id)
-                    input_line_data = request_input.pop("_input_line_data", None)
+                    input_line_no = request_id
+                    input_line_data = self._simplified_input_param(request_input)
                     if request_id < 0:
                         continue
                     self._accumulate_dispatched_request(job_id, request_id)
@@ -1293,7 +1303,7 @@ class BaseJobDriver:
                     yield InferenceRequest(
                         path=job.spec.endpoint,
                         payload=payload,
-                        ref=(request_id, custom_id, input_line_no, input_line_data),
+                        ref=(request_id, custom_id, input_line_data),
                     )
 
                 await round_drained.wait()
@@ -1353,7 +1363,8 @@ class BaseJobDriver:
             error: Optional[InferenceError],
         ) -> None:
             nonlocal job, processed_requests
-            request_id, custom_id, input_line_no, input_line_data = request.ref
+            request_id, custom_id, input_line_data = request.ref
+            input_line_no = request_id
             try:
                 if error is None and isinstance(response, dict):
                     async with self._usage_lock:

--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -73,6 +73,7 @@ from aibrix.batch.job_entity import (
     ConditionStatus,
     ConditionType,
     RequestCountStats,
+    ensure_batch_job_error,
 )
 from aibrix.context.infra import InfrastructureContext
 from aibrix.logger import init_logger
@@ -506,13 +507,9 @@ class BaseJobDriver:
     def _ensure_batch_job_error(
         error: Exception,
         default_code: BatchJobErrorCode = BatchJobErrorCode.INTERNAL_ERROR,
+        **kwargs,
     ) -> BatchJobError:
-        if isinstance(error, BatchJobError):
-            return error
-        return BatchJobError(
-            code=default_code,
-            message=str(error) or repr(error),
-        )
+        return ensure_batch_job_error(error, default_code, **kwargs)
 
     @staticmethod
     def _error_code_from_reason(reason: Optional[str]) -> BatchJobErrorCode:
@@ -903,34 +900,47 @@ class BaseJobDriver:
     ) -> tuple[int, bool]:
         """Execute one request and persist its output record."""
         request_id = request_input.pop("_request_index")
+        input_line_no = request_input.pop("_input_line_no", request_id)
+        input_line_data = request_input.pop("_input_line_data", None)
         self._accumulate_dispatched_request(job.job_id, request_id)
         custom_id = request_input.get("custom_id", "")
 
-        if "body" not in request_input:
-            raise BatchJobError(
-                code=BatchJobErrorCode.INVALID_INPUT_FILE,
-                message="Request missing 'body' field",
-                line=request_id,
+        try:
+            if "body" not in request_input:
+                raise BatchJobError(
+                    code=BatchJobErrorCode.INVALID_INPUT_FILE,
+                    message="Request missing 'body' field",
+                    param=input_line_data,
+                    line=input_line_no,
+                )
+
+            request_output, last_error = await self._send_one(
+                job.spec.endpoint, request_input["body"], request_id
             )
 
-        request_output, last_error = await self._send_one(
-            job.spec.endpoint, request_input["body"], request_id
-        )
+            if last_error is None and isinstance(request_output, dict):
+                self._accumulate_usage(
+                    job.job_id, custom_id, request_output.get("usage")
+                )
 
-        if last_error is None and isinstance(request_output, dict):
-            self._accumulate_usage(job.job_id, custom_id, request_output.get("usage"))
-
-        response = self._build_response(
-            custom_id,
-            job.job_id,
-            request_id,
-            job.spec,
-            request_output,
-            last_error,
-            request_payload=request_input.get("body"),
-        )
-        await storage.write_job_output_data(job, request_id, response)
-        return request_id, last_error is not None
+            response = self._build_response(
+                custom_id,
+                job.job_id,
+                request_id,
+                job.spec,
+                request_output,
+                last_error,
+                request_payload=request_input.get("body"),
+            )
+            await storage.write_job_output_data(job, request_id, response)
+            return request_id, last_error is not None
+        except Exception as exc:
+            raise self._ensure_batch_job_error(
+                exc,
+                default_code=self._default_failure_code,
+                line=input_line_no,
+                param=input_line_data,
+            ) from exc
 
     # ── lifecycle template ───────────────────────────────────────────────
 
@@ -1254,6 +1264,8 @@ class BaseJobDriver:
                         return
 
                     request_id = request_input.pop("_request_index", -1)
+                    input_line_no = request_input.pop("_input_line_no", request_id)
+                    input_line_data = request_input.pop("_input_line_data", None)
                     if request_id < 0:
                         continue
                     self._accumulate_dispatched_request(job_id, request_id)
@@ -1264,14 +1276,24 @@ class BaseJobDriver:
                         raise BatchJobError(
                             code=BatchJobErrorCode.INVALID_INPUT_FILE,
                             message="Request missing 'body' field",
-                            line=request_id,
+                            param=input_line_data,
+                            line=input_line_no,
                         )
 
                     custom_id = request_input.get("custom_id", "")
+                    try:
+                        payload = self._shape_payload(request_input["body"])
+                    except Exception as exc:
+                        raise self._ensure_batch_job_error(
+                            exc,
+                            default_code=self._default_failure_code,
+                            line=input_line_no,
+                            param=input_line_data,
+                        ) from exc
                     yield InferenceRequest(
                         path=job.spec.endpoint,
-                        payload=self._shape_payload(request_input["body"]),
-                        ref=(request_id, custom_id),
+                        payload=payload,
+                        ref=(request_id, custom_id, input_line_no, input_line_data),
                     )
 
                 await round_drained.wait()
@@ -1331,28 +1353,36 @@ class BaseJobDriver:
             error: Optional[InferenceError],
         ) -> None:
             nonlocal job, processed_requests
-            request_id, custom_id = request.ref
-            if error is None and isinstance(response, dict):
-                async with self._usage_lock:
-                    self._accumulate_usage(job_id, custom_id, response.get("usage"))
+            request_id, custom_id, input_line_no, input_line_data = request.ref
+            try:
+                if error is None and isinstance(response, dict):
+                    async with self._usage_lock:
+                        self._accumulate_usage(job_id, custom_id, response.get("usage"))
 
-            record = self._build_response(
-                custom_id,
-                job_id,
-                request_id,
-                job.spec,
-                response,
-                error,
-                request_payload=request.payload,
-            )
-            await storage.write_job_output_data(job, request_id, record)
-            await completed_request_ids.put((request_id, error is not None))
-            processed_requests += 1
-            await self._apply_error_injector_breakpoint(
-                job,
-                BREAKPOINT_AFTER_N_REQUESTS,
-                n=processed_requests,
-            )
+                record = self._build_response(
+                    custom_id,
+                    job_id,
+                    request_id,
+                    job.spec,
+                    response,
+                    error,
+                    request_payload=request.payload,
+                )
+                await storage.write_job_output_data(job, request_id, record)
+                await completed_request_ids.put((request_id, error is not None))
+                processed_requests += 1
+                await self._apply_error_injector_breakpoint(
+                    job,
+                    BREAKPOINT_AFTER_N_REQUESTS,
+                    n=processed_requests,
+                )
+            except Exception as exc:
+                raise self._ensure_batch_job_error(
+                    exc,
+                    default_code=self._default_failure_code,
+                    line=input_line_no,
+                    param=input_line_data,
+                ) from exc
 
         stats = DispatchStats()
         telemetry_interval = _telemetry_interval_seconds()

--- a/python/aibrix/aibrix/batch/job_entity/batch_job.py
+++ b/python/aibrix/aibrix/batch/job_entity/batch_job.py
@@ -566,14 +566,11 @@ def ensure_batch_job_error(
             param=merged_param,
             line=merged_line,
         )
-    if input_line is not None:
-        kwargs["line"] = input_line
-    if input_line_data is not None:
-        kwargs["param"] = input_line_data
     return BatchJobError(
         code=default_code,
         message=_format_exception_message(e),
-        **kwargs,
+        param=input_line_data,
+        line=input_line,
     )
 
 

--- a/python/aibrix/aibrix/batch/job_entity/batch_job.py
+++ b/python/aibrix/aibrix/batch/job_entity/batch_job.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import copy
+import os
 import re
+import traceback
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
@@ -552,10 +554,69 @@ def ensure_batch_job_error(
     e: Exception, default_code: BatchJobErrorCode, **kwargs
 ) -> BatchJobError:
     """Ensures that the exception is a BatchJobError."""
+    input_line, input_line_data = _exception_input_context(e, kwargs)
     if isinstance(e, BatchJobError):
-        return e
+        merged_line = e.line if e.line is not None else input_line
+        merged_param = e.param if e.param is not None else input_line_data
+        if merged_line == e.line and merged_param == e.param:
+            return e
+        return BatchJobError(
+            code=BatchJobErrorCode(e.code),
+            message=e.message,
+            param=merged_param,
+            line=merged_line,
+        )
+    if input_line is not None:
+        kwargs["line"] = input_line
+    if input_line_data is not None:
+        kwargs["param"] = input_line_data
+    return BatchJobError(
+        code=default_code,
+        message=_format_exception_message(e),
+        **kwargs,
+    )
+
+
+def _format_exception_message(error: BaseException) -> str:
+    """Return a stable, non-empty message for generic exceptions."""
+    class_name = error.__class__.__name__
+    text = str(error).strip()
+    if text:
+        details = f"{class_name}: {text}"
+    elif error.args:
+        details = f"{class_name}: {error.args!r}"
     else:
-        return BatchJobError(code=default_code, message=str(e) or repr(e), **kwargs)
+        details = class_name
+    source = _exception_source_details(error)
+    if source is not None:
+        return f"{details} (source: {source})"
+    return details
+
+
+def _exception_source_details(error: BaseException) -> Optional[str]:
+    """Best-effort program source location for a non-BatchJobError exception."""
+    if error.__traceback__ is None:
+        return None
+    frames = traceback.extract_tb(error.__traceback__)
+    if not frames:
+        return None
+    frame = frames[-1]
+    filename = os.path.basename(frame.filename)
+    return f"{filename}:{frame.lineno}"
+
+
+def _exception_input_context(
+    error: BaseException,
+    kwargs: Dict[str, Any],
+) -> tuple[Optional[int], Optional[str]]:
+    """Prefer user-facing input line context over internal source locations."""
+    input_line = kwargs.get("line")
+    input_line_data = kwargs.get("param")
+    if input_line is None:
+        input_line = getattr(error, "batch_input_line_no", None)
+    if input_line_data is None:
+        input_line_data = getattr(error, "batch_input_line_data", None)
+    return input_line, input_line_data
 
 
 class BatchJobStatus(_Strict):

--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -135,8 +135,11 @@ class BatchStorageAdapter:
                     locked = True
 
             if locked:
+                raw_line = line
                 request_data = json.loads(line)
                 request_data["_request_index"] = idx  # Add index for tracking
+                request_data["_input_line_no"] = idx
+                request_data["_input_line_data"] = raw_line
                 request_data["_done"] = done  # return done requests so far
                 logger.debug(
                     "Locked and will processing request in the job",

--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -135,11 +135,8 @@ class BatchStorageAdapter:
                     locked = True
 
             if locked:
-                raw_line = line
                 request_data = json.loads(line)
                 request_data["_request_index"] = idx  # Add index for tracking
-                request_data["_input_line_no"] = idx
-                request_data["_input_line_data"] = raw_line
                 request_data["_done"] = done  # return done requests so far
                 logger.debug(
                     "Locked and will processing request in the job",

--- a/python/aibrix/tests/batch/job_driver/test_base_job_driver.py
+++ b/python/aibrix/tests/batch/job_driver/test_base_job_driver.py
@@ -70,11 +70,20 @@ def test_assign_worker_id_normalizes_runtime_owner_ref_slashes():
     assert worker_id == "cluster-a-default-workload-1-token1234"
 
 
-def test_driver_error_normalization_uses_repr_for_empty_message():
-    error = BaseJobDriver._ensure_batch_job_error(TimeoutError())
+def test_ensure_batch_job_error_records_unknown_exception_source():
+    def raise_unknown():
+        raise RuntimeError("driver boom")
+
+    try:
+        raise_unknown()
+    except RuntimeError as exc:
+        error = BaseJobDriver._ensure_batch_job_error(exc)
 
     assert error.code == BatchJobErrorCode.INTERNAL_ERROR.value
-    assert error.message == "TimeoutError()"
+    assert error.message.startswith("RuntimeError: driver boom")
+    assert "(source: test_base_job_driver.py:" in error.message
+    assert error.param is None
+    assert error.line is None
 
 
 class _DeadlineStopRuntime:

--- a/python/aibrix/tests/batch/job_driver/test_base_job_driver.py
+++ b/python/aibrix/tests/batch/job_driver/test_base_job_driver.py
@@ -2,6 +2,7 @@ import asyncio
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import cast
+from unittest.mock import patch
 
 import pytest
 
@@ -84,6 +85,31 @@ def test_ensure_batch_job_error_records_unknown_exception_source():
     assert "(source: test_base_job_driver.py:" in error.message
     assert error.param is None
     assert error.line is None
+
+
+def test_log_failed_includes_input_line_and_custom_id():
+    driver = BaseJobDriver(
+        InfrastructureContext(),
+        cast(RunningJobs, None),
+    )
+    error = BatchJobError(
+        code=BatchJobErrorCode.INTERNAL_ERROR,
+        message="RuntimeError: boom",
+        param="custom_id=req-79",
+        line=79,
+    )
+
+    with patch.object(base_module.logger, "error") as mock_error:
+        driver._log_failed("job-79", error)
+
+    mock_error.assert_called_once_with(
+        "Failed to execute job",
+        job_id="job-79",
+        error_code=BatchJobErrorCode.INTERNAL_ERROR.value,
+        error="RuntimeError: boom",
+        line=79,
+        param="custom_id=req-79",
+    )
 
 
 class _DeadlineStopRuntime:

--- a/python/aibrix/tests/batch/test_job_entity.py
+++ b/python/aibrix/tests/batch/test_job_entity.py
@@ -666,6 +666,78 @@ class TestExceptionMessageConversion:
         assert error.message == "Multi-line\nerror\tmessage\nwith\ttabs"
 
 
+class TestEnsureBatchJobError:
+    def test_unknown_exception_records_traceback_source(self):
+        def raise_unknown():
+            raise RuntimeError("boom")
+
+        try:
+            raise_unknown()
+        except RuntimeError as exc:
+            error = ensure_batch_job_error(exc, BatchJobErrorCode.INTERNAL_ERROR)
+
+        assert error.code == BatchJobErrorCode.INTERNAL_ERROR.value
+        assert error.message.startswith("RuntimeError: boom")
+        assert "(source: test_job_entity.py:" in error.message
+        assert error.param is None
+        assert error.line is None
+
+    def test_unknown_exception_without_message_uses_class_name(self):
+        try:
+            raise Exception()
+        except Exception as exc:
+            error = ensure_batch_job_error(exc, BatchJobErrorCode.INTERNAL_ERROR)
+
+        assert error.message.startswith("Exception")
+
+    def test_unknown_exception_uses_input_line_context(self):
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError as exc:
+            error = ensure_batch_job_error(
+                exc,
+                BatchJobErrorCode.INTERNAL_ERROR,
+                line=79,
+                param='{"custom_id":"req-79","body":{"model":"gemma"}}',
+            )
+
+        assert error.line == 79
+        assert error.param == '{"custom_id":"req-79","body":{"model":"gemma"}}'
+        assert error.message.startswith("RuntimeError: boom")
+
+    def test_existing_batch_job_error_keeps_existing_context(self):
+        original = BatchJobError(
+            code=BatchJobErrorCode.INTERNAL_ERROR,
+            message="known",
+            param="status",
+            line=7,
+        )
+
+        error = ensure_batch_job_error(original, BatchJobErrorCode.FINALIZING_ERROR)
+
+        assert error is original
+        assert error.param == "status"
+        assert error.line == 7
+
+    def test_existing_batch_job_error_fills_missing_input_context(self):
+        original = BatchJobError(
+            code=BatchJobErrorCode.INTERNAL_ERROR,
+            message="known",
+        )
+
+        error = ensure_batch_job_error(
+            original,
+            BatchJobErrorCode.FINALIZING_ERROR,
+            line=11,
+            param='{"custom_id":"req-11"}',
+        )
+
+        assert error is not original
+        assert error.message == "known"
+        assert error.line == 11
+        assert error.param == '{"custom_id":"req-11"}'
+
+
 class TestBatchJobErrorFastAPICompatibility:
     """Test BatchJobError compatibility with FastAPI serialization."""
 

--- a/python/aibrix/tests/batch/test_job_entity.py
+++ b/python/aibrix/tests/batch/test_job_entity.py
@@ -705,6 +705,22 @@ class TestEnsureBatchJobError:
         assert error.param == "custom_id=req-79"
         assert error.message.startswith("RuntimeError: boom")
 
+    def test_unknown_exception_ignores_unexpected_kwargs(self):
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError as exc:
+            error = ensure_batch_job_error(
+                exc,
+                BatchJobErrorCode.INTERNAL_ERROR,
+                line=13,
+                param="custom_id=req-13",
+                request_id="req-13",
+            )
+
+        assert error.line == 13
+        assert error.param == "custom_id=req-13"
+        assert error.message.startswith("RuntimeError: boom")
+
     def test_existing_batch_job_error_keeps_existing_context(self):
         original = BatchJobError(
             code=BatchJobErrorCode.INTERNAL_ERROR,

--- a/python/aibrix/tests/batch/test_job_entity.py
+++ b/python/aibrix/tests/batch/test_job_entity.py
@@ -698,11 +698,11 @@ class TestEnsureBatchJobError:
                 exc,
                 BatchJobErrorCode.INTERNAL_ERROR,
                 line=79,
-                param='{"custom_id":"req-79","body":{"model":"gemma"}}',
+                param="custom_id=req-79",
             )
 
         assert error.line == 79
-        assert error.param == '{"custom_id":"req-79","body":{"model":"gemma"}}'
+        assert error.param == "custom_id=req-79"
         assert error.message.startswith("RuntimeError: boom")
 
     def test_existing_batch_job_error_keeps_existing_context(self):
@@ -729,13 +729,13 @@ class TestEnsureBatchJobError:
             original,
             BatchJobErrorCode.FINALIZING_ERROR,
             line=11,
-            param='{"custom_id":"req-11"}',
+            param="custom_id=req-11",
         )
 
         assert error is not original
         assert error.message == "known"
         assert error.line == 11
-        assert error.param == '{"custom_id":"req-11"}'
+        assert error.param == "custom_id=req-11"
 
 
 class TestBatchJobErrorFastAPICompatibility:

--- a/python/aibrix/tests/batch/test_job_entity.py
+++ b/python/aibrix/tests/batch/test_job_entity.py
@@ -103,15 +103,6 @@ class TestBatchJobError:
         assert exc_info.value.code == BatchJobErrorCode.FINALIZING_ERROR.value
         assert exc_info.value.message == "Test exception"
 
-    def test_ensure_batch_job_error_uses_repr_for_empty_message(self):
-        error = ensure_batch_job_error(
-            TimeoutError(),
-            BatchJobErrorCode.INTERNAL_ERROR,
-        )
-
-        assert error.code == BatchJobErrorCode.INTERNAL_ERROR.value
-        assert error.message == "TimeoutError()"
-
     def test_batch_job_error_with_unicode_exception(self):
         """Test creating BatchJobError with unicode characters in exception message."""
         fe = Exception("Processing failed: 文件不存在 (file not found)")


### PR DESCRIPTION
## Pull Request Description

This PR improves batch error diagnostics.

- Unknown exceptions now produce readable messages such as:
  - `RuntimeError: boom (source: base.py:1343)`
- Request-scoped failures can now carry:
  - `line`: input line number
  - `param`: input line data

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>