### PR TITLE
Close the mkstemp descriptor before unlinking in the batch driver test

### DIFF
--- a/python/aibrix/tests/batch/job_driver/test_driver.py
+++ b/python/aibrix/tests/batch/job_driver/test_driver.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import json
+import os
 import tempfile
 from pathlib import Path
 
@@ -489,5 +490,7 @@ async def test_batch_driver_survives_job_failure_with_fail_after_n_requests():
         await driver.clear_job(job_id)
 
     finally:
-        # Clean up temporary file
+        # Clean up temporary file. mkstemp hands back an open descriptor, and Windows refuses to
+        # unlink a file that still has one, so close it before removing the path.
+        os.close(temp_file_descriptor)
         Path(temp_path).unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

`test_batch_driver_survives_job_failure_with_fail_after_n_requests` creates its input file with `tempfile.mkstemp`:

```python
temp_file_descriptor, temp_path = tempfile.mkstemp(suffix=".jsonl")
```

`mkstemp` returns an open OS-level descriptor and leaves closing it to the caller. `temp_file_descriptor` appears exactly once in the file, at that line, so it is never closed. The `finally` block then unlinks the path.

POSIX allows unlinking a file that still has an open handle, so this is invisible on Linux. Windows refuses, and the test fails during teardown after all of its assertions have already passed:

```
E  PermissionError: [WinError 32] The process cannot access the file because it is
   being used by another process: 'C:\Users\...\Temp\tmp2pvftfp8.jsonl'
   tests/batch/job_driver/test_driver.py:493
```

The other three tests in this file use `NamedTemporaryFile` inside a `with` block, which closes on exit, and are unaffected. This is the only `mkstemp` call under `tests/batch/`.

## Test plan

Windows 11, Python 3.12, `pytest tests/batch`:

```
before   3 failed, 486 passed, 10 skipped
after    tests/batch/job_driver/test_driver.py -> 6 passed
```

The two other failures were `test_e2e_abnormal_job_behavior.py::test_job_cancellation_in_progress_before_preparation` and `::test_job_restore_after_mds_crash_during_finalizing_after_runtime_shutdown`. Both pass when run on their own, so they look like fallout from this test's teardown raising rather than separate defects. I have noted that rather than claiming it, since I only have the one platform to check on.

`ruff check` and `ruff format --check` are clean on the changed file.

## Related

Not linked to an issue. Found while setting up to work on the batch area for #2546.
