### PR TITLE
fix(gateway): stop double-wrapping upstream engine error responses

### DIFF
--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -756,6 +756,16 @@ func (s *Server) responseErrorProcessingWithHeaders(ctx context.Context, routing
 	}
 	klog.ErrorS(nil, "request end", "requestID", requestID, "errorCode", respErrorCode, "errorMessage", errMsg)
 
+	// On a non-2xx upstream status the body often carries the engine's own OpenAI-style
+	// error. Normalize it to a single envelope and pass it through verbatim instead of
+	// re-wrapping the raw JSON into error.message. The HTTP status stays the
+	// authoritative respErrorCode; the body's own code is preserved inside the body.
+	if normalizedBody, code, ok := normalizeUpstreamErrorBody([]byte(errMsg), respErrorCode); ok {
+		errHeaders := append(append([]*configPb.HeaderValueOption{}, headers...),
+			buildEnvoyProxyHeaders(nil, HeaderErrorResponseUnknown, "true")...)
+		return buildErrorResponseWithBody(code, normalizedBody, errHeaders)
+	}
+
 	// Determine appropriate error code based on HTTP status
 	errorCode := ""
 	if respErrorCode == 401 {

--- a/pkg/plugins/gateway/gateway_rsp_body.go
+++ b/pkg/plugins/gateway/gateway_rsp_body.go
@@ -297,15 +297,30 @@ func processLanguageResponse(requestID string, b *extProcPb.ProcessingRequest_Re
 	requestBuffers.Delete(requestID)
 
 	if err := sonic.Unmarshal(finalBody, &res); err != nil {
-		klog.ErrorS(err, "error to unmarshal response", "requestID", requestID, "responseBody", string(b.ResponseBody.GetBody()))
+		klog.ErrorS(err, "error to unmarshal response", "requestID", requestID, "responseBody", string(finalBody))
 		complete = true
 		processingRes = buildErrorResponse(envoyTypePb.StatusCode_InternalServerError, err.Error(), "", "", HeaderErrorResponseUnmarshal, "true")
 		return
 	}
 
 	if len(res.Model) == 0 {
+		// The body is not a recognized OpenAI response. Normalize any upstream error payload
+		// (nested {"error":{...}} or the flat shape) to a single envelope and pass it through;
+		// headerStatus == 0 because this 200 path carries a fake-success status, so the real
+		// status is derived from the body's numeric code (see upstreamErrorHTTPStatus).
+		if body, code, ok := normalizeUpstreamErrorBody(finalBody, 0); ok {
+			klog.ErrorS(ErrorUnknownResponse, "unexpected response", "requestID", requestID, "responseBody", string(finalBody))
+			complete = true
+			errHeaders := buildEnvoyProxyHeaders(nil, HeaderErrorResponseUnknown, "true")
+			processingRes = buildErrorResponseWithBody(code, body, errHeaders)
+			return
+		}
+
+		// Fallback: the body is not a recognizable error payload (e.g. non-JSON or an
+		// arbitrary object). Wrap the reassembled finalBody as the error message rather
+		// than the current chunk, so multi-chunk error bodies are preserved in full.
 		msg := ErrorUnknownResponse.Error()
-		responseBodyContent := string(b.ResponseBody.GetBody())
+		responseBodyContent := string(finalBody)
 		if len(responseBodyContent) != 0 {
 			msg = responseBodyContent
 		}
@@ -340,6 +355,112 @@ func processLanguageResponse(requestID string, b *extProcPb.ProcessingRequest_Re
 		}
 	}
 	return
+}
+
+// normalizeUpstreamErrorBody normalizes an upstream engine's error payload to the nested
+// {"error": {...}} shape. It recognizes both the nested form ({"error": {...}}) and the
+// flat form where the error fields sit at the top level. It returns the normalized body,
+// the HTTP status to use for the response, and whether the body was a recognizable error
+// payload (false for invalid JSON, a non-object "error" field, or for flat payloads:
+// missing message). For nested payloads, a missing message falls back to a generic error
+// string rather than rejecting the payload.
+//
+// headerStatus is the upstream HTTP status the gateway observed (> 0 for a real non-200
+// :status, 0 when the 200 header is a fake success over an error body). The HTTPS-status
+// precedence rule (header wins over body code, semantic string code only preserved) lives in
+// upstreamErrorHTTPStatus.
+func normalizeUpstreamErrorBody(body []byte, headerStatus int) (string, envoyTypePb.StatusCode, bool) {
+	if !gjson.ValidBytes(body) {
+		return "", 0, false
+	}
+
+	nested := gjson.GetBytes(body, "error")
+	if nested.Exists() && nested.IsObject() {
+		return renderErrorBody(nested), upstreamErrorHTTPStatus(nested, headerStatus), true
+	}
+
+	// Flat shape: the error fields sit at the top level. Require a JSON object with a
+	// message field so ordinary (non-error) responses such as arrays or primitives are
+	// not misclassified.
+	flat := gjson.ParseBytes(body)
+	if !flat.IsObject() || !flat.Get("message").Exists() {
+		return "", 0, false
+	}
+	return renderErrorBody(flat), upstreamErrorHTTPStatus(flat, headerStatus), true
+}
+
+// renderErrorBody renders the normalized {"error": {...}} JSON body from a gjson Result
+// representing either the nested error object or the flat error object. Fields absent from
+// the upstream payload are emitted as JSON null, except message which falls back to a
+// generic error string. The "code" field preserves whatever type the upstream supplied
+// (integer HTTP status, string semantic code, or null) verbatim.
+func renderErrorBody(e gjson.Result) string {
+	obj := map[string]interface{}{}
+
+	if m := e.Get("message"); m.Exists() && m.Type != gjson.Null {
+		obj["message"] = m.String()
+	} else {
+		obj["message"] = ErrorUnknownResponse.Error()
+	}
+
+	if t := e.Get("type"); t.Exists() && t.Type != gjson.Null {
+		obj["type"] = t.String()
+	} else {
+		obj["type"] = nil
+	}
+
+	if p := e.Get("param"); p.Exists() && p.Type != gjson.Null {
+		obj["param"] = p.Value()
+	} else {
+		obj["param"] = nil
+	}
+
+	if c := e.Get("code"); c.Exists() && c.Type != gjson.Null {
+		obj["code"] = c.Value()
+	} else {
+		obj["code"] = nil
+	}
+
+	body, err := sonic.Marshal(map[string]interface{}{"error": obj})
+	if err != nil {
+		klog.ErrorS(err, "failed to marshal upstream error body")
+		return `{"error":{"message":"internal server error while formatting error response","type":"api_error","code":null,"param":null}}`
+	}
+	return string(body)
+}
+
+// upstreamErrorHTTPStatus derives the envoy HTTP status for an upstream error payload.
+// Precedence (unified across both response paths via headerStatus):
+//
+//  1. headerStatus > 0 (a real non-200 :status): use it — authoritative, and the body's own
+//     "code" must not override a genuine transport status.
+//  2. headerStatus == 0 (a 200 body that smuggled an error): the 200 header is a fake success,
+//     so derive the status from the body's numeric "code" (stringified integers like "400" too)
+//     — this stops clients getting HTTP 200 wrapping an error body.
+//  3. A non-numeric semantic "code" (e.g. "invalid_api_key") never derives the status; it is
+//     only preserved verbatim in the body. Residual case with no usable status: return 500.
+//
+// Callers MUST pass the real observed header status (respErrorCode on the non-200 path, 0 on
+// the 200 path) rather than re-deriving it, so the rule stays in one place.
+func upstreamErrorHTTPStatus(e gjson.Result, headerStatus int) envoyTypePb.StatusCode {
+	if headerStatus > 0 {
+		return envoyTypePb.StatusCode(headerStatus)
+	}
+	c := e.Get("code")
+	if c.Exists() && c.Type == gjson.Number {
+		if v := c.Int(); v >= 100 && v < 600 {
+			return envoyTypePb.StatusCode(v)
+		}
+	}
+	// Some upstream engines or intermediary proxies stringify the status code.
+	if c.Exists() && c.Type == gjson.String {
+		if v, err := strconv.Atoi(c.String()); err == nil {
+			if v >= 100 && v < 600 {
+				return envoyTypePb.StatusCode(v)
+			}
+		}
+	}
+	return envoyTypePb.StatusCode_InternalServerError
 }
 
 func (s *Server) requestEndHelper(routingCtx *types.RoutingContext, arrival time.Time,

--- a/pkg/plugins/gateway/gateway_rsp_body_test.go
+++ b/pkg/plugins/gateway/gateway_rsp_body_test.go
@@ -23,14 +23,19 @@ import (
 	"time"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/tidwall/gjson"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 )
+
+// sentinelNull is a test-only sentinel meaning "the expected value should be JSON null".
+const sentinelNull = "<null>"
 
 // mockRateLimiter implements ratelimiter.RateLimiter for testing
 type mockRateLimiter struct {
@@ -317,6 +322,234 @@ func TestProcessLanguageResponse_ChunkedAccumulation(t *testing.T) {
 	assert.Equal(t, int64(10), promptTokens)
 	assert.Equal(t, int64(5), completionTokens)
 	assert.Equal(t, int64(15), totalTokens)
+}
+
+func TestProcessLanguageResponse_UpstreamErrorNormalization(t *testing.T) {
+	tests := []struct {
+		name      string
+		chunks    [][]byte
+		wantCode  envoyTypePb.StatusCode
+		wantMsg   string
+		wantType  string
+		wantParam string // sentinelNull means expect JSON null
+	}{
+		{
+			name:      "nested shape passthrough",
+			chunks:    [][]byte{[]byte(`{"error": {"message": "top_p must be in (0, 1], got 2.0.", "type": "BadRequestError", "param": "top_p", "code": 400}}`)},
+			wantCode:  envoyTypePb.StatusCode_BadRequest,
+			wantMsg:   "top_p must be in (0, 1], got 2.0.",
+			wantType:  "BadRequestError",
+			wantParam: "top_p",
+		},
+		{
+			name: "flat shape normalized",
+			chunks: [][]byte{[]byte(
+				`{"object": "error", "message": "max_new_tokens must be at least 0, got -1.", "type": "BadRequestError", "param": null, "code": 400}`,
+			)},
+			wantCode:  envoyTypePb.StatusCode_BadRequest,
+			wantMsg:   "max_new_tokens must be at least 0, got -1.",
+			wantType:  "BadRequestError",
+			wantParam: sentinelNull,
+		},
+		{
+			name:      "non-error JSON body falls back to string wrap",
+			chunks:    [][]byte{[]byte(`{"foo": "bar"}`)},
+			wantCode:  envoyTypePb.StatusCode_InternalServerError,
+			wantMsg:   `{"foo": "bar"}`,
+			wantType:  "api_error",
+			wantParam: sentinelNull,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestID := "test-err-norm-" + tt.name + "-" + time.Now().Format("150405.000")
+
+			var res *extProcPb.ProcessingResponse
+			var complete bool
+			for i, chunk := range tt.chunks {
+				isLast := i == len(tt.chunks)-1
+				req := &extProcPb.ProcessingRequest_ResponseBody{
+					ResponseBody: &extProcPb.HttpBody{
+						Body:        chunk,
+						EndOfStream: isLast,
+					},
+				}
+				res, complete, _, _, _ = processLanguageResponse(requestID, req)
+				if !isLast {
+					assert.False(t, complete, "should not be complete on partial chunk %d", i)
+					assert.NotNil(t, res)
+				}
+			}
+
+			assert.True(t, complete)
+			assert.NotNil(t, res)
+			immResp := res.GetImmediateResponse()
+			assert.NotNil(t, immResp)
+			assert.Equal(t, tt.wantCode, immResp.Status.Code)
+
+			errObj := gjson.Parse(immResp.Body).Get("error")
+			assert.True(t, errObj.IsObject(), "expected nested error object, got: %s", immResp.Body)
+			assert.Equal(t, tt.wantMsg, errObj.Get("message").String())
+			assert.Equal(t, tt.wantType, errObj.Get("type").String())
+
+			if tt.wantParam == sentinelNull {
+				assert.True(t, errObj.Get("param").Exists() && errObj.Get("param").Type == gjson.Null, "expected param to be null, got: %s", immResp.Body)
+			} else if tt.wantParam != "" {
+				assert.Equal(t, tt.wantParam, errObj.Get("param").String())
+			}
+		})
+	}
+}
+
+func TestNormalizeUpstreamError(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      []byte
+		wantOK    bool
+		wantCode  envoyTypePb.StatusCode
+		wantMsg   string
+		wantType  string
+		wantParam string
+		wantCodeV string
+	}{
+		{
+			name:      "nested shape with all fields",
+			body:      []byte(`{"error": {"message": "bad request", "type": "BadRequestError", "param": "top_p", "code": 400}}`),
+			wantOK:    true,
+			wantCode:  envoyTypePb.StatusCode_BadRequest,
+			wantMsg:   "bad request",
+			wantType:  "BadRequestError",
+			wantParam: "top_p",
+			wantCodeV: "400",
+		},
+		{
+			name:      "flat shape with null param",
+			body:      []byte(`{"object": "error", "message": "max_new_tokens must be at least 0, got -1.", "type": "BadRequestError", "param": null, "code": 400}`),
+			wantOK:    true,
+			wantCode:  envoyTypePb.StatusCode_BadRequest,
+			wantMsg:   "max_new_tokens must be at least 0, got -1.",
+			wantType:  "BadRequestError",
+			wantParam: sentinelNull,
+			wantCodeV: "400",
+		},
+		{
+			name:     "nested error missing message falls back to generic",
+			body:     []byte(`{"error": {"type": "BadRequestError", "code": 400}}`),
+			wantOK:   true,
+			wantCode: envoyTypePb.StatusCode_BadRequest,
+			wantMsg:  "<fallback>",
+		},
+		{
+			name:   "non-error JSON is not classified as error",
+			body:   []byte(`{"model": "test-model", "choices": []}`),
+			wantOK: false,
+		},
+		{
+			name:   "invalid JSON",
+			body:   []byte(`{invalid json}`),
+			wantOK: false,
+		},
+		{
+			name:      "string semantic code falls back to 500 but preserves code in body",
+			body:      []byte(`{"error": {"message": "invalid api key", "type": "authentication_error", "code": "invalid_api_key"}}`),
+			wantOK:    true,
+			wantCode:  envoyTypePb.StatusCode_InternalServerError,
+			wantMsg:   "invalid api key",
+			wantType:  "authentication_error",
+			wantCodeV: "invalid_api_key",
+		},
+		{
+			name:      "flat shape with only message, others null",
+			body:      []byte(`{"message": "something went wrong"}`),
+			wantOK:    true,
+			wantCode:  envoyTypePb.StatusCode_InternalServerError,
+			wantMsg:   "something went wrong",
+			wantType:  sentinelNull,
+			wantParam: sentinelNull,
+			wantCodeV: sentinelNull,
+		},
+		{
+			name:      "missing code emits null in body and falls back to 500",
+			body:      []byte(`{"error": {"message": "bad request", "type": "BadRequestError"}}`),
+			wantOK:    true,
+			wantCode:  envoyTypePb.StatusCode_InternalServerError,
+			wantMsg:   "bad request",
+			wantType:  "BadRequestError",
+			wantCodeV: sentinelNull,
+		},
+		{
+			name:      "stringified integer code is parsed for HTTP status",
+			body:      []byte(`{"error": {"message": "bad request", "type": "BadRequestError", "code": "400"}}`),
+			wantOK:    true,
+			wantCode:  envoyTypePb.StatusCode_BadRequest,
+			wantMsg:   "bad request",
+			wantType:  "BadRequestError",
+			wantCodeV: "400",
+		},
+		{
+			name:   "top-level JSON array is not classified as error",
+			body:   []byte(`[{"message": "not an error object"}]`),
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rendered, code, ok := normalizeUpstreamErrorBody(tt.body, 0)
+			assert.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				return
+			}
+			assert.Equal(t, tt.wantCode, code)
+			errObj := gjson.Parse(rendered).Get("error")
+			assert.True(t, errObj.IsObject(), "rendered: %s", rendered)
+			if tt.wantMsg == "<fallback>" {
+				assert.Equal(t, ErrorUnknownResponse.Error(), errObj.Get("message").String())
+			} else if tt.wantMsg != "" {
+				assert.Equal(t, tt.wantMsg, errObj.Get("message").String())
+			}
+			if tt.wantType == sentinelNull {
+				assert.True(t, errObj.Get("type").Type == gjson.Null, "type should be null")
+			} else if tt.wantType != "" {
+				assert.Equal(t, tt.wantType, errObj.Get("type").String())
+			}
+			if tt.wantParam == sentinelNull {
+				assert.True(t, errObj.Get("param").Type == gjson.Null, "param should be null")
+			} else if tt.wantParam != "" {
+				assert.Equal(t, tt.wantParam, errObj.Get("param").String())
+			}
+			if tt.wantCodeV == sentinelNull {
+				assert.True(t, errObj.Get("code").Type == gjson.Null, "code should be null")
+			} else if tt.wantCodeV != "" {
+				assert.Equal(t, tt.wantCodeV, errObj.Get("code").String())
+			}
+		})
+	}
+}
+
+func TestBuildErrorResponseWithBody(t *testing.T) {
+	resp := buildErrorResponseWithBody(
+		envoyTypePb.StatusCode_BadRequest,
+		`{"error":{"message":"bad","type":"BadRequestError"}}`,
+		buildEnvoyProxyHeaders(nil, "x-upstream-error", "true"),
+	)
+	immResp := resp.GetImmediateResponse()
+	assert.NotNil(t, immResp)
+	assert.Equal(t, envoyTypePb.StatusCode_BadRequest, immResp.Status.Code)
+	assert.Equal(t, `{"error":{"message":"bad","type":"BadRequestError"}}`, immResp.Body)
+
+	headers := immResp.GetHeaders().GetSetHeaders()
+	hasJSON, hasHeader := false, false
+	for _, h := range headers {
+		if h.Header.Key == "Content-Type" && h.Header.Value == "application/json" {
+			hasJSON = true
+		}
+		if h.Header.Key == "x-upstream-error" {
+			hasHeader = true
+		}
+	}
+	assert.True(t, hasJSON, "expected Content-Type: application/json header")
+	assert.True(t, hasHeader, "expected x-upstream-error header")
 }
 
 func TestHandleResponseBody_NonStreamWithUsage(t *testing.T) {

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -1015,6 +1015,62 @@ func Test_responseErrorProcessing_ErrorCodeAndMessage(t *testing.T) {
 			assert.Nil(t, errObj["code"])
 		}
 	})
+
+	t.Run("400 with nested upstream error body is not double-wrapped (#2578)", func(t *testing.T) {
+		s := &Server{gatewayClient: nil}
+		body := `{"error": {"message": "top_p must be in (0, 1], got 2.0.", "type": "BadRequestError", "param": "top_p", "code": 400}}`
+		// Provide an explicit-routing ctx so validateHTTPRouteStatus is skipped.
+		rctx := types.NewRoutingContext(context.Background(), routing.RouterLeastRequest, "m", "", "rid", "")
+		out := s.responseErrorProcessingWithHeaders(context.Background(), rctx, baseResp.GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders(), 400, "m", "rid", body)
+		ir := out.GetImmediateResponse()
+		if assert.NotNil(t, ir) {
+			assert.Equal(t, envoyTypePb.StatusCode(400), ir.GetStatus().GetCode())
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal([]byte(ir.GetBody()), &parsed))
+			errObj, ok := parsed["error"].(map[string]any)
+			require.True(t, ok, "expected nested error object, got: %s", ir.GetBody())
+			assert.Equal(t, "top_p must be in (0, 1], got 2.0.", errObj["message"])
+			assert.Equal(t, "BadRequestError", errObj["type"])
+			assert.Equal(t, "top_p", errObj["param"])
+			assert.EqualValues(t, 400, errObj["code"])
+		}
+	})
+
+	t.Run("400 with non-error body falls back to string wrap", func(t *testing.T) {
+		s := &Server{gatewayClient: nil}
+		rctx := types.NewRoutingContext(context.Background(), routing.RouterLeastRequest, "m", "", "rid", "")
+		out := s.responseErrorProcessingWithHeaders(context.Background(), rctx, nil, 400, "m", "rid", "plain text failure")
+		ir := out.GetImmediateResponse()
+		if assert.NotNil(t, ir) {
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal([]byte(ir.GetBody()), &parsed))
+			errObj := parsed["error"].(map[string]any)
+			assert.Equal(t, "plain text failure", errObj["message"])
+			assert.Equal(t, ErrorTypeInvalidRequest, errObj["type"])
+		}
+	})
+
+	// Header status wins over a semantic (string) body "code". The upstream body carries
+	// code:"invalid_api_key", but the gateway observed a 401 header status; the HTTP status
+	// must stay 401 and the string code is preserved verbatim in the body. Regression guard
+	// for the unified status-precedence rule.
+	t.Run("401 header status wins over semantic string body code", func(t *testing.T) {
+		s := &Server{gatewayClient: nil}
+		rctx := types.NewRoutingContext(context.Background(), routing.RouterLeastRequest, "m", "", "rid", "")
+		body := `{"error": {"message": "invalid api key", "type": "authentication_error", "param": null, "code": "invalid_api_key"}}`
+		out := s.responseErrorProcessingWithHeaders(context.Background(), rctx, nil, 401, "m", "rid", body)
+		ir := out.GetImmediateResponse()
+		if assert.NotNil(t, ir) {
+			assert.Equal(t, envoyTypePb.StatusCode(401), ir.GetStatus().GetCode())
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal([]byte(ir.GetBody()), &parsed))
+			errObj, ok := parsed["error"].(map[string]any)
+			require.True(t, ok, "expected nested error object, got: %s", ir.GetBody())
+			assert.Equal(t, "invalid api key", errObj["message"])
+			assert.Equal(t, "authentication_error", errObj["type"])
+			assert.Equal(t, "invalid_api_key", errObj["code"])
+		}
+	})
 }
 
 func Test_getMetricErr(t *testing.T) {
@@ -1141,6 +1197,88 @@ func TestHandleProcessingRequest_ResponseBody_ErrorFromPreviousStage_UsesErrorPr
 		assert.Equal(t, envoyTypePb.StatusCode(401), imm.GetStatus().GetCode())
 	}
 	// metricLabel should be set for response body processing
+	assert.Equal(t, gatewayRespBody, st.metricLabel)
+}
+
+// TestHandleProcessingRequest_Non200ResponseHeadersThenErrorBody is the end-to-end
+// reproduction for #2578: an upstream engine (vLLM / SGLang) returns a non-2xx status
+// with an OpenAI-style error body. The prior fix only normalized error bodies on the
+// 200 path (processLanguageResponse), so this non-200 path must normalize too,
+// otherwise the raw upstream JSON gets double-wrapped into error.message.
+func TestHandleProcessingRequest_Non200ResponseHeadersThenErrorBody(t *testing.T) {
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Status: v1.PodStatus{
+			PodIP:      "1.2.3.4",
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+		},
+	}
+	testCache := cache.NewWithPodsForTest([]*v1.Pod{testPod}, "test-model")
+	s := &Server{cache: testCache}
+
+	requestID := "req-2578"
+	routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", requestID, "")
+	routerCtx.ReqPath = PathChatCompletions
+	routerCtx.RequestTime = time.Now()
+	routerCtx.SetTargetPod(testPod)
+
+	st := &processState{
+		ctx:       context.Background(),
+		routerCtx: routerCtx,
+		requestID: requestID,
+		model:     "test-model",
+		stream:    false,
+	}
+
+	// 1) Upstream returns :status 400.
+	headersReq := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseHeaders{
+			ResponseHeaders: &extProcPb.HttpHeaders{
+				Headers: &configPb.HeaderMap{
+					Headers: []*configPb.HeaderValue{
+						{Key: ":status", RawValue: []byte("400")},
+					},
+				},
+			},
+		},
+	}
+	resp, err := s.handleProcessingRequest(st, headersReq)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.True(t, st.isRespError, "expected isRespError=true after non-200 response header")
+	assert.Equal(t, 400, st.respErrorCode)
+
+	// 2) Upstream error body arrives. This is the exact #2578 payload.
+	errorBody := `{"error": {"message": "top_p must be in (0, 1], got 2.0. (parameter=top_p, value=2.0)", "type": "BadRequestError", "param": "top_p", "code": 400}}`
+	bodyReq := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body:        []byte(errorBody),
+				EndOfStream: true,
+			},
+		},
+	}
+
+	resp, err = s.handleProcessingRequest(st, bodyReq)
+	assert.NoError(t, err)
+	if assert.NotNil(t, resp) {
+		imm := resp.GetImmediateResponse()
+		if assert.NotNil(t, imm, "expected ImmediateResponse for error path") {
+			assert.Equal(t, envoyTypePb.StatusCode(400), imm.GetStatus().GetCode())
+
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal([]byte(imm.GetBody()), &parsed))
+			errObj, ok := parsed["error"].(map[string]any)
+			require.True(t, ok, "expected nested error object, got: %s", imm.GetBody())
+
+			// The upstream message must NOT be re-wrapped into a stringified JSON.
+			assert.Equal(t, "top_p must be in (0, 1], got 2.0. (parameter=top_p, value=2.0)", errObj["message"])
+			assert.Equal(t, "BadRequestError", errObj["type"])
+			assert.Equal(t, "top_p", errObj["param"])
+			// code is preserved as the upstream integer 400 (rendered by normalizeUpstreamErrorBody).
+			assert.EqualValues(t, 400, errObj["code"])
+		}
+	}
 	assert.Equal(t, gatewayRespBody, st.metricLabel)
 }
 

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -804,26 +804,8 @@ func getChatCompletionsMessage(requestID string, chatCompletionObj openai.ChatCo
 // errorCode and param are optional (pass "" for null)
 func generateErrorResponse(statusCode envoyTypePb.StatusCode, headers []*configPb.HeaderValueOption, message, errorCode, param string) *extProcPb.ProcessingResponse {
 	// Set the Content-Type header to application/json
-	headers = append(headers, &configPb.HeaderValueOption{
-		Header: &configPb.HeaderValue{
-			Key:   "Content-Type",
-			Value: "application/json",
-		},
-	})
-
-	return &extProcPb.ProcessingResponse{
-		Response: &extProcPb.ProcessingResponse_ImmediateResponse{
-			ImmediateResponse: &extProcPb.ImmediateResponse{
-				Status: &envoyTypePb.HttpStatus{
-					Code: statusCode,
-				},
-				Headers: &extProcPb.HeaderMutation{
-					SetHeaders: headers,
-				},
-				Body: generateErrorMessageWithHTTPCode(message, int(statusCode), errorCode, param),
-			},
-		},
-	}
+	headers = append(headers, contentTypeHeader())
+	return immediateErrorResponse(statusCode, generateErrorMessageWithHTTPCode(message, int(statusCode), errorCode, param), headers)
 }
 
 // generateErrorMessage constructs a JSON error message in OpenAI format
@@ -875,8 +857,41 @@ func generateErrorMessageWithHTTPCode(message string, httpStatusCode int, errorC
 }
 
 // buildErrorResponse constructs an error response with OpenAI-compatible error format
-// errorCode and param are optional (pass "" for null)
+// errorCode and param are optional (pass "" for null). Unlike buildErrorResponseWithBody,
+// it builds the body from the supplied fields and does not add a Content-Type header.
 func buildErrorResponse(statusCode envoyTypePb.StatusCode, errBody, errorCode, param string, headers ...string) *extProcPb.ProcessingResponse {
+	return immediateErrorResponse(
+		statusCode,
+		generateErrorMessageWithHTTPCode(errBody, int(statusCode), errorCode, param),
+		buildEnvoyProxyHeaders([]*configPb.HeaderValueOption{}, headers...),
+	)
+}
+
+// buildErrorResponseWithBody constructs an immediate error response whose body is passed
+// through verbatim (already an OpenAI-shaped error payload) with no re-wrapping. The caller
+// supplies the full header set it wants to be forwarded (typically the upstream headers plus the
+// error header); a Content-Type: application/json header is always prepended.
+func buildErrorResponseWithBody(statusCode envoyTypePb.StatusCode, body string, headers []*configPb.HeaderValueOption) *extProcPb.ProcessingResponse {
+	setHeaders := make([]*configPb.HeaderValueOption, 0, 1+len(headers))
+	setHeaders = append(setHeaders, contentTypeHeader())
+	setHeaders = append(setHeaders, headers...)
+	return immediateErrorResponse(statusCode, body, setHeaders)
+}
+
+// contentTypeHeader returns a fresh Content-Type: application/json header.
+func contentTypeHeader() *configPb.HeaderValueOption {
+	return &configPb.HeaderValueOption{
+		Header: &configPb.HeaderValue{
+			Key:   "Content-Type",
+			Value: "application/json",
+		},
+	}
+}
+
+// immediateErrorResponse builds an envoy ImmediateResponse error with the given status, body,
+// and header set. Shared by all gateway error builders so the ImmediateResponse construction
+// lives in exactly one place.
+func immediateErrorResponse(statusCode envoyTypePb.StatusCode, body string, headers []*configPb.HeaderValueOption) *extProcPb.ProcessingResponse {
 	return &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_ImmediateResponse{
 			ImmediateResponse: &extProcPb.ImmediateResponse{
@@ -884,9 +899,9 @@ func buildErrorResponse(statusCode envoyTypePb.StatusCode, errBody, errorCode, p
 					Code: statusCode,
 				},
 				Headers: &extProcPb.HeaderMutation{
-					SetHeaders: buildEnvoyProxyHeaders([]*configPb.HeaderValueOption{}, headers...),
+					SetHeaders: headers,
 				},
-				Body: generateErrorMessageWithHTTPCode(errBody, int(statusCode), errorCode, param),
+				Body: body,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

When an upstream engine (vLLM / SGLang) returns an error, the gateway previously re-wrapped the raw upstream JSON body as `error.message` via `generateErrorMessage`, producing a double-nested `{"error":{"message":"{\"error\":{...}}",...}}` shape that dropped the engine's `type`/`param`/`code` . This happened on both the 200 path (body unmarshalled into `OpenAIResponse` with empty `model` → fallback re-wrap) and the non-2xx path (`responseErrorProcessingWithHeaders`).

Both paths now normalize the upstream payload to a single OpenAI-compatible `{"error":{...}}` envelope before returning it to the client — preserving the engine's original `message`/`type`/`param`, carrying the integer HTTP `code` (status) through, and passing semantic string codes (e.g. `model_not_found`) verbatim.

#### Before (client sees)

```json
{
  "error": {
    "code": null,
    "param": null,
    "message": "{\"error\":{\"message\":\"top_p must be in (0, 1], got 2.0.\",\"type\":\"BadRequestError\",\"param\":\"top_p\",\"code\":400}}",
    "type": "invalid_request_error"
  }
}
```

#### After (client sees)

```json
{
  "error": {
    "code": 400,
    "param": "top_p",
    "message": "top_p must be in (0, 1], got 2.0.",
    "type": "BadRequestError"
  }
}
```

## Changes

- **`normalizeUpstreamError()` → `normalizeUpstreamErrorBody(body, headerStatus)`** — detects both the nested `{"error":{...}}` shape and the flat `{message,type,param,code}` shape, normalizes to the nested form, and renders all fields verbatim via `renderErrorBody()`. The `headerStatus` argument carries the gateway-observed HTTP status (real non-2xx status on the error path, `0` on the 200 path where the 200 header is a fake success), centralizing the status-precedence rule in `upstreamErrorHTTPStatus()`.

- **Status precedence (unified across both paths)**
  1. `headerStatus > 0` (real non-2xx `:status`) → use it; the body's `code` must not override a genuine transport status.
  2. `headerStatus == 0` (200 body smuggling an error) → derive from the body's numeric `code` (stringified integers accepted) — avoids clients receiving HTTP 200 wrapping an error body.
  3. A non-numeric semantic `code` (e.g. `model_not_found`, `invalid_api_key`) is **never** used to derive the HTTP status; it is only preserved verbatim in the body. Residual fallback: `500`.

- **`buildErrorResponseWithBody()`** — now accepts an explicit `[]*HeaderValueOption` header set. Both call sites forward the upstream headers (e.g. routing / target-pod) and set the `x-error-response-unknown` flag.

- **`responseErrorProcessingWithHeaders()`** — when `errMsg` is a recognizable upstream error payload (nested or flat), normalize it and pass it through verbatim instead of re-wrapping the raw JSON into `error.message`.

- **`processLanguageResponse()`** — the 200-path caller now uses `normalizeUpstreamErrorBody(finalBody, 0)`; also fixed fallback logging to use the reassembled `finalBody` buffer instead of the last chunk, so multi-chunk error bodies are preserved in full.

Aibrix-native / upstream semantic string codes (`model_not_found`, `invalid_api_key`) are left unchanged in the body; only passthrough upstream integer HTTP codes are preserved as the `code` field and as the response HTTP status on the 200 path.

## Verification 

**1. Upstream engine parameter errors — no longer double-wrapped**

| Request                            | Response from client                                         |
| :--------------------------------- | :----------------------------------------------------------- |
| `top_p=2.0`                        | `{"error":{"message":"top_p must be in (0, 1], got 2.0.","type":"BadRequestError","param":null,"code":400}}` |
| `temperature=-1`                   | `{"error":{"message":"temperature must be a non-negative finite number, got -1.0.","type":"BadRequestError","param":null,"code":400}}` |
| `max_tokens=-1`                    | `{"error":{"message":"max_new_tokens must be at least 0, got -1.","type":"BadRequestError","param":null,"code":400}}` |
| invalid `messages[].role`          | `{"error":{"message":"2 validation errors:\n...","type":"Bad Request","param":null,"code":400}}` |
| `/v1/completions` missing `prompt` | `{"error":{"code":400,"message":"1 validation error:\n...","type":"Bad Request","param":null}}` |

**2. Semantic (string) codes — preserved verbatim**

| Request            | Response from client                                         |
| :----------------- | :----------------------------------------------------------- |
| unknown model      | `{"error":{"code":"model_not_found","param":"model","message":"model <MODEL_NAME> does not exist","type":"invalid_request_error"}}` |
| empty model string | `{"error":{"code":"model_not_found","param":"model","message":"model does not exist","type":"invalid_request_error"}}` |

**3. Gateway-local request-shape errors**

| Request                               | Response from client                                         |
| :------------------------------------ | :----------------------------------------------------------- |
| missing `messages` or  `messages: []` | `{"error":{"param":"messages","message":"no messages in the request body","type":"invalid_request_error","code":null}}` |
| malformed JSON body                   | `{"error":{"param":null,"message":"error processing request body","type":"invalid_request_error","code":null}}` |

## Tests

| Test                                                         | Coverage                                                     |
| :----------------------------------------------------------- | :----------------------------------------------------------- |
| `TestProcessLanguageResponse_UpstreamErrorNormalization`     | 200-path e2e: nested passthrough, flat→nested, non-error JSON fallback |
| `TestNormalizeUpstreamError`                                 | unit: nested/flat/null-param/missing-message/non-error/invalid-JSON/string-code/only-message/missing-code/stringified-int/top-level-array |
| `TestBuildErrorResponseWithBody`                             | unit: verbatim body + `Content-Type` header forwarding       |
| `Test_responseErrorProcessing_ErrorCodeAndMessage`           | non-2xx: 400 body not double-wrapped, string wrap fallback, 401 header beats semantic string body code |
| `TestHandleProcessingRequest_Non200ResponseHeadersThenErrorBody` | non-2xx ResponseHeaders → upstream error ResponseBody        |

Fixes #2578