### PR TITLE
fix(gateway): Finalize request lifecycle once

### DIFF
--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -107,6 +107,7 @@ type processState struct {
 	isGatewayRspDone bool
 	completed        bool
 	trackedModel     string
+	requestDone      sync.Once
 	rootSpan         trace.Span // main span
 	inferenceSpan    trace.Span // routing completion to final response body
 	firstRespSpan    trace.Span // routing completion to first response body chunk
@@ -146,6 +147,30 @@ func (st *processState) releaseModelInFlight() {
 		podName,
 		modelToRelease,
 	)
+}
+
+// finishRequestCount and finishRequestTrace are the only production lifecycle
+// completion points. A request can reach several terminal paths in quick
+// succession (for example, response completion followed by EOF), so cache
+// bookkeeping must be finalized exactly once while routerCtx is still owned by
+// this processState.
+func (s *Server) finishRequestCount(st *processState) {
+	st.requestDone.Do(func() {
+		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+	})
+}
+
+func (s *Server) finishRequestTrace(st *processState, usage TokenUsage) {
+	st.requestDone.Do(func() {
+		s.cache.DoneRequestTrace(
+			st.routerCtx,
+			st.requestID,
+			st.model,
+			usage.PromptTokens,
+			usage.CompletionTokens,
+			st.traceTerm,
+		)
+	})
 }
 
 func httpRouteCacheTTL() time.Duration {
@@ -207,6 +232,12 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 
 	metrics.IncGaugeMetric(metrics.GatewayInFlight, metrics.GetMetricHelp(metrics.GatewayInFlight), []string{"gateway_pod"}, podName)
 	defer func() {
+		// This is a fallback for any terminal path that did not explicitly finish
+		// bookkeeping. A non-empty model and routing context mean request-body
+		// processing progressed far enough that AddRequestCount may have run.
+		if st.model != "" && st.routerCtx != nil {
+			s.finishRequestCount(st)
+		}
 		requestBuffers.Delete(st.requestID)
 		// end spans created by this server
 		for _, span := range []trace.Span{st.toLastRespSpan, st.firstRespSpan, st.inferenceSpan} {
@@ -216,6 +247,13 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		}
 		st.releaseModelInFlight()
 		metrics.DecGaugeMetric(metrics.GatewayInFlight, metrics.GetMetricHelp(metrics.GatewayInFlight), []string{"gateway_pod"}, podName)
+		// routerCtx must remain valid until every completion path above has
+		// returned. Returning it to the pool earlier lets another request reset
+		// the same object while this Process still holds the pointer.
+		if st.routerCtx != nil {
+			st.routerCtx.Delete()
+			st.routerCtx = nil
+		}
 	}()
 
 	klog.InfoS("processing request", "requestID", st.requestID)
@@ -238,7 +276,7 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 				st.isGatewayRspDone = true
 				s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, "gateway_request_success", "200")
 			}
-			s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+			s.finishRequestCount(st)
 			return nil
 		}
 	}
@@ -276,7 +314,7 @@ func (s *Server) processOnce(srv extProcPb.ExternalProcessor_ProcessServer, st *
 	case <-s.shutdownCh:
 		if st.model != "" {
 			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503")
-			s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+			s.finishRequestCount(st)
 		}
 		klog.ErrorS(nil, "server shutdown requested; aborting blocked Recv", "request_id", st.requestID, "model", st.model)
 		return status.Error(codes.Unavailable, "server shutdown in progress")
@@ -294,7 +332,7 @@ func (s *Server) preRecvCheck(st *processState) error {
 	case <-s.shutdownCh:
 		if st.model != "" {
 			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503")
-			s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+			s.finishRequestCount(st)
 		}
 		klog.ErrorS(nil, "server shutdown requested; draining request", "request_id", st.requestID, "model", st.model)
 		return status.Error(codes.Unavailable, "server shutdown in progress")
@@ -303,7 +341,7 @@ func (s *Server) preRecvCheck(st *processState) error {
 	case <-st.ctx.Done():
 		if st.model != "" {
 			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "context_cancelled", "499")
-			s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+			s.finishRequestCount(st)
 		}
 		klog.ErrorS(st.ctx.Err(), "context cancelled", "request_id", st.requestID, "model", st.model)
 		return st.ctx.Err()
@@ -320,7 +358,7 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 		case <-s.shutdownCh:
 			if st.model != "" {
 				s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503")
-				s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+				s.finishRequestCount(st)
 			}
 			klog.ErrorS(nil, "server shutdown requested; stream closed (EOF) during shutdown drain", "requestID", st.requestID, "model", st.model)
 			return status.Error(codes.Unavailable, "server shutdown in progress")
@@ -335,7 +373,7 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 				s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, "gateway_request_success", "200")
 			}
 			klog.V(2).InfoS("stream closed (EOF): completed", "requestID", st.requestID, "model", st.model)
-			s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+			s.finishRequestCount(st)
 			return nil
 		}
 
@@ -344,7 +382,7 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "client_cancelled_eof", "499")
 		}
 		klog.ErrorS(nil, "client closed stream (EOF) before completion", "requestID", st.requestID, "model", st.model)
-		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+		s.finishRequestCount(st)
 		return io.EOF
 	}
 
@@ -355,7 +393,7 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 			st.isGatewayRspDone = true
 			s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, "gateway_request_success", "200")
 		}
-		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+		s.finishRequestCount(st)
 		return status.Error(codes.Canceled, "request canceled")
 	}
 
@@ -365,10 +403,13 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "gateway_request_fail", strconv.FormatUint(uint64(stErr.Code()), 10))
 		}
 		klog.ErrorS(err, "error receiving stream from Envoy extproc", "requestID", st.requestID, "model", st.model, "grpc_code", stErr.Code(), "grpc_message", stErr.Message())
-		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+		s.finishRequestCount(st)
 		return stErr.Err()
 	}
 
+	if st.model != "" && st.routerCtx != nil {
+		s.finishRequestCount(st)
+	}
 	klog.ErrorS(err, "error receiving stream from Envoy extproc (non-gRPC)", "requestID", st.requestID)
 	return status.Errorf(codes.Unknown, "recv stream error: %v", err)
 }
@@ -402,6 +443,7 @@ func (s *Server) handleProcessingRequest(st *processState, req *extProcPb.Proces
 		resp, st.isRespError, st.respErrorCode = s.HandleResponseHeaders(st.ctx, st.routerCtx, st.requestID, st.model, req)
 		st.lastRespHeaders = resp.GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders()
 		if st.isRespError {
+			s.finishRequestCount(st)
 			resp = s.responseForResponseHeaderError(st, resp)
 		}
 		st.metricLabel = gatewayRespHeaders
@@ -420,7 +462,11 @@ func (s *Server) handleProcessingRequest(st *processState, req *extProcPb.Proces
 			body := string(req.Request.(*extProcPb.ProcessingRequest_ResponseBody).ResponseBody.GetBody())
 			resp = s.responseErrorProcessingWithHeaders(st.ctx, st.routerCtx, st.lastRespHeaders, st.respErrorCode, st.model, st.requestID, body)
 		} else {
-			resp, st.completed = s.HandleResponseBody(st.ctx, st.routerCtx, st.requestID, req, st.user, st.rpm, st.model, st.stream, st.traceTerm, st.completed)
+			var usage TokenUsage
+			resp, st.completed, usage = s.HandleResponseBody(st.ctx, st.routerCtx, st.requestID, req, st.user, st.rpm, st.model, st.stream, st.completed)
+			if st.completed {
+				s.finishRequestTrace(st, usage)
+			}
 		}
 		st.metricLabel = gatewayRespBody
 
@@ -433,7 +479,7 @@ func (s *Server) handleProcessingRequest(st *processState, req *extProcPb.Proces
 	if resp == nil {
 		klog.ErrorS(nil, "no ProcessingResponse generated for message", "requestID", st.requestID, "msg_type", fmt.Sprintf("%T", req.Request))
 		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "no_response_err", "500")
-		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
+		s.finishRequestCount(st)
 		return nil, status.Errorf(codes.Internal, "no response generated for %T", req.Request)
 	}
 
@@ -474,12 +520,7 @@ func (s *Server) sendProcessingResponse(srv extProcPb.ExternalProcessor_ProcessS
 	if err := srv.Send(resp); err != nil && len(st.model) > 0 {
 		klog.ErrorS(err, "gateway fail to send response to envoy-proxy", "requestID", st.requestID)
 		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "send_envoy_proxy", "499")
-		s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
-		// Manually delete routerCtx on error paths;
-		// HandleResponseBody() and HandleResponseHeaders() will handle it on the happy path.
-		if st.routerCtx != nil {
-			st.routerCtx.Delete()
-		}
+		s.finishRequestCount(st)
 
 		if errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "EOF") {
 			klog.Warning("Stream already closed by client", "requestID", st.requestID)

--- a/pkg/plugins/gateway/gateway_rsp_body.go
+++ b/pkg/plugins/gateway/gateway_rsp_body.go
@@ -67,14 +67,15 @@ type OpenAIResponse struct {
 	Code int `json:"code"`
 }
 
-type tokenUsage struct {
-	promptTokens     int64
-	completionTokens int64
-	totalTokens      int64
+// TokenUsage contains the token counts reported by an inference response.
+type TokenUsage struct {
+	PromptTokens     int64
+	CompletionTokens int64
+	TotalTokens      int64
 }
 
-func processStreamingResponse(requestID string, bodyBytes []byte) (tokenUsage, *extProcPb.ProcessingResponse) {
-	var usage tokenUsage
+func processStreamingResponse(requestID string, bodyBytes []byte) (TokenUsage, *extProcPb.ProcessingResponse) {
+	var usage TokenUsage
 
 	// The previous implementation unmarshalled every single SSE chunk into a struct (openai.ChatCompletionChunk).
 	// This caused significant CPU overhead and high GC pressure under heavy concurrency.
@@ -137,21 +138,21 @@ func processStreamingResponse(requestID string, bodyBytes []byte) (tokenUsage, *
 					// the primary field is genuinely absent (Exists() == false), since a
 					// zero count is a semantically valid value.
 					if pt := usageResult.Get("prompt_tokens"); pt.Exists() {
-						usage.promptTokens = pt.Int()
+						usage.PromptTokens = pt.Int()
 					} else {
-						usage.promptTokens = usageResult.Get("input_tokens").Int()
+						usage.PromptTokens = usageResult.Get("input_tokens").Int()
 					}
 					if ct := usageResult.Get("completion_tokens"); ct.Exists() {
-						usage.completionTokens = ct.Int()
+						usage.CompletionTokens = ct.Int()
 					} else {
-						usage.completionTokens = usageResult.Get("output_tokens").Int()
+						usage.CompletionTokens = usageResult.Get("output_tokens").Int()
 					}
-					usage.totalTokens = usageResult.Get("total_tokens").Int()
+					usage.TotalTokens = usageResult.Get("total_tokens").Int()
 				}
 			}
 		}
 		// warnings when "usage" is triggered by a false positive in generated content.
-		if usage.promptTokens == 0 && usage.totalTokens == 0 {
+		if usage.PromptTokens == 0 && usage.TotalTokens == 0 {
 			klog.V(4).Infof("usage string detected but no valid tokens parsed (likely generated text), requestID: %s", requestID)
 		}
 	}
@@ -159,7 +160,16 @@ func processStreamingResponse(requestID string, bodyBytes []byte) (tokenUsage, *
 	return usage, nil
 }
 
-func (s *Server) HandleResponseBody(ctx context.Context, routerCtx *types.RoutingContext, requestID string, req *extProcPb.ProcessingRequest, user utils.User, rpm int64, model string, stream bool, traceTerm int64, hasCompleted bool) (*extProcPb.ProcessingResponse, bool) {
+// HandleResponseBody parses and accounts for a response body but deliberately
+// does not finalize cache bookkeeping or release routerCtx. Process owns that
+// lifecycle and keeps the context valid until its final deferred cleanup.
+func (s *Server) HandleResponseBody(ctx context.Context, routerCtx *types.RoutingContext, requestID string, req *extProcPb.ProcessingRequest, user utils.User, rpm int64, model string, stream bool, hasCompleted bool) (*extProcPb.ProcessingResponse, bool, TokenUsage) {
+	if routerCtx == nil {
+		return generateErrorResponse(
+			envoyTypePb.StatusCode_InternalServerError,
+			nil,
+			"routing context is nil", "", ""), true, TokenUsage{}
+	}
 	b := req.Request.(*extProcPb.ProcessingRequest_ResponseBody)
 	arrival := time.Now()
 
@@ -168,59 +178,47 @@ func (s *Server) HandleResponseBody(ctx context.Context, routerCtx *types.Routin
 	// metrics are only emitted on the final chunk. Without capturing the first
 	// arrival here, TTFT and KV-transfer time would be measured from the last
 	// chunk (≈ total request time) instead of the first token.
-	if stream && routerCtx != nil && routerCtx.FirstTokenTime.IsZero() {
+	if stream && routerCtx.FirstTokenTime.IsZero() {
 		routerCtx.FirstTokenTime = arrival
 	}
 
 	var processingRes *extProcPb.ProcessingResponse
-	var promptTokens, completionTokens, totalTokens int64
+	var usage TokenUsage
 	var headers []*configPb.HeaderValueOption
 	complete := hasCompleted
 
 	// Omitted tracer.Start(ctx, "HandleResponseBody") here to avoid excessive CPU and gRPC overhead.
 	// Creating a span for each individual token in the stream is too resource-intensive.
 
-	defer func() {
-		// Wrapped in a function to delay the evaluation of parameters. Using complete to make sure DoneRequestTrace only call once for a request.
-		if !hasCompleted && complete {
-			s.cache.DoneRequestTrace(routerCtx, requestID, model, promptTokens, completionTokens, traceTerm)
-			if routerCtx != nil {
-				routerCtx.Delete()
-			}
-		}
-	}()
-
 	if stream {
-		usage, streamRes := processStreamingResponse(requestID, b.ResponseBody.GetBody())
-		promptTokens = usage.promptTokens
-		completionTokens = usage.completionTokens
-		totalTokens = usage.totalTokens
+		var streamRes *extProcPb.ProcessingResponse
+		usage, streamRes = processStreamingResponse(requestID, b.ResponseBody.GetBody())
 		if streamRes != nil {
 			complete = true
-			return streamRes, complete
+			return streamRes, complete, usage
 		}
 	} else {
 		if isLanguageRequest(routerCtx.ReqPath) {
-			processingRes, complete, promptTokens, completionTokens, totalTokens = processLanguageResponse(requestID, b)
+			processingRes, complete, usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens = processLanguageResponse(requestID, b)
 			if processingRes != nil {
-				return processingRes, complete
+				return processingRes, complete, usage
 			}
 		}
 	}
 
-	if totalTokens != 0 {
+	if usage.TotalTokens != 0 {
 		complete = true
 
 		// Count token per user.
 		if user.Name != "" {
-			tpm, err := s.ratelimiter.Incr(routerCtx, fmt.Sprintf("%v_TPM_CURRENT", user.Name), totalTokens)
+			tpm, err := s.ratelimiter.Incr(routerCtx, fmt.Sprintf("%v_TPM_CURRENT", user.Name), usage.TotalTokens)
 			if err != nil {
 				return generateErrorResponse(
 					envoyTypePb.StatusCode_InternalServerError,
 					[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
 						Key: HeaderErrorIncrTPM, RawValue: []byte("true"),
 					}}},
-					err.Error(), "", ""), complete
+					err.Error(), "", ""), complete, usage
 			}
 
 			headers = buildEnvoyProxyHeaders(headers,
@@ -233,7 +231,7 @@ func (s *Server) HandleResponseBody(ctx context.Context, routerCtx *types.Routin
 		// requestEndHelper derives TTFT from routerCtx.FirstTokenTime for streaming
 		// requests, so passing the final arrival here (rather than the first chunk's)
 		// keeps decode-time/KV-transfer math, which spans first-token-to-end, correct.
-		fields := s.requestEndHelper(routerCtx, arrival, promptTokens, completionTokens, totalTokens)
+		fields := s.requestEndHelper(routerCtx, arrival, usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens)
 		if routerCtx.Span != nil {
 			routerCtx.Span.SetAttributes(fieldsToAttributes(fields)...)
 		}
@@ -252,7 +250,7 @@ func (s *Server) HandleResponseBody(ctx context.Context, routerCtx *types.Routin
 				},
 			},
 		},
-	}, complete
+	}, complete, usage
 }
 
 func isLanguageRequest(requestPath string) bool {

--- a/pkg/plugins/gateway/gateway_rsp_body_test.go
+++ b/pkg/plugins/gateway/gateway_rsp_body_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/vllm-project/aibrix/pkg/cache"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
@@ -319,14 +318,8 @@ func TestProcessLanguageResponse_ChunkedAccumulation(t *testing.T) {
 	assert.Equal(t, int64(15), totalTokens)
 }
 
-func TestHandleResponseBody_NonStreamNoTokens(t *testing.T) {
-	mockCache := &MockCache{Cache: cache.NewForTest()}
-	// DoneRequestTrace(ctx, requestID, model, inputTokens, outputTokens, traceTerm)
-	mockCache.On("DoneRequestTrace", mock.Anything, "test-req-id", "test-model", int64(10), int64(5), int64(0)).Maybe()
-
-	server := &Server{
-		cache: mockCache,
-	}
+func TestHandleResponseBody_NonStreamWithUsage(t *testing.T) {
+	server := &Server{}
 
 	routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", "test-req-id", "")
 	routerCtx.ReqPath = PathChatCompletions
@@ -341,11 +334,27 @@ func TestHandleResponseBody_NonStreamNoTokens(t *testing.T) {
 		},
 	}
 
-	resp, complete := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", false, 0, false)
+	resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", false, false)
 
 	assert.True(t, complete)
 	assert.NotNil(t, resp)
 	assert.NotNil(t, resp.GetResponseBody())
+	assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}, usage)
+}
+
+func TestHandleResponseBody_NilRoutingContext(t *testing.T) {
+	server := &Server{}
+	req := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{EndOfStream: true},
+		},
+	}
+
+	resp, complete, usage := server.HandleResponseBody(context.Background(), nil, "test-req-id", req, utils.User{}, 0, "test-model", false, false)
+
+	assert.True(t, complete)
+	assert.NotNil(t, resp.GetImmediateResponse())
+	assert.Equal(t, TokenUsage{}, usage)
 }
 
 func TestHandleResponseBody_PDPrefillTimingMetricsRequirePrefillEndTime(t *testing.T) {
@@ -376,10 +385,7 @@ func TestHandleResponseBody_PDPrefillTimingMetricsRequirePrefillEndTime(t *testi
 			)
 			defer cleanup()
 
-			mockCache := &MockCache{Cache: cache.NewForTest()}
-			mockCache.On("DoneRequestTrace", mock.Anything, "test-req-id", "test-model", int64(10), int64(5), int64(0)).Maybe()
-
-			server := &Server{cache: mockCache}
+			server := &Server{}
 			requestTime := time.Now().Add(-200 * time.Millisecond)
 			prefillStartTime := requestTime.Add(20 * time.Millisecond)
 			routerCtx := types.NewRoutingContext(context.Background(), "pd", "test-model", "", "test-req-id", "")
@@ -399,12 +405,12 @@ func TestHandleResponseBody_PDPrefillTimingMetricsRequirePrefillEndTime(t *testi
 				},
 			}
 
-			resp, complete := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", false, 0, false)
+			resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", false, false)
 
 			assert.True(t, complete)
 			assert.NotNil(t, resp)
+			assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}, usage)
 			assert.Equal(t, tt.wantCount, testutil.ToFloat64(prefillCounter.WithLabelValues("", "test-model", tt.wantBucket)))
-			mockCache.AssertExpectations(t)
 		})
 	}
 }
@@ -426,10 +432,7 @@ func TestHandleResponseBody_PDStreamingDecodeTimeAndTPOT(t *testing.T) {
 	)
 	defer cleanupTPOT()
 
-	mockCache := &MockCache{Cache: cache.NewForTest()}
-	mockCache.On("DoneRequestTrace", mock.Anything, "test-req-id", "test-model", int64(10), int64(5), int64(0)).Maybe()
-
-	server := &Server{cache: mockCache}
+	server := &Server{}
 	requestTime := time.Now().Add(-250 * time.Millisecond)
 	prefillStartTime := requestTime.Add(20 * time.Millisecond)
 	prefillEndTime := prefillStartTime.Add(30 * time.Millisecond)
@@ -454,29 +457,24 @@ func TestHandleResponseBody_PDStreamingDecodeTimeAndTPOT(t *testing.T) {
 		},
 	}
 
-	resp, complete := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", true, 0, false)
+	resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", true, false)
 
 	assert.True(t, complete)
 	assert.NotNil(t, resp)
+	assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}, usage)
 
 	// The final chunk arrives ~70ms after FirstTokenTime here, so decode_time must not
 	// land in the near-zero "0-1ms" bucket.
 	assert.Zero(t, testutil.ToFloat64(decodeCounter.WithLabelValues("", "test-model", "0-1ms")))
 	assert.Equal(t, 1, testutil.CollectAndCount(decodeCounter), "expected exactly one decode_time bucket to be recorded")
 	assert.Equal(t, 1, testutil.CollectAndCount(tpotCounter), "PD streaming path must emit gateway_tpot_bucket_total")
-	mockCache.AssertExpectations(t)
 }
 
 func TestHandleResponseBody_WithUserAndTPM(t *testing.T) {
-	mockCache := &MockCache{Cache: cache.NewForTest()}
-	// DoneRequestTrace(ctx, requestID, model, term, inputTokens, outputTokens) - use mock.Anything for dynamic requestID
-	mockCache.On("DoneRequestTrace", mock.Anything, mock.Anything, "test-model", int64(10), int64(5), int64(0)).Maybe()
-
 	mockRL := &mockRateLimiter{}
 	mockRL.On("Incr", mock.Anything, "test-user_TPM_CURRENT", int64(15)).Return(int64(100), nil)
 
 	server := &Server{
-		cache:       mockCache,
 		ratelimiter: mockRL,
 	}
 
@@ -494,10 +492,11 @@ func TestHandleResponseBody_WithUserAndTPM(t *testing.T) {
 		},
 	}
 
-	resp, complete := server.HandleResponseBody(context.Background(), routerCtx, requestID, req, utils.User{Name: "test-user"}, 42, "test-model", false, 0, false)
+	resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, requestID, req, utils.User{Name: "test-user"}, 42, "test-model", false, false)
 
 	assert.True(t, complete)
 	assert.NotNil(t, resp)
+	assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}, usage)
 	headers := resp.GetResponseBody().GetResponse().GetHeaderMutation().GetSetHeaders()
 	foundTPM := false
 	foundRPM := false
@@ -522,13 +521,7 @@ func TestHandleResponseBody_WithUserAndTPM(t *testing.T) {
 }
 
 func TestHandleResponseBody_NonLanguageRequest(t *testing.T) {
-	mockCache := &MockCache{Cache: cache.NewForTest()}
-	// Non-language request: no tokens from processLanguageResponse, EndOfStream triggers complete
-	mockCache.On("DoneRequestTrace", mock.Anything, "test-req-id", "test-model", int64(0), int64(0), int64(0)).Maybe()
-
-	server := &Server{
-		cache: mockCache,
-	}
+	server := &Server{}
 
 	routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", "test-req-id", "")
 	routerCtx.ReqPath = "/v1/images/generations"
@@ -543,21 +536,16 @@ func TestHandleResponseBody_NonLanguageRequest(t *testing.T) {
 		},
 	}
 
-	resp, complete := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", false, 0, false)
+	resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", false, false)
 
 	// Non-language request with EndOfStream sets complete=true
 	assert.True(t, complete)
 	assert.NotNil(t, resp)
+	assert.Equal(t, TokenUsage{}, usage)
 }
 
 func TestHandleResponseBody_EndOfStreamNoTokens(t *testing.T) {
-	mockCache := &MockCache{Cache: cache.NewForTest()}
-	// Body {} parses but has empty model - returns error, DoneRequestTrace called with 0,0,0
-	mockCache.On("DoneRequestTrace", mock.Anything, "test-req-id", "test-model", int64(0), int64(0), int64(0)).Maybe()
-
-	server := &Server{
-		cache: mockCache,
-	}
+	server := &Server{}
 
 	routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", "test-req-id", "")
 	routerCtx.ReqPath = PathChatCompletions
@@ -572,20 +560,17 @@ func TestHandleResponseBody_EndOfStreamNoTokens(t *testing.T) {
 		},
 	}
 
-	resp, complete := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", false, 0, false)
+	resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", false, false)
 
 	assert.True(t, complete)
 	assert.NotNil(t, resp)
+	assert.Equal(t, TokenUsage{}, usage)
 }
 
 func TestHandleResponseBody_TPMIncrError(t *testing.T) {
-	mockCache := &MockCache{Cache: cache.NewForTest()}
-	mockCache.On("DoneRequestTrace", mock.Anything, mock.Anything, "test-model", int64(10), int64(5), int64(0)).Maybe()
-
 	mockRL := &mockRateLimiter{}
 	mockRL.On("Incr", mock.Anything, "test-user_TPM_CURRENT", int64(15)).Return(int64(0), errors.New("mock error"))
 	server := &Server{
-		cache:       mockCache,
 		ratelimiter: mockRL,
 	}
 
@@ -603,10 +588,11 @@ func TestHandleResponseBody_TPMIncrError(t *testing.T) {
 		},
 	}
 
-	resp, complete := server.HandleResponseBody(context.Background(), routerCtx, requestID, req, utils.User{Name: "test-user"}, 0, "test-model", false, 0, false)
+	resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, requestID, req, utils.User{Name: "test-user"}, 0, "test-model", false, false)
 
 	assert.True(t, complete)
 	assert.NotNil(t, resp)
+	assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}, usage)
 	// Error response uses ImmediateResponse
 	immResp := resp.GetImmediateResponse()
 	assert.NotNil(t, immResp)
@@ -623,8 +609,7 @@ func TestHandleResponseBody_TPMIncrError(t *testing.T) {
 }
 
 func TestHandleResponseBody_LanguagePartialResponse(t *testing.T) {
-	mockCache := &MockCache{Cache: cache.NewForTest()}
-	server := &Server{cache: mockCache}
+	server := &Server{}
 
 	routerCtx := types.NewRoutingContext(context.Background(), "random", "m", "", "rid-partial", "")
 	routerCtx.ReqPath = PathChatCompletions
@@ -639,14 +624,15 @@ func TestHandleResponseBody_LanguagePartialResponse(t *testing.T) {
 		},
 	}
 
-	resp, complete := server.HandleResponseBody(context.Background(), routerCtx, "rid-partial", req, utils.User{}, 0, "m", false, 0, false)
+	resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, "rid-partial", req, utils.User{}, 0, "m", false, false)
 	assert.False(t, complete)
 	assert.NotNil(t, resp)
 	assert.NotNil(t, resp.GetResponseBody().GetResponse())
+	assert.Equal(t, TokenUsage{}, usage)
 }
 
-func TestHandleResponseBody_DoesNotDuplicateTrace(t *testing.T) {
-	mockCache := &MockCache{Cache: cache.NewForTest()}
+func TestHandleResponseBody_DoesNotFinalizeTrace(t *testing.T) {
+	mockCache := &MockCache{}
 	server := &Server{cache: mockCache}
 
 	routerCtx := types.NewRoutingContext(context.Background(), "random", "m", "", "rid", "")
@@ -662,8 +648,9 @@ func TestHandleResponseBody_DoesNotDuplicateTrace(t *testing.T) {
 		},
 	}
 
-	_, complete := server.HandleResponseBody(context.Background(), routerCtx, "rid", req, utils.User{}, 0, "m", false, 0, true)
+	_, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, "rid", req, utils.User{}, 0, "m", false, false)
 	assert.True(t, complete)
+	assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}, usage)
 	mockCache.AssertNotCalled(t, "DoneRequestTrace", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
@@ -720,12 +707,7 @@ func TestHandleResponseBody_SSEParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockCache := &MockCache{Cache: cache.NewForTest()}
-			mockCache.On("DoneRequestTrace", mock.Anything, "test-req-id", "test-model", tt.promptTokens, tt.completionTokens, int64(0)).Maybe()
-
-			server := &Server{
-				cache: mockCache,
-			}
+			server := &Server{}
 
 			routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", "test-req-id", "")
 			routerCtx.ReqPath = PathChatCompletions
@@ -741,7 +723,12 @@ func TestHandleResponseBody_SSEParsing(t *testing.T) {
 			}
 
 			// stream=true
-			resp, complete := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", true, 0, false)
+			resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", req, utils.User{}, 0, "test-model", true, false)
+			assert.Equal(t, TokenUsage{
+				PromptTokens:     tt.promptTokens,
+				CompletionTokens: tt.completionTokens,
+				TotalTokens:      tt.totalTokens,
+			}, usage)
 
 			if tt.expectError {
 				assert.True(t, complete)
@@ -765,8 +752,6 @@ func TestHandleResponseBody_SSEParsing(t *testing.T) {
 				assert.NotNil(t, resp)
 				assert.NotNil(t, resp.GetResponseBody(), "Expected ResponseBody on success")
 			}
-
-			mockCache.AssertExpectations(t)
 		})
 	}
 }

--- a/pkg/plugins/gateway/gateway_rsp_body_test.go
+++ b/pkg/plugins/gateway/gateway_rsp_body_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
+	v1 "k8s.io/api/core/v1"
 )
 
 // mockRateLimiter implements ratelimiter.RateLimiter for testing
@@ -652,6 +653,97 @@ func TestHandleResponseBody_DoesNotFinalizeTrace(t *testing.T) {
 	assert.True(t, complete)
 	assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}, usage)
 	mockCache.AssertNotCalled(t, "DoneRequestTrace", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHandleResponseBody_DoesNotFinalizeOrReleaseRoutingContext(t *testing.T) {
+	mockCache := &MockCache{}
+	server := &Server{cache: mockCache}
+
+	routerCtx := types.NewRoutingContext(
+		context.Background(), "random", "m", "", "request-a", "",
+	)
+	routerCtx.ReqPath = PathChatCompletions
+
+	req := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body: []byte(
+					`{"model":"m","usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+				),
+				EndOfStream: true,
+			},
+		},
+	}
+
+	_, complete, _ := server.HandleResponseBody(
+		context.Background(), routerCtx, "request-a",
+		req, utils.User{}, 0, "m", false, false,
+	)
+
+	assert.True(t, complete)
+	assert.Equal(t, "request-a", routerCtx.RequestID)
+
+	// Delete() changes an unrouted targetPod from nilPod to nil, preventing a
+	// subsequent SetTargetPod call from succeeding. This assertion therefore
+	// detects an early Delete deterministically, without relying on sync.Pool
+	// returning the same pointer.
+	pod := &v1.Pod{}
+	routerCtx.SetTargetPod(pod)
+	assert.True(t, routerCtx.HasRouted(),
+		"HandleResponseBody must not release RoutingContext")
+
+	mockCache.AssertNotCalled(t, "DoneRequestTrace",
+		mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything)
+	mockCache.AssertNotCalled(t, "DoneRequestCount",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestFinishRequest_FinalizesExactlyOnceAfterContextCorruption(t *testing.T) {
+	mc := &MockCache{}
+	routerCtx := types.NewRoutingContext(
+		context.Background(), "random", "m", "", "request-a", "",
+	)
+
+	st := &processState{
+		routerCtx: routerCtx,
+		requestID: "request-a",
+		model:     "m",
+		traceTerm: 7,
+	}
+
+	var recordedContextRequestID string
+	mc.On(
+		"DoneRequestTrace",
+		routerCtx,
+		"request-a",
+		"m",
+		int64(10),
+		int64(5),
+		int64(7),
+	).Run(func(args mock.Arguments) {
+		recordedContextRequestID =
+			args.Get(0).(*types.RoutingContext).RequestID
+	}).Return().Once()
+
+	server := &Server{cache: mc}
+
+	server.finishRequestTrace(st, TokenUsage{
+		PromptTokens:     10,
+		CompletionTokens: 5,
+	})
+
+	// Simulate the pointer being reset for request B.
+	routerCtx.RequestID = "request-b"
+
+	// Simulate a second finalization path later in Process.
+	server.finishRequestCount(st)
+
+	assert.Equal(t, "request-a", recordedContextRequestID)
+	mc.AssertNumberOfCalls(t, "DoneRequestTrace", 1)
+	mc.AssertNotCalled(t, "DoneRequestCount",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mc.AssertExpectations(t)
 }
 
 func TestHandleResponseBody_SSEParsing(t *testing.T) {

--- a/pkg/plugins/gateway/gateway_rsp_headers.go
+++ b/pkg/plugins/gateway/gateway_rsp_headers.go
@@ -26,6 +26,8 @@ import (
 	"github.com/vllm-project/aibrix/pkg/types"
 )
 
+// HandleResponseHeaders parses upstream headers without finalizing request
+// bookkeeping or releasing routerCtx; Process owns both lifecycle operations.
 func (s *Server) HandleResponseHeaders(ctx context.Context, routerCtx *types.RoutingContext, requestID string, model string, req *extProcPb.ProcessingRequest) (*extProcPb.ProcessingResponse, bool, int) {
 	b := req.Request.(*extProcPb.ProcessingRequest_ResponseHeaders)
 
@@ -34,14 +36,6 @@ func (s *Server) HandleResponseHeaders(ctx context.Context, routerCtx *types.Rou
 
 	var isProcessingError bool
 	var processingErrorCode int
-	defer func() {
-		if isProcessingError {
-			s.cache.DoneRequestCount(routerCtx, requestID, model, 0)
-			if routerCtx != nil {
-				routerCtx.Delete()
-			}
-		}
-	}()
 
 	headers := []*configPb.HeaderValueOption{}
 	headers = buildEnvoyProxyHeaders(headers, HeaderWentIntoReqHeaders, "true", HeaderRequestID, requestID)

--- a/pkg/plugins/gateway/gateway_rsp_headers_test.go
+++ b/pkg/plugins/gateway/gateway_rsp_headers_test.go
@@ -37,7 +37,8 @@ func Test_HandleResponseHeaders(t *testing.T) {
 	// Initialize routing algorithms if needed
 	routingalgorithms.Init()
 
-	// Mock cache to verify DoneRequestCount is called on error
+	// Header parsing is deliberately lifecycle-free. Process owns request
+	// completion and RoutingContext cleanup.
 	mockCache := &MockCache{Cache: cache.NewForTest()}
 	server := &Server{
 		cache: mockCache,
@@ -145,15 +146,6 @@ func Test_HandleResponseHeaders(t *testing.T) {
 
 			ctx := context.Background()
 
-			if tt.expected.isProcessingError {
-				mockCache.On("DoneRequestCount",
-					tt.routingCtx,
-					"test-req-id",
-					"test-model",
-					int64(0),
-				).Return()
-			}
-
 			// Build response headers input
 			headers := []*configPb.HeaderValue{
 				{Key: ":status", RawValue: []byte(tt.responseStatus)},
@@ -179,6 +171,7 @@ func Test_HandleResponseHeaders(t *testing.T) {
 			if !cmp.Equal(tt.expected.headers, actualHeaders, protocmp.Transform()) {
 				t.Fatalf("Headers do not match:\n%s", cmp.Diff(tt.expected.headers, actualHeaders, protocmp.Transform()))
 			}
+			mockCache.AssertNotCalled(t, "DoneRequestCount")
 		})
 	}
 }

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -1616,8 +1616,8 @@ func TestProcess_RecvEOF_DuringShutdown(t *testing.T) {
 // even if the client context is cancelled concurrently.
 func TestProcess_CompletedExitsLoop(t *testing.T) {
 	mc := &MockCache{}
-	// mock all funcs we need
-	mc.On("DoneRequestCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	// A successful response with usage data is finalized through
+	// DoneRequestTrace only; Process must not follow it with DoneRequestCount.
 	mc.On("AddRequestCount", mock.Anything, mock.Anything, mock.Anything).Return(int64(0))
 	mc.On("DoneRequestTrace", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mc.On("HasModel", mock.Anything).Return(true)


### PR DESCRIPTION
[Bug] Prevent stale outstanding request counts in the gateway

## Pull Request Description

This PR fixes a gateway request-lifecycle race that can leave a pod's realtime `outstanding_requests` value above zero after all requests have completed. Under sustained traffic, the stale value can accumulate and affect routing decisions that consume the realtime running-request count.

### Root cause

The production `Process` path had more than one owner of request completion:

1. `HandleResponseBody` called `DoneRequestTrace` when it found the final response body and immediately returned the request's `RoutingContext` to its `sync.Pool`.
2. After that handler returned, `Process` observed `st.completed` and called `DoneRequestCount` for the same request.
3. Response-header errors and several receive/send error paths also performed their own completion and context cleanup.

The cache's state transitions normally make repeated completion calls appear harmless. However, the first completion returned the `RoutingContext` to the pool while `Process` still retained its pointer. A concurrent request could reuse and reset that object before the old request made its second completion call.

In that interleaving, request A's stale completion consumes request B's fresh `CanDoneStats` transition while still using request A's ID. A's pod-stat record has already been removed, so B's record is not decremented. When B later completes, its transition has already been consumed and its outstanding count remains behind as dirty data.

### What changed

- Add a per-`processState` `sync.Once` guard so the production `Process` lifecycle calls exactly one of `DoneRequestCount` or `DoneRequestTrace`.
- Keep response-body parsing and token-usage extraction separate from lifecycle ownership. The successful path preserves token-aware finalization through `DoneRequestTrace`.
- Make response-header handling lifecycle-free; `Process` now owns completion for response-header errors.
- Keep `RoutingContext` owned by `Process` until its deferred cleanup, after all completion paths have returned, and only then release it to the pool.
- Add a deferred completion fallback for terminal paths that have a routed request but did not explicitly finalize it, including non-gRPC receive errors.
- Update gateway tests so header parsing is expected not to finalize requests, and a successful completed response is finalized through `DoneRequestTrace` without a following `DoneRequestCount`.

This fixes the bug at the lifecycle-ownership boundary instead of relying on idempotency flags stored inside a pooled object, because those flags legitimately reset when that object is reused by another request.

## Related Issues

N/A

## Reproduction and Manual Verification

The delay hook and load driver below are test-only tools. They intentionally are not part of this PR's committed source.

### 1. Widen the vulnerable completion window

On the parent revision, add a temporary delay immediately before the second completion in `Process`:

```diff
@@
 		if st.completed {
 			...
+			sleepForCompletionRaceTest()
 			s.cache.DoneRequestCount(st.routerCtx, st.requestID, st.model, st.traceTerm)
 			return nil
 		}
@@
+func sleepForCompletionRaceTest() {
+	value := os.Getenv("AIBRIX_TEST_COMPLETION_RACE_DELAY")
+	if value == "" {
+		return
+	}
+
+	delay, err := time.ParseDuration(value)
+	if err != nil || delay <= 0 {
+		klog.ErrorS(err, "invalid completion race test delay", "value", value)
+		return
+	}
+
+	time.Sleep(delay)
+}
```

Deploy gateway-plugin with

```text
GOMAXPROCS=1
AIBRIX_TEST_COMPLETION_RACE_DELAY=100ms
```

This makes the ordering deterministic enough to observe: response A finalizes and releases its context, request B reuses that context, and then request A executes its stale second completion.

For the fixed revision, the same local delay can be placed immediately before `s.finishRequestCount(st)`. The earlier `finishRequestTrace` has already won the `sync.Once`, and the context remains owned by request A until `Process` exits, so the delayed call is a no-op and cannot corrupt request B.

### 2. Run the open-loop completion load


Use the companion `test.py` helper attached to this PR. It uses only the Python standard library and sends successful non-streaming Chat Completions requests at a fixed open-loop arrival rate. Arrivals are scheduled independently of earlier completions, which makes context reuse during the widened completion window much more likely.

[test.py](https://github.com/user-attachments/files/31247497/test.py)


```bash
export AIBRIX_TEST_BASE_URL='http://<gateway-host>:<port>'
export AIBRIX_TEST_MODEL='<model-name>'

python3 test.py \
  --rounds 3 \
  --requests-per-round 2000 \
  --qps 50 \
  --concurrency 600 \
  --max-tokens 1 \
  --settle-seconds 20 \
  --probe-requests 3
```

The driver performs baseline requests, runs each open-loop load round, waits for real in-flight work to drain, and then sends serial probes. It prints each probe's `request_id` and `trace_id` for correlation with the gateway's `request_start` logs.

First verify that every `round_summary` reports `dropped_arrivals: 0`; otherwise increase `--concurrency` or lower `--qps`. Then locate the post-round probe IDs in the gateway logs and inspect their `outstanding_requests` values.

Expected result:

- Before this fix, after the settle period and with no real requests in flight, a reproduced race can leave `outstanding_requests` positive. The stale value may grow in later rounds.
- With this fix, the counter returns to zero after each round and stays balanced.

The race is timing-dependent without the delay hook, so a run that happens to return to zero on the old build does not disprove the issue.

## Testing

- Updated `Test_HandleResponseHeaders` to verify that response-header parsing does not call `DoneRequestCount`.
- Updated `TestProcess_CompletedExitsLoop` to verify that a successful response is finalized through `DoneRequestTrace` and is not followed by `DoneRequestCount`.
- Checked the test-only load driver's CLI with `python3 test.py --help`.
- Manual A/B procedure is documented above for the parent and fixed revisions.

Recommended targeted test command:

```bash
go test ./pkg/plugins/gateway
```

## Submission Checklist

- [x] PR title includes the appropriate prefix
- [x] Changes and root cause are explained
- [x] Regression expectations are covered by gateway tests
- [x] Test-only reproduction hooks are excluded from committed production code
- [ ] `go test ./pkg/plugins/gateway` passes in a dependency-enabled environment
- [ ] Related issue number added, if applicable
