### PR TITLE
fix: stormservie roleset stateful pod name shorten if exceed

### DIFF
--- a/pkg/controller/roleset/utils.go
+++ b/pkg/controller/roleset/utils.go
@@ -104,9 +104,9 @@ func renderStormServicePod(roleSet *orchestrationv1alpha1.RoleSet, role *orchest
 	templateHash := ctrlutil.ComputeHash(&role.Template, nil)
 	if roleIndex != nil {
 		// add role template hash to pod name, to avoid pod name duplication during rollout
-		pod.Name = fmt.Sprintf("%s-%s-%s-%d", roleSet.Name, role.Name, templateHash, *roleIndex)
+		pod.Name = utils.Shorten(fmt.Sprintf("%s-%s-%s-%d", roleSet.Name, role.Name, templateHash, *roleIndex), false, false)
 	} else {
-		pod.GenerateName = fmt.Sprintf("%s-%s-", roleSet.Name, role.Name)
+		pod.GenerateName = utils.Shorten(fmt.Sprintf("%s-%s-", roleSet.Name, role.Name), false, true)
 	}
 	pod.Namespace = roleSet.Namespace
 	if pod.Labels == nil {


### PR DESCRIPTION
## Pull Request Description
roleset pod.Name is assigned directly to pod.Spec.Hostname, which must be ≤63 chars. With long roleSet/role names, the composed name <roleSet>-<role>-<hash>-<index> overflowed this limit, producing an invalid hostname.

  Fixed by wrap the name with the existing utils.Shorten(...) helper.

## Related Issues
Resolves: #2562