### PR TITLE
fix(modeladapter): surface missing backend scheduling reasons

### DIFF
--- a/pkg/controller/modeladapter/modeladapter_controller.go
+++ b/pkg/controller/modeladapter/modeladapter_controller.go
@@ -88,6 +88,10 @@ const (
 	ModelAdapterLoadingErrorReason = "ModelAdapterLoadingError"
 	// ValidationFailedReason is added when model adapter object fails the validation
 	ValidationFailedReason = "ValidationFailed"
+	// NoReadyPodsReason is added when no backend pods are ready for scheduling.
+	NoReadyPodsReason = "NoReadyPods"
+	// InsufficientReadyPodsReason is added when fewer backend pods are ready than required.
+	InsufficientReadyPodsReason = "InsufficientReadyPods"
 	// StableInstanceFoundReason is added if there's stale pod and instance has been deleted successfully.
 	StableInstanceFoundReason = "StableInstanceFound"
 	// ConditionNotReason is added when there's no condition found in the cluster.
@@ -493,10 +497,10 @@ func (r *ModelAdapterReconciler) DoReconcile(ctx context.Context, req ctrl.Reque
 }
 
 func newSchedulingPendingCondition(instance *modelv1alpha1.ModelAdapter, available, needed int) metav1.Condition {
-	reason := "NoReadyPods"
+	reason := NoReadyPodsReason
 	message := fmt.Sprintf("ModelAdapter %s has no ready backend pods available for scheduling", klog.KObj(instance))
 	if available > 0 {
-		reason = "InsufficientReadyPods"
+		reason = InsufficientReadyPodsReason
 		message = fmt.Sprintf("ModelAdapter %s has %d ready backend pods, but needs %d for scheduling", klog.KObj(instance), available, needed)
 	}
 	return NewCondition(string(modelv1alpha1.ModelAdapterConditionTypeScheduled), metav1.ConditionFalse, reason, message)

--- a/pkg/controller/modeladapter/modeladapter_controller.go
+++ b/pkg/controller/modeladapter/modeladapter_controller.go
@@ -492,6 +492,16 @@ func (r *ModelAdapterReconciler) DoReconcile(ctx context.Context, req ctrl.Reque
 	return ctrl.Result{}, nil
 }
 
+func newSchedulingPendingCondition(instance *modelv1alpha1.ModelAdapter, available, needed int) metav1.Condition {
+	reason := "NoReadyPods"
+	message := fmt.Sprintf("ModelAdapter %s has no ready backend pods available for scheduling", klog.KObj(instance))
+	if available > 0 {
+		reason = "InsufficientReadyPods"
+		message = fmt.Sprintf("ModelAdapter %s has %d ready backend pods, but needs %d for scheduling", klog.KObj(instance), available, needed)
+	}
+	return NewCondition(string(modelv1alpha1.ModelAdapterConditionTypeScheduled), metav1.ConditionFalse, reason, message)
+}
+
 func (r *ModelAdapterReconciler) updateStatus(ctx context.Context, instance *modelv1alpha1.ModelAdapter, conditions ...metav1.Condition) error {
 	changed := false
 	for _, condition := range conditions {
@@ -665,10 +675,16 @@ func (r *ModelAdapterReconciler) reconcileLoadOnSinglePod(ctx context.Context, i
 		} else if len(candidatePods) > 0 {
 			// Some pods available but not enough, try with what we have
 			klog.Infof("Only %d ready pods available for model adapter %s, need %d more, will wait", len(candidatePods), klog.KObj(instance), neededReplicas)
+			if err := r.updateStatus(ctx, instance, newSchedulingPendingCondition(instance, len(candidatePods), neededReplicas)); err != nil {
+				return ctrl.Result{}, err
+			}
 			return ctrl.Result{RequeueAfter: time.Duration(RetryBackoffSeconds) * time.Second}, nil
 		} else {
 			// No ready pods available, wait for pods to become ready
 			klog.Infof("No ready pods available for model adapter %s, waiting for pods to become ready", klog.KObj(instance))
+			if err := r.updateStatus(ctx, instance, newSchedulingPendingCondition(instance, 0, neededReplicas)); err != nil {
+				return ctrl.Result{}, err
+			}
 			return ctrl.Result{RequeueAfter: time.Duration(RetryBackoffSeconds) * time.Second}, nil
 		}
 	} else if currentReplicas > desiredReplicas {

--- a/pkg/controller/modeladapter/modeladapter_controller_unit_tests.go
+++ b/pkg/controller/modeladapter/modeladapter_controller_unit_tests.go
@@ -19,6 +19,7 @@ package modeladapter
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -521,5 +522,28 @@ func TestScheduledPodsManagement(t *testing.T) {
 	emptyPods := r.getScheduledPods(instance)
 	if emptyPods != nil {
 		t.Errorf("Expected nil, got %v", emptyPods)
+	}
+}
+
+func TestNewSchedulingPendingCondition(t *testing.T) {
+	instance := &modelv1alpha1.ModelAdapter{ObjectMeta: metav1.ObjectMeta{Name: "adapter", Namespace: "default"}}
+
+	tests := []struct {
+		name, reason, message string
+		available, needed     int
+	}{
+		{"no ready pods", "NoReadyPods", "has no ready backend pods available for scheduling", 0, 1},
+		{"insufficient ready pods", "InsufficientReadyPods", "has 1 ready backend pods, but needs 2 for scheduling", 1, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			condition := newSchedulingPendingCondition(instance, tt.available, tt.needed)
+			if condition.Status != metav1.ConditionFalse || condition.Reason != tt.reason {
+				t.Fatalf("unexpected condition: %#v", condition)
+			}
+			if !strings.Contains(condition.Message, tt.message) {
+				t.Fatalf("message %q does not contain %q", condition.Message, tt.message)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

When a single-replica ModelAdapter has no ready backend pods, or fewer ready pods than required, the controller only logs the situation and leaves users without an actionable status message.

This change records a `Scheduled=False` condition with a specific reason and message for both cases, while preserving the existing requeue behavior.

## Validation

- `gofmt` on changed Go files
- `go test ./pkg/controller/modeladapter/...`
- `go vet ./pkg/controller/modeladapter/...`
- `git diff --check`

Fixes #1885
