### PR TITLE
fix: inject Volcano scheduler for gang pods

### DIFF
--- a/pkg/controller/roleset/utils.go
+++ b/pkg/controller/roleset/utils.go
@@ -134,6 +134,9 @@ func renderStormServicePod(roleSet *orchestrationv1alpha1.RoleSet, role *orchest
 		}
 		if roleSet.Spec.SchedulingStrategy.VolcanoSchedulingStrategy != nil {
 			pod.Labels[constants.VolcanoPodGroupNameAnnotationKey] = roleSet.Name
+			if pod.Spec.SchedulerName == "" {
+				pod.Spec.SchedulerName = "volcano"
+			}
 		}
 	}
 

--- a/pkg/controller/roleset/utils_test.go
+++ b/pkg/controller/roleset/utils_test.go
@@ -38,6 +38,30 @@ func TestGetReadyReplicaCountForRole(t *testing.T) {
 	assert.Equal(t, int32(2), count)
 }
 
+func TestRenderStormServicePodVolcanoScheduler(t *testing.T) {
+	roleSet := &orchestrationv1alpha1.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: orchestrationv1alpha1.RoleSetSpec{
+			SchedulingStrategy: &orchestrationv1alpha1.SchedulingStrategy{
+				VolcanoSchedulingStrategy: &orchestrationv1alpha1.VolcanoSchedulingStrategySpec{},
+			},
+		},
+	}
+	role := &orchestrationv1alpha1.RoleSpec{Name: "worker"}
+
+	t.Run("injects volcano when unset", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		renderStormServicePod(roleSet, role, pod, nil)
+		assert.Equal(t, "volcano", pod.Spec.SchedulerName)
+	})
+
+	t.Run("preserves an explicit scheduler", func(t *testing.T) {
+		pod := &corev1.Pod{Spec: corev1.PodSpec{SchedulerName: "custom"}}
+		renderStormServicePod(roleSet, role, pod, nil)
+		assert.Equal(t, "custom", pod.Spec.SchedulerName)
+	})
+}
+
 func TestSetAndRemoveRoleSetCondition(t *testing.T) {
 	status := &orchestrationv1alpha1.RoleSetStatus{}
 	now := metav1.Now()


### PR DESCRIPTION
## Summary

- inject `schedulerName: volcano` for pods rendered with Volcano gang scheduling when unset
- preserve explicitly configured scheduler names
- add focused unit coverage

Closes #2619

## Tests

- `git diff --check` passed
- `go test ./pkg/controller/roleset` was attempted; dependency downloads did not complete in the local environment
