### PR TITLE
fix(batch): registry template and profile when system inits.

### DIFF
--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -82,8 +82,9 @@ def _load_batch_k8s_context(
         # Determine the namespace where the batch ConfigMaps live.
         # The Helm deployment injects POD_NAMESPACE (=aibrix-system) via the
         # downward API
-        namespace_template = os.getenv(ENV_AIBRIX_TEMPLATE_NAMESPACE, MDS_NAMESPACE)
-        namespace_profile = os.getenv(ENV_AIBRIX_PROFILE_NAMESPACE, MDS_NAMESPACE)
+        pod_namespace = os.getenv("POD_NAMESPACE", MDS_NAMESPACE)
+        namespace_template = os.getenv(ENV_AIBRIX_TEMPLATE_NAMESPACE, pod_namespace)
+        namespace_profile = os.getenv(ENV_AIBRIX_PROFILE_NAMESPACE, pod_namespace)
 
         # Build ConfigMap-backed registries and load their contents synchronously
         # before the API server starts accepting requests so that incoming

--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -32,6 +32,7 @@ from aibrix.batch.client import (
     NoopEndpointSource,
 )
 from aibrix.batch.state import JobStore
+from aibrix.batch.template import k8s_profile_registry, k8s_template_registry
 from aibrix.context import InfrastructureContext
 from aibrix.logger import init_logger, logging_basic_config
 from aibrix.metadata.api.v1 import batch, files, models, users
@@ -60,6 +61,10 @@ _LOG_HTTP_BODIES = os.getenv("AIBRIX_MDS_HTTP_BODY_LOG", "").lower() in (
 )
 _METRICS_PATH = "/metrics"
 
+ENV_AIBRIX_TEMPLATE_NAMESPACE = "aibrix-batch-v1alpha-model-deployment-templates"
+ENV_AIBRIX_PROFILE_NAMESPACE = "aibrix-batch-v1alpha-batch-profiles"
+MDS_NAMESPACE = "aibrix-system"
+
 
 def _load_batch_k8s_context(
     args, context: Optional[InfrastructureContext] = None
@@ -73,6 +78,26 @@ def _load_batch_k8s_context(
     if args.enable_k8s_support:
         context.core_v1_api = k8s_client.CoreV1Api()
         context.apps_v1_api = k8s_client.AppsV1Api()
+
+        # Determine the namespace where the batch ConfigMaps live.
+        # The Helm deployment injects POD_NAMESPACE (=aibrix-system) via the
+        # downward API
+        namespace_template = os.getenv(ENV_AIBRIX_TEMPLATE_NAMESPACE, MDS_NAMESPACE)
+        namespace_profile = os.getenv(ENV_AIBRIX_PROFILE_NAMESPACE, MDS_NAMESPACE)
+
+        # Build ConfigMap-backed registries and load their contents synchronously
+        # before the API server starts accepting requests so that incoming
+        # batches never observe an empty registry.
+        context.template_registry = k8s_template_registry(
+            core_v1_api=context.core_v1_api,
+            namespace=namespace_template,
+        )
+        context.profile_registry = k8s_profile_registry(
+            core_v1_api=context.core_v1_api,
+            namespace=namespace_profile,
+        )
+        context.template_registry.reload()
+        context.profile_registry.reload()
 
     return context
 

--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -61,8 +61,8 @@ _LOG_HTTP_BODIES = os.getenv("AIBRIX_MDS_HTTP_BODY_LOG", "").lower() in (
 )
 _METRICS_PATH = "/metrics"
 
-ENV_AIBRIX_TEMPLATE_NAMESPACE = "aibrix-batch-v1alpha-model-deployment-templates"
-ENV_AIBRIX_PROFILE_NAMESPACE = "aibrix-batch-v1alpha-batch-profiles"
+ENV_AIBRIX_TEMPLATE_NAMESPACE = "AIBRIX_TEMPLATE_NAMESPACE"
+ENV_AIBRIX_PROFILE_NAMESPACE = "AIBRIX_PROFILE_NAMESPACE"
 MDS_NAMESPACE = "aibrix-system"
 
 


### PR DESCRIPTION
## Pull Request Description
Metadata-service startup with profile and template registry so batch jobs referencing ModelDeploymentTemplate / BatchProfile by name work end-to-end. 

Note: loading happens **only once during service initialization; subsequent edits to the ConfigMaps are not auto-applied currently**.



## Related Issues
Resolves: #2626

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>