### PR TITLE
Fix batch jobs losing prepared output file IDs when refresh replays an older snapshot

### DIFF
--- a/python/aibrix/aibrix/batch/batch_manager.py
+++ b/python/aibrix/aibrix/batch/batch_manager.py
@@ -831,6 +831,8 @@ class BatchManager(RunningJobs, SchedulableJobs):
 
         if self._job_entity_manager is not None:
             await self._job_entity_manager.update_job_status(validated)
+            current_job = await self.get_job(job_id)
+            return current_job if current_job is not None else validated
         await self.job_updated_handler(meta_data, validated)
         return validated
 
@@ -839,6 +841,8 @@ class BatchManager(RunningJobs, SchedulableJobs):
         updated = meta_data.copy(status)
         if self._job_entity_manager is not None:
             await self._job_entity_manager.update_job_status(updated)
+            current_job = await self.get_job(job_id)
+            return current_job if current_job is not None else updated
         await self.job_updated_handler(meta_data, updated)
         return updated
 
@@ -893,6 +897,8 @@ class BatchManager(RunningJobs, SchedulableJobs):
 
         if self._job_entity_manager is not None:
             await self._job_entity_manager.update_job_status(persisted)
+            current_job = await self.get_job(job_id)
+            return current_job if current_job is not None else persisted
         await self.job_updated_handler(meta_data, persisted)
         return persisted
 
@@ -941,8 +947,10 @@ class BatchManager(RunningJobs, SchedulableJobs):
                 )
             )
 
-        if self._job_entity_manager:
+        if self._job_entity_manager is not None:
             await self._job_entity_manager.update_job_status(persisted)
+            current_job = await self.get_job(job_id)
+            return current_job if current_job is not None else persisted
         await self.job_updated_handler(meta_data, persisted)
         return persisted
 

--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -509,7 +509,10 @@ class BaseJobDriver:
     ) -> BatchJobError:
         if isinstance(error, BatchJobError):
             return error
-        return BatchJobError(code=default_code, message=str(error))
+        return BatchJobError(
+            code=default_code,
+            message=str(error) or repr(error),
+        )
 
     @staticmethod
     def _error_code_from_reason(reason: Optional[str]) -> BatchJobErrorCode:

--- a/python/aibrix/aibrix/batch/job_entity/batch_job.py
+++ b/python/aibrix/aibrix/batch/job_entity/batch_job.py
@@ -507,7 +507,7 @@ def ensure_batch_job_error(
     if isinstance(e, BatchJobError):
         return e
     else:
-        return BatchJobError(code=default_code, message=str(e), **kwargs)
+        return BatchJobError(code=default_code, message=str(e) or repr(e), **kwargs)
 
 
 class BatchJobStatus(_Strict):

--- a/python/aibrix/aibrix/batch/state/job_entity_manager.py
+++ b/python/aibrix/aibrix/batch/state/job_entity_manager.py
@@ -21,6 +21,28 @@ from aibrix.logger import init_logger
 
 logger = init_logger(__name__)
 
+_OUTPUT_FILE_ID_FIELDS = (
+    "output_file_id",
+    "error_file_id",
+    "temp_output_file_id",
+    "temp_error_file_id",
+)
+
+
+def _output_file_ids(job: BatchJob) -> dict[str, Optional[str]]:
+    return {field: getattr(job.status, field) for field in _OUTPUT_FILE_ID_FIELDS}
+
+
+def _has_older_resource_version(old: BatchJob, new: BatchJob) -> bool:
+    old_version = old.metadata.resource_version
+    new_version = new.metadata.resource_version
+    if old_version is None or new_version is None:
+        return False
+    try:
+        return int(new_version) < int(old_version)
+    except ValueError:
+        return False
+
 
 class JobEntityManager(ABC):
     DEFAULT_JOB_PAGE_LIMIT = 20
@@ -130,7 +152,20 @@ class JobEntityManager(ABC):
         self._job_updated_handler = handler
         return old_handler
 
-    async def job_updated(self, old: BatchJob, new: BatchJob) -> bool:
+    async def job_updated(
+        self, old: BatchJob, new: BatchJob, source: str = "publisher"
+    ) -> bool:
+        if source == "refresh" and _has_older_resource_version(old, new):
+            logger.warning(
+                "Ignoring stale batch job refresh snapshot",
+                job_id=new.job_id or old.job_id,
+                old_resource_version=old.metadata.resource_version,
+                new_resource_version=new.metadata.resource_version,
+                old_file_ids=_output_file_ids(old),
+                new_file_ids=_output_file_ids(new),
+            )  # type: ignore[call-arg]
+            return False
+
         success = True
         if self._job_updated_handler is not None:
             if self._job_updated_loop is None:
@@ -226,8 +261,7 @@ class JobEntityManager(ABC):
                 self._monitored_job_snapshots[job_id] = snapshot
                 self._sync_active_job(snapshot)
                 continue
-            self._monitored_job_snapshots[job_id] = snapshot
-            await self.job_updated(old_job, snapshot)
+            await self.job_updated(old_job, snapshot, source="refresh")
 
         deleted_job_ids = set(self._monitored_job_snapshots) - set(current_jobs)
         for job_id in deleted_job_ids:
@@ -242,7 +276,7 @@ class JobEntityManager(ABC):
                 self._forget_job(job_id)
                 self._sync_active_job(latest_job)
                 continue
-            await self.job_updated(previous_job, latest_job)
+            await self.job_updated(previous_job, latest_job, source="refresh")
 
     async def _bootstrap_jobs(self) -> None:
         for job in await self._list_recovery_jobs():

--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -15,7 +15,7 @@
 import asyncio
 import json
 import uuid
-from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, cast
 
 from aibrix import envs
 from aibrix.batch.job_entity import BatchJob, BatchJobError
@@ -258,11 +258,17 @@ class BatchStorageAdapter:
         is_error = "error" in output_data and output_data["error"] is not None
         custom_id = output_data.get("custom_id")
         result_type = "error" if is_error else "output"
-        file_id = job.status.error_file_id if is_error else job.status.output_file_id
-        upload_id = (
-            job.status.temp_error_file_id
-            if is_error
-            else job.status.temp_output_file_id
+        file_id = cast(
+            str,
+            job.status.error_file_id if is_error else job.status.output_file_id,
+        )
+        upload_id = cast(
+            str,
+            (
+                job.status.temp_error_file_id
+                if is_error
+                else job.status.temp_output_file_id
+            ),
         )
         storage_type = self.storage.get_type().value
         try:

--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -24,6 +24,7 @@ from aibrix.batch.storage.batch_metastore import (
     METASTORE_LIST_PAGE_SIZE,
     delete_metadata,
     get_metadata,
+    get_metastore_type,
     is_request_done,
     is_request_locking_supported,
     list_metastore_keys,
@@ -247,19 +248,65 @@ class BatchStorageAdapter:
         # surface as the batch-level error message.
         json_str = json.dumps(output_data, default=BatchJobError.json_serializer) + "\n"
         is_error = "error" in output_data and output_data["error"] is not None
-        etag = await self.storage.upload_part(
-            job.status.error_file_id if is_error else job.status.output_file_id,
+        custom_id = output_data.get("custom_id")
+        result_type = "error" if is_error else "output"
+        file_id = (
+            job.status.error_file_id if is_error else job.status.output_file_id
+        )
+        upload_id = (
             job.status.temp_error_file_id
             if is_error
-            else job.status.temp_output_file_id,
-            request_index,
-            json_str,
+            else job.status.temp_output_file_id
         )
+        storage_type = self.storage.get_type().value
+        try:
+            etag = await self.storage.upload_part(
+                file_id,
+                upload_id,
+                request_index,
+                json_str,
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to persist batch request result",
+                job_id=job.job_id,
+                request_index=request_index,
+                custom_id=custom_id,
+                stage="output_storage_upload",
+                result_type=result_type,
+                storage_type=storage_type,
+                file_id=file_id,
+                upload_id=upload_id,
+                exception_type=type(e).__name__,
+                exception_repr=repr(e),
+                exc_info=True,
+            )  # type: ignore[call-arg]
+            raise
 
         # Unlock the request by setting completion status.
         unlock_key = self._get_request_meta_output_key(job, request_index)
         completion_status = self._get_request_meta_output_val(is_error, etag)
-        await unlock_request(unlock_key, completion_status)
+        try:
+            metastore_type = get_metastore_type().value
+        except Exception:
+            metastore_type = "unknown"
+        try:
+            await unlock_request(unlock_key, completion_status)
+        except Exception as e:
+            logger.error(
+                "Failed to persist batch request result",
+                job_id=job.job_id,
+                request_index=request_index,
+                custom_id=custom_id,
+                stage="completion_metastore_write",
+                result_type=result_type,
+                metastore_type=metastore_type,
+                metastore_key=unlock_key,
+                exception_type=type(e).__name__,
+                exception_repr=repr(e),
+                exc_info=True,
+            )  # type: ignore[call-arg]
+            raise
 
         logger.debug(
             f"Stored result for job {job.job_id} request {request_index}, status: {completion_status}"

--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -258,9 +258,7 @@ class BatchStorageAdapter:
         is_error = "error" in output_data and output_data["error"] is not None
         custom_id = output_data.get("custom_id")
         result_type = "error" if is_error else "output"
-        file_id = (
-            job.status.error_file_id if is_error else job.status.output_file_id
-        )
+        file_id = job.status.error_file_id if is_error else job.status.output_file_id
         upload_id = (
             job.status.temp_error_file_id
             if is_error

--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -234,12 +234,20 @@ class BatchStorageAdapter:
             request_index: Index of the request being processed
             output_data: Single result dictionary
         """
-        assert (
-            job.status.output_file_id
-            and job.status.error_file_id
-            and job.status.temp_output_file_id
-            and job.status.temp_error_file_id
-        )
+        required_file_ids = {
+            "output_file_id": job.status.output_file_id,
+            "error_file_id": job.status.error_file_id,
+            "temp_output_file_id": job.status.temp_output_file_id,
+            "temp_error_file_id": job.status.temp_error_file_id,
+        }
+        missing_file_ids = [
+            name for name, value in required_file_ids.items() if not value
+        ]
+        if missing_file_ids:
+            raise RuntimeError(
+                f"Batch output files are not prepared for job {job.job_id}: "
+                f"missing {', '.join(missing_file_ids)}"
+            )
 
         # output_data["error"] may be a BatchJobError when inference
         # fails (see job_driver.create_response_record). The class

--- a/python/aibrix/tests/batch/job_driver/test_base_job_driver.py
+++ b/python/aibrix/tests/batch/job_driver/test_base_job_driver.py
@@ -70,6 +70,13 @@ def test_assign_worker_id_normalizes_runtime_owner_ref_slashes():
     assert worker_id == "cluster-a-default-workload-1-token1234"
 
 
+def test_driver_error_normalization_uses_repr_for_empty_message():
+    error = BaseJobDriver._ensure_batch_job_error(TimeoutError())
+
+    assert error.code == BatchJobErrorCode.INTERNAL_ERROR.value
+    assert error.message == "TimeoutError()"
+
+
 class _DeadlineStopRuntime:
     provisions = True
 

--- a/python/aibrix/tests/batch/test_batch_manager.py
+++ b/python/aibrix/tests/batch/test_batch_manager.py
@@ -1031,6 +1031,50 @@ class MockJobEntityManager(JobEntityManager):
         return jobs
 
 
+class VersionedMockJobEntityManager(MockJobEntityManager):
+    async def update_job_status(self, job: BatchJob) -> None:
+        job_id = job.job_id
+        assert job_id is not None
+        old_job = self.jobs[job_id]
+        stored_job = job.model_copy(deep=True)
+        stored_job.metadata.resource_version = str(
+            int(old_job.metadata.resource_version or "0") + 1
+        )
+        self.jobs[job_id] = stored_job
+        await self.job_updated(old_job, stored_job)
+
+
+@pytest.mark.asyncio
+async def test_update_job_status_keeps_version_from_entity_manager_callback():
+    _set_current_loop_name("test_update_job_status_keeps_persisted_version")
+    entity_manager = VersionedMockJobEntityManager(delay=0.0)
+    job_manager = _job_manager()
+    await job_manager.set_job_entity_manager(entity_manager)
+    current_job = _in_progress_meta_job("persisted-version", total_requests=1)
+    current_job.metadata.resource_version = "5"
+    persisted_snapshot = current_job.batch_job.model_copy(deep=True)
+    entity_manager.jobs[current_job.job_id] = persisted_snapshot
+    entity_manager.active_jobs[current_job.job_id] = persisted_snapshot
+    entity_manager._monitored_job_snapshots[current_job.job_id] = (
+        persisted_snapshot.model_copy(deep=True)
+    )
+    job_manager._in_progress_jobs[current_job.job_id] = current_job
+    updated_status = current_job.status.model_copy(deep=True)
+    updated_status.output_file_id = "output"
+    updated_status.error_file_id = "error"
+    updated_status.temp_output_file_id = "temp-output"
+    updated_status.temp_error_file_id = "temp-error"
+
+    result = await job_manager.update_job_status(current_job.job_id, updated_status)
+
+    assert result.metadata.resource_version == "6"
+    assert (
+        job_manager._in_progress_jobs[current_job.job_id].metadata.resource_version
+        == "6"
+    )
+    assert result.status.output_file_id == "output"
+
+
 @pytest.mark.asyncio
 async def test_async_create_job():
     """Test that JobEntityManager assigns job_id and calls handlers correctly."""

--- a/python/aibrix/tests/batch/test_batch_storage_adapter.py
+++ b/python/aibrix/tests/batch/test_batch_storage_adapter.py
@@ -1,5 +1,7 @@
 """Unit tests for BatchStorageAdapter.finalize_job_output_data metastore-based behavior"""
 
+import json
+import logging
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
@@ -18,7 +20,7 @@ from aibrix.batch.job_entity import (
     TypeMeta,
 )
 from aibrix.batch.storage.adapter import BatchStorageAdapter
-from aibrix.storage.base import BaseStorage
+from aibrix.storage.base import BaseStorage, StorageType
 
 
 def create_test_batch_job(
@@ -89,6 +91,59 @@ def mock_storage():
     # an async generator directly, so wire a side_effect callable.
     storage.readline_iter.side_effect = _readline_iter_from_lines([])
     return storage
+
+
+def _structured_log_events(caplog) -> list[dict]:
+    return [json.loads(record.getMessage()) for record in caplog.records]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure_stage",
+    ["output_storage_upload", "completion_metastore_write"],
+)
+async def test_write_job_output_data_logs_persistence_failure(
+    mock_storage, caplog, failure_stage
+):
+    adapter = BatchStorageAdapter(mock_storage)
+    job = create_test_batch_job(job_id="job-persistence-timeout")
+    mock_storage.get_type.return_value = StorageType.TOS
+    mock_storage.upload_part.return_value = "etag-0"
+    if failure_stage == "output_storage_upload":
+        mock_storage.upload_part.side_effect = TimeoutError()
+    caplog.set_level(logging.ERROR, logger="aibrix.batch.storage.adapter")
+
+    with (
+        patch(
+            "aibrix.batch.storage.adapter.get_metastore_type",
+            return_value=StorageType.REDIS,
+        ),
+        patch(
+            "aibrix.batch.storage.adapter.unlock_request",
+            AsyncMock(
+                side_effect=(
+                    TimeoutError()
+                    if failure_stage == "completion_metastore_write"
+                    else None
+                )
+            ),
+        ),
+        pytest.raises(TimeoutError),
+    ):
+        await adapter.write_job_output_data(
+            job,
+            0,
+            {"custom_id": "request-0", "response": {"status_code": 200}},
+        )
+
+    failure_event = next(
+        event
+        for event in _structured_log_events(caplog)
+        if event.get("event") == "Failed to persist batch request result"
+    )
+    assert failure_event["job_id"] == "job-persistence-timeout"
+    assert failure_event["stage"] == failure_stage
+    assert failure_event["exception_repr"] == "TimeoutError()"
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/batch/test_batch_storage_adapter.py
+++ b/python/aibrix/tests/batch/test_batch_storage_adapter.py
@@ -98,6 +98,24 @@ def _structured_log_events(caplog) -> list[dict]:
 
 
 @pytest.mark.asyncio
+async def test_write_job_output_data_exposes_missing_output_file_ids(mock_storage):
+    adapter = BatchStorageAdapter(mock_storage)
+    job = create_test_batch_job(
+        job_id="job-missing-output-storage",
+        temp_output_file_id="",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Batch output files are not prepared for job "
+            "job-missing-output-storage: missing temp_output_file_id"
+        ),
+    ):
+        await adapter.write_job_output_data(job, 0, {})
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "failure_stage",
     ["output_storage_upload", "completion_metastore_write"],

--- a/python/aibrix/tests/batch/test_job_entity.py
+++ b/python/aibrix/tests/batch/test_job_entity.py
@@ -27,6 +27,7 @@ from aibrix.batch.job_entity import (
     ResourceAllocation,
     ResourceDetail,
     RuntimeSpec,
+    ensure_batch_job_error,
 )
 from aibrix.batch.job_entity.aibrix_metadata import MAX_CLIENT_CONCURRENCY
 from aibrix.batch.manifest.renderer import JobManifestRenderer, RenderError
@@ -100,6 +101,15 @@ class TestBatchJobError:
 
         assert exc_info.value.code == BatchJobErrorCode.FINALIZING_ERROR.value
         assert exc_info.value.message == "Test exception"
+
+    def test_ensure_batch_job_error_uses_repr_for_empty_message(self):
+        error = ensure_batch_job_error(
+            TimeoutError(),
+            BatchJobErrorCode.INTERNAL_ERROR,
+        )
+
+        assert error.code == BatchJobErrorCode.INTERNAL_ERROR.value
+        assert error.message == "TimeoutError()"
 
     def test_batch_job_error_with_unicode_exception(self):
         """Test creating BatchJobError with unicode characters in exception message."""

--- a/python/aibrix/tests/batch/test_job_store.py
+++ b/python/aibrix/tests/batch/test_job_store.py
@@ -248,6 +248,52 @@ async def test_job_store_update_persists_and_fires_updated(fake_metastore):
 
 
 @pytest.mark.asyncio
+async def test_refresh_does_not_apply_older_resource_version(
+    fake_metastore, monkeypatch
+):
+    _, _ = fake_metastore
+    store = JobStore(storage_type=StorageType.LOCAL)
+    current_job = BatchJob.new_local(spec=_spec())
+    current_job.status.state = BatchJobState.IN_PROGRESS
+    current_job.metadata.resource_version = "5"
+    current_job.status.output_file_id = "output"
+    current_job.status.error_file_id = "error"
+    current_job.status.temp_output_file_id = "temp-output"
+    current_job.status.temp_error_file_id = "temp-error"
+    stale_job = current_job.model_copy(deep=True)
+    stale_job.metadata.resource_version = "4"
+    stale_job.status.output_file_id = None
+    stale_job.status.error_file_id = None
+    stale_job.status.temp_output_file_id = None
+    stale_job.status.temp_error_file_id = None
+    published_updates = []
+
+    async def list_stale_recovery_jobs():
+        return [stale_job]
+
+    async def updated_handler(old_job, new_job):
+        published_updates.append((old_job, new_job))
+        return True
+
+    monkeypatch.setattr(store, "_list_recovery_jobs", list_stale_recovery_jobs)
+    store.active_jobs[current_job.job_id] = current_job
+    store._monitored_job_snapshots[current_job.job_id] = current_job.model_copy(
+        deep=True
+    )
+    store.on_job_updated(updated_handler)
+
+    await store.refresh()
+
+    assert published_updates == []
+    assert store.active_jobs[current_job.job_id].metadata.resource_version == "5"
+    assert store.active_jobs[current_job.job_id].status.output_file_id == "output"
+    assert (
+        store._monitored_job_snapshots[current_job.job_id].metadata.resource_version
+        == "5"
+    )
+
+
+@pytest.mark.asyncio
 async def test_job_store_delete_removes_from_metastore_and_fires_deleted(
     fake_metastore,
 ):


### PR DESCRIPTION
## Pull Request Description
- Reject refresh snapshots with an older resource version.
- Preserve the persisted resource version after status updates.
- Expose actionable messages for empty exceptions and missing output file IDs.
- Log whether request result persistence failed in object storage or the metastore.

## Related Issues

<img width="1890" height="736" alt="image" src="https://github.com/user-attachments/assets/090d3f9b-473c-44fb-985e-11ff678c4895" />



**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>