### PR TITLE
feat(metrics): add lora_adapter label to gateway request metrics

### DIFF
--- a/pkg/cache/cache_api.go
+++ b/pkg/cache/cache_api.go
@@ -76,6 +76,11 @@ type ModelCache interface {
 	//   map[string]struct{}: Set of model names
 	//   error: Error information if operation fails
 	ListModelsByPod(podName, podNamespace string) ([]string, error)
+
+	// ModelBaseModel returns the base-model name a LoRA adapter is attached to
+	// (ModelAdapter spec.baseModel, or the host pod's model label as fallback).
+	// Returns ("", false) for base models and for adapters with no known base.
+	ModelBaseModel(modelName string) (string, bool)
 }
 
 // ModelClaimBindingProvider is an optional cache extension used by the

--- a/pkg/cache/cache_impl.go
+++ b/pkg/cache/cache_impl.go
@@ -121,6 +121,15 @@ func (c *Store) ListModelsByPod(podName, podNamespace string) ([]string, error) 
 	return metaPod.Models.Array(), nil
 }
 
+// ModelBaseModel returns the base-model name a LoRA adapter is attached to.
+func (c *Store) ModelBaseModel(modelName string) (string, bool) {
+	meta, ok := c.metaModels.Load(modelName)
+	if !ok || meta.BaseModel == "" {
+		return "", false
+	}
+	return meta.BaseModel, true
+}
+
 // GetMetricValueByPod retrieves metric value for a Pod
 // Parameters:
 //

--- a/pkg/cache/informers.go
+++ b/pkg/cache/informers.go
@@ -18,6 +18,7 @@ package cache
 import (
 	"errors"
 	"strconv"
+	"strings"
 	"time"
 
 	crdinformers "github.com/vllm-project/aibrix/pkg/client/informers/externalversions"
@@ -281,6 +282,7 @@ func (c *Store) addModelAdapter(obj interface{}) {
 	for _, pod := range model.Status.Instances {
 		c.addPodAndModelMappingLockedByName(pod, model.Namespace, model.Name)
 	}
+	c.setModelBaseModelLocked(model)
 
 	klog.V(4).Infof("MODELADAPTER CREATED: %s/%s", model.Namespace, model.Name)
 	c.debugInfo()
@@ -300,8 +302,36 @@ func (c *Store) updateModelAdapter(oldObj interface{}, newObj interface{}) {
 	for _, pod := range newModel.Status.Instances {
 		c.addPodAndModelMappingLockedByName(pod, newModel.Namespace, newModel.Name)
 	}
+	c.setModelBaseModelLocked(newModel)
 
 	c.debugInfo()
+}
+
+// setModelBaseModelLocked records the adapter → base-model mapping on the cache
+// entry. Caller must hold c.mu. Prefers spec.baseModel; falls back to the host
+// pod's model.aibrix.ai/name label when spec is empty.
+func (c *Store) setModelBaseModelLocked(model *modelv1alpha1.ModelAdapter) {
+	meta, ok := c.metaModels.Load(model.Name)
+	if !ok {
+		return
+	}
+	base := ""
+	if model.Spec.BaseModel != nil {
+		base = strings.TrimSpace(*model.Spec.BaseModel)
+	}
+	if base == "" {
+		for _, podName := range model.Status.Instances {
+			metaPod, ok := c.metaPods.Load(utils.GeneratePodKey(model.Namespace, podName))
+			if !ok || metaPod.Pod == nil || metaPod.Pod.Labels == nil {
+				continue
+			}
+			if v := strings.TrimSpace(metaPod.Pod.Labels[constants.ModelLabelName]); v != "" {
+				base = v
+				break
+			}
+		}
+	}
+	meta.BaseModel = base
 }
 
 func (c *Store) deleteModelAdapter(obj interface{}) {

--- a/pkg/cache/model.go
+++ b/pkg/cache/model.go
@@ -37,5 +37,9 @@ type Model struct {
 	// QueueRouter maintains a local request queue, enabling flexible request reordering.
 	QueueRouter types.QueueRouter
 
+	// BaseModel is the served base-model name a LoRA adapter is attached to
+	// (ModelAdapter spec.baseModel). Empty for base models.
+	BaseModel string
+
 	pendingRequests int32
 }

--- a/pkg/metrics/custom_metrics.go
+++ b/pkg/metrics/custom_metrics.go
@@ -77,11 +77,7 @@ func DeleteGaugeMetricForPod(metricName string, routingCtx *types.RoutingContext
 		return
 	}
 
-	var model string
-	if routingCtx != nil {
-		model = routingCtx.Model
-	}
-	labelNames, labelValues := buildMetricLabels(pod, model, extras)
+	labelNames, labelValues := buildMetricLabels(pod, routingCtx, extras)
 	if len(canonicalNames) == 0 {
 		_ = gauge.DeleteLabelValues(labelValues...)
 		return
@@ -166,24 +162,12 @@ func IncrementCounterMetric(name string, help string, value float64, labelNames 
 }
 
 func emitGaugeMetric(routingCtx *types.RoutingContext, pod *v1.Pod, name string, value float64, extras map[string]string) {
-	var model string
-	if routingCtx == nil {
-		model = ""
-	} else {
-		model = routingCtx.Model
-	}
-	labelNames, labelValues := buildMetricLabels(pod, model, extras)
+	labelNames, labelValues := buildMetricLabels(pod, routingCtx, extras)
 	SetGaugeMetric(name, GetMetricHelp(name), value, labelNames, labelValues...)
 }
 
 func emitCounterMetric(routingCtx *types.RoutingContext, pod *v1.Pod, name string, value float64, extras map[string]string) {
-	var model string
-	if routingCtx == nil {
-		model = ""
-	} else {
-		model = routingCtx.Model
-	}
-	labelNames, labelValues := buildMetricLabels(pod, model, extras)
+	labelNames, labelValues := buildMetricLabels(pod, routingCtx, extras)
 	IncrementCounterMetricFnForTest(name, GetMetricHelp(name), value, labelNames, labelValues...)
 }
 
@@ -350,9 +334,9 @@ func SetupMetricsForTest(metricName string, labelNames []string) (*prometheus.Ga
 	testRegistry.MustRegister(testGauge)
 
 	originalFn := SetGaugeMetricFnForTest
-	SetGaugeMetricFnForTest = func(name string, help string, value float64, labels []string, labelValues ...string) {
+	SetGaugeMetricFnForTest = func(name string, help string, value float64, gotNames []string, gotValues ...string) {
 		if name == metricName {
-			testGauge.WithLabelValues(labelValues...).Set(value)
+			testGauge.WithLabelValues(projectLabelValues(labelNames, gotNames, gotValues)...).Set(value)
 		}
 	}
 
@@ -368,23 +352,36 @@ func SetupCounterMetricsForTest(metricName string, labelNames []string) (*promet
 	testRegistry.MustRegister(testCounter)
 
 	originalFn := IncrementCounterMetricFnForTest
-	IncrementCounterMetricFnForTest = func(name string, help string, value float64, labels []string, labelValues ...string) {
+	IncrementCounterMetricFnForTest = func(name string, help string, value float64, gotNames []string, gotValues ...string) {
 		if name == metricName {
-			testCounter.WithLabelValues(labelValues...).Add(value)
+			testCounter.WithLabelValues(projectLabelValues(labelNames, gotNames, gotValues)...).Add(value)
 		}
 	}
 
 	return testCounter, func() { IncrementCounterMetricFnForTest = originalFn }
 }
 
+// projectLabelValues maps emitted label values onto the subset of names a test
+// CounterVec/GaugeVec was registered with, so tests can ignore extra default
+// labels (lora_adapter, ...).
+func projectLabelValues(wantNames, gotNames, gotValues []string) []string {
+	m := make(map[string]string, len(gotNames))
+	for i, n := range gotNames {
+		if i < len(gotValues) {
+			m[n] = gotValues[i]
+		}
+	}
+	out := make([]string, len(wantNames))
+	for i, n := range wantNames {
+		out[i] = m[n]
+	}
+	return out
+}
+
 func EmitMetricToPrometheus(routingCtx *types.RoutingContext, pod *v1.Pod, metricName string, metricValue MetricValue, extra map[string]string) {
 	metricDef, exists := Metrics[metricName]
 	if !exists {
 		return
-	}
-	var model string
-	if routingCtx != nil {
-		model = routingCtx.Model
 	}
 
 	switch metricDef.MetricType.Raw {
@@ -393,7 +390,7 @@ func EmitMetricToPrometheus(routingCtx *types.RoutingContext, pod *v1.Pod, metri
 	case Counter:
 		emitCounterMetric(routingCtx, pod, metricName, metricValue.GetSimpleValue(), extra)
 	default:
-		labelNames, labelValues := buildMetricLabels(pod, model, extra)
+		labelNames, labelValues := buildMetricLabels(pod, routingCtx, extra)
 		if hv := metricValue.GetHistogramValue(); hv != nil {
 			SetHistogramMetric(metricName, GetMetricHelp(metricName), hv, labelNames, labelValues...)
 			p50, _ := hv.GetPercentile(50)
@@ -406,8 +403,8 @@ func EmitMetricToPrometheus(routingCtx *types.RoutingContext, pod *v1.Pod, metri
 	}
 }
 
-func buildMetricLabels(pod *v1.Pod, model string, extras map[string]string) ([]string, []string) {
-	defaultLabelMap := generateDefaultMetricLabelsMap(pod, model)
+func buildMetricLabels(pod *v1.Pod, routingCtx *types.RoutingContext, extras map[string]string) ([]string, []string) {
+	defaultLabelMap := generateDefaultMetricLabelsMap(pod, routingCtx)
 	labelNames := make([]string, 0, len(defaultLabelMap)+len(extras))
 	labelValues := make([]string, 0, len(defaultLabelMap)+len(extras))
 
@@ -441,23 +438,37 @@ func buildMetricLabels(pod *v1.Pod, model string, extras map[string]string) ([]s
 	return labelNames, labelValues
 }
 
-func generateDefaultMetricLabelsMap(pod *v1.Pod, model string) map[string]string {
+func generateDefaultMetricLabelsMap(pod *v1.Pod, routingCtx *types.RoutingContext) map[string]string {
+	model, loraAdapter := metricModelLabels(routingCtx)
 	if pod == nil {
 		return map[string]string{
-			"model":       model,
-			"gateway_pod": gatewayPodName,
+			"model":        model,
+			"lora_adapter": loraAdapter,
+			"gateway_pod":  gatewayPodName,
 		}
 	}
 	return map[string]string{
 		"namespace":          pod.Namespace,
 		"pod":                pod.Name,
 		"model":              model,
+		"lora_adapter":       loraAdapter,
 		"engine_type":        GetEngineType(*pod),
 		"roleset":            utils.GetPodEnv(pod, "ROLESET_NAME", ""),
 		"role":               resolvePodRole(pod),
 		"role_replica_index": utils.GetPodEnv(pod, "ROLE_REPLICA_INDEX", ""),
 		"gateway_pod":        gatewayPodName,
 	}
+}
+
+// metricModelLabels returns (model, lora_adapter) for gateway request metrics.
+// model is always the served base-model name so existing $model dashboard
+// filters keep working. For a LoRA request, lora_adapter is the adapter name;
+// for a base-model request it is empty.
+func metricModelLabels(routingCtx *types.RoutingContext) (model, loraAdapter string) {
+	if routingCtx == nil {
+		return "", ""
+	}
+	return routingCtx.MetricModel(), routingCtx.MetricLoraAdapter()
 }
 
 func resolvePodRole(pod *v1.Pod) string {

--- a/pkg/metrics/custom_metrics_test.go
+++ b/pkg/metrics/custom_metrics_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/vllm-project/aibrix/pkg/types"
 )
 
 const (
@@ -218,4 +219,29 @@ func TestSetHistogramMetric(t *testing.T) {
 		assert.InDelta(t, 3.0, h.GetSampleSum(), 1e-9)
 	}
 	assert.True(t, found)
+}
+
+func TestBuildMetricLabels_LoraVsBase(t *testing.T) {
+	t.Setenv("POD_NAME", "gw-0")
+	gatewayPodName = "gw-0"
+
+	loraCtx := &types.RoutingContext{Model: "hip-adapter", BaseModel: "qwen3-8b"}
+	names, values := buildMetricLabels(nil, loraCtx, nil)
+	got := zipLabels(names, values)
+	assert.Equal(t, "qwen3-8b", got["model"])
+	assert.Equal(t, "hip-adapter", got["lora_adapter"])
+
+	baseCtx := &types.RoutingContext{Model: "qwen3-8b"}
+	names, values = buildMetricLabels(nil, baseCtx, nil)
+	got = zipLabels(names, values)
+	assert.Equal(t, "qwen3-8b", got["model"])
+	assert.Equal(t, "", got["lora_adapter"])
+}
+
+func zipLabels(names, values []string) map[string]string {
+	out := make(map[string]string, len(names))
+	for i, n := range names {
+		out[n] = values[i]
+	}
+	return out
 }

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -125,12 +125,12 @@ func (st *processState) trackModelInFlight() {
 		st.releaseModelInFlight()
 	}
 	st.trackedModel = st.model
+	labelNames, labelValues := st.modelInFlightLabels()
 	metrics.IncGaugeMetric(
 		metrics.GatewayModelInFlight,
 		metrics.GetMetricHelp(metrics.GatewayModelInFlight),
-		[]string{"gateway_pod", "model"},
-		podName,
-		st.model,
+		labelNames,
+		labelValues...,
 	)
 }
 
@@ -140,13 +140,29 @@ func (st *processState) releaseModelInFlight() {
 	}
 	modelToRelease := st.trackedModel
 	st.trackedModel = ""
+	labelNames, labelValues := st.modelInFlightLabelsFor(modelToRelease)
 	metrics.DecGaugeMetric(
 		metrics.GatewayModelInFlight,
 		metrics.GetMetricHelp(metrics.GatewayModelInFlight),
-		[]string{"gateway_pod", "model"},
-		podName,
-		modelToRelease,
+		labelNames,
+		labelValues...,
 	)
+}
+
+func (st *processState) modelInFlightLabels() ([]string, []string) {
+	return st.modelInFlightLabelsFor(st.model)
+}
+
+func (st *processState) modelInFlightLabelsFor(model string) ([]string, []string) {
+	loraAdapter := ""
+	if st.routerCtx != nil {
+		if m := st.routerCtx.MetricModel(); m != "" {
+			model = m
+		}
+		loraAdapter = st.routerCtx.MetricLoraAdapter()
+	}
+	return []string{"gateway_pod", "model", "lora_adapter"},
+		[]string{podName, model, loraAdapter}
 }
 
 // finishRequestCount and finishRequestTrace are the only production lifecycle
@@ -274,7 +290,7 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 			klog.V(4).InfoS("request actively finished, breaking ext_proc stream", "requestID", st.requestID)
 			if st.model != "" && !st.isGatewayRspDone {
 				st.isGatewayRspDone = true
-				s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, "gateway_request_success", "200")
+				s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, "gateway_request_success", "200", st.routerCtx)
 			}
 			s.finishRequestCount(st)
 			return nil
@@ -313,7 +329,7 @@ func (s *Server) processOnce(srv extProcPb.ExternalProcessor_ProcessServer, st *
 		req = r.req
 	case <-s.shutdownCh:
 		if st.model != "" {
-			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503")
+			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503", st.routerCtx)
 			s.finishRequestCount(st)
 		}
 		klog.ErrorS(nil, "server shutdown requested; aborting blocked Recv", "request_id", st.requestID, "model", st.model)
@@ -331,7 +347,7 @@ func (s *Server) preRecvCheck(st *processState) error {
 	select {
 	case <-s.shutdownCh:
 		if st.model != "" {
-			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503")
+			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503", st.routerCtx)
 			s.finishRequestCount(st)
 		}
 		klog.ErrorS(nil, "server shutdown requested; draining request", "request_id", st.requestID, "model", st.model)
@@ -340,7 +356,7 @@ func (s *Server) preRecvCheck(st *processState) error {
 	// Client cancelled or deadline exceeded
 	case <-st.ctx.Done():
 		if st.model != "" {
-			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "context_cancelled", "499")
+			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "context_cancelled", "499", st.routerCtx)
 			s.finishRequestCount(st)
 		}
 		klog.ErrorS(st.ctx.Err(), "context cancelled", "request_id", st.requestID, "model", st.model)
@@ -357,7 +373,7 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 		// check for shutdown
 		case <-s.shutdownCh:
 			if st.model != "" {
-				s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503")
+				s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "aibrix_gateway_server_shutdown", "503", st.routerCtx)
 				s.finishRequestCount(st)
 			}
 			klog.ErrorS(nil, "server shutdown requested; stream closed (EOF) during shutdown drain", "requestID", st.requestID, "model", st.model)
@@ -370,7 +386,7 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 		if st.completed {
 			if st.model != "" && !st.isGatewayRspDone {
 				st.isGatewayRspDone = true
-				s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, "gateway_request_success", "200")
+				s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, "gateway_request_success", "200", st.routerCtx)
 			}
 			klog.V(2).InfoS("stream closed (EOF): completed", "requestID", st.requestID, "model", st.model)
 			s.finishRequestCount(st)
@@ -379,7 +395,7 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 
 		// client closed stream (EOF)
 		if st.model != "" {
-			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "client_cancelled_eof", "499")
+			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "client_cancelled_eof", "499", st.routerCtx)
 		}
 		klog.ErrorS(nil, "client closed stream (EOF) before completion", "requestID", st.requestID, "model", st.model)
 		s.finishRequestCount(st)
@@ -391,7 +407,7 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 	if ok && stErr.Code() == codes.Canceled {
 		if st.model != "" && !st.isGatewayRspDone {
 			st.isGatewayRspDone = true
-			s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, "gateway_request_success", "200")
+			s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, "gateway_request_success", "200", st.routerCtx)
 		}
 		s.finishRequestCount(st)
 		return status.Error(codes.Canceled, "request canceled")
@@ -400,7 +416,7 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 	// Record failed request metric for other gRPC errors
 	if ok {
 		if st.model != "" {
-			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "gateway_request_fail", strconv.FormatUint(uint64(stErr.Code()), 10))
+			s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "gateway_request_fail", strconv.FormatUint(uint64(stErr.Code()), 10), st.routerCtx)
 		}
 		klog.ErrorS(err, "error receiving stream from Envoy extproc", "requestID", st.requestID, "model", st.model, "grpc_code", stErr.Code(), "grpc_message", stErr.Message())
 		s.finishRequestCount(st)
@@ -478,7 +494,7 @@ func (s *Server) handleProcessingRequest(st *processState, req *extProcPb.Proces
 
 	if resp == nil {
 		klog.ErrorS(nil, "no ProcessingResponse generated for message", "requestID", st.requestID, "msg_type", fmt.Sprintf("%T", req.Request))
-		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "no_response_err", "500")
+		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "no_response_err", "500", st.routerCtx)
 		s.finishRequestCount(st)
 		return nil, status.Errorf(codes.Internal, "no response generated for %T", req.Request)
 	}
@@ -493,14 +509,14 @@ func (s *Server) handleProcessingRequest(st *processState, req *extProcPb.Proces
 		}
 		if st.completed && !st.isGatewayRspDone {
 			st.isGatewayRspDone = true
-			s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, st.metricLabel+"_success", "200")
+			s.emitMetricsCounterHelper(metrics.GatewayRequestModelSuccessTotal, st.model, st.metricLabel+"_success", "200", st.routerCtx)
 		}
 		return resp, nil
 	}
 
 	statusCode := strconv.Itoa(int(resp.GetImmediateResponse().GetStatus().GetCode()))
 	metricFail := getMetricErr(resp.GetImmediateResponse(), st.metricLabel)
-	s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, metricFail+"_fail", statusCode)
+	s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, metricFail+"_fail", statusCode, st.routerCtx)
 
 	return resp, nil
 }
@@ -519,7 +535,7 @@ func (s *Server) responseForResponseHeaderError(st *processState, resp *extProcP
 func (s *Server) sendProcessingResponse(srv extProcPb.ExternalProcessor_ProcessServer, st *processState, resp *extProcPb.ProcessingResponse) error {
 	if err := srv.Send(resp); err != nil && len(st.model) > 0 {
 		klog.ErrorS(err, "gateway fail to send response to envoy-proxy", "requestID", st.requestID)
-		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "send_envoy_proxy", "499")
+		s.emitMetricsCounterHelper(metrics.GatewayRequestModelFailTotal, st.model, "send_envoy_proxy", "499", st.routerCtx)
 		s.finishRequestCount(st)
 
 		if errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "EOF") {
@@ -780,9 +796,12 @@ func (s *Server) responseErrorProcessingWithHeaders(ctx context.Context, routing
 		errMsg, errorCode, "")
 }
 
-func (s *Server) emitMetricsCounterHelper(metricName, model, status, statusCode string) {
+func (s *Server) emitMetricsCounterHelper(metricName, model, status, statusCode string, routingCtx *types.RoutingContext) {
+	if routingCtx == nil {
+		routingCtx = &types.RoutingContext{Model: model}
+	}
 	labels := buildGatewayPodMetricLabels(model, status, statusCode)
-	metrics.EmitMetricToPrometheus(&types.RoutingContext{Model: model}, nil, metricName, &metrics.SimpleMetricValue{Value: 1.0}, labels)
+	metrics.EmitMetricToPrometheus(routingCtx, nil, metricName, &metrics.SimpleMetricValue{Value: 1.0}, labels)
 }
 
 func getMetricErr(resp *extProcPb.ImmediateResponse, metricLabel string) string {

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -75,6 +75,9 @@ func (s *Server) HandleRequestBody(ctx context.Context, routingCtx *types.Routin
 	routingCtx.Message = message
 	routingCtx.Stream = stream
 	routingCtx.ReqBody = body.RequestBody.GetBody()
+	if base, ok := s.cache.ModelBaseModel(model); ok {
+		routingCtx.BaseModel = base
+	}
 
 	// early reject if model doesn't exist or no pods are ready
 	var podsArr types.PodList

--- a/pkg/plugins/gateway/gateway_test.go
+++ b/pkg/plugins/gateway/gateway_test.go
@@ -1902,6 +1902,45 @@ func TestModelInFlightTracking(t *testing.T) {
 	require.Equal(t, "dec", gauges[1]["_dir"])
 }
 
+func TestModelInFlightTracking_LoraAdapter(t *testing.T) {
+	var gauges []map[string]string
+	originalIncFn := metrics.IncGaugeMetricFnForTest
+	originalDecFn := metrics.DecGaugeMetricFnForTest
+	defer func() {
+		metrics.IncGaugeMetricFnForTest = originalIncFn
+		metrics.DecGaugeMetricFnForTest = originalDecFn
+	}()
+	recordFn := func(dir string) func(name string, help string, labelNames []string, labelValues ...string) {
+		return func(name string, help string, labelNames []string, labelValues ...string) {
+			if name != metrics.GatewayModelInFlight {
+				return
+			}
+			labels := make(map[string]string, len(labelNames))
+			for i, ln := range labelNames {
+				labels[ln] = labelValues[i]
+			}
+			labels["_dir"] = dir
+			gauges = append(gauges, labels)
+		}
+	}
+	metrics.IncGaugeMetricFnForTest = recordFn("inc")
+	metrics.DecGaugeMetricFnForTest = recordFn("dec")
+
+	st := &processState{
+		model:     "hip-adapter",
+		routerCtx: &types.RoutingContext{Model: "hip-adapter", BaseModel: "qwen3-8b"},
+	}
+	st.trackModelInFlight()
+	require.Len(t, gauges, 1)
+	require.Equal(t, "qwen3-8b", gauges[0]["model"])
+	require.Equal(t, "hip-adapter", gauges[0]["lora_adapter"])
+
+	st.releaseModelInFlight()
+	require.Len(t, gauges, 2)
+	require.Equal(t, "qwen3-8b", gauges[1]["model"])
+	require.Equal(t, "hip-adapter", gauges[1]["lora_adapter"])
+}
+
 func TestModelInFlightTracking_ModelChange(t *testing.T) {
 	var gauges []map[string]string
 	originalIncFn := metrics.IncGaugeMetricFnForTest

--- a/pkg/plugins/gateway/gateway_test_helpers.go
+++ b/pkg/plugins/gateway/gateway_test_helpers.go
@@ -116,6 +116,18 @@ func (m *MockCache) ListModelsByPod(namespace string, podName string) ([]string,
 	return args.Get(0).([]string), args.Error(1)
 }
 
+// ModelBaseModel is called on the request path so LoRA metrics can record
+// both the adapter name and its base model. Default to ("", false).
+func (m *MockCache) ModelBaseModel(model string) (string, bool) {
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "ModelBaseModel" {
+			args := m.Called(model)
+			return args.String(0), args.Bool(1)
+		}
+	}
+	return "", false
+}
+
 // MockGatewayClient implements gatewayapi.Clientset interface
 type MockGatewayClient struct {
 	mock.Mock

--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -83,8 +83,11 @@ type PostRouteUpdater interface {
 // It can be extended with more fields as needed in the future.
 type RoutingContext struct {
 	context.Context
-	Algorithm      RoutingAlgorithm
-	Model          string
+	Algorithm RoutingAlgorithm
+	Model     string
+	// BaseModel is the served base-model name when Model is a LoRA adapter.
+	// Empty for base-model requests.
+	BaseModel      string
 	Engine         string
 	Stream         bool
 	Message        string
@@ -348,6 +351,27 @@ func (r *RoutingContext) targetAddressWithPort(podIP string, port int) string {
 	return fmt.Sprintf("%v:%v", podIP, port)
 }
 
+// MetricModel returns the model name to emit on gateway metrics.
+// For a LoRA request this is the attached base model; otherwise the requested name.
+func (r *RoutingContext) MetricModel() string {
+	if r == nil {
+		return ""
+	}
+	if r.BaseModel != "" {
+		return r.BaseModel
+	}
+	return r.Model
+}
+
+// MetricLoraAdapter returns the adapter name for gateway metrics.
+// Empty for base-model requests.
+func (r *RoutingContext) MetricLoraAdapter() string {
+	if r == nil || r.BaseModel == "" || r.BaseModel == r.Model {
+		return ""
+	}
+	return r.Model
+}
+
 func (r *RoutingContext) getError() (err error) {
 	errAddr := r.lastError.Load()
 	if errAddr != nil {
@@ -360,6 +384,7 @@ func (r *RoutingContext) reset(ctx context.Context, algorithms RoutingAlgorithm,
 	r.Context = ctx
 	r.Algorithm = algorithms
 	r.Model = model
+	r.BaseModel = ""
 	r.Engine = ""
 	r.Stream = false
 	r.Message = message

--- a/pkg/types/router_context_test.go
+++ b/pkg/types/router_context_test.go
@@ -75,6 +75,7 @@ var _ = Describe("RouterContext", func() {
 		Expect(rctx.targetPod.Load()).To(BeNil()) // target pod set
 		Expect(rctx.getError()).ToNot(BeNil())    // No blocking
 
+		rctx.BaseModel = "stale-base"
 		rctx.Delete()
 		ctx2 := context.Background()
 		rctx2 := NewRoutingContext(ctx2, "algorithm2", "model2", "message2", "r2", "")
@@ -83,6 +84,7 @@ var _ = Describe("RouterContext", func() {
 		Expect(rctx2.Algorithm).To(Equal(RoutingAlgorithm("algorithm2")))
 		Expect(rctx.RequestID).To(Equal("r2"))
 		Expect(rctx2.Model).To(Equal("model2"))
+		Expect(rctx2.BaseModel).To(Equal(""))
 		Expect(rctx2.Message).To(Equal("message2"))
 		Expect(rctx.predictor).To(BeNil())
 		shouldBlock(func() { rctx.TargetPod() }, 100*time.Millisecond)
@@ -90,6 +92,16 @@ var _ = Describe("RouterContext", func() {
 		Expect(rctx.getError()).To(BeNil()) // No blocking
 
 		rctx.Delete()
+	})
+
+	It("should MetricModel use the base model for LoRA requests", func() {
+		lora := &RoutingContext{Model: "hip-adapter", BaseModel: "qwen3-8b"}
+		Expect(lora.MetricModel()).To(Equal("qwen3-8b"))
+		Expect(lora.MetricLoraAdapter()).To(Equal("hip-adapter"))
+
+		plain := &RoutingContext{Model: "qwen3-8b"}
+		Expect(plain.MetricModel()).To(Equal("qwen3-8b"))
+		Expect(plain.MetricLoraAdapter()).To(Equal(""))
 	})
 
 	It("should SetTargetPod accept nil", func() {


### PR DESCRIPTION
## Pull Request Description
Track LoRA-adapter requests distinctly from base-model requests on gateway metrics. RoutingContext gains a BaseModel field, populated from cache.ModelBaseModel (sourced from ModelAdapter spec.baseModel, falling back to the host pod's model label). MetricModel/ MetricLoraAdapter derive the model/lora_adapter label pair so existing $model dashboard filters keep resolving to the base model.

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>