### PR TITLE
docs: document gateway target headers

### DIFF
--- a/docs/source/features/gateway-plugins.rst
+++ b/docs/source/features/gateway-plugins.rst
@@ -305,20 +305,50 @@ Target and General Headers
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 75
+   :widths: 25 20 55
 
    * - Header Name
+     - Direction
      - Description
    * - ``request-id``
+     - Response
      - Unique request ID associated with the client request. Useful for correlating logs.
    * - ``x-went-into-req-headers``
+     - Backend request, Response
      - Indicates whether request headers were processed correctly. Used for debugging header parsing issues.
    * - ``target-pod``
-     - The destination pod selected by the routing algorithm. Useful for verifying routing decisions.
+     - Response
+     - Name of the destination pod selected by the routing algorithm. Useful for verifying routing decisions.
+   * - ``target-pod-ip``
+     - Response
+     - Address of the destination pod selected by the routing algorithm.
    * - ``routing-strategy``
-     - The routing strategy applied to this request.
+     - Request, Response
+     - Selects the routing strategy for the request and reports the strategy applied in the response.
    * - ``external-filter``
+     - Request
      - Label selector expression used to further filter candidate pods before routing.
+   * - ``model``
+     - Backend request
+     - Model name injected into the backend request when no explicit routing strategy is selected.
+   * - ``config-profile``
+     - Request
+     - Selects a model configuration profile for the request.
+   * - ``x-session-id``
+     - Request, Response
+     - Session identifier used by ``session-affinity`` routing. The response value should be sent on subsequent requests to retain affinity.
+   * - ``x-aibrix-session-key``
+     - Request
+     - Caller-owned opaque session key used by ``session-affinity`` routing.
+   * - ``traceparent``
+     - Request, Backend request
+     - W3C Trace Context propagated through requests initiated by the gateway, including prefill-decode routing.
+   * - ``prefill-target-pod``
+     - Response
+     - Name of the prefill pod selected by ``pd`` routing.
+   * - ``prefill-target-pod-ip``
+     - Response
+     - Address of the prefill pod selected by ``pd`` routing.
 
 Routing and Error Debugging Headers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/features/gateway-plugins.rst
+++ b/docs/source/features/gateway-plugins.rst
@@ -321,7 +321,7 @@ Target and General Headers
      - Name of the destination pod selected by the routing algorithm. Useful for verifying routing decisions.
    * - ``target-pod-ip``
      - Response
-     - Address of the destination pod selected by the routing algorithm.
+     - IP address of the destination pod selected by the routing algorithm.
    * - ``routing-strategy``
      - Request, Response
      - Selects the routing strategy for the request and reports the strategy applied in the response.
@@ -348,7 +348,7 @@ Target and General Headers
      - Name of the prefill pod selected by ``pd`` routing.
    * - ``prefill-target-pod-ip``
      - Response
-     - Address of the prefill pod selected by ``pd`` routing.
+     - IP address of the prefill pod selected by ``pd`` routing.
 
 Routing and Error Debugging Headers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/features/gateway-plugins.rst
+++ b/docs/source/features/gateway-plugins.rst
@@ -211,6 +211,8 @@ Specialized
   .. note::
       ``x-session-id`` encodes only network location. It is not a security token and must not be used for authentication or authorization.
 
+      Callers can instead send a stable, opaque ``x-aibrix-session-key`` value. The gateway consistently maps that value to a ready pod without exposing a backend address. The key is only used when ``routing-strategy`` is ``session-affinity`` and must not be used for authentication or authorization.
+
   .. code-block:: bash
 
       curl -v http://${ENDPOINT}/v1/chat/completions \
@@ -317,14 +319,14 @@ Target and General Headers
      - Backend request, Response
      - Indicates whether request headers were processed correctly. Used for debugging header parsing issues.
    * - ``target-pod``
-     - Response
-     - Name of the destination pod selected by the routing algorithm. Useful for verifying routing decisions.
+     - Backend request, Response
+     - Identifies the destination selected by the routing algorithm: the backend request receives its ``IP:port`` address, while the response reports its pod name.
    * - ``target-pod-ip``
      - Response
-     - IP address of the destination pod selected by the routing algorithm.
+     - ``IP:port`` address of the destination pod selected by the routing algorithm.
    * - ``routing-strategy``
-     - Request, Response
-     - Selects the routing strategy for the request and reports the strategy applied in the response.
+     - Request, Backend request, Response
+     - Selects the routing strategy for the request, forwards the applied strategy to the backend, and reports it in the response.
    * - ``external-filter``
      - Request
      - Label selector expression used to further filter candidate pods before routing.
@@ -334,6 +336,9 @@ Target and General Headers
    * - ``config-profile``
      - Request
      - Selects a model configuration profile for the request.
+   * - ``x-aibrix-config-profile``
+     - Response
+     - Reports the concrete profile selected when ``config-profile`` is ``auto``.
    * - ``x-session-id``
      - Request, Response
      - Session identifier used by ``session-affinity`` routing. The response value should be sent on subsequent requests to retain affinity.


### PR DESCRIPTION
## Summary
- add request/backend-request/response directions to the target and general headers reference
- document gateway headers for target addresses, config profiles, sessions, tracing, and PD routing
- clarify the direction and behavior of existing entries

Closes #2596.

## Validation
- `git diff --check`
- `python -m sphinx -W --keep-going -b html docs/source <output>` (the changed page renders; the build reports the same two pre-existing warnings reproduced on untouched `main`: an explicit-markup warning later in `gateway-plugins.rst` and `advanced-k8s-examples.rst` not being in a toctree)
