### PR TITLE
[Misc] gateway: deduplicate session affinity header constants

### DIFF
--- a/pkg/plugins/gateway/algorithms/simple_session_affinity.go
+++ b/pkg/plugins/gateway/algorithms/simple_session_affinity.go
@@ -32,11 +32,7 @@ import (
 
 const (
 	RouterSessionAffinity types.RoutingAlgorithm = "session-affinity"
-	// NOTE: sessionIDHeader must strictly match types.HeaderSessionID
-	// defined in pkg/plugins/gateway/types.go to prevent routing failures.
-	sessionIDHeader  string = "x-session-id"
-	sessionKeyHeader string = "x-aibrix-session-key"
-	maxSessionKeyLen        = 256
+	maxSessionKeyLen                              = 256
 )
 
 func init() {
@@ -59,7 +55,7 @@ func (r *sessionAffinityRouter) Route(ctx *types.RoutingContext, readyPodList ty
 		return r.fallbackRoute(ctx, readyPodList)
 	}
 
-	sessionID := ctx.ReqHeaders[sessionIDHeader]
+	sessionID := ctx.ReqHeaders[types.HeaderSessionID]
 	var targetAddr string
 
 	if sessionID != "" {
@@ -90,7 +86,7 @@ func (r *sessionAffinityRouter) Route(ctx *types.RoutingContext, readyPodList ty
 		}
 	}
 
-	if selected := rendezvousPod(ctx, readyPodList.All(), ctx.ReqHeaders[sessionKeyHeader]); selected != nil {
+	if selected := rendezvousPod(ctx, readyPodList.All(), ctx.ReqHeaders[types.HeaderSessionKey]); selected != nil {
 		port := utils.GetModelPortForPod(ctx.RequestID, selected)
 		addr := net.JoinHostPort(selected.Status.PodIP, strconv.Itoa(int(port)))
 		ctx.SetTargetPod(selected)
@@ -151,7 +147,7 @@ func (r *sessionAffinityRouter) setSessionHeader(ctx *types.RoutingContext, addr
 	if ctx.RespHeaders == nil {
 		ctx.RespHeaders = make(map[string]string)
 	}
-	ctx.RespHeaders[sessionIDHeader] = base64.StdEncoding.EncodeToString([]byte(addr))
+	ctx.RespHeaders[types.HeaderSessionID] = base64.StdEncoding.EncodeToString([]byte(addr))
 }
 
 // fallbackRoute selects a random ready pod and returns its IP:Port as the target address.
@@ -192,7 +188,7 @@ func (r *sessionAffinityRouter) ScoreAll(ctx *types.RoutingContext, readyPodList
 		return scores, scored, nil
 	}
 
-	sessionID := ctx.ReqHeaders[sessionIDHeader]
+	sessionID := ctx.ReqHeaders[types.HeaderSessionID]
 	var targetAddr string
 
 	if sessionID != "" {
@@ -224,7 +220,7 @@ func (r *sessionAffinityRouter) ScoreAll(ctx *types.RoutingContext, readyPodList
 	}
 
 	if !matchedSessionID {
-		if selected := rendezvousPod(ctx, pods, ctx.ReqHeaders[sessionKeyHeader]); selected != nil {
+		if selected := rendezvousPod(ctx, pods, ctx.ReqHeaders[types.HeaderSessionKey]); selected != nil {
 			for i, pod := range pods {
 				if pod == selected {
 					scores[i] = 1

--- a/pkg/plugins/gateway/algorithms/simple_session_affinity.go
+++ b/pkg/plugins/gateway/algorithms/simple_session_affinity.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	RouterSessionAffinity types.RoutingAlgorithm = "session-affinity"
-	maxSessionKeyLen                              = 256
+	maxSessionKeyLen                             = 256
 )
 
 func init() {

--- a/pkg/plugins/gateway/algorithms/simple_session_affinity_test.go
+++ b/pkg/plugins/gateway/algorithms/simple_session_affinity_test.go
@@ -39,7 +39,7 @@ func TestSessionAffinityRouter(t *testing.T) {
 		{
 			name: "valid session ID matches ready pod",
 			reqHeaders: map[string]string{
-				sessionIDHeader: base64.StdEncoding.EncodeToString([]byte("10.0.0.2:8000")),
+				types.HeaderSessionID: base64.StdEncoding.EncodeToString([]byte("10.0.0.2:8000")),
 			},
 			readyPods: []*v1.Pod{
 				newPod("pod1", "10.0.0.1", true, map[string]string{"model.aibrix.ai/port": "8000"}),
@@ -62,7 +62,7 @@ func TestSessionAffinityRouter(t *testing.T) {
 		{
 			name: "invalid base64 session ID → fallback",
 			reqHeaders: map[string]string{
-				sessionIDHeader: "%%%INVALID_BASE64%%%",
+				types.HeaderSessionID: "%%%INVALID_BASE64%%%",
 			},
 			readyPods: []*v1.Pod{
 				newPod("a", "192.168.1.10", true, map[string]string{"model.aibrix.ai/port": "8000"}),
@@ -74,7 +74,7 @@ func TestSessionAffinityRouter(t *testing.T) {
 		{
 			name: "session ID points to non-existent address → fallback",
 			reqHeaders: map[string]string{
-				sessionIDHeader: base64.StdEncoding.EncodeToString([]byte("10.99.99.99:8000")), // non-existent IP
+				types.HeaderSessionID: base64.StdEncoding.EncodeToString([]byte("10.99.99.99:8000")), // non-existent IP
 			},
 			readyPods: []*v1.Pod{
 				newPod("x", "10.1.1.1", true, map[string]string{"model.aibrix.ai/port": "8000"}),
@@ -103,13 +103,13 @@ func TestSessionAffinityRouter(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.NotNil(t, ctx.RespHeaders, "RespHeaders should not be nil")
-			assert.Contains(t, ctx.RespHeaders, sessionIDHeader, "Response must include session ID header")
+			assert.Contains(t, ctx.RespHeaders, types.HeaderSessionID, "Response must include session ID header")
 
 			// verify the returned address is one of the expected ready pod addresses
 			assert.Contains(t, tt.expectPossibleAddrs, addr, "selected address must be one of the ready pods' IP:port")
 
 			// verify that the session ID in the response decodes to the same address
-			sessionB64 := ctx.RespHeaders[sessionIDHeader]
+			sessionB64 := ctx.RespHeaders[types.HeaderSessionID]
 			sessionBytes, decodeErr := base64.StdEncoding.DecodeString(sessionB64)
 			assert.NoError(t, decodeErr, "session ID must be valid base64")
 			actualSessionAddr := string(sessionBytes)
@@ -149,7 +149,7 @@ func TestSessionAffinity_ScoreAll(t *testing.T) {
 	// 2. With session ID targeting pA
 	ctx2 := types.NewRoutingContext(context.Background(), "test", "m1", "", "req", "")
 	ctx2.ReqHeaders = make(map[string]string)
-	ctx2.ReqHeaders[sessionIDHeader] = base64.StdEncoding.EncodeToString([]byte("1.1.1.1:8000"))
+	ctx2.ReqHeaders[types.HeaderSessionID] = base64.StdEncoding.EncodeToString([]byte("1.1.1.1:8000"))
 
 	scores, _, err = scorer.ScoreAll(ctx2, podList)
 	assert.NoError(t, err)
@@ -173,13 +173,13 @@ func TestSessionAffinityPostRouteUpdateFollowsFinalTargetPod(t *testing.T) {
 	router := &sessionAffinityRouter{}
 	ctx := types.NewRoutingContext(context.Background(), "test", "m1", "", "req", "")
 	ctx.ReqHeaders = map[string]string{
-		sessionIDHeader: base64.StdEncoding.EncodeToString([]byte("1.1.1.1:8000")),
+		types.HeaderSessionID: base64.StdEncoding.EncodeToString([]byte("1.1.1.1:8000")),
 	}
 
 	err := router.PostRouteUpdate(ctx, podList, podB)
 	assert.NoError(t, err)
 
-	sessionBytes, decodeErr := base64.StdEncoding.DecodeString(ctx.RespHeaders[sessionIDHeader])
+	sessionBytes, decodeErr := base64.StdEncoding.DecodeString(ctx.RespHeaders[types.HeaderSessionID])
 	assert.NoError(t, decodeErr)
 	assert.Equal(t, "2.2.2.2:8000", string(sessionBytes))
 }
@@ -192,11 +192,11 @@ func TestSessionAffinityOpaqueKeyIsDeterministic(t *testing.T) {
 
 	route := func(pods []*v1.Pod) string {
 		ctx := types.NewRoutingContext(context.Background(), "test", "model1", "", "", "")
-		ctx.ReqHeaders = map[string]string{sessionKeyHeader: "agent-session-42"}
+		ctx.ReqHeaders = map[string]string{types.HeaderSessionKey: "agent-session-42"}
 		addr, err := router.Route(ctx, newMockPodList(pods, nil))
 		assert.NoError(t, err)
-		assert.NotEmpty(t, ctx.RespHeaders[sessionIDHeader])
-		assert.NotContains(t, ctx.RespHeaders, sessionKeyHeader)
+		assert.NotEmpty(t, ctx.RespHeaders[types.HeaderSessionID])
+		assert.NotContains(t, ctx.RespHeaders, types.HeaderSessionKey)
 		return addr
 	}
 
@@ -211,8 +211,8 @@ func TestSessionAffinityCookieTakesPrecedenceOverOpaqueKey(t *testing.T) {
 	router := &sessionAffinityRouter{}
 	ctx := types.NewRoutingContext(context.Background(), "test", "model1", "", "", "")
 	ctx.ReqHeaders = map[string]string{
-		sessionIDHeader:  base64.StdEncoding.EncodeToString([]byte("10.0.0.2:8000")),
-		sessionKeyHeader: "agent-session-42",
+		types.HeaderSessionID:  base64.StdEncoding.EncodeToString([]byte("10.0.0.2:8000")),
+		types.HeaderSessionKey: "agent-session-42",
 	}
 
 	addr, err := router.Route(ctx, newMockPodList([]*v1.Pod{podA, podB}, nil))
@@ -226,7 +226,7 @@ func TestSessionAffinityOpaqueKeyScoreAll(t *testing.T) {
 	pods := []*v1.Pod{podA, podB}
 	router := &sessionAffinityRouter{}
 	ctx := types.NewRoutingContext(context.Background(), "test", "model1", "", "", "")
-	ctx.ReqHeaders = map[string]string{sessionKeyHeader: "agent-session-42"}
+	ctx.ReqHeaders = map[string]string{types.HeaderSessionKey: "agent-session-42"}
 
 	scores, scored, err := router.ScoreAll(ctx, newMockPodList(pods, nil))
 	assert.NoError(t, err)

--- a/pkg/plugins/gateway/types.go
+++ b/pkg/plugins/gateway/types.go
@@ -19,6 +19,8 @@ package gateway
 import (
 	"errors"
 	"sync"
+
+	"github.com/vllm-project/aibrix/pkg/types"
 )
 
 const (
@@ -54,12 +56,10 @@ const (
 	HeaderConfigProfile       = "config-profile"
 	HeaderAIBrixConfigProfile = "x-aibrix-config-profile"
 	// HeaderSessionID is the header used for session affinity routing.
-	// NOTE: If you change this value, you MUST also update sessionIDHeader in
-	// pkg/plugins/gateway/algorithms/simple_session_affinity.go
-	HeaderSessionID = "x-session-id"
+	HeaderSessionID = types.HeaderSessionID
 	// HeaderSessionKey carries a caller-owned, opaque session key. Unlike
 	// HeaderSessionID, it never encodes or exposes a backend address.
-	HeaderSessionKey  = "x-aibrix-session-key"
+	HeaderSessionKey  = types.HeaderSessionKey
 	HeaderTraceParent = "traceparent"
 
 	// RPM & TPM Update Errors

--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -67,6 +67,14 @@ const (
 	PolarityMost                  // Higher score is better
 )
 
+const (
+	// HeaderSessionID is the header used for session affinity routing.
+	HeaderSessionID = "x-session-id"
+	// HeaderSessionKey carries a caller-owned, opaque session key. Unlike
+	// HeaderSessionID, it never encodes or exposes a backend address.
+	HeaderSessionKey = "x-aibrix-session-key"
+)
+
 // PodScorer defines the interface for strategies that support batch soft-scoring
 type PodScorer interface {
 	ScoreAll(ctx *RoutingContext, readyPodList PodList) (scores []float64, scored []bool, err error)


### PR DESCRIPTION
## Pull Request Description

The session affinity header names were defined in two separate places:

- `pkg/plugins/gateway/types.go`: `HeaderSessionID` and `HeaderSessionKey`
- `pkg/plugins/gateway/algorithms/simple_session_affinity.go`: local `sessionIDHeader` / `sessionKeyHeader` (copies of the same strings)

There was already a `NOTE` comment warning that the two copies had to stay in sync manually. If one side ever changed without updating the other, the session-affinity router would silently parse the wrong header — breaking sticky or session-key routing.

Moved the canonical values into `pkg/types` (which the algorithm package already imports), so both places reference a single definition. `gateway/types.go` re-exports them as typed aliases for backward compatibility with existing callers.

## Related Issues
Resolves: #2597

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[x] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

</details>