### PR TITLE
feat(gateway): add auto config profile selection

### DIFF
--- a/development/app/config/mock/config-profile.yaml
+++ b/development/app/config/mock/config-profile.yaml
@@ -30,6 +30,15 @@ spec:
               "throughput": {
                 "routingStrategy": "throughput"
               },
+              "cache-friendly": {
+                "routingStrategy": "least-kv-cache"
+              },
+              "long-generation": {
+                "routingStrategy": "throughput",
+                "routingConfig": {
+                  "maxTokensGte": 2048
+                }
+              },
               "rps-limited": {
                 "routingStrategy": "least-request",
                 "requestsPerSecond": 1

--- a/docs/source/features/gateway-plugins.rst
+++ b/docs/source/features/gateway-plugins.rst
@@ -533,11 +533,28 @@ Add the ``model.aibrix.ai/config`` annotation to the pod template of your ``Depl
           "defaultProfile": "default",
           "profiles": {
             "default": {
-              "routingStrategy": "least-latency",
-              "requestsPerSecond": 100
+              "routingStrategy": "least-request",
+              "requestsPerSecond": 200
             },
-            "batch": {
-              "routingStrategy": "throughput"
+            "large-input": {
+              "routingStrategy": "pd",
+              "routingConfig": {
+                "promptLenBucketMinLength": 8192,
+                "promptTokensGte": 8192,
+                "prefillScorePolicy": "prefix_cache",
+                "decodeScorePolicy": "load_balancing"
+              },
+              "requestsPerSecond": 50
+            },
+            "cache-friendly": {
+              "routingStrategy": "least-kv-cache",
+              "requestsPerSecond": 150
+            },
+            "offline-generation": {
+              "routingStrategy": "throughput",
+              "routingConfig": {
+                "maxTokensGte": 2048
+              }
             }
           }
         }
@@ -569,7 +586,7 @@ locks the strategy: the remaining per-profile knobs (``requestsPerSecond``,
 
 Two request headers drive the config at request time:
 
-* ``config-profile`` selects a named profile; when absent, ``defaultProfile`` (or ``"default"``) is used.
+* ``config-profile`` selects a named profile; when absent, ``defaultProfile`` (or ``"default"``) is used. ``config-profile: auto`` asks the gateway to select a concrete profile from request-local hints in each profile's ``routingConfig``.
 * ``routing-strategy`` overrides the selected profile's ``routingStrategy``, unless ``lockedRoutingStrategy`` is set (see Routing strategy priority below).
 
 .. code-block:: bash
@@ -579,6 +596,14 @@ Two request headers drive the config at request time:
       -H "config-profile: batch" \
       -H "Content-Type: application/json" \
       -d '{"model": "my-model", "messages": [{"role": "user", "content": "Summarize..."}]}'
+
+.. code-block:: bash
+
+    # Let the gateway resolve a concrete profile from routingConfig hints
+    curl http://${ENDPOINT}/v1/chat/completions \
+      -H "config-profile: auto" \
+      -H "Content-Type: application/json" \
+      -d '{"model": "my-model", "messages": [{"role": "user", "content": "Summarize..."}], "max_tokens": 4096}'
 
 **Top-level fields**
 
@@ -594,7 +619,6 @@ Two request headers drive the config at request time:
      - Profile name used when no ``config-profile`` header is sent. Falls back to ``"default"`` when omitted.
    * - ``profiles``
      - Map of named profiles, each carrying the per-profile fields below.
-
 **Profile fields**
 
 .. list-table::
@@ -608,13 +632,21 @@ Two request headers drive the config at request time:
    * - ``requestsPerSecond``
      - Model-level RPS cap for this profile. Requests that exceed the limit are rejected with HTTP 429. Omit or set to ``0`` for no limit. See `Production Model Deployments <../production/model-deployment.html>`_ for details.
    * - ``routingConfig``
-     - Algorithm-specific settings as a nested JSON object. Currently used by the ``pd`` strategy for prompt-length bucketing and standard inference pod configuration. See `Prefill-Decode Disaggregation <pd-disaggregation.html>`_ for details.
+     - Algorithm-specific settings as a nested JSON object. ``config-profile: auto`` also reads request-local selection hints from this object. Currently supported auto-selection hints are ``promptTokensGte``, ``promptTokensLt``, ``maxTokensGte`` and ``maxTokensLt``. Existing strategy-specific fields, such as ``promptLenBucketMinLength`` for ``pd``, remain available. See `Prefill-Decode Disaggregation <pd-disaggregation.html>`_ for details.
+
+When ``config-profile: auto`` is used, the gateway evaluates the supported
+request-local hints inside each profile's ``routingConfig``. A profile matches
+only when all of its supported hints match the request. If no profile matches,
+the gateway uses ``defaultProfile`` (or ``"default"``). ``promptTokens*`` uses
+the gateway's existing prompt text extraction and local token estimation.
+``maxTokens*`` reads ``max_tokens`` first, then ``max_completion_tokens`` when
+``max_tokens`` is absent.
 
 **Routing strategy priority** (highest to lowest):
 
 1. ``lockedRoutingStrategy`` pinned model-wide in the config — always wins when set, even over the ``routing-strategy`` header.
 2. ``routing-strategy`` request header.
-3. ``routingStrategy`` from the resolved config profile.
+3. ``routingStrategy`` from the resolved profile. The resolved profile comes from the concrete ``config-profile`` header, ``config-profile: auto`` routingConfig hints, or ``defaultProfile``.
 4. ``ROUTING_ALGORITHM`` environment variable on the gateway plugin.
 
 **Backward compatibility**: if a pod has no ``model.aibrix.ai/config`` annotation, the gateway falls back to the ``routing-strategy`` request header and then the ``ROUTING_ALGORITHM`` env (steps 2 and 4 above). No migration is required for existing deployments.

--- a/pkg/plugins/gateway/configprofiles/configprofiles.go
+++ b/pkg/plugins/gateway/configprofiles/configprofiles.go
@@ -22,6 +22,7 @@ package configprofiles
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -42,6 +43,21 @@ type ModelConfigProfile struct {
 	RequestsPerSecond int64           `json:"requestsPerSecond,omitempty"`
 }
 
+// autoProfileRoutingConfig holds request-local profile selection hints embedded
+// in each profile's routingConfig.
+type autoProfileRoutingConfig struct {
+	PromptTokensGte *int   `json:"promptTokensGte,omitempty"`
+	PromptTokensLt  *int   `json:"promptTokensLt,omitempty"`
+	MaxTokensGte    *int64 `json:"maxTokensGte,omitempty"`
+	MaxTokensLt     *int64 `json:"maxTokensLt,omitempty"`
+}
+
+// RequestFeatures are the request attributes used by automatic profile selection.
+type RequestFeatures struct {
+	PromptTokens *int
+	MaxTokens    *int64
+}
+
 // ModelConfigProfiles is the root JSON structure from model.aibrix.ai/config.
 type ModelConfigProfiles struct {
 	// LockedRoutingStrategy, when set, pins the routing strategy model-wide.
@@ -57,18 +73,171 @@ type ModelConfigProfiles struct {
 // Returns nil only if no default profile exists.
 func (c *ModelConfigProfiles) GetProfile(name string) *ModelConfigProfile {
 	if name != "" {
-		if p, ok := c.Profiles[name]; ok {
-			return &p
+		if p := c.GetProfileExact(name); p != nil {
+			return p
 		}
 	}
 	// Fall back to default
 	if name = c.DefaultProfile; name == "" {
 		name = DefaultProfileName
 	}
+	return c.GetProfileExact(name)
+}
+
+// GetProfileExact returns the named profile without falling back.
+func (c *ModelConfigProfiles) GetProfileExact(name string) *ModelConfigProfile {
 	if p, ok := c.Profiles[name]; ok {
 		return &p
 	}
 	return nil
+}
+
+// DefaultProfileOrName returns defaultProfile, or "default" when it is not set.
+func (c *ModelConfigProfiles) DefaultProfileOrName() string {
+	if c.DefaultProfile != "" {
+		return c.DefaultProfile
+	}
+	return DefaultProfileName
+}
+
+// ResolveAutoProfileName resolves config-profile: auto to a concrete profile name.
+func (c *ModelConfigProfiles) ResolveAutoProfileName(features RequestFeatures) string {
+	if c == nil {
+		return DefaultProfileName
+	}
+	if name, ok := c.bestAutoProfileName(features); ok {
+		return name
+	}
+	return c.DefaultProfileOrName()
+}
+
+func (c *ModelConfigProfiles) bestAutoProfileName(features RequestFeatures) (string, bool) {
+	names := make([]string, 0, len(c.Profiles))
+	for name := range c.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var bestName string
+	var best autoProfileRoutingConfig
+	bestSet := false
+	for _, name := range names {
+		profile := c.Profiles[name]
+		criteria, ok := parseAutoProfileRoutingConfig(profile.RoutingConfig)
+		if !ok || !criteria.matches(features) {
+			continue
+		}
+		if !bestSet || criteria.moreSpecificThan(best) {
+			bestName = name
+			best = criteria
+			bestSet = true
+		}
+	}
+	return bestName, bestSet
+}
+
+func parseAutoProfileRoutingConfig(raw json.RawMessage) (autoProfileRoutingConfig, bool) {
+	if len(raw) == 0 {
+		return autoProfileRoutingConfig{}, false
+	}
+	var cfg autoProfileRoutingConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return autoProfileRoutingConfig{}, false
+	}
+	return cfg, cfg.hasAutoSelectionHints()
+}
+
+func (c autoProfileRoutingConfig) hasAutoSelectionHints() bool {
+	return c.PromptTokensGte != nil || c.PromptTokensLt != nil || c.MaxTokensGte != nil || c.MaxTokensLt != nil
+}
+
+func (c autoProfileRoutingConfig) matches(features RequestFeatures) bool {
+	if c.PromptTokensGte != nil || c.PromptTokensLt != nil {
+		if features.PromptTokens == nil {
+			return false
+		}
+		if c.PromptTokensGte != nil && *features.PromptTokens < *c.PromptTokensGte {
+			return false
+		}
+		if c.PromptTokensLt != nil && *features.PromptTokens >= *c.PromptTokensLt {
+			return false
+		}
+	}
+	if c.MaxTokensGte != nil {
+		if features.MaxTokens == nil || *features.MaxTokens < *c.MaxTokensGte {
+			return false
+		}
+	}
+	if c.MaxTokensLt != nil {
+		if features.MaxTokens == nil || *features.MaxTokens >= *c.MaxTokensLt {
+			return false
+		}
+	}
+	return true
+}
+
+func (c autoProfileRoutingConfig) moreSpecificThan(other autoProfileRoutingConfig) bool {
+	if c.hintCount() != other.hintCount() {
+		return c.hintCount() > other.hintCount()
+	}
+	if c.promptTokensGteValue() != other.promptTokensGteValue() {
+		return c.promptTokensGteValue() > other.promptTokensGteValue()
+	}
+	if c.promptTokensLtValue() != other.promptTokensLtValue() {
+		return c.promptTokensLtValue() < other.promptTokensLtValue()
+	}
+	if c.maxTokensGteValue() != other.maxTokensGteValue() {
+		return c.maxTokensGteValue() > other.maxTokensGteValue()
+	}
+	if c.maxTokensLtValue() != other.maxTokensLtValue() {
+		return c.maxTokensLtValue() < other.maxTokensLtValue()
+	}
+	return false
+}
+
+func (c autoProfileRoutingConfig) hintCount() int {
+	count := 0
+	if c.PromptTokensGte != nil {
+		count++
+	}
+	if c.PromptTokensLt != nil {
+		count++
+	}
+	if c.MaxTokensGte != nil {
+		count++
+	}
+	if c.MaxTokensLt != nil {
+		count++
+	}
+	return count
+}
+
+func (c autoProfileRoutingConfig) promptTokensGteValue() int {
+	if c.PromptTokensGte == nil {
+		return 0
+	}
+	return *c.PromptTokensGte
+}
+
+func (c autoProfileRoutingConfig) promptTokensLtValue() int {
+	if c.PromptTokensLt == nil {
+		return int(^uint(0) >> 1)
+	}
+	return *c.PromptTokensLt
+}
+
+func (c autoProfileRoutingConfig) maxTokensGteValue() int64 {
+	if c.MaxTokensGte == nil {
+		return 0
+	}
+	return *c.MaxTokensGte
+}
+
+func (c autoProfileRoutingConfig) maxTokensLtValue() int64 {
+	if c.MaxTokensLt == nil {
+		return int64(^uint64(0) >> 1)
+	}
+	return *c.MaxTokensLt
 }
 
 // ResolveProfileFromPod resolves the model config from a single pod annotation and
@@ -89,14 +258,37 @@ func ResolveProfileFromPod(pod *v1.Pod, headerProfile string) *ModelConfigProfil
 // model-wide locked routing strategy ("" when unset). The locked strategy applies
 // even when no profile resolves.
 func ResolveConfig(pods []*v1.Pod, headerProfile string) (*ModelConfigProfile, string) {
+	profile, _, locked := ResolveConfigForRequest(pods, headerProfile, RequestFeatures{})
+	return profile, locked
+}
+
+// ResolveConfigForRequest resolves the model config from the first pod carrying a
+// model.aibrix.ai/config annotation. If headerProfile is "auto", request-local
+// hints in each profile's routingConfig are evaluated and the returned
+// profileName is the concrete profile selected for this request.
+func ResolveConfigForRequest(pods []*v1.Pod, headerProfile string, features RequestFeatures) (*ModelConfigProfile, string, string) {
 	for _, pod := range pods {
 		cfg := parseConfigFromPod(pod)
 		if cfg == nil {
 			continue
 		}
-		return cfg.GetProfile(headerProfile), cfg.LockedRoutingStrategy
+		profileName := strings.TrimSpace(headerProfile)
+		if strings.EqualFold(profileName, "auto") {
+			selectedName := cfg.ResolveAutoProfileName(features)
+			if profile := cfg.GetProfileExact(selectedName); profile != nil {
+				return profile, selectedName, cfg.LockedRoutingStrategy
+			}
+			fallbackName := cfg.DefaultProfileOrName()
+			klog.Warningf("auto profile selection referenced missing profile %q; falling back to %q", selectedName, fallbackName)
+			return cfg.GetProfileExact(fallbackName), fallbackName, cfg.LockedRoutingStrategy
+		}
+		if profile := cfg.GetProfileExact(profileName); profile != nil {
+			return profile, profileName, cfg.LockedRoutingStrategy
+		}
+		fallbackName := cfg.DefaultProfileOrName()
+		return cfg.GetProfileExact(fallbackName), fallbackName, cfg.LockedRoutingStrategy
 	}
-	return nil, ""
+	return nil, "", ""
 }
 
 // parseConfigFromPod parses the model config from a single pod annotation.

--- a/pkg/plugins/gateway/configprofiles/configprofiles_test.go
+++ b/pkg/plugins/gateway/configprofiles/configprofiles_test.go
@@ -26,6 +26,16 @@ import (
 	"github.com/vllm-project/aibrix/pkg/constants"
 )
 
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+const randomRoutingStrategy = "random"
+
 func TestParseModelConfig(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -47,6 +57,10 @@ func TestParseModelConfig(t *testing.T) {
 		{
 			name: "with routingConfig",
 			json: `{"profiles":{"default":{"routingStrategy":"pd","routingConfig":{"key":"value"}}}}`,
+		},
+		{
+			name: "with auto profile hints in routingConfig",
+			json: `{"defaultProfile":"default","profiles":{"default":{"routingStrategy":"random"},"large":{"routingStrategy":"pd","routingConfig":{"promptTokensGte":8192}}}}`,
 		},
 		{
 			name:    "invalid json",
@@ -74,6 +88,179 @@ func TestParseModelConfig(t *testing.T) {
 			}
 			if tt.json != "" && cfg == nil {
 				t.Errorf("ParseModelConfig() expected config for non-empty input")
+			}
+		})
+	}
+}
+
+func TestResolveConfigForRequestAutoProfileRoutingConfigHints(t *testing.T) {
+	configJSON := `{
+		"defaultProfile":"default",
+		"profiles":{
+			"default":{"routingStrategy":"random"},
+			"large-input":{"routingStrategy":"pd","routingConfig":{"promptTokensGte":8192}},
+			"offline-generation":{"routingStrategy":"throughput","routingConfig":{"maxTokensGte":2048}},
+			"combined":{"routingStrategy":"least-request","routingConfig":{"promptTokensGte":8192,"maxTokensGte":2048}},
+			"broad-short-input":{"routingStrategy":"least-request","routingConfig":{"promptTokensLt":2048}},
+			"narrow-short-input":{"routingStrategy":"least-latency","routingConfig":{"promptTokensLt":512}},
+			"broad-short-output":{"routingStrategy":"least-request","routingConfig":{"maxTokensLt":4096}},
+			"narrow-short-output":{"routingStrategy":"random","routingConfig":{"maxTokensLt":1024}}
+		}
+	}`
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pod1",
+			Namespace:   "default",
+			Annotations: map[string]string{constants.ModelAnnoConfig: configJSON},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		headerProfile string
+		features      RequestFeatures
+		wantProfile   string
+		wantName      string
+	}{
+		{
+			name:          "concrete profile bypasses auto selection",
+			headerProfile: "offline-generation",
+			features:      RequestFeatures{PromptTokens: intPtr(9000)},
+			wantProfile:   "throughput",
+			wantName:      "offline-generation",
+		},
+		{
+			name:          "auto selects prompt token profile",
+			headerProfile: "auto",
+			features:      RequestFeatures{PromptTokens: intPtr(9000)},
+			wantProfile:   "pd",
+			wantName:      "large-input",
+		},
+		{
+			name:          "auto selects max token profile",
+			headerProfile: "auto",
+			features:      RequestFeatures{MaxTokens: int64Ptr(2048)},
+			wantProfile:   "throughput",
+			wantName:      "offline-generation",
+		},
+		{
+			name:          "auto selects more specific matching profile",
+			headerProfile: "auto",
+			features:      RequestFeatures{PromptTokens: intPtr(9000), MaxTokens: int64Ptr(2048)},
+			wantProfile:   "least-request",
+			wantName:      "combined",
+		},
+		{
+			name:          "auto falls back when no profile hints match",
+			headerProfile: "auto",
+			features:      RequestFeatures{PromptTokens: intPtr(2048)},
+			wantProfile:   randomRoutingStrategy,
+			wantName:      "default",
+		},
+		{
+			name:          "auto selects narrower prompt token upper bound",
+			headerProfile: "auto",
+			features:      RequestFeatures{PromptTokens: intPtr(100)},
+			wantProfile:   "least-latency",
+			wantName:      "narrow-short-input",
+		},
+		{
+			name:          "auto selects narrower max token upper bound",
+			headerProfile: "auto",
+			features:      RequestFeatures{MaxTokens: int64Ptr(512)},
+			wantProfile:   randomRoutingStrategy,
+			wantName:      "narrow-short-output",
+		},
+		{
+			name:          "auto does not match prompt token hint when prompt tokens are unknown",
+			headerProfile: "auto",
+			features:      RequestFeatures{},
+			wantProfile:   randomRoutingStrategy,
+			wantName:      "default",
+		},
+		{
+			name:          "case insensitive auto value",
+			headerProfile: " AUTO ",
+			features:      RequestFeatures{PromptTokens: intPtr(9000)},
+			wantProfile:   "pd",
+			wantName:      "large-input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, name, locked := ResolveConfigForRequest([]*v1.Pod{pod}, tt.headerProfile, tt.features)
+			if profile == nil {
+				t.Fatal("ResolveConfigForRequest() profile = nil")
+			}
+			if profile.RoutingStrategy != tt.wantProfile {
+				t.Errorf("ResolveConfigForRequest().RoutingStrategy = %s, want %s", profile.RoutingStrategy, tt.wantProfile)
+			}
+			if name != tt.wantName {
+				t.Errorf("ResolveConfigForRequest() name = %q, want %q", name, tt.wantName)
+			}
+			if locked != "" {
+				t.Errorf("ResolveConfigForRequest() locked = %q, want empty", locked)
+			}
+		})
+	}
+}
+
+func TestResolveConfigForRequestConcreteProfileFallbackName(t *testing.T) {
+	configJSON := `{
+		"defaultProfile":"default",
+		"profiles":{
+			"default":{"routingStrategy":"random"},
+			"pd":{"routingStrategy":"pd"}
+		}
+	}`
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{constants.ModelAnnoConfig: configJSON}}}
+
+	profile, name, _ := ResolveConfigForRequest([]*v1.Pod{pod}, "missing", RequestFeatures{})
+	if profile == nil {
+		t.Fatal("ResolveConfigForRequest() profile = nil")
+	}
+	if profile.RoutingStrategy != randomRoutingStrategy {
+		t.Errorf("ResolveConfigForRequest().RoutingStrategy = %s, want %s", profile.RoutingStrategy, randomRoutingStrategy)
+	}
+	if name != "default" {
+		t.Errorf("ResolveConfigForRequest() name = %q, want default", name)
+	}
+}
+
+func TestResolveConfigForRequestAutoFallbacks(t *testing.T) {
+	tests := []struct {
+		name        string
+		configJSON  string
+		wantProfile string
+		wantName    string
+	}{
+		{
+			name:        "missing auto selection hints use default profile",
+			configJSON:  `{"defaultProfile":"default","profiles":{"default":{"routingStrategy":"random"},"pd":{"routingStrategy":"pd"}}}`,
+			wantProfile: randomRoutingStrategy,
+			wantName:    "default",
+		},
+		{
+			name:        "invalid routingConfig hint is ignored",
+			configJSON:  `{"defaultProfile":"default","profiles":{"default":{"routingStrategy":"random"},"pd":{"routingStrategy":"pd","routingConfig":"invalid"}}}`,
+			wantProfile: randomRoutingStrategy,
+			wantName:    "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{constants.ModelAnnoConfig: tt.configJSON}}}
+			profile, name, _ := ResolveConfigForRequest([]*v1.Pod{pod}, "auto", RequestFeatures{PromptTokens: intPtr(2)})
+			if profile == nil {
+				t.Fatal("ResolveConfigForRequest() profile = nil")
+			}
+			if profile.RoutingStrategy != tt.wantProfile {
+				t.Errorf("ResolveConfigForRequest().RoutingStrategy = %s, want %s", profile.RoutingStrategy, tt.wantProfile)
+			}
+			if name != tt.wantName {
+				t.Errorf("ResolveConfigForRequest() name = %q, want %q", name, tt.wantName)
 			}
 		})
 	}

--- a/pkg/plugins/gateway/types.go
+++ b/pkg/plugins/gateway/types.go
@@ -44,14 +44,15 @@ const (
 	HeaderErrorMultipartParsing = "x-error-multipart-parsing"
 
 	// Request & Target Headers
-	HeaderWentIntoReqHeaders = "x-went-into-req-headers"
-	HeaderTargetPodIP        = "target-pod-ip"
-	HeaderTargetPod          = "target-pod"
-	HeaderRoutingStrategy    = "routing-strategy"
-	HeaderRequestID          = "request-id"
-	HeaderModel              = "model"
-	HeaderExternalFilter     = "external-filter"
-	HeaderConfigProfile      = "config-profile"
+	HeaderWentIntoReqHeaders  = "x-went-into-req-headers"
+	HeaderTargetPodIP         = "target-pod-ip"
+	HeaderTargetPod           = "target-pod"
+	HeaderRoutingStrategy     = "routing-strategy"
+	HeaderRequestID           = "request-id"
+	HeaderModel               = "model"
+	HeaderExternalFilter      = "external-filter"
+	HeaderConfigProfile       = "config-profile"
+	HeaderAIBrixConfigProfile = "x-aibrix-config-profile"
 	// HeaderSessionID is the header used for session affinity routing.
 	// NOTE: If you change this value, you MUST also update sessionIDHeader in
 	// pkg/plugins/gateway/algorithms/simple_session_affinity.go

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -653,12 +653,29 @@ func validateStreamOptions(requestID string, user utils.User, stream *bool, stre
 // locked routing strategy onto routingCtx.ConfigProfile.
 //   - The profile is selected by the config-profile header, falling back to
 //     defaultProfile (or "default") in the JSON.
+//   - config-profile: auto evaluates request-local hints in profile routingConfig
+//     and resolves to a concrete profile before routing strategy derivation.
 //   - lockedRoutingStrategy (top-level) is applied even when no profile resolves, so a
 //     model-wide lock cannot be bypassed by selecting a profile or sending a header.
 func applyConfigProfile(routingCtx *types.RoutingContext, pods []*v1.Pod) {
-	profile, locked := configprofiles.ResolveConfig(pods, routingCtx.ReqConfigProfile)
+	if routingCtx == nil {
+		return
+	}
+	reqConfigProfile := routingCtx.ReqConfigProfile
+	var features configprofiles.RequestFeatures
+	if strings.EqualFold(strings.TrimSpace(reqConfigProfile), "auto") {
+		features = buildConfigProfileRequestFeatures(routingCtx)
+	}
+	profile, profileName, locked := configprofiles.ResolveConfigForRequest(pods, reqConfigProfile, features)
 	if profile == nil && locked == "" {
 		return
+	}
+	if strings.EqualFold(strings.TrimSpace(reqConfigProfile), "auto") && profileName != "" {
+		routingCtx.ReqConfigProfile = profileName
+		if routingCtx.RespHeaders == nil {
+			routingCtx.RespHeaders = make(map[string]string)
+		}
+		routingCtx.RespHeaders[HeaderAIBrixConfigProfile] = profileName
 	}
 	cp := &types.ResolvedConfigProfile{LockedRoutingStrategy: locked}
 	if profile != nil {
@@ -667,6 +684,56 @@ func applyConfigProfile(routingCtx *types.RoutingContext, pods []*v1.Pod) {
 		cp.RequestsPerSecond = profile.RequestsPerSecond
 	}
 	routingCtx.ConfigProfile = cp
+}
+
+func buildConfigProfileRequestFeatures(routingCtx *types.RoutingContext) configprofiles.RequestFeatures {
+	if routingCtx == nil {
+		return configprofiles.RequestFeatures{}
+	}
+	features := configprofiles.RequestFeatures{
+		PromptTokens: estimatePromptTokens(routingCtx.Message),
+		MaxTokens:    maxTokensFromRequestBody(routingCtx.ReqBody),
+	}
+	return features
+}
+
+func estimatePromptTokens(message string) *int {
+	tokens, err := utils.TokenizeInputText(message)
+	if err != nil {
+		klog.V(4).InfoS("failed to estimate prompt tokens for config profile selection", "err", err)
+		return nil
+	}
+	tokenCount := len(tokens)
+	return &tokenCount
+}
+
+func maxTokensFromRequestBody(body []byte) *int64 {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+	var req map[string]json.RawMessage
+	if err := sonic.Unmarshal(body, &req); err != nil {
+		return nil
+	}
+	if v, ok := int64Field(req, "max_tokens"); ok {
+		return &v
+	}
+	if v, ok := int64Field(req, "max_completion_tokens"); ok {
+		return &v
+	}
+	return nil
+}
+
+func int64Field(req map[string]json.RawMessage, key string) (int64, bool) {
+	raw, ok := req[key]
+	if !ok {
+		return 0, false
+	}
+	var v int64
+	if err := sonic.Unmarshal(raw, &v); err != nil {
+		return 0, false
+	}
+	return v, true
 }
 
 var defaultRoutingStrategy, defaultRoutingStrategyEnabled = utils.LookupEnv(EnvRoutingAlgorithm)

--- a/pkg/plugins/gateway/util_test.go
+++ b/pkg/plugins/gateway/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gateway
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -26,10 +27,19 @@ import (
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 	"go.opentelemetry.io/otel/attribute"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+const autoConfigProfile = "auto"
 
 func Test_ValidateRequestBody(t *testing.T) {
 	testCases := []struct {
@@ -1426,6 +1436,201 @@ func TestFieldsToAttributes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, fieldsToAttributes(tt.fields))
+		})
+	}
+}
+
+func TestApplyConfigProfile_AutoProfileRoutingConfigHints(t *testing.T) {
+	profileJSON := `{
+		"defaultProfile":"default",
+		"profiles":{
+			"default":{"routingStrategy":"least-request"},
+			"large-input":{"routingStrategy":"pd","routingConfig":{"promptTokensGte":4},"requestsPerSecond":5},
+			"offline-generation":{"routingStrategy":"throughput","routingConfig":{"maxTokensGte":2048}}
+		}
+	}`
+	pods := []*v1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pod-a",
+			Annotations: map[string]string{constants.ModelAnnoConfig: profileJSON},
+		},
+	}}
+
+	ctx := types.NewRoutingContext(context.Background(), "", "", "", "request-1", "")
+	ctx.ReqConfigProfile = autoConfigProfile
+	ctx.Message = "one two three four"
+	ctx.ReqBody = []byte(`{"max_tokens":128}`)
+	ctx.ReqHeaders = map[string]string{}
+
+	applyConfigProfile(ctx, pods)
+
+	assert.NotNil(t, ctx.ConfigProfile)
+	assert.Equal(t, "pd", ctx.ConfigProfile.RoutingStrategy)
+	assert.Equal(t, int64(5), ctx.ConfigProfile.RequestsPerSecond)
+	assert.Equal(t, "large-input", ctx.ReqConfigProfile)
+	assert.Equal(t, "large-input", ctx.RespHeaders[HeaderAIBrixConfigProfile])
+}
+
+func TestApplyConfigProfile_AutoProfileRoutingConfigHintFallbacks(t *testing.T) {
+	tests := []struct {
+		name             string
+		profileJSON      string
+		reqHeaders       map[string]string
+		reqBody          []byte
+		wantStrategy     string
+		wantReqProfile   string
+		wantProfileHdr   string
+		wantHeaderAbsent bool
+	}{
+		{
+			name: "no matching hint uses default profile",
+			profileJSON: `{
+				"defaultProfile":"default",
+				"profiles":{"default":{"routingStrategy":"least-request"},"throughput":{"routingStrategy":"throughput","routingConfig":{"maxTokensGte":2048}}}
+			}`,
+			reqHeaders:     map[string]string{},
+			reqBody:        []byte(`{"max_tokens":128}`),
+			wantStrategy:   "least-request",
+			wantReqProfile: "default",
+			wantProfileHdr: "default",
+		},
+		{
+			name: "invalid routingConfig hint uses default profile",
+			profileJSON: `{
+				"defaultProfile":"default",
+				"profiles":{"default":{"routingStrategy":"least-request"},"large-input":{"routingStrategy":"pd","routingConfig":"invalid"}}
+			}`,
+			reqHeaders:     map[string]string{},
+			reqBody:        []byte(`{"max_tokens":128}`),
+			wantStrategy:   "least-request",
+			wantReqProfile: "default",
+			wantProfileHdr: "default",
+		},
+		{
+			name: "routing strategy header does not skip auto selection",
+			profileJSON: `{
+				"defaultProfile":"default",
+				"profiles":{"default":{"routingStrategy":"least-request"},"large-input":{"routingStrategy":"pd","routingConfig":{"promptTokensGte":1},"requestsPerSecond":5}}
+			}`,
+			reqHeaders:     map[string]string{HeaderRoutingStrategy: "throughput"},
+			reqBody:        []byte(`{"max_tokens":128}`),
+			wantStrategy:   "pd",
+			wantReqProfile: "large-input",
+			wantProfileHdr: "large-input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pods := []*v1.Pod{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "pod-a",
+					Annotations: map[string]string{constants.ModelAnnoConfig: tt.profileJSON},
+				},
+			}}
+			ctx := types.NewRoutingContext(context.Background(), "", "", "", "request-1", "")
+			ctx.ReqConfigProfile = autoConfigProfile
+			ctx.Message = "prompt"
+			ctx.ReqBody = tt.reqBody
+			ctx.ReqHeaders = tt.reqHeaders
+
+			applyConfigProfile(ctx, pods)
+
+			assert.NotNil(t, ctx.ConfigProfile)
+			assert.Equal(t, tt.wantStrategy, ctx.ConfigProfile.RoutingStrategy)
+			assert.Equal(t, tt.wantReqProfile, ctx.ReqConfigProfile)
+			if tt.wantHeaderAbsent {
+				assert.NotContains(t, ctx.RespHeaders, HeaderAIBrixConfigProfile)
+			} else {
+				assert.Equal(t, tt.wantProfileHdr, ctx.RespHeaders[HeaderAIBrixConfigProfile])
+			}
+		})
+	}
+}
+
+func TestApplyConfigProfile_BuildsFeaturesOnlyForAutoSelection(t *testing.T) {
+	profileJSON := `{
+		"defaultProfile":"default",
+		"profiles":{
+			"default":{"routingStrategy":"least-request"},
+			"batch":{"routingStrategy":"throughput","routingConfig":{"promptTokensGte":1}}
+		}
+	}`
+	pods := []*v1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pod-a",
+			Annotations: map[string]string{constants.ModelAnnoConfig: profileJSON},
+		},
+	}}
+
+	tests := []struct {
+		name             string
+		reqConfigProfile string
+		reqHeaders       map[string]string
+		wantStrategy     string
+		wantReqProfile   string
+	}{
+		{
+			name:             "concrete profile skips request feature parsing",
+			reqConfigProfile: "batch",
+			reqHeaders:       map[string]string{},
+			wantStrategy:     "throughput",
+			wantReqProfile:   "batch",
+		},
+		{
+			name:             "routing strategy header still resolves auto profile",
+			reqConfigProfile: autoConfigProfile,
+			reqHeaders:       map[string]string{HeaderRoutingStrategy: "throughput"},
+			wantStrategy:     "throughput",
+			wantReqProfile:   "batch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := types.NewRoutingContext(context.Background(), "", "", "", "request-1", "")
+			ctx.ReqConfigProfile = tt.reqConfigProfile
+			ctx.ReqHeaders = tt.reqHeaders
+			ctx.ReqBody = []byte(`{`)
+			ctx.Message = "prompt"
+
+			applyConfigProfile(ctx, pods)
+
+			assert.NotNil(t, ctx.ConfigProfile)
+			assert.Equal(t, tt.wantStrategy, ctx.ConfigProfile.RoutingStrategy)
+			assert.Equal(t, tt.wantReqProfile, ctx.ReqConfigProfile)
+			if tt.reqConfigProfile == autoConfigProfile {
+				assert.Equal(t, tt.wantReqProfile, ctx.RespHeaders[HeaderAIBrixConfigProfile])
+			} else {
+				assert.NotContains(t, ctx.RespHeaders, HeaderAIBrixConfigProfile)
+			}
+		})
+	}
+}
+
+func TestMaxTokensFromRequestBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		want *int64
+	}{
+		{name: "max tokens", body: []byte(`{"max_tokens":128}`), want: int64Ptr(128)},
+		{name: "max completion tokens", body: []byte(`{"max_completion_tokens":256}`), want: int64Ptr(256)},
+		{name: "max tokens wins", body: []byte(`{"max_tokens":128,"max_completion_tokens":256}`), want: int64Ptr(128)},
+		{name: "absent", body: []byte(`{"model":"m"}`), want: nil},
+		{name: "invalid", body: []byte(`{`), want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maxTokensFromRequestBody(tt.body)
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			if assert.NotNil(t, got) {
+				assert.Equal(t, *tt.want, *got)
+			}
 		})
 	}
 }

--- a/test/e2e/routing_config_profile_test.go
+++ b/test/e2e/routing_config_profile_test.go
@@ -31,10 +31,11 @@ import (
 // causes the gateway plugin to select the correct routing-strategy from the model's
 // config (model.aibrix.ai/config annotation).
 //
-// The config is defined in development/app/config/mock/config-profile-llama2-patch.yaml
-// (mirrors config-profile.yaml structure):
+// The config is defined in development/app/config/mock/config-profile.yaml:
 //   - defaultProfile: "least-request"
 //   - profiles: "least-request" (routingStrategy: least-request), "throughput" (routingStrategy: throughput)
+//   - profile: "cache-friendly" (routingStrategy: least-kv-cache)
+//   - routingConfig auto-selection hints for long-generation request classes
 //
 // The gateway resolves config-profile header -> ResolveConfig -> deriveRoutingStrategyFromContext
 // and sets routing-strategy in the response headers.
@@ -85,5 +86,43 @@ func TestConfigProfileRoutingStrategy(t *testing.T) {
 		got := dst.Header.Get("routing-strategy")
 		assert.Equal(t, "throughput", got,
 			"config-profile: throughput should select routing-strategy throughput")
+	})
+
+	t.Run("config_profile_cache_friendly", func(t *testing.T) {
+		var dst *http.Response
+		client := createOpenAIClientWithConfigProfile(gatewayURL, apiKey, "cache-friendly", option.WithResponseInto(&dst))
+
+		_, err := client.Chat.Completions.New(context.TODO(), openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage(msg)},
+			Model:    modelNameQwen3,
+		})
+		require.NoError(t, err)
+
+		got := dst.Header.Get("routing-strategy")
+		assert.Equal(t, "least-kv-cache", got,
+			"config-profile: cache-friendly should select routing-strategy least-kv-cache")
+	})
+}
+
+// TestAutoConfigProfileRoutingStrategy verifies config-profile: auto resolves to a
+// concrete profile from request features before routing strategy derivation.
+func TestAutoConfigProfileRoutingStrategy(t *testing.T) {
+	msg := "auto config-profile routing test message"
+
+	t.Run("auto_profile_max_tokens_rule", func(t *testing.T) {
+		var dst *http.Response
+		client := createOpenAIClientWithConfigProfile(gatewayURL, apiKey, "auto", option.WithResponseInto(&dst))
+
+		_, err := client.Chat.Completions.New(context.TODO(), openai.ChatCompletionNewParams{
+			Messages:  []openai.ChatCompletionMessageParamUnion{openai.UserMessage(msg)},
+			Model:     modelNameQwen3,
+			MaxTokens: openai.Int(2048),
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "long-generation", dst.Header.Get("x-aibrix-config-profile"),
+			"config-profile: auto should resolve to long-generation profile from max_tokens")
+		assert.Equal(t, "throughput", dst.Header.Get("routing-strategy"),
+			"long-generation profile should use throughput routing strategy")
 	})
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -138,7 +138,7 @@ func createOpenAIClientWithRoutingStrategy(baseURL, apiKey, routingStrategy stri
 // The gateway plugin selects routing-strategy from the model's config profile (model.aibrix.ai/config)
 // based on this header, rather than from the routing-strategy header.
 func createOpenAIClientWithConfigProfile(baseURL, apiKey, configProfile string,
-	respOpt option.RequestOption) openai.Client {
+	respOpts ...option.RequestOption) openai.Client {
 	transport := &http.Transport{
 		DisableKeepAlives: true,
 		MaxIdleConns:      0,
@@ -157,8 +157,10 @@ func createOpenAIClientWithConfigProfile(baseURL, apiKey, configProfile string,
 	if configProfile != "" {
 		opts = append(opts, option.WithHeader("config-profile", configProfile))
 	}
-	if respOpt != nil {
-		opts = append(opts, respOpt)
+	for _, respOpt := range respOpts {
+		if respOpt != nil {
+			opts = append(opts, respOpt)
+		}
 	}
 
 	return openai.NewClient(opts...)


### PR DESCRIPTION
## Summary
- Add request-aware auto config profile selection for `config-profile: auto`.
- Resolve `auto` from request-local hints embedded in each profile `routingConfig` instead of a separate `autoProfileSelection` / `when` rule layer.
- Support `promptTokensGte`, `promptTokensLt`, `maxTokensGte`, and `maxTokensLt` as the first set of auto-selection hints.
- Resolve auto selection to a concrete profile before routing strategy derivation and expose `x-aibrix-config-profile` in response headers for debugging.
- Extend docs, mock config, and e2e coverage for concrete profiles and auto max-token selection.

## Notes
- Header/path/stream matching was removed to keep the schema flat and routing-focused.
- `routing-strategy` request headers override only the final routing strategy; they do not skip profile resolution, so non-strategy profile fields still apply.
- `cacheGte` is not included in this PR because cache matching requires cache-aware routing state/scoring that is not available in the profile-selection phase yet.

## Test Plan
- `go test ./pkg/plugins/gateway/...`
- `go test ./test/e2e -run '^$'`
- `git diff --check`

Fixes #2568