### PR TITLE
fix(kvcache): decode vLLM map-format KV events; tier-aware prefix scoring

### DIFF
--- a/pkg/cache/kvcache/decoder_vllm_compat_test.go
+++ b/pkg/cache/kvcache/decoder_vllm_compat_test.go
@@ -1,0 +1,157 @@
+package kvcache
+
+// decoder_vllm_compat_test.go — decoder compatibility with the real vLLM wire
+// formats, verified against byte-exact payloads generated with msgspec
+// (vllm/distributed/kv_events.py):
+//
+//   - map encoding: vLLM >= #42892 (2026-06), single event per ZMQ message
+//   - array encoding: vLLM < #42892, single event per ZMQ message
+//   - [ts, events] batch: legacy batch wrapper
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Real vLLM main (msgspec map encoding, post-#42892) fixtures.
+const (
+	vllmMapMinimal   = "88a474797065ab426c6f636b53746f726564ac626c6f636b5f68617368657391c420000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fb1706172656e745f626c6f636b5f68617368c0a9746f6b656e5f6964739401020304aa626c6f636b5f73697a6504a76c6f72615f6964c0a66d656469756dc0a96c6f72615f6e616d65c0"
+	vllmMapHybrid    = "89a474797065ab426c6f636b53746f726564ac626c6f636b5f68617368657391c420000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fb1706172656e745f626c6f636b5f68617368c0a9746f6b656e5f6964739401020304aa626c6f636b5f73697a6504a76c6f72615f6964c0a66d656469756da3475055a96c6f72615f6e616d65c0a967726f75705f69647801"
+	vllmMapExtraKeys = "8aa474797065ab426c6f636b53746f726564ac626c6f636b5f68617368657391c420000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fb1706172656e745f626c6f636b5f68617368c0a9746f6b656e5f6964739401020304aa626c6f636b5f73697a6504a76c6f72615f6964c0a66d656469756da3475055a96c6f72615f6e616d65a9616461707465722d31aa65787472615f6b6579739192a4696d6730a4656d6230a967726f75705f69647802"
+	vllmMapMaximal   = "8da474797065ab426c6f636b53746f726564ac626c6f636b5f68617368657391c420000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fb1706172656e745f626c6f636b5f68617368c0a9746f6b656e5f6964739401020304aa626c6f636b5f73697a6504a76c6f72615f696401a66d656469756da3475055a96c6f72615f6e616d65a9616461707465722d31aa65787472615f6b6579739192a4696d6730a4656d6230a967726f75705f69647805b26b765f63616368655f737065635f6b696e64a6687962726964bc6b765f63616368655f737065635f736c6964696e675f77696e646f77cc80a86c6f63616c697479a54c4f43414c"
+	vllmMapRemoved   = "84a474797065ac426c6f636b52656d6f766564ac626c6f636b5f68617368657391c420000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fa66d656469756da3475055a967726f75705f69647801"
+	vllmMapCleared   = "81a474797065b0416c6c426c6f636b73436c6561726564"
+)
+
+// Legacy array fixtures (pre-#42892). batch-wrapped and bare forms.
+const (
+	legacyArrayHybrid = "92cb41d954fc40000000919aab426c6f636b53746f72656491c420000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fc0940102030404c0a3475055c0c001"
+	legacyArrayShort  = "92cb41d954fc400000009195ab426c6f636b53746f726564926566c0940102030404"
+)
+
+func decodeHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex: %v", err)
+	}
+	return b
+}
+
+func requireSingleBlockStored(t *testing.T, data []byte) *BlockStoredEvent {
+	t.Helper()
+	batch, err := DecodeEventBatch(data, "m", "p")
+	require.NoError(t, err)
+	require.Len(t, batch.Events, 1)
+	ev, ok := batch.Events[0].(*BlockStoredEvent)
+	require.True(t, ok, "expected *BlockStoredEvent, got %T", batch.Events[0])
+	return ev
+}
+
+// Current vLLM map encoding: every sample must decode and carry metadata.
+func TestDecodeVLLMMapFormatBlockStored(t *testing.T) {
+	ev := requireSingleBlockStored(t, decodeHex(t, vllmMapHybrid))
+	assert.Equal(t, "m", ev.ModelName)
+	assert.Equal(t, "p", ev.PodName)
+	require.NotNil(t, ev.Medium)
+	assert.Equal(t, "GPU", *ev.Medium)
+	require.NotNil(t, ev.GroupIdx)
+	assert.Equal(t, int64(1), *ev.GroupIdx)
+	assert.Nil(t, ev.LoraName)
+	assert.Nil(t, ev.LoraID)
+}
+
+func TestDecodeVLLMMapFormatExtraKeys(t *testing.T) {
+	ev := requireSingleBlockStored(t, decodeHex(t, vllmMapExtraKeys))
+	require.NotNil(t, ev.Medium)
+	assert.Equal(t, "GPU", *ev.Medium)
+	require.NotNil(t, ev.LoraName)
+	assert.Equal(t, "adapter-1", *ev.LoraName)
+	require.NotNil(t, ev.GroupIdx)
+	assert.Equal(t, int64(2), *ev.GroupIdx)
+	// extra_keys: one entry per block, ["img0", "emb0"] for the single block.
+	require.Len(t, ev.ExtraKeys, 1)
+	require.Len(t, ev.ExtraKeys[0], 2)
+	assert.Equal(t, "img0", ev.ExtraKeys[0][0])
+	assert.Equal(t, "emb0", ev.ExtraKeys[0][1])
+}
+
+func TestDecodeVLLMMapFormatMaximal(t *testing.T) {
+	ev := requireSingleBlockStored(t, decodeHex(t, vllmMapMaximal))
+	require.NotNil(t, ev.LoraID)
+	assert.Equal(t, int64(1), *ev.LoraID)
+	require.NotNil(t, ev.Medium)
+	assert.Equal(t, "GPU", *ev.Medium)
+	require.NotNil(t, ev.LoraName)
+	assert.Equal(t, "adapter-1", *ev.LoraName)
+	require.NotNil(t, ev.GroupIdx)
+	assert.Equal(t, int64(5), *ev.GroupIdx)
+	require.NotNil(t, ev.KVCacheSpecKind)
+	assert.Equal(t, "hybrid", *ev.KVCacheSpecKind)
+	require.NotNil(t, ev.KVCacheSpecSlidingWindow)
+	assert.Equal(t, int64(128), *ev.KVCacheSpecSlidingWindow)
+	require.NotNil(t, ev.Locality)
+	assert.Equal(t, "LOCAL", *ev.Locality)
+}
+
+func TestDecodeVLLMMapFormatMinimal(t *testing.T) {
+	ev := requireSingleBlockStored(t, decodeHex(t, vllmMapMinimal))
+	assert.Nil(t, ev.LoraID)
+	assert.Nil(t, ev.Medium)
+	assert.Nil(t, ev.LoraName)
+	assert.Nil(t, ev.GroupIdx)
+	assert.Nil(t, ev.ExtraKeys)
+	// tokens must still be parsed: 4 tokens, block_size 4 → 1 block
+	require.Len(t, ev.TokenIDs, 1)
+	assert.Equal(t, []byte{0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4}, ev.TokenIDs[0])
+}
+
+func TestDecodeVLLMMapFormatBlockRemoved(t *testing.T) {
+	batch, err := DecodeEventBatch(decodeHex(t, vllmMapRemoved), "m", "p")
+	require.NoError(t, err)
+	require.Len(t, batch.Events, 1)
+	ev, ok := batch.Events[0].(*BlockRemovedEvent)
+	require.True(t, ok)
+	require.NotNil(t, ev.Medium)
+	assert.Equal(t, "GPU", *ev.Medium)
+	require.NotNil(t, ev.GroupIdx)
+	assert.Equal(t, int64(1), *ev.GroupIdx)
+}
+
+func TestDecodeVLLMMapFormatAllBlocksCleared(t *testing.T) {
+	batch, err := DecodeEventBatch(decodeHex(t, vllmMapCleared), "m", "p")
+	require.NoError(t, err)
+	require.Len(t, batch.Events, 1)
+	_, ok := batch.Events[0].(*AllBlocksClearedEvent)
+	require.True(t, ok)
+}
+
+// Legacy array encoding (pre-#42892): the vLLM publisher sent ONE event array
+// per message ("BlockStored" tag first, no [ts, events] wrapper).
+func TestDecodeLegacySingleEventArray(t *testing.T) {
+	// Same payload as legacyArrayHybrid but without the [ts, events] wrapper.
+	ev := requireSingleBlockStored(t, decodeHex(t, "9aab426c6f636b53746f72656491c420000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fc0940102030404c0a3475055c0c001"))
+	require.NotNil(t, ev.Medium)
+	assert.Equal(t, "GPU", *ev.Medium)
+	require.NotNil(t, ev.GroupIdx)
+	assert.Equal(t, int64(1), *ev.GroupIdx)
+}
+
+// Legacy batch wrapper [ts, [event]] must keep working.
+func TestDecodeLegacyBatchWrapper(t *testing.T) {
+	ev := requireSingleBlockStored(t, decodeHex(t, legacyArrayHybrid))
+	require.NotNil(t, ev.Medium)
+	assert.Equal(t, "GPU", *ev.Medium)
+	require.NotNil(t, ev.GroupIdx)
+	assert.Equal(t, int64(1), *ev.GroupIdx)
+}
+
+func TestDecodeLegacyBatchWrapperShort(t *testing.T) {
+	ev := requireSingleBlockStored(t, decodeHex(t, legacyArrayShort))
+	assert.Equal(t, []int64{101, 102}, ev.BlockHashes)
+	assert.Nil(t, ev.Medium)
+	assert.Nil(t, ev.GroupIdx)
+}

--- a/pkg/cache/kvcache/event_types.go
+++ b/pkg/cache/kvcache/event_types.go
@@ -100,17 +100,24 @@ type BlockStoredEvent struct {
 	ParentBlockHash *int64    // Decoded from vLLM, supports both old and new formats
 	TokenIDs        [][]byte
 
-	// Optional fields carried by newer vLLM builds (positions 5-9). Decoded
-	// best-effort; nil when the connected vLLM does not emit them. These are
-	// exposed here so prefix-cache routing can key and score on them; see
-	// issue #2285. Consumption is handled separately.
-	LoraID   *int64  // position 5; deprecated upstream in favor of LoraName
-	Medium   *string // position 6; storage tier, e.g. "GPU"/"cpu" (nil = unspecified)
-	LoraName *string // position 7; canonical adapter id
-	// position 8 (extra_keys) is intentionally not decoded here; it is consumed
-	// in the follow-up PR for block-hash reconstruction. GroupIdx is read at its
-	// fixed position 9 regardless.
-	GroupIdx *int64 // position 9; KV-cache group for hybrid-attention models
+	// Optional fields carried by newer vLLM builds. Decoded best-effort; nil
+	// when the connected vLLM does not emit them. These are exposed here so
+	// prefix-cache routing can key and score on them; see issue #2285.
+	// Consumption is handled separately.
+	LoraID   *int64  // deprecated upstream in favor of LoraName
+	Medium   *string // storage tier, e.g. "GPU"/"CPU"/"STORAGE" (nil = unspecified)
+	LoraName *string // canonical adapter id
+	// ExtraKeys carries one entry per block in BlockHashes (may be nil per
+	// block). It is used for block-hash reconstruction on the KV-event
+	// consumer side; retained here instead of being dropped at decode time.
+	ExtraKeys [][]interface{}
+	GroupIdx  *int64 // KV-cache group for hybrid-attention models
+
+	// Cache-spec metadata (hybrid attention: sliding window info).
+	KVCacheSpecKind          *string
+	KVCacheSpecSlidingWindow *int64
+	// Locality of the blocks relative to the publisher ("LOCAL"/"REMOTE").
+	Locality *string
 
 	// NOTE: These are NOT part of msgpack
 	Timestamp time.Time `msgpack:"-"`
@@ -141,6 +148,12 @@ type BlockRemovedEvent struct {
 	_           struct{}  `msgpack:",array"`
 	Type        EventType `msgpack:"-"`
 	BlockHashes []int64   // Decoded from vLLM, supports both old and new formats
+
+	// Optional fields carried by newer vLLM builds. Used to scope removals to
+	// the correct storage tier / KV-cache group.
+	Medium   *string
+	GroupIdx *int64
+	Locality *string
 
 	// NOTE: These are NOT part of msgpack
 	Timestamp time.Time `msgpack:"-"`

--- a/pkg/cache/kvcache/msgpack_decoder.go
+++ b/pkg/cache/kvcache/msgpack_decoder.go
@@ -24,41 +24,108 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// DecodeEventBatch parses a raw msgpack batch of events.
+// DecodeEventBatch parses a raw msgpack payload of KV cache events.
 // The subscriber must supply batch timestamp + model/pod name.
+//
+// The real vLLM ZMQ publisher emits ONE event per message, encoded with
+// msgspec:
+//
+//   - vLLM >= #42892 (2026-06): map encoding, a flat map with a "type" key:
+//     {"type": "BlockStored", "block_hashes": [...], ...}
+//   - vLLM < #42892: positional array encoding with the tag first:
+//     ["BlockStored", block_hashes, parent_block_hash, token_ids, block_size, ...]
+//
+// In addition, older code paths (and aibrix's own test encoder) wrap events in
+// a batch array: [ts, [event1, event2, ...]] (optionally with a third
+// data_parallel_rank element). All three shapes are accepted here.
 func DecodeEventBatch(
 	data []byte,
 	modelName string,
 	podName string,
 ) (*EventBatch, error) {
-	// The batch contains [ts, events]
-	var rawBatch []interface{}
-	if err := msgpack.Unmarshal(data, &rawBatch); err != nil {
+	var raw interface{}
+	if err := msgpack.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal event batch: %w", err)
 	}
+
+	switch v := raw.(type) {
+	case map[string]interface{}:
+		// Current vLLM (map encoding): a single event payload.
+		evt, err := parseEventMap(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse map event: %w", err)
+		}
+		ts := time.Now().UTC()
+		applyBatchMetadata(evt, ts, modelName, podName)
+		return &EventBatch{
+			Timestamp: ts,
+			Events:    []KVEvent{evt},
+		}, nil
+
+	case []interface{}:
+		return decodeEventArray(v, modelName, podName)
+
+	default:
+		return nil, fmt.Errorf("unexpected event payload type: %T", raw)
+	}
+}
+
+// decodeEventArray dispatches an array payload to either a single legacy event
+// (tag string first, as the pre-#42892 vLLM publisher emits) or a batch
+// [ts, events] (aibrix encoder / older batch mode).
+func decodeEventArray(arr []interface{}, modelName, podName string) (*EventBatch, error) {
+	if len(arr) == 0 {
+		return nil, fmt.Errorf("empty event array payload")
+	}
+
+	switch arr[0].(type) {
+	case string:
+		// Single legacy event: [tag, fields...]
+		evt, err := parseEventArray(arr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse single event: %w", err)
+		}
+		ts := time.Now().UTC()
+		applyBatchMetadata(evt, ts, modelName, podName)
+		return &EventBatch{
+			Timestamp: ts,
+			Events:    []KVEvent{evt},
+		}, nil
+
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		// Batch: [ts, events] (+ optional data_parallel_rank)
+		return decodeBatchArray(arr, modelName, podName)
+
+	default:
+		return nil, fmt.Errorf("unexpected first element type in event payload: %T", arr[0])
+	}
+}
+
+// decodeBatchArray parses the [ts, events] batch wrapper.
+func decodeBatchArray(arr []interface{}, modelName, podName string) (*EventBatch, error) {
 	// if size of rawBatch is 3, the third element is the data parallel rank
 	// data_parallel_rank is not used in aibrix now
-	if len(rawBatch) == 3 {
-		if data_parallel_rank, err := parseInt(rawBatch[2]); err != nil {
-			return nil, fmt.Errorf("data_parallel_rank is not an int: %T", rawBatch[2])
+	if len(arr) == 3 {
+		if data_parallel_rank, err := parseInt(arr[2]); err != nil {
+			return nil, fmt.Errorf("data_parallel_rank is not an int: %T", arr[2])
 		} else {
 			klog.V(4).Infof("event has data_parallel_rank: %d", data_parallel_rank)
 		}
-	} else if len(rawBatch) != 2 {
-		return nil, fmt.Errorf("expected 2 elements in batch (ts, events), got %d", len(rawBatch))
+	} else if len(arr) != 2 {
+		return nil, fmt.Errorf("expected 2 elements in batch (ts, events), got %d", len(arr))
 	}
 
 	// 0: batch timestamp
-	tsFloat, ok := rawBatch[0].(float64)
+	tsFloat, ok := arr[0].(float64)
 	if !ok {
-		return nil, fmt.Errorf("invalid batch timestamp type: %T", rawBatch[0])
+		return nil, fmt.Errorf("invalid batch timestamp type: %T", arr[0])
 	}
 	batchTS := time.Unix(int64(tsFloat), int64((tsFloat-float64(int64(tsFloat)))*1e9)).UTC()
 
 	// 1: events array
-	eventsRaw, ok := rawBatch[1].([]interface{})
+	eventsRaw, ok := arr[1].([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("expected events array, got %T", rawBatch[1])
+		return nil, fmt.Errorf("expected events array, got %T", arr[1])
 	}
 
 	batch := &EventBatch{
@@ -67,12 +134,16 @@ func DecodeEventBatch(
 	}
 
 	for i, raw := range eventsRaw {
-		arr, ok := raw.([]interface{})
-		if !ok {
-			return nil, fmt.Errorf("event %d: expected msgpack array, got %T", i, raw)
+		var evt KVEvent
+		var err error
+		switch e := raw.(type) {
+		case []interface{}:
+			evt, err = parseEventArray(e)
+		case map[string]interface{}:
+			evt, err = parseEventMap(e)
+		default:
+			return nil, fmt.Errorf("event %d: expected msgpack array or map, got %T", i, raw)
 		}
-
-		evt, err := parseEventArray(arr)
 		if err != nil {
 			return nil, fmt.Errorf("event %d: %w", i, err)
 		}
@@ -154,8 +225,7 @@ func parseEventArray(arr []interface{}) (KVEvent, error) {
 
 		// Optional fields added by newer vLLM builds. msgspec omit_defaults may
 		// drop trailing ones, so read by position with bounds checks and leave
-		// the rest nil. Position 8 (extra_keys) is skipped here; group_idx is
-		// still indexed at its fixed position 9.
+		// the rest nil.
 		if len(arr) > 5 {
 			if ev.LoraID, err = toInt64Ptr(arr[5]); err != nil {
 				return nil, fmt.Errorf("invalid lora_id: %w", err)
@@ -171,9 +241,29 @@ func parseEventArray(arr []interface{}) (KVEvent, error) {
 				return nil, fmt.Errorf("invalid lora_name: %w", err)
 			}
 		}
+		if len(arr) > 8 {
+			if ev.ExtraKeys, err = toExtraKeys(arr[8]); err != nil {
+				return nil, fmt.Errorf("invalid extra_keys: %w", err)
+			}
+		}
 		if len(arr) > 9 {
 			if ev.GroupIdx, err = toInt64Ptr(arr[9]); err != nil {
 				return nil, fmt.Errorf("invalid group_idx: %w", err)
+			}
+		}
+		if len(arr) > 10 {
+			if ev.KVCacheSpecKind, err = toStringPtr(arr[10]); err != nil {
+				return nil, fmt.Errorf("invalid kv_cache_spec_kind: %w", err)
+			}
+		}
+		if len(arr) > 11 {
+			if ev.KVCacheSpecSlidingWindow, err = toInt64Ptr(arr[11]); err != nil {
+				return nil, fmt.Errorf("invalid kv_cache_spec_sliding_window: %w", err)
+			}
+		}
+		if len(arr) > 12 {
+			if ev.Locality, err = toStringPtr(arr[12]); err != nil {
+				return nil, fmt.Errorf("invalid locality: %w", err)
 			}
 		}
 
@@ -194,6 +284,24 @@ func parseEventArray(arr []interface{}) (KVEvent, error) {
 			BlockHashes: blockHashes,
 		}
 
+		// BlockRemoved carries [tag, block_hashes, medium, group_idx, locality]
+		// in newer vLLM builds. Read by position with bounds checks.
+		if len(arr) > 2 {
+			if ev.Medium, err = toStringPtr(arr[2]); err != nil {
+				return nil, fmt.Errorf("invalid medium: %w", err)
+			}
+		}
+		if len(arr) > 3 {
+			if ev.GroupIdx, err = toInt64Ptr(arr[3]); err != nil {
+				return nil, fmt.Errorf("invalid group_idx: %w", err)
+			}
+		}
+		if len(arr) > 4 {
+			if ev.Locality, err = toStringPtr(arr[4]); err != nil {
+				return nil, fmt.Errorf("invalid locality: %w", err)
+			}
+		}
+
 		return ev, nil
 
 	case EventTypeAllCleared:
@@ -204,6 +312,150 @@ func parseEventArray(arr []interface{}) (KVEvent, error) {
 	default:
 		return nil, fmt.Errorf("unknown event type: %s", tag)
 	}
+}
+
+// parseEventMap parses a single event encoded as a msgpack map (vLLM's
+// post-#42892 encoding). The map is flat, with the event type under the
+// "type" key and all fields under their Python attribute names.
+func parseEventMap(m map[string]interface{}) (KVEvent, error) {
+	rawTag, ok := m["type"]
+	if !ok {
+		return nil, fmt.Errorf("map event missing 'type' key")
+	}
+	tagStr, ok := rawTag.(string)
+	if !ok {
+		return nil, fmt.Errorf("event tag not string: %T", rawTag)
+	}
+	tag := EventType(tagStr)
+
+	switch tag {
+
+	case EventTypeBlockStored:
+		blockHashes, err := toBlockHashSlice(m["block_hashes"])
+		if err != nil {
+			return nil, fmt.Errorf("invalid block_hashes: %w", err)
+		}
+
+		parentHash, err := toBlockHashPtr(m["parent_block_hash"])
+		if err != nil {
+			return nil, fmt.Errorf("invalid parent_block_hash: %w", err)
+		}
+
+		rawTokenIDs, ok := m["token_ids"].([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid token_ids type: %T", m["token_ids"])
+		}
+
+		blockSize, err := parseInt(m["block_size"])
+		if err != nil {
+			return nil, fmt.Errorf("invalid block_size: %w", err)
+		}
+
+		tokenIDs := make([]uint32, len(rawTokenIDs))
+		for i, v := range rawTokenIDs {
+			n, err := parseUint32(v)
+			if err != nil {
+				return nil, fmt.Errorf("token_ids[%d]: %w", i, err)
+			}
+			tokenIDs[i] = n
+		}
+
+		tokens, err := convertTokenIDs(tokenIDs, blockSize)
+		if err != nil {
+			return nil, err
+		}
+
+		ev := &BlockStoredEvent{
+			Type:            EventTypeBlockStored,
+			BlockHashes:     blockHashes,
+			ParentBlockHash: parentHash,
+			TokenIDs:        tokens,
+		}
+
+		if ev.LoraID, err = toInt64Ptr(m["lora_id"]); err != nil {
+			return nil, fmt.Errorf("invalid lora_id: %w", err)
+		}
+		if ev.Medium, err = toStringPtr(m["medium"]); err != nil {
+			return nil, fmt.Errorf("invalid medium: %w", err)
+		}
+		if ev.LoraName, err = toStringPtr(m["lora_name"]); err != nil {
+			return nil, fmt.Errorf("invalid lora_name: %w", err)
+		}
+		if ev.ExtraKeys, err = toExtraKeys(m["extra_keys"]); err != nil {
+			return nil, fmt.Errorf("invalid extra_keys: %w", err)
+		}
+		if ev.GroupIdx, err = toInt64Ptr(m["group_idx"]); err != nil {
+			return nil, fmt.Errorf("invalid group_idx: %w", err)
+		}
+		if ev.KVCacheSpecKind, err = toStringPtr(m["kv_cache_spec_kind"]); err != nil {
+			return nil, fmt.Errorf("invalid kv_cache_spec_kind: %w", err)
+		}
+		if ev.KVCacheSpecSlidingWindow, err = toInt64Ptr(m["kv_cache_spec_sliding_window"]); err != nil {
+			return nil, fmt.Errorf("invalid kv_cache_spec_sliding_window: %w", err)
+		}
+		if ev.Locality, err = toStringPtr(m["locality"]); err != nil {
+			return nil, fmt.Errorf("invalid locality: %w", err)
+		}
+
+		return ev, nil
+
+	case EventTypeBlockRemoved:
+		blockHashes, err := toBlockHashSlice(m["block_hashes"])
+		if err != nil {
+			return nil, fmt.Errorf("invalid block_hashes: %w", err)
+		}
+
+		ev := &BlockRemovedEvent{
+			Type:        tag,
+			BlockHashes: blockHashes,
+		}
+
+		if ev.Medium, err = toStringPtr(m["medium"]); err != nil {
+			return nil, fmt.Errorf("invalid medium: %w", err)
+		}
+		if ev.GroupIdx, err = toInt64Ptr(m["group_idx"]); err != nil {
+			return nil, fmt.Errorf("invalid group_idx: %w", err)
+		}
+		if ev.Locality, err = toStringPtr(m["locality"]); err != nil {
+			return nil, fmt.Errorf("invalid locality: %w", err)
+		}
+
+		return ev, nil
+
+	case EventTypeAllCleared:
+		return &AllBlocksClearedEvent{
+			Type: tag,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown event type: %s", tag)
+	}
+}
+
+// toExtraKeys converts the extra_keys field (one entry per block, each a list
+// of hash-computation inputs or nil) into [][]interface{}. A nil field or a
+// list of nils yields a nil slice so callers can treat it as "not provided".
+func toExtraKeys(v any) ([][]interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	raw, ok := v.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected []interface{}, got %T", v)
+	}
+	out := make([][]interface{}, len(raw))
+	for i, x := range raw {
+		if x == nil {
+			out[i] = nil
+			continue
+		}
+		entry, ok := x.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("extra_keys[%d]: expected []interface{}, got %T", i, x)
+		}
+		out[i] = entry
+	}
+	return out, nil
 }
 
 func applyBatchMetadata(evt KVEvent, ts time.Time, model, pod string) {

--- a/pkg/cache/store_providers.go
+++ b/pkg/cache/store_providers.go
@@ -180,6 +180,9 @@ func (a *syncIndexerAdapter) ProcessBlockStored(ctx context.Context, event kveve
 		SourcePod:       event.SourcePod,
 		ParentBlockHash: event.ParentBlockHash,
 		Tokens:          event.Tokens,
+		Medium:          event.Medium,
+		LoraName:        event.LoraName,
+		GroupIdx:        event.GroupIdx,
 	}
 
 	return a.indexer.ProcessBlockStored(syncEvent)
@@ -193,6 +196,8 @@ func (a *syncIndexerAdapter) ProcessBlockRemoved(ctx context.Context, event kvev
 		ModelName:   event.ModelName,
 		LoraID:      event.LoraID,
 		SourcePod:   event.SourcePod,
+		Medium:      event.Medium,
+		GroupIdx:    event.GroupIdx,
 	}
 
 	return a.indexer.ProcessBlockRemoved(syncEvent)

--- a/pkg/kvevent/handler.go
+++ b/pkg/kvevent/handler.go
@@ -78,6 +78,18 @@ func (h *eventHandler) handleBlockStored(ctx context.Context, event *kvcache.Blo
 
 	// Convert to sync event
 	// Note: BlockHashes are already []int64 after msgpack decoding
+	var groupIdx int64 = -1
+	if event.GroupIdx != nil {
+		groupIdx = *event.GroupIdx
+	}
+	var medium string
+	if event.Medium != nil {
+		medium = *event.Medium
+	}
+	var loraName string
+	if event.LoraName != nil {
+		loraName = *event.LoraName
+	}
 	syncEvent := BlockStoredEvent{
 		BlockHashes:     event.BlockHashes,
 		ModelName:       h.modelName,
@@ -85,6 +97,9 @@ func (h *eventHandler) handleBlockStored(ctx context.Context, event *kvcache.Blo
 		SourcePod:       h.podKey,
 		ParentBlockHash: event.ParentBlockHash,
 		Tokens:          event.TokenIDs,
+		Medium:          medium,
+		LoraName:        loraName,
+		GroupIdx:        groupIdx,
 	}
 
 	// Process event
@@ -112,11 +127,21 @@ func (h *eventHandler) handleBlockRemoved(ctx context.Context, event *kvcache.Bl
 
 	// Convert to sync event
 	// Note: BlockHashes are already []int64 after msgpack decoding
+	var groupIdx int64 = -1
+	if event.GroupIdx != nil {
+		groupIdx = *event.GroupIdx
+	}
+	var medium string
+	if event.Medium != nil {
+		medium = *event.Medium
+	}
 	syncEvent := BlockRemovedEvent{
 		BlockHashes: event.BlockHashes,
 		ModelName:   h.modelName,
 		LoraID:      h.loraID,
 		SourcePod:   h.podKey,
+		Medium:      medium,
+		GroupIdx:    groupIdx,
 	}
 
 	// Process event

--- a/pkg/kvevent/interfaces.go
+++ b/pkg/kvevent/interfaces.go
@@ -79,6 +79,16 @@ type BlockStoredEvent struct {
 	SourcePod       string
 	ParentBlockHash *int64
 	Tokens          [][]byte // Converted from [][]int32 TokenIDs
+
+	// Medium is the storage tier the blocks live on ("GPU"/"CPU"/"STORAGE";
+	// empty when the publisher does not emit it). Used for tier-aware scoring.
+	Medium string
+	// LoraName is the canonical adapter id ("" = base model). Reserved for
+	// per-adapter index isolation.
+	LoraName string
+	// GroupIdx is the KV-cache group for hybrid-attention models (-1 when
+	// unspecified). Reserved for per-group index isolation.
+	GroupIdx int64
 }
 
 type BlockRemovedEvent struct {
@@ -86,4 +96,10 @@ type BlockRemovedEvent struct {
 	ModelName   string
 	LoraID      int64
 	SourcePod   string
+
+	// Medium is the storage tier the blocks live on ("GPU"/"CPU"/"STORAGE").
+	Medium string
+	// GroupIdx is the KV-cache group for hybrid-attention models (-1 when
+	// unspecified).
+	GroupIdx int64
 }

--- a/pkg/utils/syncprefixcacheindexer/events.go
+++ b/pkg/utils/syncprefixcacheindexer/events.go
@@ -33,6 +33,17 @@ type BlockStored struct {
 	ModelName string
 	LoraID    int64 // -1 for no adapter
 
+	// Medium is the storage tier the blocks live on: "GPU"/"CPU"/"STORAGE".
+	// Empty when the connected vLLM does not emit it. Used to score pods with
+	// non-GPU prefixes lower during routing (see issue #2285).
+	Medium string
+	// LoraName is the canonical adapter id ("" = base model). Reserved for
+	// per-adapter index isolation; not yet consumed by the index key.
+	LoraName string
+	// GroupIdx is the KV-cache group for hybrid-attention models (-1 when
+	// unspecified). Reserved for per-group index isolation.
+	GroupIdx int64
+
 	// Source pod that stored these blocks
 	SourcePod string
 }
@@ -45,6 +56,12 @@ type BlockRemoved struct {
 	// Context information
 	ModelName string
 	LoraID    int64 // -1 for no adapter
+
+	// Medium is the storage tier the blocks live on ("GPU"/"CPU"/"STORAGE").
+	Medium string
+	// GroupIdx is the KV-cache group for hybrid-attention models (-1 when
+	// unspecified).
+	GroupIdx int64
 
 	// Source pod that removed these blocks (optional)
 	SourcePod string

--- a/pkg/utils/syncprefixcacheindexer/medium_scoring_test.go
+++ b/pkg/utils/syncprefixcacheindexer/medium_scoring_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncprefixcacheindexer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMediumWeight verifies the tier weights used to score non-GPU prefixes.
+func TestMediumWeight(t *testing.T) {
+	assert.Equal(t, 1.0, mediumWeight(MediumGPU))
+	assert.Equal(t, 0.5, mediumWeight(MediumCPU))
+	assert.Equal(t, 0.25, mediumWeight(MediumStorage))
+	// Unspecified tier keeps full strength for backward compatibility.
+	assert.Equal(t, 1.0, mediumWeight(""))
+	assert.Equal(t, 1.0, mediumWeight("unknown-tier"))
+}
+
+// TestMatchPrefixMediumWeighting verifies that pods holding a prefix only on a
+// slower tier are scored lower than pods holding it on GPU, while pods with an
+// unspecified tier keep the legacy full score.
+func TestMatchPrefixMediumWeighting(t *testing.T) {
+	table := NewSyncPrefixHashTable()
+	defer table.Close()
+
+	model := "medium-test-model"
+	tokens := make([]byte, 32) // 2 blocks of default block size 16
+	for i := range tokens {
+		tokens[i] = byte(i)
+	}
+	hashes := table.GetPrefixHashes(tokens)
+	require.Len(t, hashes, 2)
+
+	readyPods := map[string]struct{}{"p-gpu": {}, "p-cpu": {}, "p-storage": {}, "p-unspecified": {}}
+
+	require.NoError(t, table.AddPrefixWithMedium(model, -1, "p-gpu", MediumGPU, hashes))
+	require.NoError(t, table.AddPrefixWithMedium(model, -1, "p-cpu", MediumCPU, hashes))
+	require.NoError(t, table.AddPrefixWithMedium(model, -1, "p-storage", MediumStorage, hashes))
+	require.NoError(t, table.AddPrefixWithMedium(model, -1, "p-unspecified", "", hashes))
+
+	matched, _ := table.MatchPrefix(model, -1, tokens, readyPods)
+
+	assert.Equal(t, 100, matched["p-gpu"], "GPU tier must keep full score")
+	assert.Equal(t, 50, matched["p-cpu"], "CPU tier must be scored lower")
+	assert.Equal(t, 25, matched["p-storage"], "STORAGE tier must be scored lowest")
+	assert.Equal(t, 100, matched["p-unspecified"], "unspecified tier keeps legacy full score")
+}
+
+// TestProcessBlockStoredMediumScoring verifies the event ingestion path records
+// the tier carried by the BlockStored event and that MatchPrefix weights it.
+// vLLM emits one BlockStored event per block, chained via ParentBlockHash.
+func TestProcessBlockStoredMediumScoring(t *testing.T) {
+	table := NewSyncPrefixHashTable()
+	defer table.Close()
+
+	model := "event-medium-model"
+	block1 := make([]byte, 16)
+	block2 := make([]byte, 16)
+	for i := range block2 {
+		block2[i] = byte(16 + i)
+	}
+
+	storeOnPod := func(pod, medium string) {
+		// Block 1: parent is the engine-side NONE (nil).
+		err := table.ProcessBlockStored(BlockStored{
+			BlockHashes: []int64{9001},
+			Tokens:      [][]byte{block1},
+			ModelName:   model,
+			LoraID:      -1,
+			SourcePod:   pod,
+			Medium:      medium,
+		})
+		require.NoError(t, err)
+		// Block 2: parent is block 1's engine hash.
+		parent := int64(9001)
+		err = table.ProcessBlockStored(BlockStored{
+			BlockHashes:     []int64{9002},
+			ParentBlockHash: &parent,
+			Tokens:          [][]byte{block2},
+			ModelName:       model,
+			LoraID:          -1,
+			SourcePod:       pod,
+			Medium:          medium,
+		})
+		require.NoError(t, err)
+	}
+
+	storeOnPod("p-gpu", MediumGPU)
+	storeOnPod("p-cpu", MediumCPU)
+
+	tokens := append(append([]byte{}, block1...), block2...)
+	readyPods := map[string]struct{}{"p-gpu": {}, "p-cpu": {}}
+	matched, _ := table.MatchPrefix(model, -1, tokens, readyPods)
+
+	assert.Equal(t, 100, matched["p-gpu"], "GPU tier must keep full score")
+	assert.Equal(t, 50, matched["p-cpu"], "CPU tier must be scored lower")
+}
+
+// TestAddPrefixWithoutMediumKeepsLegacyBehavior covers the plain AddPrefix path
+// (no tier information): entries score at full strength.
+func TestAddPrefixWithoutMediumKeepsLegacyBehavior(t *testing.T) {
+	table := NewSyncPrefixHashTable()
+	defer table.Close()
+
+	model := "legacy-medium-model"
+	tokens := make([]byte, 16)
+	hashes := table.GetPrefixHashes(tokens)
+	require.Len(t, hashes, 1)
+
+	require.NoError(t, table.AddPrefix(model, -1, "p1", hashes))
+
+	matched, _ := table.MatchPrefix(model, -1, tokens, map[string]struct{}{"p1": {}})
+	assert.Equal(t, 100, matched["p1"])
+}

--- a/pkg/utils/syncprefixcacheindexer/sync_hash.go
+++ b/pkg/utils/syncprefixcacheindexer/sync_hash.go
@@ -39,6 +39,15 @@ const (
 	evictionBatchSize              = 100 // Process contexts in batches
 )
 
+// Storage tier constants mirroring vLLM's kv_events.py (MEDIUM_GPU/CPU/STORAGE).
+// A prefix held only on a slower tier is a weaker routing signal than one on
+// GPU, so match scores are weighted by tier (see mediumWeight).
+const (
+	MediumGPU     = "GPU"
+	MediumCPU     = "CPU"
+	MediumStorage = "STORAGE"
+)
+
 var (
 	maxContexts           = utils.LoadEnvInt("AIBRIX_SYNC_MAX_CONTEXTS", defaultMaxContexts)
 	maxPrefixesPerContext = utils.LoadEnvInt("AIBRIX_SYNC_MAX_PREFIXES_PER_CONTEXT", defaultMaxPrefixesPerContext)
@@ -71,6 +80,9 @@ type ModelContext struct {
 type PodInfo struct {
 	LastAccessTime atomic.Int64 // Unix timestamp (lock-free update)
 	SourcePod      string
+	// Medium is the storage tier this pod holds the prefix on
+	// ("GPU"/"CPU"/"STORAGE"; empty when the publisher does not emit it).
+	Medium string
 }
 
 // PrefixStore manages prefix hashes for a specific (model, lora_id) context
@@ -218,11 +230,18 @@ func (s *SyncPrefixHashTable) MatchPrefix(modelName string, loraID int64, tokens
 
 		prefixMatchPercent := (i + 1) * 100 / len(prefixHashes)
 
-		// Find ready pods with this prefix
+		// Find ready pods with this prefix. Scores are weighted by the
+		// storage tier the pod holds the prefix on: a pod that only has the
+		// prefix on CPU/STORAGE is a weaker hit than one with it on GPU
+		// (issue #2285). Later prefixes overwrite with higher percentages;
+		// per pod we keep the best weighted score.
 		hasMatch := false
-		for podName := range pods {
+		for podName, podInfo := range pods {
 			if _, isReady := readyPods[podName]; isReady {
-				prefixMatchPods[podName] = prefixMatchPercent
+				weighted := int(float64(prefixMatchPercent) * mediumWeight(podInfo.Medium))
+				if cur, ok := prefixMatchPods[podName]; !ok || weighted > cur {
+					prefixMatchPods[podName] = weighted
+				}
 				hasMatch = true
 			}
 		}
@@ -310,7 +329,7 @@ func (s *SyncPrefixHashTable) ProcessBlockStored(event BlockStored) error {
 
 		prefixStore := contextData.prefixStore
 		for _, update := range prefixUpdates {
-			s.addPrefixToPodLocked(prefixStore, update.hash, update.pod)
+			s.addPrefixToPodLocked(prefixStore, update.hash, update.pod, event.Medium)
 		}
 	}
 
@@ -371,8 +390,18 @@ func (s *SyncPrefixHashTable) ProcessAllBlocksCleared(event AllBlocksCleared) er
 	return nil
 }
 
-// AddPrefix adds prefix hashes for a specific model/lora context and pod
+// AddPrefix adds prefix hashes for a specific model/lora context and pod.
+// The medium is unknown here (callers without tier information), so entries
+// are stored as unspecified, which scores as a full-strength GPU hit for
+// backward compatibility.
 func (s *SyncPrefixHashTable) AddPrefix(modelName string, loraID int64, podName string, prefixHashes []uint64) error {
+	return s.AddPrefixWithMedium(modelName, loraID, podName, "", prefixHashes)
+}
+
+// AddPrefixWithMedium is AddPrefix with the storage tier the pod holds the
+// prefixes on. The tier is recorded per (prefix, pod) so MatchPrefix can score
+// non-GPU prefixes lower.
+func (s *SyncPrefixHashTable) AddPrefixWithMedium(modelName string, loraID int64, podName, medium string, prefixHashes []uint64) error {
 	ctx := ModelContext{
 		ModelName: modelName,
 		LoraID:    loraID,
@@ -411,6 +440,7 @@ func (s *SyncPrefixHashTable) AddPrefix(modelName string, loraID int64, podName 
 		} else {
 			pods[podName] = &PodInfo{
 				SourcePod: podName,
+				Medium:    medium,
 			}
 			pods[podName].LastAccessTime.Store(now)
 		}
@@ -536,7 +566,7 @@ func (s *SyncPrefixHashTable) computeHash(parentHash uint64, blockTokens []byte)
 }
 
 // addPrefixToPodLocked adds or updates pod info for a prefix (caller must hold lock)
-func (s *SyncPrefixHashTable) addPrefixToPodLocked(prefixStore *PrefixStore, prefixHash uint64, podName string) {
+func (s *SyncPrefixHashTable) addPrefixToPodLocked(prefixStore *PrefixStore, prefixHash uint64, podName, medium string) {
 	now := time.Now().Unix()
 
 	pods, exists := prefixStore.prefixMap[prefixHash]
@@ -551,8 +581,25 @@ func (s *SyncPrefixHashTable) addPrefixToPodLocked(prefixStore *PrefixStore, pre
 	} else {
 		pods[podName] = &PodInfo{
 			SourcePod: podName,
+			Medium:    medium,
 		}
 		pods[podName].LastAccessTime.Store(now)
+	}
+}
+
+// mediumWeight returns the routing score weight for a storage tier. Entries
+// without tier information (empty medium, e.g. from older vLLM or the plain
+// AddPrefix path) score at full strength to preserve legacy behavior.
+func mediumWeight(medium string) float64 {
+	switch medium {
+	case MediumGPU:
+		return 1.0
+	case MediumCPU:
+		return 0.5
+	case MediumStorage:
+		return 0.25
+	default:
+		return 1.0
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #2285. While investigating, I found a larger compatibility break:
vLLM switched KV event encoding from positional arrays to **msgpack maps** in
[vllm-project/vllm#42892](https://github.com/vllm-project/vllm/pull/42892)
(merged 2026-06-09). `DecodeEventBatch` still expected `[ts, events]` arrays,
so **every** KV event payload from current vLLM fails to unmarshal
(`msgpack: invalid code=0x88 decoding array length`) — kv-events prefix
routing is effectively dead against current vLLM. The legacy publisher also
sent one event per ZMQ message (tag-first array), which the batch-shaped
decoder never handled either.

## Changes

- `pkg/cache/kvcache/msgpack_decoder.go`: accept all three wire shapes —
  map single event (current vLLM), tag-first array single event (legacy
  vLLM), and `[ts, events]` batch (older code paths / test encoder).
- Parse every `BlockStored`/`BlockRemoved` field: `lora_id`, `medium`,
  `lora_name`, `extra_keys`, `group_idx`, `kv_cache_spec_kind`,
  `kv_cache_spec_sliding_window`, `locality`.
- `pkg/utils/syncprefixcacheindexer`: record the storage `medium` per
  (prefix, pod) and weight `MatchPrefix` scores (GPU=1.0, CPU=0.5,
  STORAGE=0.25; unspecified keeps full score for backward compatibility)
  so pods holding a prefix only on a slower tier are not over-credited.
- Plumb `medium`/`lora_name`/`group_idx` through the `kvevent` handler and
  `store_providers` adapter (previously dropped at the handler).

## Tests

New `decoder_vllm_compat_test.go` verifies decoding against **byte-exact
payloads generated with the real msgspec encoder** for both current map and
legacy array formats (single-event and batch shapes). New
`medium_scoring_test.go` covers tier weighting via `AddPrefixWithMedium` and
the event ingestion path. All existing `kvcache` and
`syncprefixcacheindexer` tests keep passing.

## Follow-up

The `(model, lora_name, group_idx)` index keying part of #2285 needs a
request-side adapter id (`RoutingContext` has no LoRA field today); see the
issue thread.