### PR TITLE
[Misc] Share session-affinity header constants

### DIFF
--- a/pkg/constants/gateway.go
+++ b/pkg/constants/gateway.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	// HeaderSessionID identifies the backend selected for session-affinity routing.
+	HeaderSessionID = "x-session-id"
+
+	// HeaderSessionKey carries a caller-owned opaque key for session-affinity routing.
+	HeaderSessionKey = "x-aibrix-session-key"
+)

--- a/pkg/plugins/gateway/algorithms/simple_session_affinity.go
+++ b/pkg/plugins/gateway/algorithms/simple_session_affinity.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 
@@ -30,14 +31,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
-	RouterSessionAffinity types.RoutingAlgorithm = "session-affinity"
-	// NOTE: sessionIDHeader must strictly match types.HeaderSessionID
-	// defined in pkg/plugins/gateway/types.go to prevent routing failures.
-	sessionIDHeader  string = "x-session-id"
-	sessionKeyHeader string = "x-aibrix-session-key"
-	maxSessionKeyLen        = 256
-)
+const RouterSessionAffinity types.RoutingAlgorithm = "session-affinity"
+
+const maxSessionKeyLen = 256
 
 func init() {
 	Register(RouterSessionAffinity, NewSessionAffinityRouter)
@@ -59,7 +55,7 @@ func (r *sessionAffinityRouter) Route(ctx *types.RoutingContext, readyPodList ty
 		return r.fallbackRoute(ctx, readyPodList)
 	}
 
-	sessionID := ctx.ReqHeaders[sessionIDHeader]
+	sessionID := ctx.ReqHeaders[constants.HeaderSessionID]
 	var targetAddr string
 
 	if sessionID != "" {
@@ -90,7 +86,7 @@ func (r *sessionAffinityRouter) Route(ctx *types.RoutingContext, readyPodList ty
 		}
 	}
 
-	if selected := rendezvousPod(ctx, readyPodList.All(), ctx.ReqHeaders[sessionKeyHeader]); selected != nil {
+	if selected := rendezvousPod(ctx, readyPodList.All(), ctx.ReqHeaders[constants.HeaderSessionKey]); selected != nil {
 		port := utils.GetModelPortForPod(ctx.RequestID, selected)
 		addr := net.JoinHostPort(selected.Status.PodIP, strconv.Itoa(int(port)))
 		ctx.SetTargetPod(selected)
@@ -151,7 +147,7 @@ func (r *sessionAffinityRouter) setSessionHeader(ctx *types.RoutingContext, addr
 	if ctx.RespHeaders == nil {
 		ctx.RespHeaders = make(map[string]string)
 	}
-	ctx.RespHeaders[sessionIDHeader] = base64.StdEncoding.EncodeToString([]byte(addr))
+	ctx.RespHeaders[constants.HeaderSessionID] = base64.StdEncoding.EncodeToString([]byte(addr))
 }
 
 // fallbackRoute selects a random ready pod and returns its IP:Port as the target address.
@@ -192,7 +188,7 @@ func (r *sessionAffinityRouter) ScoreAll(ctx *types.RoutingContext, readyPodList
 		return scores, scored, nil
 	}
 
-	sessionID := ctx.ReqHeaders[sessionIDHeader]
+	sessionID := ctx.ReqHeaders[constants.HeaderSessionID]
 	var targetAddr string
 
 	if sessionID != "" {
@@ -224,7 +220,7 @@ func (r *sessionAffinityRouter) ScoreAll(ctx *types.RoutingContext, readyPodList
 	}
 
 	if !matchedSessionID {
-		if selected := rendezvousPod(ctx, pods, ctx.ReqHeaders[sessionKeyHeader]); selected != nil {
+		if selected := rendezvousPod(ctx, pods, ctx.ReqHeaders[constants.HeaderSessionKey]); selected != nil {
 			for i, pod := range pods {
 				if pod == selected {
 					scores[i] = 1

--- a/pkg/plugins/gateway/algorithms/simple_session_affinity_test.go
+++ b/pkg/plugins/gateway/algorithms/simple_session_affinity_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/types"
 
 	v1 "k8s.io/api/core/v1"
@@ -39,7 +40,7 @@ func TestSessionAffinityRouter(t *testing.T) {
 		{
 			name: "valid session ID matches ready pod",
 			reqHeaders: map[string]string{
-				sessionIDHeader: base64.StdEncoding.EncodeToString([]byte("10.0.0.2:8000")),
+				constants.HeaderSessionID: base64.StdEncoding.EncodeToString([]byte("10.0.0.2:8000")),
 			},
 			readyPods: []*v1.Pod{
 				newPod("pod1", "10.0.0.1", true, map[string]string{"model.aibrix.ai/port": "8000"}),
@@ -62,7 +63,7 @@ func TestSessionAffinityRouter(t *testing.T) {
 		{
 			name: "invalid base64 session ID → fallback",
 			reqHeaders: map[string]string{
-				sessionIDHeader: "%%%INVALID_BASE64%%%",
+				constants.HeaderSessionID: "%%%INVALID_BASE64%%%",
 			},
 			readyPods: []*v1.Pod{
 				newPod("a", "192.168.1.10", true, map[string]string{"model.aibrix.ai/port": "8000"}),
@@ -74,7 +75,7 @@ func TestSessionAffinityRouter(t *testing.T) {
 		{
 			name: "session ID points to non-existent address → fallback",
 			reqHeaders: map[string]string{
-				sessionIDHeader: base64.StdEncoding.EncodeToString([]byte("10.99.99.99:8000")), // non-existent IP
+				constants.HeaderSessionID: base64.StdEncoding.EncodeToString([]byte("10.99.99.99:8000")), // non-existent IP
 			},
 			readyPods: []*v1.Pod{
 				newPod("x", "10.1.1.1", true, map[string]string{"model.aibrix.ai/port": "8000"}),
@@ -103,13 +104,13 @@ func TestSessionAffinityRouter(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.NotNil(t, ctx.RespHeaders, "RespHeaders should not be nil")
-			assert.Contains(t, ctx.RespHeaders, sessionIDHeader, "Response must include session ID header")
+			assert.Contains(t, ctx.RespHeaders, constants.HeaderSessionID, "Response must include session ID header")
 
 			// verify the returned address is one of the expected ready pod addresses
 			assert.Contains(t, tt.expectPossibleAddrs, addr, "selected address must be one of the ready pods' IP:port")
 
 			// verify that the session ID in the response decodes to the same address
-			sessionB64 := ctx.RespHeaders[sessionIDHeader]
+			sessionB64 := ctx.RespHeaders[constants.HeaderSessionID]
 			sessionBytes, decodeErr := base64.StdEncoding.DecodeString(sessionB64)
 			assert.NoError(t, decodeErr, "session ID must be valid base64")
 			actualSessionAddr := string(sessionBytes)
@@ -149,7 +150,7 @@ func TestSessionAffinity_ScoreAll(t *testing.T) {
 	// 2. With session ID targeting pA
 	ctx2 := types.NewRoutingContext(context.Background(), "test", "m1", "", "req", "")
 	ctx2.ReqHeaders = make(map[string]string)
-	ctx2.ReqHeaders[sessionIDHeader] = base64.StdEncoding.EncodeToString([]byte("1.1.1.1:8000"))
+	ctx2.ReqHeaders[constants.HeaderSessionID] = base64.StdEncoding.EncodeToString([]byte("1.1.1.1:8000"))
 
 	scores, _, err = scorer.ScoreAll(ctx2, podList)
 	assert.NoError(t, err)
@@ -173,13 +174,13 @@ func TestSessionAffinityPostRouteUpdateFollowsFinalTargetPod(t *testing.T) {
 	router := &sessionAffinityRouter{}
 	ctx := types.NewRoutingContext(context.Background(), "test", "m1", "", "req", "")
 	ctx.ReqHeaders = map[string]string{
-		sessionIDHeader: base64.StdEncoding.EncodeToString([]byte("1.1.1.1:8000")),
+		constants.HeaderSessionID: base64.StdEncoding.EncodeToString([]byte("1.1.1.1:8000")),
 	}
 
 	err := router.PostRouteUpdate(ctx, podList, podB)
 	assert.NoError(t, err)
 
-	sessionBytes, decodeErr := base64.StdEncoding.DecodeString(ctx.RespHeaders[sessionIDHeader])
+	sessionBytes, decodeErr := base64.StdEncoding.DecodeString(ctx.RespHeaders[constants.HeaderSessionID])
 	assert.NoError(t, decodeErr)
 	assert.Equal(t, "2.2.2.2:8000", string(sessionBytes))
 }
@@ -192,11 +193,11 @@ func TestSessionAffinityOpaqueKeyIsDeterministic(t *testing.T) {
 
 	route := func(pods []*v1.Pod) string {
 		ctx := types.NewRoutingContext(context.Background(), "test", "model1", "", "", "")
-		ctx.ReqHeaders = map[string]string{sessionKeyHeader: "agent-session-42"}
+		ctx.ReqHeaders = map[string]string{constants.HeaderSessionKey: "agent-session-42"}
 		addr, err := router.Route(ctx, newMockPodList(pods, nil))
 		assert.NoError(t, err)
-		assert.NotEmpty(t, ctx.RespHeaders[sessionIDHeader])
-		assert.NotContains(t, ctx.RespHeaders, sessionKeyHeader)
+		assert.NotEmpty(t, ctx.RespHeaders[constants.HeaderSessionID])
+		assert.NotContains(t, ctx.RespHeaders, constants.HeaderSessionKey)
 		return addr
 	}
 
@@ -211,8 +212,8 @@ func TestSessionAffinityCookieTakesPrecedenceOverOpaqueKey(t *testing.T) {
 	router := &sessionAffinityRouter{}
 	ctx := types.NewRoutingContext(context.Background(), "test", "model1", "", "", "")
 	ctx.ReqHeaders = map[string]string{
-		sessionIDHeader:  base64.StdEncoding.EncodeToString([]byte("10.0.0.2:8000")),
-		sessionKeyHeader: "agent-session-42",
+		constants.HeaderSessionID:  base64.StdEncoding.EncodeToString([]byte("10.0.0.2:8000")),
+		constants.HeaderSessionKey: "agent-session-42",
 	}
 
 	addr, err := router.Route(ctx, newMockPodList([]*v1.Pod{podA, podB}, nil))
@@ -226,7 +227,7 @@ func TestSessionAffinityOpaqueKeyScoreAll(t *testing.T) {
 	pods := []*v1.Pod{podA, podB}
 	router := &sessionAffinityRouter{}
 	ctx := types.NewRoutingContext(context.Background(), "test", "model1", "", "", "")
-	ctx.ReqHeaders = map[string]string{sessionKeyHeader: "agent-session-42"}
+	ctx.ReqHeaders = map[string]string{constants.HeaderSessionKey: "agent-session-42"}
 
 	scores, scored, err := router.ScoreAll(ctx, newMockPodList(pods, nil))
 	assert.NoError(t, err)

--- a/pkg/plugins/gateway/gateway_req_headers.go
+++ b/pkg/plugins/gateway/gateway_req_headers.go
@@ -73,9 +73,9 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, roo
 		case HeaderConfigProfile:
 			reqConfigProfile = strings.TrimSpace(string(n.RawValue))
 		case constants.HeaderSessionID:
-			reqHeaders[n.Key] = string(n.RawValue)
+			reqHeaders[constants.HeaderSessionID] = string(n.RawValue)
 		case constants.HeaderSessionKey:
-			reqHeaders[n.Key] = string(n.RawValue)
+			reqHeaders[constants.HeaderSessionKey] = string(n.RawValue)
 		case HeaderTraceParent: // Preserve the trace context for requests initiated by the gateway plugin. like PD
 			reqHeaders[n.Key] = string(n.RawValue)
 			if !rootSpan.SpanContext().HasTraceID() { // prefers rootSpan traceID over traceparent

--- a/pkg/plugins/gateway/gateway_req_headers.go
+++ b/pkg/plugins/gateway/gateway_req_headers.go
@@ -65,11 +65,11 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, roo
 		case authorizationKey:
 			reqHeaders[n.Key] = string(n.RawValue)
 		case HeaderExternalFilter:
-			reqHeaders[n.Key] = string(n.RawValue)
+			reqHeaders[HeaderExternalFilter] = string(n.RawValue)
 		case contentTypeKey:
-			reqHeaders[n.Key] = string(n.RawValue)
+			reqHeaders[contentTypeKey] = string(n.RawValue)
 		case HeaderRoutingStrategy:
-			reqHeaders[n.Key] = string(n.RawValue)
+			reqHeaders[HeaderRoutingStrategy] = string(n.RawValue)
 		case HeaderConfigProfile:
 			reqConfigProfile = strings.TrimSpace(string(n.RawValue))
 		case constants.HeaderSessionID:
@@ -77,7 +77,7 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, roo
 		case constants.HeaderSessionKey:
 			reqHeaders[constants.HeaderSessionKey] = string(n.RawValue)
 		case HeaderTraceParent: // Preserve the trace context for requests initiated by the gateway plugin. like PD
-			reqHeaders[n.Key] = string(n.RawValue)
+			reqHeaders[HeaderTraceParent] = string(n.RawValue)
 			if !rootSpan.SpanContext().HasTraceID() { // prefers rootSpan traceID over traceparent
 				requestID = GetTraceID(string(n.RawValue), requestID)
 			}

--- a/pkg/plugins/gateway/gateway_req_headers.go
+++ b/pkg/plugins/gateway/gateway_req_headers.go
@@ -29,6 +29,7 @@ import (
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 
+	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 )
@@ -71,9 +72,9 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, roo
 			reqHeaders[n.Key] = string(n.RawValue)
 		case HeaderConfigProfile:
 			reqConfigProfile = strings.TrimSpace(string(n.RawValue))
-		case HeaderSessionID:
+		case constants.HeaderSessionID:
 			reqHeaders[n.Key] = string(n.RawValue)
-		case HeaderSessionKey:
+		case constants.HeaderSessionKey:
 			reqHeaders[n.Key] = string(n.RawValue)
 		case HeaderTraceParent: // Preserve the trace context for requests initiated by the gateway plugin. like PD
 			reqHeaders[n.Key] = string(n.RawValue)

--- a/pkg/plugins/gateway/gateway_req_headers_test.go
+++ b/pkg/plugins/gateway/gateway_req_headers_test.go
@@ -18,6 +18,7 @@ package gateway
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -166,10 +167,10 @@ func Test_handleRequestHeaders(t *testing.T) {
 			validate: defaultSuccessValidator,
 		},
 		{
-			name: "extract x-session-id for session affinity routing",
+			name: "extract mixed-case x-session-id for session affinity routing",
 			requestHeaders: []*configPb.HeaderValue{
 				{
-					Key:      HeaderSessionID,
+					Key:      strings.ToUpper(HeaderSessionID),
 					RawValue: []byte("MTI3LjAuMC4xOjg4OTk="),
 				},
 				{
@@ -194,10 +195,10 @@ func Test_handleRequestHeaders(t *testing.T) {
 			validate: defaultSuccessValidator,
 		},
 		{
-			name: "extract opaque session key for session affinity routing",
+			name: "extract mixed-case opaque session key for session affinity routing",
 			requestHeaders: []*configPb.HeaderValue{
 				{
-					Key:      HeaderSessionKey,
+					Key:      strings.ToUpper(HeaderSessionKey),
 					RawValue: []byte("agent-session-42"),
 				},
 				{

--- a/pkg/plugins/gateway/gateway_req_headers_test.go
+++ b/pkg/plugins/gateway/gateway_req_headers_test.go
@@ -167,6 +167,100 @@ func Test_handleRequestHeaders(t *testing.T) {
 			validate: defaultSuccessValidator,
 		},
 		{
+			name: "normalize mixed-case request header keys",
+			requestHeaders: []*configPb.HeaderValue{
+				{
+					Key:      strings.ToUpper(HeaderExternalFilter),
+					RawValue: []byte("gpu=true"),
+				},
+				{
+					Key:      strings.ToUpper(contentTypeKey),
+					RawValue: []byte("application/json"),
+				},
+				{
+					Key:      strings.ToUpper(HeaderRoutingStrategy),
+					RawValue: []byte("random"),
+				},
+				{
+					Key:      strings.ToUpper(HeaderTraceParent),
+					RawValue: []byte("00-" + traceID + "-00f067aa0ba902b7-01"),
+				},
+			},
+			expected: testResponse{
+				statusCode: envoyTypePb.StatusCode_OK,
+				headers: []*configPb.HeaderValueOption{
+					{Header: &configPb.HeaderValue{Key: HeaderWentIntoReqHeaders, RawValue: []byte("true")}},
+				},
+				routingCtx: &types.RoutingContext{
+					ReqHeaders: map[string]string{
+						HeaderExternalFilter:  "gpu=true",
+						contentTypeKey:        "application/json",
+						HeaderRoutingStrategy: "random",
+						HeaderTraceParent:     "00-" + traceID + "-00f067aa0ba902b7-01",
+					},
+				},
+				user: utils.User{},
+				rpm:  0,
+			},
+			validate: defaultSuccessValidator,
+		},
+		{
+			name: "extract x-session-id for session affinity routing",
+			requestHeaders: []*configPb.HeaderValue{
+				{
+					Key:      HeaderSessionID,
+					RawValue: []byte("MTI3LjAuMC4xOjg4OTk="),
+				},
+				{
+					Key:      HeaderRoutingStrategy,
+					RawValue: []byte("session-affinity"),
+				},
+			},
+			expected: testResponse{
+				statusCode: envoyTypePb.StatusCode_OK,
+				headers: []*configPb.HeaderValueOption{
+					{Header: &configPb.HeaderValue{Key: HeaderWentIntoReqHeaders, RawValue: []byte("true")}},
+				},
+				routingCtx: &types.RoutingContext{
+					ReqHeaders: map[string]string{
+						HeaderSessionID:       "MTI3LjAuMC4xOjg4OTk=",
+						HeaderRoutingStrategy: "session-affinity",
+					},
+				},
+				user: utils.User{},
+				rpm:  0,
+			},
+			validate: defaultSuccessValidator,
+		},
+		{
+			name: "extract opaque session key for session affinity routing",
+			requestHeaders: []*configPb.HeaderValue{
+				{
+					Key:      HeaderSessionKey,
+					RawValue: []byte("agent-session-42"),
+				},
+				{
+					Key:      HeaderRoutingStrategy,
+					RawValue: []byte("session-affinity"),
+				},
+			},
+			expected: testResponse{
+				statusCode: envoyTypePb.StatusCode_OK,
+				headers: []*configPb.HeaderValueOption{
+					{Header: &configPb.HeaderValue{Key: HeaderWentIntoReqHeaders, RawValue: []byte("true")}},
+				},
+				routingCtx: &types.RoutingContext{
+					ReqHeaders: map[string]string{
+						HeaderSessionKey:      "agent-session-42",
+						HeaderRoutingStrategy: "session-affinity",
+					},
+				},
+				user: utils.User{},
+				rpm:  0,
+			},
+			validate: defaultSuccessValidator,
+		},
+		{
 			name: "extract mixed-case x-session-id for session affinity routing",
 			requestHeaders: []*configPb.HeaderValue{
 				{

--- a/pkg/plugins/gateway/types.go
+++ b/pkg/plugins/gateway/types.go
@@ -19,6 +19,8 @@ package gateway
 import (
 	"errors"
 	"sync"
+
+	"github.com/vllm-project/aibrix/pkg/constants"
 )
 
 const (
@@ -53,13 +55,10 @@ const (
 	HeaderExternalFilter      = "external-filter"
 	HeaderConfigProfile       = "config-profile"
 	HeaderAIBrixConfigProfile = "x-aibrix-config-profile"
-	// HeaderSessionID is the header used for session affinity routing.
-	// NOTE: If you change this value, you MUST also update sessionIDHeader in
-	// pkg/plugins/gateway/algorithms/simple_session_affinity.go
-	HeaderSessionID = "x-session-id"
-	// HeaderSessionKey carries a caller-owned, opaque session key. Unlike
-	// HeaderSessionID, it never encodes or exposes a backend address.
-	HeaderSessionKey  = "x-aibrix-session-key"
+	// HeaderSessionID aliases the shared session-affinity header used by request parsing and routing.
+	HeaderSessionID = constants.HeaderSessionID
+	// HeaderSessionKey aliases the shared opaque session-key header.
+	HeaderSessionKey  = constants.HeaderSessionKey
 	HeaderTraceParent = "traceparent"
 
 	// RPM & TPM Update Errors


### PR DESCRIPTION
## Pull Request Description

Centralizes the session-affinity request header names in the shared `pkg/constants` package.

- Uses the shared constants from request-header parsing and session-affinity routing.
- Normalizes matched session headers to canonical keys so mixed-case inputs reach the router reliably.
- Normalizes the other routing/body header keys consumed by exact lookup, while preserving `Authorization` casing for upstream forwarding.
- Updates routing and request-header tests to use the same source of truth and cover canonical and case-insensitive input.
- Retains the existing exported gateway constants as aliases for source compatibility.

This removes duplicate literal definitions, prevents parser/router drift, and preserves existing exported names.

## Related Issues

Resolves: #2597

## Validation

- [x] `GOTOOLCHAIN=go1.22.6 go test ./pkg/constants ./pkg/plugins/gateway ./pkg/plugins/gateway/algorithms`
- [x] `GOTOOLCHAIN=go1.22.6 make lint-all`
- [x] `GOTOOLCHAIN=go1.22.6 make test`
- [x] `GOTOOLCHAIN=go1.22.6 make test-race-condition`
- [x] `GOTOOLCHAIN=go1.22.6 make test-integration` (43 controller specs and 48 webhook specs passed)

## Submission Checklist

- [x] PR title includes an appropriate prefix.
- [x] Changes are clearly explained in the PR description.
- [x] New and existing tests pass successfully.
- [x] Code follows the existing project style.
- [x] Documentation was reviewed; no update is needed for this internal refactor.
- [x] Full lint, unit, race, and integration validation completed without regressions.
