### PR TITLE
fix(chart): correct HTTPS gateway listener patch path

### DIFF
--- a/dist/chart/templates/gateway-instance/gateway.yaml
+++ b/dist/chart/templates/gateway-instance/gateway.yaml
@@ -202,7 +202,7 @@ spec:
       name: {{ .Release.Namespace }}/{{ include "aibrix.fullname" . }}-eg/https
       operation:
         op: add
-        path: /default_filter_chain/filters/{{- if gt (int .Values.gateway.clientTrafficPolicy.connection.connectionLimit.value) 0 }}1{{- else }}0{{- end }}/typed_config/preserve_external_request_id
+        path: /filter_chains/0/filters/{{ if gt (int .Values.gateway.clientTrafficPolicy.connection.connectionLimit.value) 0 }}1{{ else }}0{{ end }}/typed_config/preserve_external_request_id
         value: {{ .Values.gateway.envoyPatchPolicy.preserveExternalRequestID }}
     {{- end }}
 {{- end }}

--- a/dist/chart/templates/gateway-instance/gateway.yaml
+++ b/dist/chart/templates/gateway-instance/gateway.yaml
@@ -202,7 +202,7 @@ spec:
       name: {{ .Release.Namespace }}/{{ include "aibrix.fullname" . }}-eg/https
       operation:
         op: add
-        path: /filter_chains/0/filters/{{ if gt (int .Values.gateway.clientTrafficPolicy.connection.connectionLimit.value) 0 }}1{{ else }}0{{ end }}/typed_config/preserve_external_request_id
+        path: /filter_chains/0/filters/{{- if gt (int .Values.gateway.clientTrafficPolicy.connection.connectionLimit.value) 0 }}1{{- else }}0{{- end }}/typed_config/preserve_external_request_id
         value: {{ .Values.gateway.envoyPatchPolicy.preserveExternalRequestID }}
     {{- end }}
 {{- end }}

--- a/dist/chart/tests/gateway_tls_hostname_test.yaml
+++ b/dist/chart/tests/gateway_tls_hostname_test.yaml
@@ -60,7 +60,7 @@ tests:
       gateway.enable: true
       gateway.envoyAsSideCar: false
       gateway.http.enabled: false
-        gateway.clientTrafficPolicy.connection.connectionLimit.value: 1024
+      gateway.clientTrafficPolicy.connection.connectionLimit.value: 1024
       gateway.tls.enabled: true
       gateway.tls.hostname: "*.example.com"
       gateway.tls.secretName: "aibrix-gateway-tls"

--- a/dist/chart/tests/gateway_tls_hostname_test.yaml
+++ b/dist/chart/tests/gateway_tls_hostname_test.yaml
@@ -60,6 +60,7 @@ tests:
       gateway.enable: true
       gateway.envoyAsSideCar: false
       gateway.http.enabled: false
+        gateway.clientTrafficPolicy.connection.connectionLimit.value: 1024
       gateway.tls.enabled: true
       gateway.tls.hostname: "*.example.com"
       gateway.tls.secretName: "aibrix-gateway-tls"

--- a/dist/chart/tests/gateway_tls_hostname_test.yaml
+++ b/dist/chart/tests/gateway_tls_hostname_test.yaml
@@ -76,3 +76,6 @@ tests:
       - equal:
           path: spec.jsonPatches[2].name
           value: aibrix-system/aibrix-eg/https
+      - equal:
+          path: spec.jsonPatches[2].operation.path
+          value: /filter_chains/0/filters/1/typed_config/preserve_external_request_id


### PR DESCRIPTION
## Summary
- fix the HTTPS listener patch in `gateway.yaml` to target the actual listener filter chain instead of `default_filter_chain`
- add a regression assertion in `gateway_tls_hostname_test.yaml` to verify the rendered JSON patch path for the HTTPS listener

## Why
The previous HTTPS patch path produced an invalid xDS listener shape for the TLS listener, which could prevent Envoy from accepting the generated listener config. Adding an explicit assertion on the rendered patch path helps catch the regression early in chart tests.