### PR TITLE
fix(console): prevent queued jobs from being skipped indefinitely

### DIFF
--- a/apps/console/api/planner/impl/planner.go
+++ b/apps/console/api/planner/impl/planner.go
@@ -307,9 +307,35 @@ func (q *Planner) Recover(ctx context.Context) error {
 			continue
 		}
 
+		// A completion window starts when MDS accepts the batch, not while the
+		// job is waiting in the planner queue. So, when recovering pre-provision
+		// states, clear the legacy expiresAt in case it was set.
+		modified := false
+		if (job.status == plannerapi.JobStatusQueued || job.status == plannerapi.JobStatusPlanned) &&
+			!job.expiresAt.IsZero() {
+			job.expiresAt = time.Time{}
+			modified = true
+		}
+
+		// A process can stop after changing the in-memory status to planned
+		// but before Provision returns, so a recovered planned job must be
+		// scheduled again.
+		if job.status == plannerapi.JobStatusPlanned {
+			job.status = plannerapi.JobStatusQueued
+			modified = true
+		}
+
+		if modified {
+			if job.batch != nil {
+				job.batch.Status = job.status.ToBatchStatus()
+				job.batch.ExpiresAt = 0
+			}
+			q.persist(ctx, job)
+		}
+
 		q.jobs[job.req.JobID] = job
 		// Re-enqueue the job onto the queue based on the status
-		if job.status == plannerapi.JobStatusQueued || job.status == plannerapi.JobStatusPlanned {
+		if job.status == plannerapi.JobStatusQueued {
 			q.pendingQueue.Push(job, 0)
 			job.queue = q.pendingQueue
 		} else {
@@ -361,12 +387,10 @@ func (q *Planner) Enqueue(ctx context.Context, req *plannerapi.EnqueueRequest) (
 		q.mu.Unlock()
 		return nil, fmt.Errorf("%w: duplicate job_id %q", plannerapi.ErrInvalidJob, req.JobID)
 	}
-	completionWindow, _ := utils.ParseCompletionWindow(string(req.BatchParams.CompletionWindow))
 	job := &queuedJob{
 		req:        req,
 		status:     plannerapi.JobStatusQueued,
 		queuedAt:   now,
-		expiresAt:  now.Add(completionWindow),
 		pqPriority: 0,
 		queue:      q.pendingQueue,
 	}

--- a/apps/console/api/planner/impl/planner_test.go
+++ b/apps/console/api/planner/impl/planner_test.go
@@ -31,6 +31,7 @@ import (
 	plannerclient "github.com/vllm-project/aibrix/apps/console/api/planner/client"
 	rmtypes "github.com/vllm-project/aibrix/apps/console/api/resource_manager/types"
 	"github.com/vllm-project/aibrix/apps/console/api/store"
+	"github.com/vllm-project/aibrix/apps/console/api/store/models"
 )
 
 const (
@@ -423,7 +424,168 @@ func TestEnqueueReturnsPendingPlaceholder(t *testing.T) {
 	if job.Batch == nil || job.Batch.Status != openai.BatchStatus("queued") {
 		t.Errorf("Batch.Status = %v, want queued", job.Batch)
 	}
+
+	q.mu.RLock()
+	queued := q.jobs["j1"]
+	q.mu.RUnlock()
+	queued.mu.RLock()
+	expiresAt := queued.expiresAt
+	queued.mu.RUnlock()
+	if !expiresAt.IsZero() {
+		t.Fatalf("queued job deadline = %v, want zero until resource allocation or MDS submission", expiresAt)
+	}
 	close(release)
+}
+
+func TestRecoverReschedulesPreProvisionJobWithLegacyExpiredDeadline(t *testing.T) {
+	for _, recoveredStatus := range []plannerapi.JobStatus{
+		plannerapi.JobStatusQueued,
+		plannerapi.JobStatusPlanned,
+	} {
+		t.Run(string(recoveredStatus), func(t *testing.T) {
+			memStore := store.NewMemoryStore(nil)
+			t.Cleanup(func() { _ = memStore.Close() })
+
+			queuedAt := time.Now().UTC().Add(-2 * time.Hour)
+			legacyDeadline := queuedAt.Add(time.Hour)
+			jobID := "j-recover-" + string(recoveredStatus)
+			if err := memStore.UpsertJob(context.Background(), &models.Job{
+				ID:               jobID,
+				Endpoint:         "/v1/chat/completions",
+				InputDataset:     "file-" + jobID,
+				CompletionWindow: "1h",
+				Status:           string(recoveredStatus),
+				QueuedAt:         &queuedAt,
+				ExpiresAt:        &legacyDeadline,
+			}); err != nil {
+				t.Fatalf("persist legacy job: %v", err)
+			}
+
+			provisionStarted := make(chan struct{})
+			unblockProvision := make(chan struct{})
+			var provisionOnce sync.Once
+			prov := &fakeProvisioner{
+				ProvisionFn: func(ctx context.Context, req *rmtypes.ResourceProvision) (*rmtypes.ProvisionResult, error) {
+					provisionOnce.Do(func() { close(provisionStarted) })
+					select {
+					case <-unblockProvision:
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					}
+					return &rmtypes.ProvisionResult{
+						ProvisionID:    "prov-" + req.IdempotencyKey,
+						IdempotencyKey: req.IdempotencyKey,
+						Status:         rmtypes.ProvisionStatusRunning,
+					}, nil
+				},
+			}
+			q := NewPlanner(PlannerConfig{
+				BatchClient:            &fakeBatchClient{},
+				Provisioner:            prov,
+				Store:                  memStore,
+				PolicyType:             PlanningPolicyTypeSimple,
+				WorkerCount:            1,
+				PlanningInterval:       100 * time.Millisecond,
+				MaxConcurrentProvision: 1,
+			})
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(func() {
+				cancel()
+				_ = q.Close()
+			})
+			if err := q.Recover(ctx); err != nil {
+				t.Fatalf("Recover: %v", err)
+			}
+
+			select {
+			case <-provisionStarted:
+			case <-time.After(defaultTimeout):
+				t.Fatalf("recovered %s job with legacy deadline was not provisioned", recoveredStatus)
+			}
+
+			q.mu.RLock()
+			recovered := q.jobs[jobID]
+			q.mu.RUnlock()
+			recovered.mu.RLock()
+			expiresAt := recovered.expiresAt
+			recovered.mu.RUnlock()
+			if !expiresAt.IsZero() {
+				t.Fatalf("recovered pre-provision deadline = %v, want legacy deadline cleared", expiresAt)
+			}
+
+			storedJob, err := memStore.GetJob(context.Background(), jobID)
+			if err != nil {
+				t.Fatalf("GetJob from store: %v", err)
+			}
+			if storedJob == nil {
+				t.Fatal("recovered job missing from store")
+			}
+			if storedJob.Status != string(plannerapi.JobStatusQueued) {
+				t.Fatalf("stored job status = %q, want %q", storedJob.Status, plannerapi.JobStatusQueued)
+			}
+			if storedJob.ExpiresAt != nil && !storedJob.ExpiresAt.IsZero() {
+				t.Fatalf("stored job expiresAt = %v, want zero/nil", storedJob.ExpiresAt)
+			}
+
+			listedJobs, err := q.ListJobs(context.Background(), &plannerapi.ListJobsRequest{Limit: 10})
+			if err != nil {
+				t.Fatalf("ListJobs after recovery: %v", err)
+			}
+			if len(listedJobs.Data) != 1 {
+				t.Fatalf("ListJobs returned %d jobs, want 1", len(listedJobs.Data))
+			}
+			if listedJobs.Data[0].Batch.Status != openai.BatchStatus("queued") {
+				t.Fatalf("listed job status = %q, want queued", listedJobs.Data[0].Batch.Status)
+			}
+			if listedJobs.Data[0].Batch.ExpiresAt != 0 {
+				t.Fatalf("listed job expiresAt = %d, want 0", listedJobs.Data[0].Batch.ExpiresAt)
+			}
+
+			visibleJob, err := q.GetJob(context.Background(), jobID)
+			if err != nil {
+				t.Fatalf("GetJob after recovery: %v", err)
+			}
+			if visibleJob.Batch.Status != openai.BatchStatus("queued") {
+				t.Fatalf("recovered job status = %q, want queued", visibleJob.Batch.Status)
+			}
+			if visibleJob.Batch.ExpiresAt != 0 {
+				t.Fatalf("recovered job expiresAt = %d, want 0", visibleJob.Batch.ExpiresAt)
+			}
+
+			close(unblockProvision)
+		})
+	}
+}
+
+func TestSimplePolicySchedulesQueuedJobPastLegacyDeadline(t *testing.T) {
+	q := NewPlanner(PlannerConfig{
+		BatchClient:            &fakeBatchClient{},
+		Provisioner:            &fakeProvisioner{},
+		PolicyType:             PlanningPolicyTypeSimple,
+		MaxConcurrentProvision: 1,
+	})
+	job := &queuedJob{
+		req:       validReq("j-legacy-deadline"),
+		status:    plannerapi.JobStatusQueued,
+		expiresAt: time.Now().UTC().Add(-time.Hour),
+		queue:     q.pendingQueue,
+	}
+	q.pendingQueue.Push(job, 0)
+
+	if err := q.policy.Plan(context.Background(), PlanningInput[*queuedJob]{
+		PlannerBackend: q.backend,
+		RunningQueue:   q.runningQueue,
+		PendingQueue:   q.pendingQueue,
+	}); err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	job.mu.RLock()
+	scheduled := job.scheduledResource
+	job.mu.RUnlock()
+	if scheduled == nil {
+		t.Fatal("queued job with legacy deadline was skipped instead of scheduled")
+	}
 }
 
 func TestHappyPathReachesSubmitted(t *testing.T) {

--- a/apps/console/api/planner/impl/planning_policy.go
+++ b/apps/console/api/planner/impl/planning_policy.go
@@ -178,15 +178,10 @@ func (p *SimplePolicy) Plan(ctx context.Context, input PlanningInput[*queuedJob]
 			return false
 		}
 		job.mu.RLock()
-		expired := !job.expiresAt.IsZero() && job.expiresAt.Before(time.Now().UTC())
 		status := job.status
 		hasSchedule := job.scheduledResource != nil
 		job.mu.RUnlock()
 
-		if expired {
-			klog.Infof("[planner] Plan job_id=%q expired, skip", job.req.JobID)
-			return true
-		}
 		if !status.IsTerminal() && status != plannerapi.JobStatusCancelling {
 			// Already scheduled, skip
 			if hasSchedule {


### PR DESCRIPTION
## Pull Request Description
The planner started the completion window when a job was enqueued. Once that deadline elapsed, the scheduling policy skipped the job without transitioning it to a terminal state. This left older jobs stuck in queued while newer jobs continued to provision and run.

In this fix, planner does not consider queuing time as part of the completion window and therefore will not skip any jobs in the queue.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>