### PR TITLE
docs(samples): add health and readiness probes to volcano-engine examples

### DIFF
--- a/samples/volcano-engine/deepseek-8b-kv-cluster.yaml
+++ b/samples/volcano-engine/deepseek-8b-kv-cluster.yaml
@@ -130,6 +130,33 @@ spec:
               vke.volcengine.com/rdma: "1"
               cpu: "10"
               memory: "120G"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
           securityContext:
             capabilities:
               add:

--- a/samples/volcano-engine/deepseek-8b-kv-direct.yaml
+++ b/samples/volcano-engine/deepseek-8b-kv-direct.yaml
@@ -128,6 +128,33 @@ spec:
               vke.volcengine.com/rdma: "1"
               cpu: "10"
               memory: "120G"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
           securityContext:
             capabilities:
               add:

--- a/samples/volcano-engine/deepseek-8b-kv-dram.yaml
+++ b/samples/volcano-engine/deepseek-8b-kv-dram.yaml
@@ -118,6 +118,33 @@ spec:
               vke.volcengine.com/rdma: "1"
               cpu: "10"
               memory: "120G"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
           securityContext:
             capabilities:
               add:

--- a/samples/volcano-engine/deepseek-8b-naive.yaml
+++ b/samples/volcano-engine/deepseek-8b-naive.yaml
@@ -97,6 +97,33 @@ spec:
               nvidia.com/gpu: "1"
               cpu: "10"
               memory: "20G"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
       volumes:
         - name: model-hostpath
           hostPath:


### PR DESCRIPTION
## Summary

Follow-up to #2264 (which added probes to the quickstart, kvcache, adapter, and multimodality samples): the four `samples/volcano-engine/` model deployments still lack health and readiness checks.

These deployments run `vllm serve` on port 8000, but with no probes the pod reports Ready as soon as it starts — before the model finishes downloading and loading. Requests routed to the pod during model loading fail. This is exactly the premature-traffic-routing problem described in #685.

## Changes

Add the same liveness/readiness/startup probe block used by the quickstart and other samples (see #2264) to:

- `samples/volcano-engine/deepseek-8b-naive.yaml`
- `samples/volcano-engine/deepseek-8b-kv-cluster.yaml`
- `samples/volcano-engine/deepseek-8b-kv-direct.yaml`
- `samples/volcano-engine/deepseek-8b-kv-dram.yaml`

Each probes `GET /health` on port 8000 (the vLLM serve port), with a startup probe tolerating up to 150s of model loading before the readiness probe gates traffic.

## Testing

- All four files parse as valid YAML (multi-doc: Deployment + Service).
- Probe block matches the template in `samples/quickstart/model.yaml` (merged via #2264).
- Probes target the vLLM container's serve port (8000) / `/health`, which vLLM serves.

## Checklist

- [x] Linked Issue or clearly described motivation (#685)
- [x] Added/updated docs (sample manifests)
- [x] No behavior change beyond Kubernetes pod scheduling
- [x] Backward compatibility considered (additive, standard probes only)