### PR TITLE
[Bug] Honor per-request force_download override on S3/TOS downloads

### DIFF
--- a/python/aibrix/aibrix/downloader/s3.py
+++ b/python/aibrix/aibrix/downloader/s3.py
@@ -363,7 +363,9 @@ class S3BaseDownloader(BaseDownloader):
             local_path=local_path, file_name=relative_path, source=self._source.value
         )
 
-        if not need_to_download(local_file, meta_data_file, file_size, etag):
+        if not need_to_download(
+            local_file, meta_data_file, file_size, etag, self.force_download
+        ):
             return
 
         # construct TransferConfig

--- a/python/aibrix/aibrix/downloader/tos.py
+++ b/python/aibrix/aibrix/downloader/tos.py
@@ -188,7 +188,9 @@ class TOSDownloaderV1(BaseDownloader):
             local_path=local_path, file_name=relative_path, source=self._source.value
         )
 
-        if not need_to_download(local_file, meta_data_file, file_size, etag):
+        if not need_to_download(
+            local_file, meta_data_file, file_size, etag, self.force_download
+        ):
             return
         num_threads = (
             self.download_extra_config.num_threads or envs.DOWNLOADER_NUM_THREADS

--- a/python/aibrix/aibrix/downloader/utils.py
+++ b/python/aibrix/aibrix/downloader/utils.py
@@ -75,9 +75,14 @@ def need_to_download(
     meta_data_file: Union[Path, str],
     expected_file_size: int,
     expected_etag: str,
+    force_download: bool = False,
 ) -> bool:
     _file_name = Path(local_file).name
-    if not envs.DOWNLOADER_FORCE_DOWNLOAD and envs.DOWNLOADER_CHECK_FILE_EXIST:
+    if (
+        not force_download
+        and not envs.DOWNLOADER_FORCE_DOWNLOAD
+        and envs.DOWNLOADER_CHECK_FILE_EXIST
+    ):
         if check_file_exist(
             local_file, meta_data_file, expected_file_size, expected_etag
         ):
@@ -88,7 +93,8 @@ def need_to_download(
     else:
         logger.info(
             f"File {_file_name} start downloading directly "
-            f"for DOWNLOADER_FORCE_DOWNLOAD={envs.DOWNLOADER_FORCE_DOWNLOAD}, "
+            f"for force_download={force_download}, "
+            f"DOWNLOADER_FORCE_DOWNLOAD={envs.DOWNLOADER_FORCE_DOWNLOAD}, "
             f"DOWNLOADER_CHECK_FILE_EXIST={envs.DOWNLOADER_CHECK_FILE_EXIST}"
         )
     return True

--- a/python/aibrix/tests/downloader/test_downloader_s3.py
+++ b/python/aibrix/tests/downloader/test_downloader_s3.py
@@ -22,8 +22,9 @@ from aibrix.common.errors import (
     ArgNotCongiuredError,
     ModelNotFoundError,
 )
-from aibrix.downloader.base import get_downloader
+from aibrix.downloader.base import DownloadExtraConfig, get_downloader
 from aibrix.downloader.s3 import S3Downloader
+from aibrix.downloader.utils import meta_file, save_meta_data
 
 S3_BOTO3_MODULE = "aibrix.downloader.s3.boto3"
 ENVS_MODULE = "aibrix.downloader.s3.envs"
@@ -211,6 +212,92 @@ def test_s3_atomic_write(monkeypatch, tmp_path):
     final = tmp_path / "m" / "path" / "file.txt"
     assert final.exists()
     assert not Path(str(final) + ".part").exists()
+
+
+def _make_fake_s3_client_for_force_download_test():
+    class FakeS3Client:
+        def __init__(self):
+            self.objects = {
+                "bucket": {"path/file.txt": {"ETag": "etag", "ContentLength": 4}}
+            }
+            self.download_calls = 0
+
+        def head_bucket(self, Bucket):
+            return {}
+
+        def head_object(self, Bucket, Key):
+            return self.objects[Bucket][Key]
+
+        def get_paginator(self, name):
+            assert name == "list_objects_v2"
+            return types.SimpleNamespace(
+                paginate=lambda **kwargs: iter(
+                    [{"Contents": [{"Key": "path/file.txt"}], "KeyCount": 1}]
+                )
+            )
+
+        def download_file(self, Bucket, Key, Filename, Config, Callback=None):
+            self.download_calls += 1
+            Path(Filename).parent.mkdir(parents=True, exist_ok=True)
+            Path(Filename).write_bytes(b"data")
+
+    return FakeS3Client()
+
+
+def _prepopulate_matching_local_file(model_path, source_value):
+    # Matches the relative path S3BaseDownloader.download() computes for
+    # this fixture (see test_s3_atomic_write above): "path/file.txt".
+    local_file = model_path / "path" / "file.txt"
+    local_file.parent.mkdir(parents=True, exist_ok=True)
+    local_file.write_bytes(b"data")
+    meta_data_file = meta_file(model_path, "path/file.txt", source=source_value)
+    save_meta_data(meta_data_file, "etag")
+
+
+def test_s3_skips_matching_file_when_not_forced(monkeypatch, tmp_path):
+    # Control for test_s3_force_download_override_bypasses_exist_check: with
+    # no force_download override, a local file matching remote ETag/size is
+    # skipped, as before.
+    from aibrix.downloader import s3 as s3_mod
+
+    fake_client = _make_fake_s3_client_for_force_download_test()
+    monkeypatch.setattr(
+        s3_mod,
+        "boto3",
+        types.SimpleNamespace(client=lambda service_name, config, **auth: fake_client),
+    )
+
+    d = s3_mod.S3Downloader("s3://bucket/path/file.txt", model_name="m")
+    _prepopulate_matching_local_file(tmp_path / "m", d.source.value)
+
+    d.download_model(local_path=str(tmp_path))
+
+    assert fake_client.download_calls == 0
+
+
+def test_s3_force_download_override_bypasses_exist_check(monkeypatch, tmp_path):
+    # Regression test: DownloadExtraConfig(force_download=True) must force a
+    # re-download even when the local file already matches remote size/etag,
+    # the same guarantee HuggingFaceDownloader already provides.
+    from aibrix.downloader import s3 as s3_mod
+
+    fake_client = _make_fake_s3_client_for_force_download_test()
+    monkeypatch.setattr(
+        s3_mod,
+        "boto3",
+        types.SimpleNamespace(client=lambda service_name, config, **auth: fake_client),
+    )
+
+    d = s3_mod.S3Downloader(
+        "s3://bucket/path/file.txt",
+        model_name="m",
+        download_extra_config=DownloadExtraConfig(force_download=True),
+    )
+    _prepopulate_matching_local_file(tmp_path / "m", d.source.value)
+
+    d.download_model(local_path=str(tmp_path))
+
+    assert fake_client.download_calls == 1
 
 
 def test_s3_recursive_download(monkeypatch, tmp_path):

--- a/python/aibrix/tests/downloader/test_downloader_tos_v1.py
+++ b/python/aibrix/tests/downloader/test_downloader_tos_v1.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import types
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -20,8 +22,9 @@ from aibrix.common.errors import (
     ArgNotCongiuredError,
     ModelNotFoundError,
 )
-from aibrix.downloader.base import get_downloader
+from aibrix.downloader.base import DownloadExtraConfig, get_downloader
 from aibrix.downloader.tos import TOSDownloaderV1
+from aibrix.downloader.utils import meta_file, save_meta_data
 
 TOS_MODULE = "aibrix.downloader.tos.tos"
 ENVS_MODULE = "aibrix.downloader.tos.envs"
@@ -88,3 +91,77 @@ def test_get_downloader_tos_path_empty_path(mock_tos):
     with pytest.raises(ArgNotCongiuredError) as exception:
         get_downloader("tos://bucket/")
     assert "`bucket_path` is not configured" in str(exception.value)
+
+
+def _make_fake_tos_client_for_force_download_test():
+    class FakeTosClient:
+        def __init__(self):
+            self.download_calls = 0
+
+        def head_bucket(self, bucket):
+            return {}
+
+        def list_objects_type2(self, bucket, prefix, delimiter=None):
+            # single-file model_uri: exactly one object, matching bucket_path,
+            # so TOSDownloaderV1._is_directory() returns False.
+            return types.SimpleNamespace(
+                contents=[types.SimpleNamespace(key="file.txt")]
+            )
+
+        def head_object(self, bucket, key):
+            return types.SimpleNamespace(etag="etag", content_length=4)
+
+        def download_file(self, bucket, key, file_path, task_num, **kwargs):
+            self.download_calls += 1
+            Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(file_path).write_bytes(b"data")
+
+    return FakeTosClient()
+
+
+def _prepopulate_matching_local_file(model_path, source_value):
+    local_file = model_path / "file.txt"
+    local_file.parent.mkdir(parents=True, exist_ok=True)
+    local_file.write_bytes(b"data")
+    meta_data_file = meta_file(model_path, "file.txt", source=source_value)
+    save_meta_data(meta_data_file, "etag")
+
+
+@mock.patch(ENVS_DOWNLOADER_TOS_VERSION, DOWNLOADER_TOS_VERSION)
+@mock.patch(ENVS_MODULE, env_group)
+@mock.patch(TOS_MODULE)
+def test_tos_v1_skips_matching_file_when_not_forced(mock_tos, tmp_path):
+    # Control for test_tos_v1_force_download_override_bypasses_exist_check:
+    # with no force_download override, a local file matching the remote
+    # etag/size is skipped, as before.
+    fake_client = _make_fake_tos_client_for_force_download_test()
+    mock_tos.TosClientV2.return_value = fake_client
+
+    d = TOSDownloaderV1("tos://bucket/file.txt", model_name="m")
+    _prepopulate_matching_local_file(tmp_path / "m", d.source.value)
+
+    d.download_model(local_path=str(tmp_path))
+
+    assert fake_client.download_calls == 0
+
+
+@mock.patch(ENVS_DOWNLOADER_TOS_VERSION, DOWNLOADER_TOS_VERSION)
+@mock.patch(ENVS_MODULE, env_group)
+@mock.patch(TOS_MODULE)
+def test_tos_v1_force_download_override_bypasses_exist_check(mock_tos, tmp_path):
+    # Regression test: DownloadExtraConfig(force_download=True) must force a
+    # re-download even when the local file already matches remote etag/size,
+    # mirroring test_s3_force_download_override_bypasses_exist_check.
+    fake_client = _make_fake_tos_client_for_force_download_test()
+    mock_tos.TosClientV2.return_value = fake_client
+
+    d = TOSDownloaderV1(
+        "tos://bucket/file.txt",
+        model_name="m",
+        download_extra_config=DownloadExtraConfig(force_download=True),
+    )
+    _prepopulate_matching_local_file(tmp_path / "m", d.source.value)
+
+    d.download_model(local_path=str(tmp_path))
+
+    assert fake_client.download_calls == 1

--- a/python/aibrix/tests/downloader/test_utils.py
+++ b/python/aibrix/tests/downloader/test_utils.py
@@ -117,6 +117,14 @@ def test_need_to_download_not_call(mock_check: mock.Mock):
     need_to_download("file", "file.metadata", 10, "etag")
     mock_check.assert_not_called()
 
+    # per-request force_download=True must skip the check even though both
+    # env vars would otherwise make it run (this is the DownloadExtraConfig
+    # override S3Downloader/TOSDownloader pass in as `self.force_download`)
+    envs.DOWNLOADER_FORCE_DOWNLOAD = False
+    envs.DOWNLOADER_CHECK_FILE_EXIST = True
+    need_to_download("file", "file.metadata", 10, "etag", force_download=True)
+    mock_check.assert_not_called()
+
     # recover envs
     envs.DOWNLOADER_FORCE_DOWNLOAD = origin_force_download_env
     envs.DOWNLOADER_CHECK_FILE_EXIST = origin_check_file_exist


### PR DESCRIPTION
## Pull Request Description

`need_to_download()` only checked the process-wide `DOWNLOADER_FORCE_DOWNLOAD` env var. `BaseDownloader.__post_init__` already computes a per-request `self.force_download` from `DownloadExtraConfig.force_download`, and `HuggingFaceDownloader` passes it through correctly, but `S3BaseDownloader.download()` (shared by `S3Downloader` and `TOSDownloaderV2`) and `TOSDownloaderV1.download()` both dropped it when calling `need_to_download()`. So a caller passing `download_extra_config={"force_download": True}` had that request silently ignored on the S3/TOS paths whenever the local file already matched the remote ETag/size: no error, just a skipped download.

The fix adds a `force_download` parameter to `need_to_download()` and passes `self.force_download` at both call sites (`s3.py:366`, `tos.py:191`), leaving the existing env-var behavior untouched for callers that do not pass an override.

## Related Issues
Resolves: #2565

## Verification

- `python -m pytest tests/downloader/` (41 tests): new regression tests fail on `main` (`TypeError` in `test_utils.py`, wrong `download_calls` count in the S3/TOS end-to-end tests) and pass on this branch, for all three affected classes (`S3Downloader`, `TOSDownloaderV1`, `TOSDownloaderV2` shares `S3Downloader`'s code path). Each new test has a control counterpart proving the non-forced skip path is unchanged.
- Full suite `tests/` (986 tests) and `ruff check` / `ruff format --check` / `mypy .` all pass, on both Python 3.10 and 3.12 (the matrix's extremes) in Docker.
- Line coverage on the diff's changed lines confirmed via `coverage run/report`, including the `TOSDownloaderV1` call site, which no pre-existing test exercised.
- Not verified against a live S3/TOS/HF backend; all tests fake the SDK clients, consistent with the existing test suite in this package.
