### PR TITLE
[API] Validate RoleSet role specifications

### DIFF
--- a/api/orchestration/v1alpha1/roleset_types.go
+++ b/api/orchestration/v1alpha1/roleset_types.go
@@ -27,7 +27,10 @@ import (
 
 // RoleSetSpec defines the desired state of RoleSet
 type RoleSetSpec struct {
-	Roles []RoleSpec `json:"roles,omitempty"`
+	// +kubebuilder:validation:MinItems=1
+	// +listType=map
+	// +listMapKey=name
+	Roles []RoleSpec `json:"roles"`
 
 	// +optional
 	// +kubebuilder:validation:Enum={Parallel,Sequential,Interleave}
@@ -195,10 +198,15 @@ type DisruptionTolerance struct {
 }
 
 type RoleSpec struct {
-	Name string `json:"name,omitempty"`
+	// Name identifies the role and is used to derive child resource names.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	Name string `json:"name"`
 
 	// Replicas is the number of desired replicas.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// UpgradeOrder specifies the order in which this role should be upgraded.

--- a/api/orchestration/v1alpha1/stormservice_types.go
+++ b/api/orchestration/v1alpha1/stormservice_types.go
@@ -70,7 +70,7 @@ type RoleSetTemplateSpec struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// +optional
+	// +kubebuilder:validation:Required
 	Spec *RoleSetSpec `json:"spec,omitempty"`
 }
 

--- a/config/crd/orchestration/orchestration.aibrix.ai_rolesets.yaml
+++ b/config/crd/orchestration/orchestration.aibrix.ai_rolesets.yaml
@@ -47,6 +47,9 @@ spec:
                           x-kubernetes-int-or-string: true
                       type: object
                     name:
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     podGroupSize:
                       format: int32
@@ -55,6 +58,7 @@ spec:
                       type: integer
                     replicas:
                       format: int32
+                      minimum: 0
                       type: integer
                     schedulingStrategy:
                       maxProperties: 1
@@ -3866,8 +3870,14 @@ spec:
                       format: int32
                       minimum: 1
                       type: integer
+                  required:
+                  - name
                   type: object
+                minItems: 1
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               schedulingStrategy:
                 maxProperties: 1
                 properties:
@@ -4056,6 +4066,8 @@ spec:
                 - Sequential
                 - Interleave
                 type: string
+            required:
+            - roles
             type: object
           status:
             properties:

--- a/config/crd/orchestration/orchestration.aibrix.ai_stormservices.yaml
+++ b/config/crd/orchestration/orchestration.aibrix.ai_stormservices.yaml
@@ -4144,6 +4144,8 @@ spec:
                     required:
                     - roles
                     type: object
+                required:
+                - spec
                 type: object
               updateStrategy:
                 properties:

--- a/config/crd/orchestration/orchestration.aibrix.ai_stormservices.yaml
+++ b/config/crd/orchestration/orchestration.aibrix.ai_stormservices.yaml
@@ -122,6 +122,9 @@ spec:
                                   x-kubernetes-int-or-string: true
                               type: object
                             name:
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             podGroupSize:
                               format: int32
@@ -130,6 +133,7 @@ spec:
                               type: integer
                             replicas:
                               format: int32
+                              minimum: 0
                               type: integer
                             schedulingStrategy:
                               maxProperties: 1
@@ -3941,8 +3945,14 @@ spec:
                               format: int32
                               minimum: 1
                               type: integer
+                          required:
+                          - name
                           type: object
+                        minItems: 1
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       schedulingStrategy:
                         maxProperties: 1
                         properties:
@@ -4131,6 +4141,8 @@ spec:
                         - Sequential
                         - Interleave
                         type: string
+                    required:
+                    - roles
                     type: object
                 type: object
               updateStrategy:

--- a/dist/chart/crds/orchestration.aibrix.ai_rolesets.yaml
+++ b/dist/chart/crds/orchestration.aibrix.ai_rolesets.yaml
@@ -47,6 +47,9 @@ spec:
                           x-kubernetes-int-or-string: true
                       type: object
                     name:
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     podGroupSize:
                       format: int32
@@ -55,6 +58,7 @@ spec:
                       type: integer
                     replicas:
                       format: int32
+                      minimum: 0
                       type: integer
                     schedulingStrategy:
                       maxProperties: 1
@@ -3866,8 +3870,14 @@ spec:
                       format: int32
                       minimum: 1
                       type: integer
+                  required:
+                  - name
                   type: object
+                minItems: 1
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               schedulingStrategy:
                 maxProperties: 1
                 properties:
@@ -4056,6 +4066,8 @@ spec:
                 - Sequential
                 - Interleave
                 type: string
+            required:
+            - roles
             type: object
           status:
             properties:

--- a/dist/chart/crds/orchestration.aibrix.ai_stormservices.yaml
+++ b/dist/chart/crds/orchestration.aibrix.ai_stormservices.yaml
@@ -4144,6 +4144,8 @@ spec:
                     required:
                     - roles
                     type: object
+                required:
+                - spec
                 type: object
               updateStrategy:
                 properties:

--- a/dist/chart/crds/orchestration.aibrix.ai_stormservices.yaml
+++ b/dist/chart/crds/orchestration.aibrix.ai_stormservices.yaml
@@ -122,6 +122,9 @@ spec:
                                   x-kubernetes-int-or-string: true
                               type: object
                             name:
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             podGroupSize:
                               format: int32
@@ -130,6 +133,7 @@ spec:
                               type: integer
                             replicas:
                               format: int32
+                              minimum: 0
                               type: integer
                             schedulingStrategy:
                               maxProperties: 1
@@ -3941,8 +3945,14 @@ spec:
                               format: int32
                               minimum: 1
                               type: integer
+                          required:
+                          - name
                           type: object
+                        minItems: 1
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       schedulingStrategy:
                         maxProperties: 1
                         properties:
@@ -4131,6 +4141,8 @@ spec:
                         - Sequential
                         - Interleave
                         type: string
+                    required:
+                    - roles
                     type: object
                 type: object
               updateStrategy:

--- a/test/integration/webhook/roleset_validation_test.go
+++ b/test/integration/webhook/roleset_validation_test.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -81,6 +82,15 @@ var _ = ginkgo.Describe("RoleSet spec admission", func() {
 			gomega.Expect(k8sClient.Create(ctx, stormService)).To(gomega.HaveOccurred())
 		})
 	}
+
+	ginkgo.It("rejects a StormService without a nested spec", func() {
+		stormService := validStormService("nested-missing-spec", ns.Name, []orchestrationapi.RoleSpec{
+			validRole("worker", 1),
+		})
+		stormService.Spec.Template.Spec = nil
+		err := k8sClient.Create(ctx, stormService)
+		gomega.Expect(apierrors.IsInvalid(err)).To(gomega.BeTrue(), "expected schema validation error, got %v", err)
+	})
 
 	ginkgo.It("accepts zero replicas and multiple distinct roles", func() {
 		roles := []orchestrationapi.RoleSpec{

--- a/test/integration/webhook/roleset_validation_test.go
+++ b/test/integration/webhook/roleset_validation_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	orchestrationapi "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/test/utils/wrapper"
+)
+
+var _ = ginkgo.Describe("RoleSet spec admission", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "roleset-validation-"},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(k8sClient.Delete(ctx, ns)).To(gomega.Succeed())
+	})
+
+	type invalidRolesCase struct {
+		name  string
+		roles []orchestrationapi.RoleSpec
+	}
+
+	invalidCases := []invalidRolesCase{
+		{
+			name:  "empty roles",
+			roles: []orchestrationapi.RoleSpec{},
+		},
+		{
+			name: "duplicate role names",
+			roles: []orchestrationapi.RoleSpec{
+				validRole("worker", 1),
+				validRole("worker", 2),
+			},
+		},
+		{
+			name:  "non-DNS-1123 role name",
+			roles: []orchestrationapi.RoleSpec{validRole("bad_role", 1)},
+		},
+		{
+			name:  "negative replicas",
+			roles: []orchestrationapi.RoleSpec{validRole("worker", -1)},
+		},
+	}
+
+	for _, tc := range invalidCases {
+		tc := tc
+		ginkgo.It("rejects "+tc.name+" on direct RoleSet creation", func() {
+			roleSet := validRoleSet("direct-invalid", ns.Name, tc.roles)
+			gomega.Expect(k8sClient.Create(ctx, roleSet)).To(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("rejects "+tc.name+" on nested StormService creation", func() {
+			stormService := validStormService("nested-invalid", ns.Name, tc.roles)
+			gomega.Expect(k8sClient.Create(ctx, stormService)).To(gomega.HaveOccurred())
+		})
+	}
+
+	ginkgo.It("accepts zero replicas and multiple distinct roles", func() {
+		roles := []orchestrationapi.RoleSpec{
+			validRole("leader", 0),
+			validRole("worker", 2),
+		}
+
+		roleSet := validRoleSet("direct-valid", ns.Name, roles)
+		gomega.Expect(k8sClient.Create(ctx, roleSet)).To(gomega.Succeed())
+
+		stormService := validStormService("nested-valid", ns.Name, roles)
+		gomega.Expect(k8sClient.Create(ctx, stormService)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("rejects an invalid direct RoleSet update", func() {
+		roleSet := validRoleSet("direct-update", ns.Name, []orchestrationapi.RoleSpec{
+			validRole("worker", 1),
+		})
+		gomega.Expect(k8sClient.Create(ctx, roleSet)).To(gomega.Succeed())
+
+		roleSet.Spec.Roles = append(roleSet.Spec.Roles, validRole("worker", 2))
+		gomega.Expect(k8sClient.Update(ctx, roleSet)).To(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("rejects an invalid nested StormService update", func() {
+		stormService := validStormService("nested-update", ns.Name, []orchestrationapi.RoleSpec{
+			validRole("worker", 1),
+		})
+		gomega.Expect(k8sClient.Create(ctx, stormService)).To(gomega.Succeed())
+
+		stormService.Spec.Template.Spec.Roles[0].Replicas = ptr.To(int32(-1))
+		gomega.Expect(k8sClient.Update(ctx, stormService)).To(gomega.HaveOccurred())
+	})
+})
+
+func validRole(name string, replicas int32) orchestrationapi.RoleSpec {
+	return orchestrationapi.RoleSpec{
+		Name:     name,
+		Replicas: ptr.To(replicas),
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app": "validation-test"},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "runtime",
+					Image: "example.invalid/runtime:latest",
+				}},
+			},
+		},
+	}
+}
+
+func validRoleSet(name, namespace string, roles []orchestrationapi.RoleSpec) *orchestrationapi.RoleSet {
+	return &orchestrationapi.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: orchestrationapi.RoleSetSpec{
+			Roles:          copyRoles(roles),
+			UpdateStrategy: orchestrationapi.SequentialRoleSetStrategyType,
+		},
+	}
+}
+
+func validStormService(name, namespace string, roles []orchestrationapi.RoleSpec) *orchestrationapi.StormService {
+	stormService := wrapper.MakeStormService(name).
+		Namespace(namespace).
+		WithDefaultConfiguration().
+		Obj()
+	stormService.Spec.Template.Spec.Roles = copyRoles(roles)
+	return stormService
+}
+
+func copyRoles(roles []orchestrationapi.RoleSpec) []orchestrationapi.RoleSpec {
+	spec := &orchestrationapi.RoleSetSpec{Roles: roles}
+	return spec.DeepCopy().Roles
+}

--- a/test/integration/webhook/roleset_validation_test.go
+++ b/test/integration/webhook/roleset_validation_test.go
@@ -18,7 +18,6 @@ package webhook
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -82,15 +81,6 @@ var _ = ginkgo.Describe("RoleSet spec admission", func() {
 			gomega.Expect(k8sClient.Create(ctx, stormService)).To(gomega.HaveOccurred())
 		})
 	}
-
-	ginkgo.It("rejects a StormService without a nested spec", func() {
-		stormService := validStormService("nested-missing-spec", ns.Name, []orchestrationapi.RoleSpec{
-			validRole("worker", 1),
-		})
-		stormService.Spec.Template.Spec = nil
-		err := k8sClient.Create(ctx, stormService)
-		gomega.Expect(apierrors.IsInvalid(err)).To(gomega.BeTrue(), "expected schema validation error, got %v", err)
-	})
 
 	ginkgo.It("accepts zero replicas and multiple distinct roles", func() {
 		roles := []orchestrationapi.RoleSpec{

--- a/test/integration/webhook/stormservice_webhook_test.go
+++ b/test/integration/webhook/stormservice_webhook_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	orchestrationapi "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
@@ -132,15 +133,21 @@ var _ = ginkgo.Describe("stormservice default webhook", func() {
 	)
 
 	type testValidatingCase struct {
-		stormservice func() *orchestrationapi.StormService
-		failed       bool
+		stormservice  func() *orchestrationapi.StormService
+		failed        bool
+		expectInvalid bool
 	}
 	ginkgo.DescribeTable("test validating",
 		func(tc *testValidatingCase) {
+			err := k8sClient.Create(ctx, tc.stormservice())
 			if tc.failed {
-				gomega.Expect(k8sClient.Create(ctx, tc.stormservice())).Should(gomega.HaveOccurred())
+				gomega.Expect(err).Should(gomega.HaveOccurred())
+				if tc.expectInvalid {
+					gomega.Expect(apierrors.IsInvalid(err)).To(gomega.BeTrue(),
+						"expected schema validation error, got %v", err)
+				}
 			} else {
-				gomega.Expect(k8sClient.Create(ctx, tc.stormservice())).To(gomega.Succeed())
+				gomega.Expect(err).To(gomega.Succeed())
 			}
 		},
 		// Valid StormService with short name and default config (includes sidecar annotations).
@@ -152,6 +159,19 @@ var _ = ginkgo.Describe("stormservice default webhook", func() {
 					Obj()
 			},
 			failed: false,
+		}),
+
+		ginkgo.Entry("rejects a missing nested RoleSet spec", &testValidatingCase{
+			stormservice: func() *orchestrationapi.StormService {
+				stormService := wrapper.MakeStormService("missing-nested-spec").
+					Namespace(ns.Name).
+					WithDefaultConfiguration().
+					Obj()
+				stormService.Spec.Template.Spec = nil
+				return stormService
+			},
+			failed:        true,
+			expectInvalid: true,
 		}),
 
 		// StormService name exceeds 63 characters → rejected by Kubernetes naming rules.


### PR DESCRIPTION
## Pull Request Description

RoleSet role constraints were absent from the CRD schema, so invalid specs reached the controllers and could produce misleading Ready status or repeated reconciliation.

This change validates the shared RoleSetSpec at API admission:

- require at least one role;
- use the required role name as the Kubernetes map-list key, rejecting duplicates;
- require DNS-1123 role names of at most 63 characters;
- reject negative per-role replicas while preserving zero;
- require `StormService.spec.template.spec`, preventing the validating webhook from dereferencing a nil nested spec; and
- regenerate both direct RoleSet and nested StormService CRD schemas.

The integration suite now covers all invalid create cases for both resources, a missing nested StormService spec, valid zero-replica and multi-role specs, and invalid updates for both resources.

## Related Issues

Fixes #2583

## Validation

- make test-integration-webhook (60/60 passed)
- focused RoleSet admission envtest (12/12 passed)
- make test (all non-e2e/non-integration Go packages passed)
- make manifests-all generate
- make verify-codegen
- direct byte-for-byte comparison of every generated base CRD with its module and Helm chart copy

The repository verify-crd-sync script could not complete under the system Bash 3.2 because it uses associative arrays; it reported an unbound variable before comparisons. The direct comparison above covers the same generated-file consistency check.