### PR TITLE
[Bug] Reject unparseable metric targetValue in controller and surface HPA generation failures in status

### DIFF
--- a/pkg/controller/podautoscaler/hpa_resources.go
+++ b/pkg/controller/podautoscaler/hpa_resources.go
@@ -99,7 +99,7 @@ func makeHPAWithBounds(pa *pav1.PodAutoscaler, scalingContext scalingctx.Scaling
 				})
 
 			case pav1.Memory:
-				memory := resource.NewQuantity(int64(targetValue)*1024*1024, resource.BinarySI)
+				memory := resource.NewQuantity(int64(math.Ceil(targetValue))*1024*1024, resource.BinarySI)
 				hpa.Spec.Metrics = append(hpa.Spec.Metrics, autoscalingv2.MetricSpec{
 					Type: autoscalingv2.ResourceMetricSourceType,
 					Resource: &autoscalingv2.ResourceMetricSource{
@@ -112,7 +112,7 @@ func makeHPAWithBounds(pa *pav1.PodAutoscaler, scalingContext scalingctx.Scaling
 				})
 
 			default:
-				targetQuantity := resource.NewQuantity(int64(targetValue), resource.DecimalSI)
+				targetQuantity := resource.NewQuantity(int64(math.Ceil(targetValue)), resource.DecimalSI)
 				hpa.Spec.Metrics = append(hpa.Spec.Metrics, autoscalingv2.MetricSpec{
 					Type: autoscalingv2.PodsMetricSourceType,
 					Pods: &autoscalingv2.PodsMetricSource{

--- a/pkg/controller/podautoscaler/hpa_resources.go
+++ b/pkg/controller/podautoscaler/hpa_resources.go
@@ -17,13 +17,14 @@ limitations under the License.
 package podautoscaler
 
 import (
+	"errors"
 	"fmt"
 	"math"
-	"strconv"
 	"strings"
 
 	pav1 "github.com/vllm-project/aibrix/api/autoscaling/v1alpha1"
 	scalingctx "github.com/vllm-project/aibrix/pkg/controller/podautoscaler/context"
+	"github.com/vllm-project/aibrix/pkg/utils/pametrics"
 	"github.com/vllm-project/aibrix/pkg/utils/paschedules"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -32,6 +33,8 @@ import (
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 )
+
+var errInvalidHPABounds = errors.New("invalid HPA replica bounds")
 
 // MakeHPA creates an HPA resource from a PodAutoscaler resource.
 func makeHPA(pa *pav1.PodAutoscaler, scalingContext scalingctx.ScalingContext) (*autoscalingv2.HorizontalPodAutoscaler, error) {
@@ -68,7 +71,7 @@ func makeHPAWithBounds(pa *pav1.PodAutoscaler, scalingContext scalingctx.Scaling
 		hpa.Spec.MinReplicas = &minReplicas
 		// if minReplicas exist, check validation of minReplicas and maxReplicas
 		if maxReplicas < minReplicas {
-			return nil, fmt.Errorf("HPA Strategy: maxReplicas %d must be equal or larger than minReplicas %d", maxReplicas, minReplicas)
+			return nil, fmt.Errorf("%w: HPA Strategy: maxReplicas %d must be equal or larger than minReplicas %d", errInvalidHPABounds, maxReplicas, minReplicas)
 		}
 	}
 
@@ -79,7 +82,7 @@ func makeHPAWithBounds(pa *pav1.PodAutoscaler, scalingContext scalingctx.Scaling
 	}
 
 	for _, source := range sources {
-		if targetValue, err := strconv.ParseFloat(source.TargetValue, 64); err != nil {
+		if targetValue, err := pametrics.ParseTargetValue(source.TargetValue); err != nil {
 			return nil, fmt.Errorf("failed to parse target value of the metric source: %w", err)
 		} else {
 			klog.V(4).InfoS("Creating HPA", "metric", source.TargetMetric, "target", targetValue)

--- a/pkg/controller/podautoscaler/hpa_resources.go
+++ b/pkg/controller/podautoscaler/hpa_resources.go
@@ -82,7 +82,7 @@ func makeHPAWithBounds(pa *pav1.PodAutoscaler, scalingContext scalingctx.Scaling
 	}
 
 	for _, source := range sources {
-		if targetValue, err := pametrics.ParseTargetValue(source.TargetValue); err != nil {
+		if targetValue, err := pametrics.ParseHPATargetValue(source.TargetValue, source.TargetMetric); err != nil {
 			return nil, fmt.Errorf("failed to parse target value of the metric source: %w", err)
 		} else {
 			klog.V(4).InfoS("Creating HPA", "metric", source.TargetMetric, "target", targetValue)

--- a/pkg/controller/podautoscaler/hpa_resources_test.go
+++ b/pkg/controller/podautoscaler/hpa_resources_test.go
@@ -171,6 +171,53 @@ func TestMakeHPA(t *testing.T) {
 	assert.Equal(t, expectedHPA, actualHPA)
 }
 
+func TestMakeHPAFractionalTargetValueRoundsUp(t *testing.T) {
+	pa := &autoscalingv1alpha1.PodAutoscaler{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-fractional-pa",
+			Namespace: "default",
+		},
+		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+			ScaleTargetRef: corev1.ObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "test-llm",
+			},
+			MinReplicas: ptr.To(int32(1)),
+			MaxReplicas: int32(5),
+			MetricsSources: []autoscalingv1alpha1.MetricSource{
+				{
+					MetricSourceType: autoscalingv1alpha1.RESOURCE,
+					TargetMetric:     "memory",
+					TargetValue:      "0.5",
+				},
+				{
+					MetricSourceType: autoscalingv1alpha1.POD,
+					TargetMetric:     "gpu_cache_usage_perc",
+					TargetValue:      "1.2",
+				},
+			},
+		},
+	}
+
+	hpa, err := makeHPA(pa, context.NewBaseScalingContext())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, hpa)
+	assert.Len(t, hpa.Spec.Metrics, 2)
+
+	// Fractional targetValue must round up (like the CPU path) instead of being
+	// truncated by int64(): 0.5 MiB -> 1 MiB, never 0 bytes.
+	memoryTarget := hpa.Spec.Metrics[0].Resource.Target
+	assert.NotNil(t, memoryTarget.AverageValue)
+	assert.Equal(t, int64(1*1024*1024), memoryTarget.AverageValue.Value())
+
+	// 1.2 -> 2 for pod metrics.
+	podsTarget := hpa.Spec.Metrics[1].Pods.Target
+	assert.NotNil(t, podsTarget.AverageValue)
+	assert.Equal(t, int64(2), podsTarget.AverageValue.Value())
+}
+
 func TestMakeHPAWithScheduledBounds(t *testing.T) {
 	pa := &autoscalingv1alpha1.PodAutoscaler{
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/controller/podautoscaler/hpa_resources_test.go
+++ b/pkg/controller/podautoscaler/hpa_resources_test.go
@@ -249,3 +249,26 @@ func TestMakeHPAWithScheduledBounds(t *testing.T) {
 	assert.Equal(t, int32(3), *hpa.Spec.MinReplicas)
 	assert.Equal(t, int32(12), hpa.Spec.MaxReplicas)
 }
+
+func TestMakeHPAWithInvalidScheduledBounds(t *testing.T) {
+	pa := &autoscalingv1alpha1.PodAutoscaler{
+		ObjectMeta: v1.ObjectMeta{Name: "test-llm-pa", Namespace: "default"},
+		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+			ScaleTargetRef: corev1.ObjectReference{APIVersion: "apps/v1", Kind: "Deployment", Name: "test-llm"},
+			MetricsSources: []autoscalingv1alpha1.MetricSource{{
+				MetricSourceType: autoscalingv1alpha1.RESOURCE,
+				TargetMetric:     "cpu",
+				TargetValue:      "30",
+			}},
+		},
+	}
+
+	_, err := makeHPAWithBounds(pa, context.NewBaseScalingContext(), paschedules.Bounds{MinReplicas: 3, MaxReplicas: 2})
+
+	assert.ErrorIs(t, err, errInvalidHPABounds)
+	assert.Equal(t, ReasonInvalidBounds, reasonForHPAGenerationError(err))
+}
+
+func TestReasonForHPAGenerationErrorDefaultsToMetricsConfig(t *testing.T) {
+	assert.Equal(t, ReasonMetricsConfigError, reasonForHPAGenerationError(assert.AnError))
+}

--- a/pkg/controller/podautoscaler/hpa_resources_test.go
+++ b/pkg/controller/podautoscaler/hpa_resources_test.go
@@ -218,6 +218,52 @@ func TestMakeHPAFractionalTargetValueRoundsUp(t *testing.T) {
 	assert.Equal(t, int64(2), podsTarget.AverageValue.Value())
 }
 
+func TestMakeHPARejectsTargetValueOverflow(t *testing.T) {
+	tests := map[string]struct {
+		metricSourceType autoscalingv1alpha1.MetricSourceType
+		targetMetric     string
+		targetValue      string
+	}{
+		"cpu": {
+			metricSourceType: autoscalingv1alpha1.RESOURCE,
+			targetMetric:     "cpu",
+			targetValue:      "2147483647.1",
+		},
+		"memory": {
+			metricSourceType: autoscalingv1alpha1.RESOURCE,
+			targetMetric:     "memory",
+			targetValue:      "8796093022207.1",
+		},
+		"pods": {
+			metricSourceType: autoscalingv1alpha1.CUSTOM,
+			targetMetric:     "requests",
+			targetValue:      "9223372036854775808",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			pa := &autoscalingv1alpha1.PodAutoscaler{
+				ObjectMeta: v1.ObjectMeta{Name: "test-overflow-pa", Namespace: "default"},
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					ScaleTargetRef: corev1.ObjectReference{APIVersion: "apps/v1", Kind: "Deployment", Name: "test-llm"},
+					MinReplicas:    ptr.To(int32(1)),
+					MaxReplicas:    5,
+					MetricsSources: []autoscalingv1alpha1.MetricSource{{
+						MetricSourceType: tt.metricSourceType,
+						TargetMetric:     tt.targetMetric,
+						TargetValue:      tt.targetValue,
+					}},
+				},
+			}
+
+			_, err := makeHPA(pa, context.NewBaseScalingContext())
+
+			assert.ErrorContains(t, err, "must be representable as an HPA metric target")
+		})
+	}
+}
+
 func TestMakeHPAWithScheduledBounds(t *testing.T) {
 	pa := &autoscalingv1alpha1.PodAutoscaler{
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -29,6 +29,8 @@ package podautoscaler
 import (
 	"context"
 	"fmt"
+	"math"
+	"strconv"
 	"sync"
 	"time"
 
@@ -499,6 +501,22 @@ func (r *PodAutoscalerReconciler) validateMetricsSources(pa *autoscalingv1alpha1
 			return invalid(ReasonMetricsConfigError,
 				fmt.Sprintf("metricsSource[%d]: targetValue must be specified", i))
 		}
+		// Mirror the webhook's validateMetricTargetValue: targetValue must be a
+		// plain positive float (e.g., "50"), not a Kubernetes quantity (e.g., "100m").
+		// Without this check an unparseable value passes validateSpec and later
+		// fails in makeHPAWithBounds, leaving the PodAutoscaler stuck reporting
+		// ValidSpec=True/Ready=True while no HPA can ever be generated.
+		targetValue, err := strconv.ParseFloat(ms.TargetValue, 64)
+		if err != nil {
+			return invalid(ReasonMetricsConfigError,
+				fmt.Sprintf("metricsSource[%d]: targetValue %q must be a valid number", i, ms.TargetValue))
+		}
+		// ParseFloat accepts "NaN", "Inf" and "Infinity" without error, and NaN
+		// comparisons are always false, so these must be rejected explicitly.
+		if math.IsNaN(targetValue) || math.IsInf(targetValue, 0) || targetValue <= 0 {
+			return invalid(ReasonMetricsConfigError,
+				fmt.Sprintf("metricsSource[%d]: targetValue %q must be a finite number greater than 0", i, ms.TargetValue))
+		}
 
 		var result ValidationResult
 		switch ms.MetricSourceType {
@@ -612,7 +630,9 @@ func (r *PodAutoscalerReconciler) setInvalidSpecStatus(
 		Conditions:      conds,
 		ScheduledBounds: scheduledBoundsStatus(pa, time.Now()),
 	}
-	return r.updateStatusIfNeeded(ctx, st, pa)
+	paCopy := pa.DeepCopy()
+	paCopy.Status = *st
+	return r.updateStatusIfNeeded(ctx, &pa.Status, paCopy)
 }
 
 // Run periodically enqueues all PodAutoscaler objects until ctx is cancelled.
@@ -745,6 +765,11 @@ func (r *PodAutoscalerReconciler) reconcileHPA(ctx context.Context, pa autoscali
 	hpa, err := makeHPAWithBounds(&pa, scalingContext, bounds)
 	if err != nil {
 		klog.ErrorS(err, "Failed to generate a HPA object", "PA", ktypes.NamespacedName{Name: pa.Name, Namespace: pa.Namespace})
+		// Surface the failure in the PodAutoscaler conditions so the resource
+		// never keeps reporting Ready/ValidSpec while no HPA can be generated.
+		if statusErr := r.setInvalidSpecStatus(ctx, &pa, ReasonMetricsConfigError, err.Error()); statusErr != nil {
+			klog.ErrorS(statusErr, "Failed to update PodAutoscaler status after HPA generation failure", "PA", ktypes.NamespacedName{Name: pa.Name, Namespace: pa.Namespace})
+		}
 		return ctrl.Result{}, err
 	}
 	hpaName := ktypes.NamespacedName{

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -28,9 +28,8 @@ package podautoscaler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
-	"math"
-	"strconv"
 	"sync"
 	"time"
 
@@ -41,6 +40,7 @@ import (
 	"github.com/vllm-project/aibrix/pkg/controller/podautoscaler/metrics"
 	"github.com/vllm-project/aibrix/pkg/controller/podautoscaler/monitor"
 	podutils "github.com/vllm-project/aibrix/pkg/utils"
+	"github.com/vllm-project/aibrix/pkg/utils/pametrics"
 	"github.com/vllm-project/aibrix/pkg/utils/paschedules"
 	"k8s.io/apimachinery/pkg/labels"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -48,7 +48,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -285,7 +285,7 @@ func (r *PodAutoscalerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	var pa autoscalingv1alpha1.PodAutoscaler
 	if err := r.Get(ctx, req.NamespacedName, &pa); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Object might have been deleted after reconcile request
 			r.cleanupDeletedPA(req.NamespacedName)
 			klog.Infof("PodAutoscaler resource not found. Object %s must have been deleted", req.NamespacedName)
@@ -501,21 +501,10 @@ func (r *PodAutoscalerReconciler) validateMetricsSources(pa *autoscalingv1alpha1
 			return invalid(ReasonMetricsConfigError,
 				fmt.Sprintf("metricsSource[%d]: targetValue must be specified", i))
 		}
-		// Mirror the webhook's validateMetricTargetValue: targetValue must be a
-		// plain positive float (e.g., "50"), not a Kubernetes quantity (e.g., "100m").
-		// Without this check an unparseable value passes validateSpec and later
-		// fails in makeHPAWithBounds, leaving the PodAutoscaler stuck reporting
-		// ValidSpec=True/Ready=True while no HPA can ever be generated.
-		targetValue, err := strconv.ParseFloat(ms.TargetValue, 64)
+		_, err := pametrics.ParseTargetValue(ms.TargetValue)
 		if err != nil {
 			return invalid(ReasonMetricsConfigError,
-				fmt.Sprintf("metricsSource[%d]: targetValue %q must be a valid number", i, ms.TargetValue))
-		}
-		// ParseFloat accepts "NaN", "Inf" and "Infinity" without error, and NaN
-		// comparisons are always false, so these must be rejected explicitly.
-		if math.IsNaN(targetValue) || math.IsInf(targetValue, 0) || targetValue <= 0 {
-			return invalid(ReasonMetricsConfigError,
-				fmt.Sprintf("metricsSource[%d]: targetValue %q must be a finite number greater than 0", i, ms.TargetValue))
+				fmt.Sprintf("metricsSource[%d]: targetValue %q %s", i, ms.TargetValue, err))
 		}
 
 		var result ValidationResult
@@ -605,7 +594,10 @@ func (r *PodAutoscalerReconciler) setInvalidSpecStatus(
 	pa *autoscalingv1alpha1.PodAutoscaler,
 	reason, msg string,
 ) error {
-	conds := pa.Status.Conditions
+	// SetStatusCondition updates existing entries in place. Work on a deep copy
+	// so the old status remains an immutable baseline for updateStatusIfNeeded.
+	paCopy := pa.DeepCopy()
+	conds := paCopy.Status.Conditions
 	now := metav1.Now()
 
 	apimeta.SetStatusCondition(&conds, metav1.Condition{
@@ -624,13 +616,12 @@ func (r *PodAutoscalerReconciler) setInvalidSpecStatus(
 	})
 
 	st := &autoscalingv1alpha1.PodAutoscalerStatus{
-		LastScaleTime:   pa.Status.LastScaleTime,
-		DesiredScale:    pa.Status.DesiredScale,
-		ActualScale:     pa.Status.ActualScale,
+		LastScaleTime:   paCopy.Status.LastScaleTime,
+		DesiredScale:    paCopy.Status.DesiredScale,
+		ActualScale:     paCopy.Status.ActualScale,
 		Conditions:      conds,
-		ScheduledBounds: scheduledBoundsStatus(pa, time.Now()),
+		ScheduledBounds: scheduledBoundsStatus(paCopy, time.Now()),
 	}
-	paCopy := pa.DeepCopy()
 	paCopy.Status = *st
 	return r.updateStatusIfNeeded(ctx, &pa.Status, paCopy)
 }
@@ -685,11 +676,14 @@ func (r *PodAutoscalerReconciler) enqueuePodAutoscalers(ctx context.Context) err
 func computeStatus(ctx context.Context, pa autoscalingv1alpha1.PodAutoscaler,
 	specValidationResult, conflictValidationResult ValidationResult) *autoscalingv1alpha1.PodAutoscalerStatus {
 	now := metav1.Now()
+	// SetStatusCondition mutates existing entries in place, so the desired
+	// status must not share the input status's Conditions backing array.
+	conditions := pa.Status.DeepCopy().Conditions
 	st := &autoscalingv1alpha1.PodAutoscalerStatus{
 		LastScaleTime:   pa.Status.LastScaleTime,
 		DesiredScale:    pa.Status.DesiredScale,
 		ActualScale:     pa.Status.ActualScale,
-		Conditions:      pa.Status.Conditions, // upsert onto existing
+		Conditions:      conditions, // upsert onto an isolated copy
 		ScheduledBounds: scheduledBoundsStatus(&pa, now.Time),
 	}
 
@@ -767,7 +761,7 @@ func (r *PodAutoscalerReconciler) reconcileHPA(ctx context.Context, pa autoscali
 		klog.ErrorS(err, "Failed to generate a HPA object", "PA", ktypes.NamespacedName{Name: pa.Name, Namespace: pa.Namespace})
 		// Surface the failure in the PodAutoscaler conditions so the resource
 		// never keeps reporting Ready/ValidSpec while no HPA can be generated.
-		if statusErr := r.setInvalidSpecStatus(ctx, &pa, ReasonMetricsConfigError, err.Error()); statusErr != nil {
+		if statusErr := r.setInvalidSpecStatus(ctx, &pa, reasonForHPAGenerationError(err), err.Error()); statusErr != nil {
 			klog.ErrorS(statusErr, "Failed to update PodAutoscaler status after HPA generation failure", "PA", ktypes.NamespacedName{Name: pa.Name, Namespace: pa.Namespace})
 		}
 		return ctrl.Result{}, err
@@ -779,7 +773,7 @@ func (r *PodAutoscalerReconciler) reconcileHPA(ctx context.Context, pa autoscali
 
 	existingHPA := &autoscalingv2.HorizontalPodAutoscaler{}
 	err = r.Get(ctx, hpaName, existingHPA)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && apierrors.IsNotFound(err) {
 		// HPA does not exist, create a new one.
 		klog.InfoS("Creating a new HPA", "HPA", hpaName)
 		if err = r.Create(ctx, hpa); err != nil {
@@ -813,6 +807,13 @@ func (r *PodAutoscalerReconciler) reconcileHPA(ctx context.Context, pa autoscali
 		klog.ErrorS(err, "Failed to update PodAutoscaler status")
 	}
 	return resultWithNextScheduleRequeue(&pa, now), nil
+}
+
+func reasonForHPAGenerationError(err error) string {
+	if stderrors.Is(err, errInvalidHPABounds) {
+		return ReasonInvalidBounds
+	}
+	return ReasonMetricsConfigError
 }
 
 // reconcileCustomPA handles KPA and APA strategies using WorkloadScaler (generic /scale or StormService role-level).

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -294,6 +294,12 @@ func (r *PodAutoscalerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		klog.ErrorS(err, "Failed to get PodAutoscaler", "obj", req.NamespacedName)
 		return ctrl.Result{}, err
 	}
+	// Deterministic spec failures are terminal for the current generation. A
+	// status update also enqueues the object, so honor the recorded generation
+	// instead of briefly reporting the same unchanged spec as valid again.
+	if hasObservedInvalidSpec(&pa) {
+		return ctrl.Result{}, nil
+	}
 
 	// validate spec; if invalid, write conditions and exit without requeue
 	specVR := r.validateSpec(&pa)
@@ -501,7 +507,12 @@ func (r *PodAutoscalerReconciler) validateMetricsSources(pa *autoscalingv1alpha1
 			return invalid(ReasonMetricsConfigError,
 				fmt.Sprintf("metricsSource[%d]: targetValue must be specified", i))
 		}
-		_, err := pametrics.ParseTargetValue(ms.TargetValue)
+		var err error
+		if pa.Spec.ScalingStrategy == autoscalingv1alpha1.HPA {
+			_, err = pametrics.ParseHPATargetValue(ms.TargetValue, ms.TargetMetric)
+		} else {
+			_, err = pametrics.ParseTargetValue(ms.TargetValue)
+		}
 		if err != nil {
 			return invalid(ReasonMetricsConfigError,
 				fmt.Sprintf("metricsSource[%d]: targetValue %q %s", i, ms.TargetValue, err))
@@ -605,6 +616,15 @@ func (r *PodAutoscalerReconciler) setInvalidSpecStatus(
 		Status:             metav1.ConditionFalse,
 		Reason:             reason,
 		Message:            msg,
+		ObservedGeneration: pa.Generation,
+		LastTransitionTime: now,
+	})
+	apimeta.SetStatusCondition(&conds, metav1.Condition{
+		Type:               ConditionAbleToScale,
+		Status:             metav1.ConditionFalse,
+		Reason:             ReasonInvalidSpec,
+		Message:            msg,
+		ObservedGeneration: pa.Generation,
 		LastTransitionTime: now,
 	})
 	apimeta.SetStatusCondition(&conds, metav1.Condition{
@@ -612,6 +632,7 @@ func (r *PodAutoscalerReconciler) setInvalidSpecStatus(
 		Status:             metav1.ConditionFalse,
 		Reason:             ReasonInvalidSpec,
 		Message:            "Spec invalid; controller will not reconcile until fixed.",
+		ObservedGeneration: pa.Generation,
 		LastTransitionTime: now,
 	})
 
@@ -620,6 +641,7 @@ func (r *PodAutoscalerReconciler) setInvalidSpecStatus(
 		DesiredScale:    paCopy.Status.DesiredScale,
 		ActualScale:     paCopy.Status.ActualScale,
 		Conditions:      conds,
+		ScalingHistory:  paCopy.Status.ScalingHistory,
 		ScheduledBounds: scheduledBoundsStatus(paCopy, time.Now()),
 	}
 	paCopy.Status = *st
@@ -684,6 +706,7 @@ func computeStatus(ctx context.Context, pa autoscalingv1alpha1.PodAutoscaler,
 		DesiredScale:    pa.Status.DesiredScale,
 		ActualScale:     pa.Status.ActualScale,
 		Conditions:      conditions, // upsert onto an isolated copy
+		ScalingHistory:  pa.Status.ScalingHistory,
 		ScheduledBounds: scheduledBoundsStatus(&pa, now.Time),
 	}
 
@@ -693,6 +716,7 @@ func computeStatus(ctx context.Context, pa autoscalingv1alpha1.PodAutoscaler,
 		Status:             boolToCond(specValidationResult.Valid),
 		Reason:             map[bool]string{true: ReasonAsExpected, false: specValidationResult.Reason}[specValidationResult.Valid],
 		Message:            specValidationResult.Message,
+		ObservedGeneration: pa.Generation,
 		LastTransitionTime: now,
 	})
 
@@ -763,8 +787,9 @@ func (r *PodAutoscalerReconciler) reconcileHPA(ctx context.Context, pa autoscali
 		// never keeps reporting Ready/ValidSpec while no HPA can be generated.
 		if statusErr := r.setInvalidSpecStatus(ctx, &pa, reasonForHPAGenerationError(err), err.Error()); statusErr != nil {
 			klog.ErrorS(statusErr, "Failed to update PodAutoscaler status after HPA generation failure", "PA", ktypes.NamespacedName{Name: pa.Name, Namespace: pa.Namespace})
+			return ctrl.Result{}, stderrors.Join(err, statusErr)
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, nil
 	}
 	hpaName := ktypes.NamespacedName{
 		Name:      hpa.Name,
@@ -814,6 +839,14 @@ func reasonForHPAGenerationError(err error) string {
 		return ReasonInvalidBounds
 	}
 	return ReasonMetricsConfigError
+}
+
+func hasObservedInvalidSpec(pa *autoscalingv1alpha1.PodAutoscaler) bool {
+	condition := apimeta.FindStatusCondition(pa.Status.Conditions, ConditionValidSpec)
+	return pa.Generation > 0 &&
+		condition != nil &&
+		condition.Status == metav1.ConditionFalse &&
+		condition.ObservedGeneration == pa.Generation
 }
 
 // reconcileCustomPA handles KPA and APA strategies using WorkloadScaler (generic /scale or StormService role-level).

--- a/pkg/controller/podautoscaler/podautoscaler_controller_test.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -403,6 +404,41 @@ func TestValidateSpecRejectsInvalidTargetValue(t *testing.T) {
 	}
 }
 
+func TestValidateSpecRejectsHPATargetValueOverflow(t *testing.T) {
+	tests := map[string]struct {
+		targetMetric string
+		targetValue  string
+	}{
+		"cpu":    {targetMetric: "cpu", targetValue: "2147483647.1"},
+		"memory": {targetMetric: "memory", targetValue: "8796093022207.1"},
+		"pods":   {targetMetric: "requests", targetValue: "9223372036854775808"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			pa := validPodAutoscalerForSpec()
+			pa.Spec.ScalingStrategy = autoscalingv1alpha1.HPA
+			pa.Spec.MetricsSources[0].TargetMetric = tt.targetMetric
+			pa.Spec.MetricsSources[0].TargetValue = tt.targetValue
+			if tt.targetMetric != "cpu" && tt.targetMetric != "memory" {
+				pa.Spec.MetricsSources[0].MetricSourceType = autoscalingv1alpha1.CUSTOM
+			}
+
+			result := (&PodAutoscalerReconciler{}).validateSpec(pa)
+
+			if result.Valid {
+				t.Fatalf("expected HPA targetValue %q for %s to be rejected", tt.targetValue, tt.targetMetric)
+			}
+			if result.Reason != ReasonMetricsConfigError {
+				t.Fatalf("expected reason=%s, got %s", ReasonMetricsConfigError, result.Reason)
+			}
+			if !strings.Contains(result.Message, "must be representable as an HPA metric target") {
+				t.Fatalf("unexpected message: %q", result.Message)
+			}
+		})
+	}
+}
+
 func TestSetInvalidSpecStatusPersistsConditions(t *testing.T) {
 	ctx := context.Background()
 
@@ -416,6 +452,15 @@ func TestSetInvalidSpecStatusPersistsConditions(t *testing.T) {
 	pa.Kind = "PodAutoscaler"
 	pa.Namespace = ns
 	pa.Name = "test-pa"
+	pa.Generation = 7
+	pa.Status.ScalingHistory = []autoscalingv1alpha1.ScalingDecision{{
+		Timestamp:     metav1.NewTime(time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)),
+		PreviousScale: 1,
+		NewScale:      2,
+		Reason:        "test scaling decision",
+		Success:       true,
+	}}
+	wantScalingHistory := append([]autoscalingv1alpha1.ScalingDecision(nil), pa.Status.ScalingHistory...)
 	// Simulate an existing PodAutoscaler after a successful reconcile. In this
 	// case every condition updated by setInvalidSpecStatus already exists, so no
 	// append can accidentally hide a shared Conditions backing array.
@@ -450,14 +495,47 @@ func TestSetInvalidSpecStatusPersistsConditions(t *testing.T) {
 	if validSpec.Reason != ReasonMetricsConfigError {
 		t.Fatalf("expected reason=%s, got %s", ReasonMetricsConfigError, validSpec.Reason)
 	}
+	if validSpec.ObservedGeneration != pa.Generation {
+		t.Fatalf("expected observedGeneration=%d, got %d", pa.Generation, validSpec.ObservedGeneration)
+	}
+	ableToScale := apimeta.FindStatusCondition(latest.Status.Conditions, ConditionAbleToScale)
+	if ableToScale == nil || ableToScale.Status != metav1.ConditionFalse {
+		t.Fatalf("expected AbleToScale=False to be persisted, got %+v", ableToScale)
+	}
 	ready := apimeta.FindStatusCondition(latest.Status.Conditions, ConditionReady)
 	if ready == nil || ready.Status != metav1.ConditionFalse {
 		t.Fatalf("expected Ready=False to be persisted, got %+v", ready)
+	}
+	if len(latest.Status.ScalingHistory) != len(wantScalingHistory) {
+		t.Fatalf("scaling history length changed: got %d, want %d", len(latest.Status.ScalingHistory), len(wantScalingHistory))
+	}
+	gotDecision, wantDecision := latest.Status.ScalingHistory[0], wantScalingHistory[0]
+	if !gotDecision.Timestamp.Time.Equal(wantDecision.Timestamp.Time) ||
+		gotDecision.PreviousScale != wantDecision.PreviousScale ||
+		gotDecision.NewScale != wantDecision.NewScale ||
+		gotDecision.Reason != wantDecision.Reason ||
+		gotDecision.Success != wantDecision.Success ||
+		gotDecision.Error != wantDecision.Error {
+		t.Fatalf("scaling history changed: got %+v, want %+v", latest.Status.ScalingHistory, wantScalingHistory)
+	}
+	if !hasObservedInvalidSpec(latest) {
+		t.Fatal("expected invalid spec to be gated for the observed generation")
+	}
+	latest.Generation++
+	if hasObservedInvalidSpec(latest) {
+		t.Fatal("expected a new spec generation to be reconciled")
 	}
 }
 
 func TestComputeStatusDoesNotMutateInputConditions(t *testing.T) {
 	pa := validPodAutoscalerForSpec()
+	pa.Status.ScalingHistory = []autoscalingv1alpha1.ScalingDecision{{
+		Timestamp:     metav1.NewTime(time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)),
+		PreviousScale: 1,
+		NewScale:      2,
+		Reason:        "test scaling decision",
+		Success:       true,
+	}}
 	for _, condition := range []metav1.Condition{
 		{Type: ConditionValidSpec, Status: metav1.ConditionTrue, Reason: ReasonAsExpected},
 		{Type: ConditionScalingActive, Status: metav1.ConditionFalse, Reason: ReasonStable},
@@ -485,6 +563,9 @@ func TestComputeStatusDoesNotMutateInputConditions(t *testing.T) {
 	ready := apimeta.FindStatusCondition(newStatus.Conditions, ConditionReady)
 	if ready == nil || ready.Status != metav1.ConditionFalse {
 		t.Fatalf("expected computed Ready=False, got %+v", ready)
+	}
+	if !reflect.DeepEqual(newStatus.ScalingHistory, pa.Status.ScalingHistory) {
+		t.Fatalf("computeStatus did not preserve scaling history: got %+v, want %+v", newStatus.ScalingHistory, pa.Status.ScalingHistory)
 	}
 }
 

--- a/pkg/controller/podautoscaler/podautoscaler_controller_test.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller_test.go
@@ -24,11 +24,13 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -340,6 +342,112 @@ func TestValidateSpecRejectsInvalidBaseReplicaBounds(t *testing.T) {
 				t.Fatalf("expected message %q, got %q", tt.wantMessage, result.Message)
 			}
 		})
+	}
+}
+
+func TestValidateSpecRejectsInvalidTargetValue(t *testing.T) {
+	tests := map[string]struct {
+		targetValue string
+		wantReason  string
+		wantMessage string
+	}{
+		"kubernetes quantity format": {
+			targetValue: "100m",
+			wantReason:  ReasonMetricsConfigError,
+			wantMessage: `metricsSource[0]: targetValue "100m" must be a valid number`,
+		},
+		"non-numeric": {
+			targetValue: "abc",
+			wantReason:  ReasonMetricsConfigError,
+			wantMessage: `metricsSource[0]: targetValue "abc" must be a valid number`,
+		},
+		"zero": {
+			targetValue: "0",
+			wantReason:  ReasonMetricsConfigError,
+			wantMessage: `metricsSource[0]: targetValue "0" must be a finite number greater than 0`,
+		},
+		"negative": {
+			targetValue: "-5",
+			wantReason:  ReasonMetricsConfigError,
+			wantMessage: `metricsSource[0]: targetValue "-5" must be a finite number greater than 0`,
+		},
+		"NaN": {
+			targetValue: "NaN",
+			wantReason:  ReasonMetricsConfigError,
+			wantMessage: `metricsSource[0]: targetValue "NaN" must be a finite number greater than 0`,
+		},
+		"positive infinity": {
+			targetValue: "+Inf",
+			wantReason:  ReasonMetricsConfigError,
+			wantMessage: `metricsSource[0]: targetValue "+Inf" must be a finite number greater than 0`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			pa := validPodAutoscalerForSpec()
+			pa.Spec.MetricsSources[0].TargetValue = tt.targetValue
+
+			result := (&PodAutoscalerReconciler{}).validateSpec(pa)
+
+			if result.Valid {
+				t.Fatalf("expected targetValue %q to be rejected", tt.targetValue)
+			}
+			if result.Reason != tt.wantReason {
+				t.Fatalf("expected reason=%s, got %s", tt.wantReason, result.Reason)
+			}
+			if result.Message != tt.wantMessage {
+				t.Fatalf("expected message %q, got %q", tt.wantMessage, result.Message)
+			}
+		})
+	}
+}
+
+func TestSetInvalidSpecStatusPersistsConditions(t *testing.T) {
+	ctx := context.Background()
+
+	sch := runtime.NewScheme()
+	_ = scheme.AddToScheme(sch)
+	_ = corev1.AddToScheme(sch)
+	_ = autoscalingv1alpha1.AddToScheme(sch)
+
+	pa := validPodAutoscalerForSpec()
+	pa.APIVersion = autoscalingv1alpha1.GroupVersion.String()
+	pa.Kind = "PodAutoscaler"
+	pa.Namespace = ns
+	pa.Name = "test-pa"
+	// Simulate what computeStatus writes during Reconcile: ValidSpec=True.
+	apimeta.SetStatusCondition(&pa.Status.Conditions, metav1.Condition{
+		Type:   ConditionValidSpec,
+		Status: metav1.ConditionTrue,
+		Reason: ReasonAsExpected,
+	})
+
+	cl := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithStatusSubresource(&autoscalingv1alpha1.PodAutoscaler{}).
+		WithObjects(pa).
+		Build()
+	r := &PodAutoscalerReconciler{Client: cl}
+
+	if err := r.setInvalidSpecStatus(ctx, pa, ReasonMetricsConfigError, "boom"); err != nil {
+		t.Fatalf("setInvalidSpecStatus returned error: %v", err)
+	}
+
+	latest := &autoscalingv1alpha1.PodAutoscaler{}
+	if err := cl.Get(ctx, ktypes.NamespacedName{Namespace: ns, Name: "test-pa"}, latest); err != nil {
+		t.Fatalf("failed to get updated PodAutoscaler: %v", err)
+	}
+	validSpec := apimeta.FindStatusCondition(latest.Status.Conditions, ConditionValidSpec)
+	if validSpec == nil || validSpec.Status != metav1.ConditionFalse {
+		t.Fatalf("expected ValidSpec=False to be persisted, got %+v", validSpec)
+	}
+	if validSpec.Reason != ReasonMetricsConfigError {
+		t.Fatalf("expected reason=%s, got %s", ReasonMetricsConfigError, validSpec.Reason)
+	}
+	ready := apimeta.FindStatusCondition(latest.Status.Conditions, ConditionReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse {
+		t.Fatalf("expected Ready=False to be persisted, got %+v", ready)
 	}
 }
 

--- a/pkg/controller/podautoscaler/podautoscaler_controller_test.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller_test.go
@@ -416,12 +416,17 @@ func TestSetInvalidSpecStatusPersistsConditions(t *testing.T) {
 	pa.Kind = "PodAutoscaler"
 	pa.Namespace = ns
 	pa.Name = "test-pa"
-	// Simulate what computeStatus writes during Reconcile: ValidSpec=True.
-	apimeta.SetStatusCondition(&pa.Status.Conditions, metav1.Condition{
-		Type:   ConditionValidSpec,
-		Status: metav1.ConditionTrue,
-		Reason: ReasonAsExpected,
-	})
+	// Simulate an existing PodAutoscaler after a successful reconcile. In this
+	// case every condition updated by setInvalidSpecStatus already exists, so no
+	// append can accidentally hide a shared Conditions backing array.
+	for _, condition := range []metav1.Condition{
+		{Type: ConditionValidSpec, Status: metav1.ConditionTrue, Reason: ReasonAsExpected},
+		{Type: ConditionScalingActive, Status: metav1.ConditionFalse, Reason: ReasonStable},
+		{Type: ConditionAbleToScale, Status: metav1.ConditionTrue, Reason: ReasonConfigured},
+		{Type: ConditionReady, Status: metav1.ConditionTrue, Reason: ReasonAsExpected},
+	} {
+		apimeta.SetStatusCondition(&pa.Status.Conditions, condition)
+	}
 
 	cl := fake.NewClientBuilder().
 		WithScheme(sch).
@@ -448,6 +453,38 @@ func TestSetInvalidSpecStatusPersistsConditions(t *testing.T) {
 	ready := apimeta.FindStatusCondition(latest.Status.Conditions, ConditionReady)
 	if ready == nil || ready.Status != metav1.ConditionFalse {
 		t.Fatalf("expected Ready=False to be persisted, got %+v", ready)
+	}
+}
+
+func TestComputeStatusDoesNotMutateInputConditions(t *testing.T) {
+	pa := validPodAutoscalerForSpec()
+	for _, condition := range []metav1.Condition{
+		{Type: ConditionValidSpec, Status: metav1.ConditionTrue, Reason: ReasonAsExpected},
+		{Type: ConditionScalingActive, Status: metav1.ConditionFalse, Reason: ReasonStable},
+		{Type: ConditionAbleToScale, Status: metav1.ConditionTrue, Reason: ReasonConfigured},
+		{Type: ConditionReady, Status: metav1.ConditionTrue, Reason: ReasonAsExpected},
+	} {
+		apimeta.SetStatusCondition(&pa.Status.Conditions, condition)
+	}
+	originalStatus := pa.Status.DeepCopy()
+
+	newStatus := computeStatus(
+		context.Background(),
+		*pa,
+		invalid(ReasonMetricsConfigError, "invalid targetValue"),
+		validOK(),
+	)
+
+	if !reflect.DeepEqual(pa.Status, *originalStatus) {
+		t.Fatalf("computeStatus mutated its input status: got %+v, want %+v", pa.Status, *originalStatus)
+	}
+	validSpec := apimeta.FindStatusCondition(newStatus.Conditions, ConditionValidSpec)
+	if validSpec == nil || validSpec.Status != metav1.ConditionFalse {
+		t.Fatalf("expected computed ValidSpec=False, got %+v", validSpec)
+	}
+	ready := apimeta.FindStatusCondition(newStatus.Conditions, ConditionReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse {
+		t.Fatalf("expected computed Ready=False, got %+v", ready)
 	}
 }
 

--- a/pkg/utils/pametrics/target_value.go
+++ b/pkg/utils/pametrics/target_value.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pametrics
+
+import (
+	"errors"
+	"math"
+	"strconv"
+)
+
+var (
+	errInvalidTargetValue     = errors.New("must be a valid number")
+	errNonPositiveTargetValue = errors.New("must be a finite number greater than 0")
+)
+
+// ParseTargetValue parses the plain positive floating-point format shared by
+// PodAutoscaler admission, controller validation, and HPA generation.
+func ParseTargetValue(value string) (float64, error) {
+	targetValue, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, errInvalidTargetValue
+	}
+	if math.IsNaN(targetValue) || math.IsInf(targetValue, 0) || targetValue <= 0 {
+		return 0, errNonPositiveTargetValue
+	}
+	return targetValue, nil
+}

--- a/pkg/utils/pametrics/target_value.go
+++ b/pkg/utils/pametrics/target_value.go
@@ -18,14 +18,19 @@ package pametrics
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"strconv"
+	"strings"
 )
 
 var (
 	errInvalidTargetValue     = errors.New("must be a valid number")
 	errNonPositiveTargetValue = errors.New("must be a finite number greater than 0")
+	errTargetValueOutOfRange  = errors.New("must be representable as an HPA metric target")
 )
+
+const bytesPerMiB = int64(1024 * 1024)
 
 // ParseTargetValue parses the plain positive floating-point format shared by
 // PodAutoscaler admission, controller validation, and HPA generation.
@@ -36,6 +41,32 @@ func ParseTargetValue(value string) (float64, error) {
 	}
 	if math.IsNaN(targetValue) || math.IsInf(targetValue, 0) || targetValue <= 0 {
 		return 0, errNonPositiveTargetValue
+	}
+	return targetValue, nil
+}
+
+// ParseHPATargetValue parses a target value and verifies that rounding it up
+// cannot overflow the integer representation used by the HPA API.
+func ParseHPATargetValue(value, targetMetric string) (float64, error) {
+	targetValue, err := ParseTargetValue(value)
+	if err != nil {
+		return 0, err
+	}
+
+	roundedTarget := math.Ceil(targetValue)
+	var inRange bool
+	switch strings.ToLower(targetMetric) {
+	case "cpu":
+		inRange = roundedTarget <= math.MaxInt32
+	case "memory":
+		inRange = roundedTarget <= float64(math.MaxInt64/bytesPerMiB)
+	default:
+		// float64(math.MaxInt64) rounds to 2^63, which is already outside
+		// the int64 range, so use an exclusive upper bound here.
+		inRange = roundedTarget < math.Ldexp(1, 63)
+	}
+	if !inRange {
+		return 0, fmt.Errorf("%w for targetMetric %q", errTargetValueOutOfRange, targetMetric)
 	}
 	return targetValue, nil
 }

--- a/pkg/utils/pametrics/target_value_test.go
+++ b/pkg/utils/pametrics/target_value_test.go
@@ -50,3 +50,31 @@ func TestParseTargetValue(t *testing.T) {
 		})
 	}
 }
+
+func TestParseHPATargetValue(t *testing.T) {
+	tests := map[string]struct {
+		value        string
+		targetMetric string
+		wantErr      error
+	}{
+		"cpu maximum":        {value: "2147483647", targetMetric: "cpu"},
+		"cpu overflow":       {value: "2147483647.1", targetMetric: "cpu", wantErr: errTargetValueOutOfRange},
+		"memory maximum MiB": {value: "8796093022207", targetMetric: "memory"},
+		"memory multiplication overflow": {
+			value:        "8796093022207.1",
+			targetMetric: "memory",
+			wantErr:      errTargetValueOutOfRange,
+		},
+		"pod target below int64 limit": {value: "9223372036854774784", targetMetric: "requests"},
+		"pod target int64 overflow":    {value: "9223372036854775808", targetMetric: "requests", wantErr: errTargetValueOutOfRange},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseHPATargetValue(tt.value, tt.targetMetric)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("ParseHPATargetValue(%q, %q) error=%v, want %v", tt.value, tt.targetMetric, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/utils/pametrics/target_value_test.go
+++ b/pkg/utils/pametrics/target_value_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pametrics
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseTargetValue(t *testing.T) {
+	tests := map[string]struct {
+		value   string
+		want    float64
+		wantErr error
+	}{
+		"integer":           {value: "50", want: 50},
+		"fraction":          {value: "0.5", want: 0.5},
+		"quantity":          {value: "100m", wantErr: errInvalidTargetValue},
+		"non-numeric":       {value: "abc", wantErr: errInvalidTargetValue},
+		"zero":              {value: "0", wantErr: errNonPositiveTargetValue},
+		"negative":          {value: "-1", wantErr: errNonPositiveTargetValue},
+		"not a number":      {value: "NaN", wantErr: errNonPositiveTargetValue},
+		"positive infinity": {value: "+Inf", wantErr: errNonPositiveTargetValue},
+		"negative infinity": {value: "-Inf", wantErr: errNonPositiveTargetValue},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseTargetValue(tt.value)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("ParseTargetValue(%q) error=%v, want %v", tt.value, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseTargetValue(%q)=%v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/webhook/podautoscaler_webhook.go
+++ b/pkg/webhook/podautoscaler_webhook.go
@@ -210,17 +210,17 @@ func validateMetricsSources(pa *autoscalingv1alpha1.PodAutoscaler, specPath *fie
 	}
 	for i := range pa.Spec.MetricsSources {
 		ms := &pa.Spec.MetricsSources[i]
-		errs = append(errs, validateMetricSource(ms, metricsPath.Index(i))...)
+		errs = append(errs, validateMetricSource(ms, pa.Spec.ScalingStrategy, metricsPath.Index(i))...)
 	}
 	return errs
 }
 
-func validateMetricSource(ms *autoscalingv1alpha1.MetricSource, msPath *field.Path) field.ErrorList {
+func validateMetricSource(ms *autoscalingv1alpha1.MetricSource, strategy autoscalingv1alpha1.ScalingStrategyType, msPath *field.Path) field.ErrorList {
 	var errs field.ErrorList
 	if ms.TargetMetric == "" {
 		errs = append(errs, field.Required(msPath.Child("targetMetric"), "must be set"))
 	}
-	errs = append(errs, validateMetricTargetValue(ms, msPath)...)
+	errs = append(errs, validateMetricTargetValue(ms, strategy, msPath)...)
 
 	switch ms.MetricSourceType {
 	case autoscalingv1alpha1.POD:
@@ -243,12 +243,17 @@ func validateMetricSource(ms *autoscalingv1alpha1.MetricSource, msPath *field.Pa
 	return errs
 }
 
-func validateMetricTargetValue(ms *autoscalingv1alpha1.MetricSource, msPath *field.Path) field.ErrorList {
+func validateMetricTargetValue(ms *autoscalingv1alpha1.MetricSource, strategy autoscalingv1alpha1.ScalingStrategyType, msPath *field.Path) field.ErrorList {
 	if ms.TargetValue == "" {
 		return field.ErrorList{field.Required(msPath.Child("targetValue"), "must be set")}
 	}
 
-	_, err := pametrics.ParseTargetValue(ms.TargetValue)
+	var err error
+	if strategy == autoscalingv1alpha1.HPA {
+		_, err = pametrics.ParseHPATargetValue(ms.TargetValue, ms.TargetMetric)
+	} else {
+		_, err = pametrics.ParseTargetValue(ms.TargetValue)
+	}
 	if err != nil {
 		return field.ErrorList{field.Invalid(msPath.Child("targetValue"), ms.TargetValue, err.Error())}
 	}

--- a/pkg/webhook/podautoscaler_webhook.go
+++ b/pkg/webhook/podautoscaler_webhook.go
@@ -19,6 +19,7 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -252,8 +253,10 @@ func validateMetricTargetValue(ms *autoscalingv1alpha1.MetricSource, msPath *fie
 	if err != nil {
 		return field.ErrorList{field.Invalid(msPath.Child("targetValue"), ms.TargetValue, "must be a valid number")}
 	}
-	if targetValue <= 0 {
-		return field.ErrorList{field.Invalid(msPath.Child("targetValue"), ms.TargetValue, "must be greater than 0")}
+	// ParseFloat accepts "NaN", "Inf" and "Infinity" without error, and NaN
+	// comparisons are always false, so these must be rejected explicitly.
+	if math.IsNaN(targetValue) || math.IsInf(targetValue, 0) || targetValue <= 0 {
+		return field.ErrorList{field.Invalid(msPath.Child("targetValue"), ms.TargetValue, "must be a finite number greater than 0")}
 	}
 	return nil
 }

--- a/pkg/webhook/podautoscaler_webhook.go
+++ b/pkg/webhook/podautoscaler_webhook.go
@@ -19,8 +19,6 @@ package webhook
 import (
 	"context"
 	"fmt"
-	"math"
-	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	autoscalingv1alpha1 "github.com/vllm-project/aibrix/api/autoscaling/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/utils/pametrics"
 	"github.com/vllm-project/aibrix/pkg/utils/paschedules"
 )
 
@@ -249,14 +248,9 @@ func validateMetricTargetValue(ms *autoscalingv1alpha1.MetricSource, msPath *fie
 		return field.ErrorList{field.Required(msPath.Child("targetValue"), "must be set")}
 	}
 
-	targetValue, err := strconv.ParseFloat(ms.TargetValue, 64)
+	_, err := pametrics.ParseTargetValue(ms.TargetValue)
 	if err != nil {
-		return field.ErrorList{field.Invalid(msPath.Child("targetValue"), ms.TargetValue, "must be a valid number")}
-	}
-	// ParseFloat accepts "NaN", "Inf" and "Infinity" without error, and NaN
-	// comparisons are always false, so these must be rejected explicitly.
-	if math.IsNaN(targetValue) || math.IsInf(targetValue, 0) || targetValue <= 0 {
-		return field.ErrorList{field.Invalid(msPath.Child("targetValue"), ms.TargetValue, "must be a finite number greater than 0")}
+		return field.ErrorList{field.Invalid(msPath.Child("targetValue"), ms.TargetValue, err.Error())}
 	}
 	return nil
 }

--- a/pkg/webhook/podautoscaler_webhook_test.go
+++ b/pkg/webhook/podautoscaler_webhook_test.go
@@ -213,7 +213,7 @@ func TestPodAutoscalerCustomValidator_validatePodAutoscaler(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "must be greater than 0",
+			errorMsg:    "must be a finite number greater than 0",
 		},
 		"Negative Target Value": {
 			pa: &autoscalingv1alpha1.PodAutoscaler{
@@ -233,7 +233,7 @@ func TestPodAutoscalerCustomValidator_validatePodAutoscaler(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "must be greater than 0",
+			errorMsg:    "must be a finite number greater than 0",
 		},
 		"Invalid Number Target Value": {
 			pa: &autoscalingv1alpha1.PodAutoscaler{
@@ -275,6 +275,48 @@ func TestPodAutoscalerCustomValidator_validatePodAutoscaler(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "must be a valid number",
+		},
+		"NaN Target Value": {
+			pa: &autoscalingv1alpha1.PodAutoscaler{
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					ScaleTargetRef: corev1.ObjectReference{
+						Name: "test-deployment",
+						Kind: "Deployment",
+					},
+					MaxReplicas:     10,
+					ScalingStrategy: autoscalingv1alpha1.HPA,
+					MetricsSources: []autoscalingv1alpha1.MetricSource{
+						{
+							MetricSourceType: autoscalingv1alpha1.RESOURCE,
+							TargetMetric:     "cpu",
+							TargetValue:      "NaN",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "must be a finite number greater than 0",
+		},
+		"Positive Infinity Target Value": {
+			pa: &autoscalingv1alpha1.PodAutoscaler{
+				Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+					ScaleTargetRef: corev1.ObjectReference{
+						Name: "test-deployment",
+						Kind: "Deployment",
+					},
+					MaxReplicas:     10,
+					ScalingStrategy: autoscalingv1alpha1.HPA,
+					MetricsSources: []autoscalingv1alpha1.MetricSource{
+						{
+							MetricSourceType: autoscalingv1alpha1.RESOURCE,
+							TargetMetric:     "cpu",
+							TargetValue:      "+Inf",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "must be a finite number greater than 0",
 		},
 		"Negative MinReplicas": {
 			pa: &autoscalingv1alpha1.PodAutoscaler{

--- a/pkg/webhook/podautoscaler_webhook_test.go
+++ b/pkg/webhook/podautoscaler_webhook_test.go
@@ -65,6 +65,43 @@ func TestPodAutoscalerCustomValidator_MetricsSources(t *testing.T) {
 	})
 }
 
+func TestPodAutoscalerCustomValidator_HPAMetricTargetBounds(t *testing.T) {
+	validator := &PodAutoscalerCustomValidator{}
+	tests := map[string]autoscalingv1alpha1.MetricSource{
+		"cpu": {
+			MetricSourceType: autoscalingv1alpha1.RESOURCE,
+			TargetMetric:     "cpu",
+			TargetValue:      "2147483647.1",
+		},
+		"memory": {
+			MetricSourceType: autoscalingv1alpha1.RESOURCE,
+			TargetMetric:     "memory",
+			TargetValue:      "8796093022207.1",
+		},
+		"pods": {
+			MetricSourceType: autoscalingv1alpha1.CUSTOM,
+			TargetMetric:     "requests",
+			TargetValue:      "9223372036854775808",
+		},
+	}
+
+	for name, source := range tests {
+		t.Run(name, func(t *testing.T) {
+			pa := &autoscalingv1alpha1.PodAutoscaler{Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+				ScaleTargetRef:  corev1.ObjectReference{Name: "test-deployment", Kind: "Deployment"},
+				MaxReplicas:     10,
+				ScalingStrategy: autoscalingv1alpha1.HPA,
+				MetricsSources:  []autoscalingv1alpha1.MetricSource{source},
+			}}
+
+			err := validator.validatePodAutoscaler(pa)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "must be representable as an HPA metric target")
+		})
+	}
+}
+
 func TestPodAutoscalerCustomValidator_Schedules(t *testing.T) {
 	validator := &PodAutoscalerCustomValidator{}
 	validPA := func(schedules []autoscalingv1alpha1.PodAutoscalerSchedule) *autoscalingv1alpha1.PodAutoscaler {


### PR DESCRIPTION
## Pull Request Description
  
  Fixes the remaining controller-side gap of #2590.
  
  Root cause: when the validating webhook is bypassed (it registers with
  `failurePolicy=ignore`, so an unavailable webhook, an environment without the
  webhook deployed, or direct API writes all admit the object), a
  `metricsSources[*].targetValue` that the HPA generation path cannot parse
  (e.g. Kubernetes quantity-style `"100m"`) passes `validateSpec`. The
  PodAutoscaler then keeps reporting `ValidSpec=True` / `Ready=True` while
  `makeHPAWithBounds` fails on every reconcile with
  `strconv.ParseFloat: parsing "100m": invalid syntax` and no HPA is ever
  created.

  Note: PR #2529 already fixed the webhook side of this issue (the webhook now
  rejects quantity-style `targetValue`, negative `minReplicas`, and
  non-positive `maxReplicas`). This PR closes the remaining gap by aligning the
  controller with the webhook and making the status honest.

  Changes:
  - `validateMetricsSources` now mirrors the webhook's
    `validateMetricTargetValue`: `targetValue` must parse as a plain positive
    float (`"50"`), not a Kubernetes quantity (`"100m"`). Invalid values are
    rejected with `ReasonMetricsConfigError`, so the PodAutoscaler reports
    `ValidSpec=False` / `Ready=False` and the reconcile loop stops retrying a
    spec that can never work.
  - `reconcileHPA` now calls `setInvalidSpecStatus` (previously dead code) when
    `makeHPAWithBounds` fails, so any HPA generation failure surfaces in the
    PodAutoscaler conditions instead of only in controller logs.
  - `makeHPAWithBounds` rounds fractional memory/pod targetValues up with
    `math.Ceil` instead of truncating them via `int64()` (e.g. `"0.5"` MiB
    previously became 0 bytes), consistent with the existing CPU path.

  Tests:
  - `TestValidateSpecRejectsInvalidTargetValue`: `"100m"`, `"abc"`, `"0"`,
    `"-5"` are all rejected with `ReasonMetricsConfigError`.
  - `TestMakeHPAFractionalTargetValueRoundsUp`: `"0.5"` MiB -> 1 MiB and
    `"1.2"` -> 2 for pod metrics.
  - Local verification: `go build ./...`, `go vet ./pkg/controller/podautoscaler/...`,
    `gofmt`, and `go test ./pkg/controller/podautoscaler/... ./pkg/webhook/...`
    all pass.

  ## Related Issues

  Resolves: #2590

  ---

  <details>
  <summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>
  
  <p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain highcode quality, please adhere to the
  following guidelines:</p>
  
  <h3>Pull Request Title Format</h3>
  <p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
  <ul>
      <li><code>[Bug]</code>: Corrections to existing functionality</li>
      <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
      <li><code>[Docs]</code>: Updates or additions to documentation</li>
      <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
      <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
      <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
  </ul>
  <p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

  <h3>Submission Checklist</h3>
  <ul>
      <li>[x] PR title includes appropriate prefix(es)</li>
      <li>[x] Changes are clearly explained in the PR description</li>
      <li>[x] New and existing tests pass successfully</li>
      <li>[x] Code adheres to project style and best practices</li>
      <li>[x] Documentation updated to reflect changes (if applicable)</li>
      <li>[x] Thorough testing completed, no regressions introduced</li>
  </ul>
  
  <p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution
  standards.</p>

  </details>
  standards.</p>

  </details>