### PR TITLE
[Bug] stop KPA/APA scaling down on unknown metrics

### DIFF
--- a/pkg/controller/podautoscaler/metrics/fetcher.go
+++ b/pkg/controller/podautoscaler/metrics/fetcher.go
@@ -97,10 +97,9 @@ func (f *RestMetricsFetcher) fetchFromPod(ctx context.Context, pod v1.Pod, sourc
 	// Use the centralized engine fetcher with real pod information
 	metricValue, err := f.engineFetcher.FetchTypedMetric(ctx, endpoint, engineType, identifier, source.TargetMetric)
 	if err != nil {
-		klog.Warningf("Failed to fetch metric %s from pod %s: %v. Returning zero value.",
+		klog.Warningf("Failed to fetch metric %s from pod %s: %v",
 			source.TargetMetric, identifier, err)
-		// Return zero value with warning instead of error - business logic can decide how to handle
-		return 0.0, nil
+		return 0.0, err
 	}
 
 	return metricValue.GetSimpleValue(), nil
@@ -276,9 +275,9 @@ func (f *ExternalMetricsFetcher) fetchFromGPUOptimizer(ctx context.Context, pod 
 	// This gives us a global value that we need to adapt to per-pod semantics
 	metricValue, err := f.engineFetcher.FetchTypedMetric(ctx, source.Endpoint, "external", "gpu-optimizer", source.TargetMetric)
 	if err != nil {
-		klog.Warningf("Failed to fetch metric %s from GPU-Optimizer %s: %v. Returning zero value.",
+		klog.Warningf("Failed to fetch metric %s from GPU-Optimizer %s: %v",
 			source.TargetMetric, source.Endpoint, err)
-		return 0.0, nil
+		return 0.0, err
 	}
 
 	// Adaptation: Global metric -> per-pod value

--- a/pkg/controller/podautoscaler/metrics/fetcher.go
+++ b/pkg/controller/podautoscaler/metrics/fetcher.go
@@ -134,15 +134,14 @@ func (f *ResourceMetricsFetcher) fetchResourceMetric(ctx context.Context, pod v1
 		"metric", source.TargetMetric)
 
 	if f.metricsClient == nil {
-		klog.Warningf("Kubernetes resource metrics client not initialized for metric %s", source.TargetMetric)
-		return 0.0, nil
+		return 0.0, fmt.Errorf("kubernetes resource metrics client not initialized for metric %s", source.TargetMetric)
 	}
 
 	// Use existing ResourceMetricsFetcher logic
 	podMetrics, err := f.metricsClient.MetricsV1beta1().PodMetricses(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	if err != nil {
-		klog.Warningf("Failed to fetch resource metrics for pod %s: %v. Returning zero value.", pod.Name, err)
-		return 0.0, nil
+		klog.Warningf("Failed to fetch resource metrics for pod %s: %v", pod.Name, err)
+		return 0.0, err
 	}
 
 	var total float64
@@ -192,8 +191,7 @@ func (f *CustomMetricsFetcher) fetchCustomMetric(ctx context.Context, pod v1.Pod
 		"metric", source.TargetMetric)
 
 	if f.customMetricsClient == nil {
-		klog.Warningf("Kubernetes custom metrics client not initialized for metric %s", source.TargetMetric)
-		return 0.0, nil
+		return 0.0, fmt.Errorf("kubernetes custom metrics client not initialized for metric %s", source.TargetMetric)
 	}
 
 	// Use existing CustomMetricsFetcher logic
@@ -209,8 +207,8 @@ func (f *CustomMetricsFetcher) fetchCustomMetric(ctx context.Context, pod v1.Pod
 
 	metricList, err := f.customMetricsClient.NamespacedMetrics(pod.Namespace).GetForObject(podGK, podRef.Name, source.TargetMetric, labels.Everything())
 	if err != nil {
-		klog.Warningf("Failed to fetch custom metric %s for pod %s: %v. Returning zero value.", source.TargetMetric, pod.Name, err)
-		return 0.0, nil
+		klog.Warningf("Failed to fetch custom metric %s for pod %s: %v", source.TargetMetric, pod.Name, err)
+		return 0.0, err
 	}
 
 	return float64(metricList.Value.Value()), nil

--- a/pkg/controller/podautoscaler/metrics/fetcher.go
+++ b/pkg/controller/podautoscaler/metrics/fetcher.go
@@ -101,6 +101,9 @@ func (f *RestMetricsFetcher) fetchFromPod(ctx context.Context, pod v1.Pod, sourc
 			source.TargetMetric, identifier, err)
 		return 0.0, err
 	}
+	if metricValue == nil {
+		return 0.0, fmt.Errorf("metric value is nil for %s", source.TargetMetric)
+	}
 
 	return metricValue.GetSimpleValue(), nil
 }
@@ -278,6 +281,9 @@ func (f *ExternalMetricsFetcher) fetchFromGPUOptimizer(ctx context.Context, pod 
 		klog.Warningf("Failed to fetch metric %s from GPU-Optimizer %s: %v",
 			source.TargetMetric, source.Endpoint, err)
 		return 0.0, err
+	}
+	if metricValue == nil {
+		return 0.0, fmt.Errorf("metric value is nil for %s", source.TargetMetric)
 	}
 
 	// Adaptation: Global metric -> per-pod value

--- a/pkg/controller/podautoscaler/metrics/fetcher_test.go
+++ b/pkg/controller/podautoscaler/metrics/fetcher_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -37,12 +38,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	clientgotesting "k8s.io/client-go/testing"
+	custommetricsv1beta2 "k8s.io/metrics/pkg/apis/custom_metrics/v1beta2"
 	externalmetricsv1beta1 "k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
 	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/clientset/versioned"
+	"k8s.io/metrics/pkg/client/custom_metrics"
 	externalmetricsfake "k8s.io/metrics/pkg/client/external_metrics/fake"
 	"k8s.io/utils/ptr"
 )
@@ -218,6 +223,97 @@ func TestResourceMetricsFetcher_FetchPodMetrics(t *testing.T) {
 	assert.Equal(t, expectedMetricValue, actualMetricValue)
 }
 
+func TestResourceMetricsFetcher_NilClientReturnsError(t *testing.T) {
+	fetcher := NewResourceMetricsFetcher(nil)
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+		},
+	}
+	source := autoscalingv1alpha1.MetricSource{
+		MetricSourceType: autoscalingv1alpha1.RESOURCE,
+		TargetMetric:     "cpu",
+	}
+
+	actualMetricValue, err := fetcher.FetchPodMetrics(context.TODO(), pod, source)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "kubernetes resource metrics client not initialized")
+	assert.Equal(t, 0.0, actualMetricValue)
+}
+
+func TestResourceMetricsFetcher_FetchFailureReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	metricsClient, err := versioned.NewForConfig(&rest.Config{
+		Host: server.URL,
+	})
+	require.NoError(t, err)
+	fetcher := NewResourceMetricsFetcher(metricsClient)
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+		},
+	}
+	source := autoscalingv1alpha1.MetricSource{
+		MetricSourceType: autoscalingv1alpha1.RESOURCE,
+		TargetMetric:     "cpu",
+	}
+
+	actualMetricValue, err := fetcher.FetchPodMetrics(context.TODO(), pod, source)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0.0, actualMetricValue)
+}
+
+func TestCustomMetricsFetcher_NilClientReturnsError(t *testing.T) {
+	fetcher := NewCustomMetricsFetcher(nil)
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+		},
+	}
+	source := autoscalingv1alpha1.MetricSource{
+		MetricSourceType: autoscalingv1alpha1.CUSTOM,
+		TargetMetric:     "queue_depth",
+	}
+
+	actualMetricValue, err := fetcher.FetchPodMetrics(context.TODO(), pod, source)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "kubernetes custom metrics client not initialized")
+	assert.Equal(t, 0.0, actualMetricValue)
+}
+
+func TestCustomMetricsFetcher_FetchFailureReturnsError(t *testing.T) {
+	fetcher := NewCustomMetricsFetcher(&stubCustomMetricsClient{
+		err: errors.New("custom metrics api unavailable"),
+	})
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+		},
+	}
+	source := autoscalingv1alpha1.MetricSource{
+		MetricSourceType: autoscalingv1alpha1.CUSTOM,
+		TargetMetric:     "queue_depth",
+	}
+
+	actualMetricValue, err := fetcher.FetchPodMetrics(context.TODO(), pod, source)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "custom metrics api unavailable")
+	assert.Equal(t, 0.0, actualMetricValue)
+}
+
 func TestExternalMetricsFetcher_FetchPodMetricsFromK8sExternalMetrics(t *testing.T) {
 	externalClient := &externalmetricsfake.FakeExternalMetricsClient{}
 	externalClient.AddReactor("list", "queue_depth", func(action clientgotesting.Action) (bool, runtime.Object, error) {
@@ -306,4 +402,24 @@ func parseURL(rawURL string) (string, string) {
 		return "", ""
 	}
 	return u.Hostname(), u.Port()
+}
+
+type stubCustomMetricsClient struct {
+	err error
+}
+
+func (s *stubCustomMetricsClient) RootScopedMetrics() custom_metrics.MetricsInterface {
+	return s
+}
+
+func (s *stubCustomMetricsClient) NamespacedMetrics(string) custom_metrics.MetricsInterface {
+	return s
+}
+
+func (s *stubCustomMetricsClient) GetForObject(schema.GroupKind, string, string, labels.Selector) (*custommetricsv1beta2.MetricValue, error) {
+	return nil, s.err
+}
+
+func (s *stubCustomMetricsClient) GetForObjects(schema.GroupKind, labels.Selector, string, labels.Selector) (*custommetricsv1beta2.MetricValueList, error) {
+	return nil, s.err
 }

--- a/pkg/controller/podautoscaler/metrics/fetcher_test.go
+++ b/pkg/controller/podautoscaler/metrics/fetcher_test.go
@@ -98,6 +98,74 @@ func TestRestMetricsFetcher_FetchPodMetrics(t *testing.T) {
 	assert.Equal(t, expectedMetricValue, actualMetricValue)
 }
 
+func TestRestMetricsFetcher_UnknownMetricReturnsError(t *testing.T) {
+	fetcher := NewRestMetricsFetcherWithConfig(metrics.EngineMetricsFetcherConfig{
+		Timeout:    time.Second,
+		MaxRetries: 0,
+	})
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-1",
+			Labels: map[string]string{
+				constants.ModelLabelEngine: "vllm",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "127.0.0.1",
+		},
+	}
+	source := autoscalingv1alpha1.MetricSource{
+		MetricSourceType: autoscalingv1alpha1.POD,
+		TargetMetric:     "running_requests",
+		Port:             "8000",
+	}
+
+	actualMetricValue, err := fetcher.FetchPodMetrics(context.TODO(), pod, source)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in central registry")
+	assert.Equal(t, 0.0, actualMetricValue)
+}
+
+func TestRestMetricsFetcher_FetchFailureReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	ip, port := parseURL(server.URL)
+	require.NotEmpty(t, ip)
+	require.NotEmpty(t, port)
+
+	fetcher := NewRestMetricsFetcherWithConfig(metrics.EngineMetricsFetcherConfig{
+		Timeout:    time.Second,
+		MaxRetries: 0,
+	})
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-1",
+			Labels: map[string]string{
+				constants.ModelLabelEngine: "vllm",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: ip,
+		},
+	}
+	source := autoscalingv1alpha1.MetricSource{
+		MetricSourceType: autoscalingv1alpha1.POD,
+		TargetMetric:     "gpu_cache_usage_perc",
+		Port:             port,
+	}
+
+	actualMetricValue, err := fetcher.FetchPodMetrics(context.TODO(), pod, source)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0.0, actualMetricValue)
+}
+
 func TestResourceMetricsFetcher_FetchPodMetrics(t *testing.T) {
 	expectedMetricValue := 50000.0
 

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -38,7 +38,6 @@ import (
 	scalingctx "github.com/vllm-project/aibrix/pkg/controller/podautoscaler/context"
 	"github.com/vllm-project/aibrix/pkg/controller/podautoscaler/metrics"
 	"github.com/vllm-project/aibrix/pkg/controller/podautoscaler/monitor"
-	enginemetrics "github.com/vllm-project/aibrix/pkg/metrics"
 	podutils "github.com/vllm-project/aibrix/pkg/utils"
 	"github.com/vllm-project/aibrix/pkg/utils/paschedules"
 	"k8s.io/apimachinery/pkg/labels"
@@ -536,12 +535,6 @@ func (r *PodAutoscalerReconciler) validatePodMetricSource(ms *autoscalingv1alpha
 	}
 	if ms.Path == "" {
 		return invalid(ReasonMetricsConfigError, "path is required for metricSourceType=pod.")
-	}
-	if ms.TargetMetric != "" {
-		if _, ok := enginemetrics.Metrics[ms.TargetMetric]; !ok {
-			return invalid(ReasonMetricsConfigError,
-				fmt.Sprintf("unknown targetMetric %q; must be a metric in the central registry (for example num_requests_running, gpu_cache_usage_perc).", ms.TargetMetric))
-		}
 	}
 	return validOK()
 }

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -38,6 +38,7 @@ import (
 	scalingctx "github.com/vllm-project/aibrix/pkg/controller/podautoscaler/context"
 	"github.com/vllm-project/aibrix/pkg/controller/podautoscaler/metrics"
 	"github.com/vllm-project/aibrix/pkg/controller/podautoscaler/monitor"
+	enginemetrics "github.com/vllm-project/aibrix/pkg/metrics"
 	podutils "github.com/vllm-project/aibrix/pkg/utils"
 	"github.com/vllm-project/aibrix/pkg/utils/paschedules"
 	"k8s.io/apimachinery/pkg/labels"
@@ -473,11 +474,14 @@ func (r *PodAutoscalerReconciler) validateScalingStrategy(pa *autoscalingv1alpha
 	if !checkValidAutoscalingStrategy(pa.Spec.ScalingStrategy) {
 		return invalid(ReasonInvalidScalingStrategy, "Unsupported scalingStrategy; must be one of HPA/KPA/APA.")
 	}
-	if pa.Spec.ScalingStrategy == autoscalingv1alpha1.HPA &&
-		pa.Spec.SubTargetSelector != nil &&
-		pa.Spec.SubTargetSelector.RoleName != "" {
-		return invalid(ReasonInvalidScalingStrategy,
-			"subTargetSelector.roleName is not supported with scalingStrategy=HPA; use APA or KPA for StormService role-level autoscaling.")
+	if pa.Spec.SubTargetSelector != nil && pa.Spec.SubTargetSelector.RoleName != "" {
+		if pa.Spec.ScalingStrategy == autoscalingv1alpha1.HPA {
+			return invalid(ReasonInvalidScalingStrategy,
+				"subTargetSelector.roleName is not supported with scalingStrategy=HPA; use APA or KPA for StormService role-level autoscaling.")
+		}
+		if pa.Spec.ScaleTargetRef.Kind != StormService {
+			return invalid(ReasonInvalidSpec, "subTargetSelector.roleName is only supported for StormService.")
+		}
 	}
 	return validOK()
 }
@@ -532,6 +536,12 @@ func (r *PodAutoscalerReconciler) validatePodMetricSource(ms *autoscalingv1alpha
 	}
 	if ms.Path == "" {
 		return invalid(ReasonMetricsConfigError, "path is required for metricSourceType=pod.")
+	}
+	if ms.TargetMetric != "" {
+		if _, ok := enginemetrics.Metrics[ms.TargetMetric]; !ok {
+			return invalid(ReasonMetricsConfigError,
+				fmt.Sprintf("unknown targetMetric %q; must be a metric in the central registry (for example num_requests_running, gpu_cache_usage_perc).", ms.TargetMetric))
+		}
 	}
 	return validOK()
 }

--- a/pkg/controller/podautoscaler/podautoscaler_controller_test.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller_test.go
@@ -140,6 +140,100 @@ func TestValidateMetricsSourcesRequiresTargetMetricForK8sExternalMetrics(t *test
 	}
 }
 
+func TestValidateMetricsSourcesRejectsUnknownPodMetric(t *testing.T) {
+	r := &PodAutoscalerReconciler{}
+	pa := &autoscalingv1alpha1.PodAutoscaler{
+		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+			MetricsSources: []autoscalingv1alpha1.MetricSource{
+				{
+					MetricSourceType: autoscalingv1alpha1.POD,
+					ProtocolType:     autoscalingv1alpha1.HTTP,
+					Port:             "8000",
+					Path:             "/metrics",
+					TargetMetric:     "running_requests",
+					TargetValue:      "1",
+				},
+			},
+		},
+	}
+
+	result := r.validateMetricsSources(pa)
+
+	if result.Valid {
+		t.Fatal("expected unknown POD targetMetric to be invalid")
+	}
+	if result.Reason != ReasonMetricsConfigError {
+		t.Fatalf("expected reason=%s, got %s", ReasonMetricsConfigError, result.Reason)
+	}
+	if result.Message != "unknown targetMetric \"running_requests\"; must be a metric in the central registry (for example num_requests_running, gpu_cache_usage_perc)." {
+		t.Fatalf("unexpected message: %s", result.Message)
+	}
+}
+
+func TestValidateMetricsSourcesAllowsKnownPodMetric(t *testing.T) {
+	r := &PodAutoscalerReconciler{}
+	pa := &autoscalingv1alpha1.PodAutoscaler{
+		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+			MetricsSources: []autoscalingv1alpha1.MetricSource{
+				{
+					MetricSourceType: autoscalingv1alpha1.POD,
+					ProtocolType:     autoscalingv1alpha1.HTTP,
+					Port:             "8000",
+					Path:             "/metrics",
+					TargetMetric:     "num_requests_running",
+					TargetValue:      "1",
+				},
+			},
+		},
+	}
+
+	result := r.validateMetricsSources(pa)
+
+	if !result.Valid {
+		t.Fatalf("expected known POD targetMetric to be valid, got reason=%s message=%s", result.Reason, result.Message)
+	}
+}
+
+func TestValidateSpecRejectsKPARoleSubtargetForDeployment(t *testing.T) {
+	r := &PodAutoscalerReconciler{}
+	pa := &autoscalingv1alpha1.PodAutoscaler{
+		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+			ScaleTargetRef: corev1.ObjectReference{
+				Name: "custom-pa-target",
+				Kind: "Deployment",
+			},
+			SubTargetSelector: &autoscalingv1alpha1.SubTargetSelector{
+				RoleName: "prefill",
+			},
+			MinReplicas:     ptr.To(int32(1)),
+			MaxReplicas:     6,
+			ScalingStrategy: autoscalingv1alpha1.KPA,
+			MetricsSources: []autoscalingv1alpha1.MetricSource{
+				{
+					MetricSourceType: autoscalingv1alpha1.POD,
+					ProtocolType:     autoscalingv1alpha1.HTTP,
+					Port:             "8000",
+					Path:             "/metrics",
+					TargetMetric:     "num_requests_running",
+					TargetValue:      "1",
+				},
+			},
+		},
+	}
+
+	result := r.validateSpec(pa)
+
+	if result.Valid {
+		t.Fatal("expected KPA with subTargetSelector.roleName on a Deployment to be invalid")
+	}
+	if result.Reason != ReasonInvalidSpec {
+		t.Fatalf("expected reason=%s, got %s", ReasonInvalidSpec, result.Reason)
+	}
+	if result.Message != "subTargetSelector.roleName is only supported for StormService." {
+		t.Fatalf("unexpected message: %s", result.Message)
+	}
+}
+
 func TestValidateSpecRejectsHPARoleSubtarget(t *testing.T) {
 	r := &PodAutoscalerReconciler{}
 	pa := &autoscalingv1alpha1.PodAutoscaler{

--- a/pkg/controller/podautoscaler/podautoscaler_controller_test.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller_test.go
@@ -140,7 +140,7 @@ func TestValidateMetricsSourcesRequiresTargetMetricForK8sExternalMetrics(t *test
 	}
 }
 
-func TestValidateMetricsSourcesRejectsUnknownPodMetric(t *testing.T) {
+func TestValidateMetricsSourcesAllowsUnregisteredPodMetric(t *testing.T) {
 	r := &PodAutoscalerReconciler{}
 	pa := &autoscalingv1alpha1.PodAutoscaler{
 		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
@@ -159,14 +159,8 @@ func TestValidateMetricsSourcesRejectsUnknownPodMetric(t *testing.T) {
 
 	result := r.validateMetricsSources(pa)
 
-	if result.Valid {
-		t.Fatal("expected unknown POD targetMetric to be invalid")
-	}
-	if result.Reason != ReasonMetricsConfigError {
-		t.Fatalf("expected reason=%s, got %s", ReasonMetricsConfigError, result.Reason)
-	}
-	if result.Message != "unknown targetMetric \"running_requests\"; must be a metric in the central registry (for example num_requests_running, gpu_cache_usage_perc)." {
-		t.Fatalf("unexpected message: %s", result.Message)
+	if !result.Valid {
+		t.Fatalf("expected unregistered POD targetMetric to be valid, got reason=%s message=%s", result.Reason, result.Message)
 	}
 }
 

--- a/pkg/webhook/podautoscaler_webhook.go
+++ b/pkg/webhook/podautoscaler_webhook.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	autoscalingv1alpha1 "github.com/vllm-project/aibrix/api/autoscaling/v1alpha1"
-	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/utils/paschedules"
 )
 
@@ -272,15 +271,6 @@ func validatePodMetricSource(ms *autoscalingv1alpha1.MetricSource, msPath *field
 	}
 	if ms.Path == "" {
 		errs = append(errs, field.Required(msPath.Child("path"), "required for metricSourceType=pod"))
-	}
-	if ms.TargetMetric != "" {
-		if _, ok := metrics.Metrics[ms.TargetMetric]; !ok {
-			errs = append(errs, field.Invalid(
-				msPath.Child("targetMetric"),
-				ms.TargetMetric,
-				"unknown metric; must be a name in the central registry (for example num_requests_running, gpu_cache_usage_perc)",
-			))
-		}
 	}
 	return errs
 }

--- a/pkg/webhook/podautoscaler_webhook.go
+++ b/pkg/webhook/podautoscaler_webhook.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	autoscalingv1alpha1 "github.com/vllm-project/aibrix/api/autoscaling/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/utils/paschedules"
 )
 
@@ -196,6 +197,9 @@ func validateScalingStrategy(pa *autoscalingv1alpha1.PodAutoscaler, specPath *fi
 	if err := validateHPARoleSubtarget(pa, specPath); err != nil {
 		errs = append(errs, err)
 	}
+	if err := validateRoleSubtargetKind(pa, specPath); err != nil {
+		errs = append(errs, err)
+	}
 	return errs
 }
 
@@ -269,6 +273,15 @@ func validatePodMetricSource(ms *autoscalingv1alpha1.MetricSource, msPath *field
 	if ms.Path == "" {
 		errs = append(errs, field.Required(msPath.Child("path"), "required for metricSourceType=pod"))
 	}
+	if ms.TargetMetric != "" {
+		if _, ok := metrics.Metrics[ms.TargetMetric]; !ok {
+			errs = append(errs, field.Invalid(
+				msPath.Child("targetMetric"),
+				ms.TargetMetric,
+				"unknown metric; must be a name in the central registry (for example num_requests_running, gpu_cache_usage_perc)",
+			))
+		}
+	}
 	return errs
 }
 
@@ -335,6 +348,19 @@ func validateHPARoleSubtarget(pa *autoscalingv1alpha1.PodAutoscaler, specPath *f
 	return field.Forbidden(
 		specPath.Child("subTargetSelector").Child("roleName"),
 		"not supported with scalingStrategy=HPA; use APA or KPA for StormService role-level autoscaling",
+	)
+}
+
+func validateRoleSubtargetKind(pa *autoscalingv1alpha1.PodAutoscaler, specPath *field.Path) *field.Error {
+	if pa.Spec.SubTargetSelector == nil || pa.Spec.SubTargetSelector.RoleName == "" {
+		return nil
+	}
+	if pa.Spec.ScaleTargetRef.Kind == "" || pa.Spec.ScaleTargetRef.Kind == "StormService" {
+		return nil
+	}
+	return field.Forbidden(
+		specPath.Child("subTargetSelector").Child("roleName"),
+		"only supported for StormService",
 	)
 }
 

--- a/pkg/webhook/podautoscaler_webhook_test.go
+++ b/pkg/webhook/podautoscaler_webhook_test.go
@@ -343,6 +343,106 @@ func TestPodAutoscalerCustomValidator_validatePodAutoscaler(t *testing.T) {
 			expectError: true,
 			errorMsg:    "subTargetSelector",
 		},
+		"KPA Deployment Does Not Support Role Subtarget": {
+			pa: &autoscalingv1alpha1.PodAutoscaler{
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					ScaleTargetRef: corev1.ObjectReference{
+						Name: "test-deployment",
+						Kind: "Deployment",
+					},
+					SubTargetSelector: &autoscalingv1alpha1.SubTargetSelector{
+						RoleName: "prefill",
+					},
+					MaxReplicas:     6,
+					ScalingStrategy: autoscalingv1alpha1.KPA,
+					MetricsSources: []autoscalingv1alpha1.MetricSource{
+						{
+							MetricSourceType: autoscalingv1alpha1.POD,
+							ProtocolType:     autoscalingv1alpha1.HTTP,
+							Port:             "8000",
+							Path:             "/metrics",
+							TargetMetric:     "num_requests_running",
+							TargetValue:      "1",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "subTargetSelector",
+		},
+		"KPA StormService Role Subtarget Is Allowed": {
+			pa: &autoscalingv1alpha1.PodAutoscaler{
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					ScaleTargetRef: corev1.ObjectReference{
+						Name: "test-stormservice",
+						Kind: "StormService",
+					},
+					SubTargetSelector: &autoscalingv1alpha1.SubTargetSelector{
+						RoleName: "prefill",
+					},
+					MaxReplicas:     6,
+					ScalingStrategy: autoscalingv1alpha1.KPA,
+					MetricsSources: []autoscalingv1alpha1.MetricSource{
+						{
+							MetricSourceType: autoscalingv1alpha1.POD,
+							ProtocolType:     autoscalingv1alpha1.HTTP,
+							Port:             "8000",
+							Path:             "/metrics",
+							TargetMetric:     "num_requests_running",
+							TargetValue:      "1",
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		"Unknown POD TargetMetric Is Rejected": {
+			pa: &autoscalingv1alpha1.PodAutoscaler{
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					ScaleTargetRef: corev1.ObjectReference{
+						Name: "test-deployment",
+						Kind: "Deployment",
+					},
+					MaxReplicas:     6,
+					ScalingStrategy: autoscalingv1alpha1.APA,
+					MetricsSources: []autoscalingv1alpha1.MetricSource{
+						{
+							MetricSourceType: autoscalingv1alpha1.POD,
+							ProtocolType:     autoscalingv1alpha1.HTTP,
+							Port:             "8000",
+							Path:             "/metrics",
+							TargetMetric:     "running_requests",
+							TargetValue:      "1",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "targetMetric",
+		},
+		"Known POD TargetMetric Is Allowed": {
+			pa: &autoscalingv1alpha1.PodAutoscaler{
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					ScaleTargetRef: corev1.ObjectReference{
+						Name: "test-deployment",
+						Kind: "Deployment",
+					},
+					MaxReplicas:     6,
+					ScalingStrategy: autoscalingv1alpha1.APA,
+					MetricsSources: []autoscalingv1alpha1.MetricSource{
+						{
+							MetricSourceType: autoscalingv1alpha1.POD,
+							ProtocolType:     autoscalingv1alpha1.HTTP,
+							Port:             "8000",
+							Path:             "/metrics",
+							TargetMetric:     "num_requests_running",
+							TargetValue:      "1",
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
 		"Observe Window Must Be Positive": {
 			pa: &autoscalingv1alpha1.PodAutoscaler{
 				Spec: autoscalingv1alpha1.PodAutoscalerSpec{

--- a/pkg/webhook/podautoscaler_webhook_test.go
+++ b/pkg/webhook/podautoscaler_webhook_test.go
@@ -396,7 +396,7 @@ func TestPodAutoscalerCustomValidator_validatePodAutoscaler(t *testing.T) {
 			},
 			expectError: false,
 		},
-		"Unknown POD TargetMetric Is Rejected": {
+		"Unregistered POD TargetMetric Is Allowed": {
 			pa: &autoscalingv1alpha1.PodAutoscaler{
 				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
 					ScaleTargetRef: corev1.ObjectReference{
@@ -417,8 +417,7 @@ func TestPodAutoscalerCustomValidator_validatePodAutoscaler(t *testing.T) {
 					},
 				},
 			},
-			expectError: true,
-			errorMsg:    "targetMetric",
+			expectError: false,
 		},
 		"Known POD TargetMetric Is Allowed": {
 			pa: &autoscalingv1alpha1.PodAutoscaler{


### PR DESCRIPTION
## Pull Request Description

KPA/APA treated a missing pod metric as `0`, so an unknown `targetMetric` (for example `running_requests` instead of `num_requests_running`) looked like idle load and scaled the workload down. `subTargetSelector.roleName` was also accepted on a Deployment even though role-level scaling is StormService-only.

This change:

- Makes `RestMetricsFetcher` return fetch errors instead of a synthetic `0`. Collector/autoscaler already skip failed scrapes; if every source fails, reconcile reports `FailedComputeScale` and does not change replica count.
- Does **not** reject `metricSourceType=pod` `targetMetric` names against the central registry. Admission and controller spec validation stay open so unregistered (but otherwise valid) pod metrics are not blocked. Kubernetes `external`/`domain`/`custom` metrics are unchanged.
- Rejects `subTargetSelector.roleName` unless `scaleTargetRef.kind` is `StormService` (HPA + roleName remains forbidden).

The current registry key is `num_requests_running`. `running_requests` is not aliased; a typo still fails at scrape time rather than scaling down.

## Related Issues
Resolves: #2591