### PR TITLE
[Bug] Reject invalid Volcano gang scheduling configuration in StormService webhook

### DIFF
--- a/pkg/webhook/stormservice_webhook.go
+++ b/pkg/webhook/stormservice_webhook.go
@@ -227,16 +227,40 @@ func (r *StormServiceCustomDefaulter) ValidateUpdate(_ context.Context, oldObj, 
 	if err := validateStormServiceMode(stormService); err != nil {
 		return nil, err
 	}
-	// Re-validate the scheduling strategy only when the RoleSet template changed. Objects that
-	// predate this validation must keep accepting metadata-only updates, in particular the
-	// controller's finalizer removal, or they could never be deleted.
+	// Re-run the scheduling validation only when one of its inputs changed; its result cannot
+	// differ otherwise. Objects that predate this validation must keep accepting unrelated
+	// updates, in particular the controller's finalizer removal, or they could never be deleted.
+	// Comparing the whole template would not do: the defaulter may inject the sidecar into an
+	// object that was stored without it, which looks like a template change on every update.
 	oldStormService, ok := oldObj.(*orchestrationv1alpha1.StormService)
-	if !ok || !equality.Semantic.DeepEqual(oldStormService.Spec.Template.Spec, stormService.Spec.Template.Spec) {
+	if !ok || schedulingConfigChanged(oldStormService.Spec.Template.Spec, stormService.Spec.Template.Spec) {
 		if err := validateStormServiceSchedulingStrategy(stormService); err != nil {
 			return nil, err
 		}
 	}
 	return nil, nil
+}
+
+// schedulingConfigChanged reports whether any input of validateRoleSetSchedulingStrategy differs
+// between two RoleSet specs: the RoleSet-level strategy, the role names, or a role's strategy.
+// Reordering roles counts as a change, which only errs on the side of re-validating.
+func schedulingConfigChanged(oldSpec, newSpec *orchestrationv1alpha1.RoleSetSpec) bool {
+	if oldSpec == nil || newSpec == nil {
+		return oldSpec != newSpec
+	}
+	if !equality.Semantic.DeepEqual(oldSpec.SchedulingStrategy, newSpec.SchedulingStrategy) {
+		return true
+	}
+	if len(oldSpec.Roles) != len(newSpec.Roles) {
+		return true
+	}
+	for i := range newSpec.Roles {
+		if oldSpec.Roles[i].Name != newSpec.Roles[i].Name ||
+			!equality.Semantic.DeepEqual(oldSpec.Roles[i].SchedulingStrategy, newSpec.Roles[i].SchedulingStrategy) {
+			return true
+		}
+	}
+	return false
 }
 
 // validateStormServiceMode rejects mode/replicas combinations that cannot be satisfied.

--- a/pkg/webhook/stormservice_webhook.go
+++ b/pkg/webhook/stormservice_webhook.go
@@ -19,9 +19,16 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -174,6 +181,9 @@ func (r *StormServiceCustomDefaulter) ValidateCreate(ctx context.Context, obj ru
 	if err := validateStormServiceMode(stormService); err != nil {
 		return nil, err
 	}
+	if err := validateStormServiceSchedulingStrategy(stormService); err != nil {
+		return nil, err
+	}
 
 	// 1. Validate StormService.Name itself (≤63, DNS-1123 compliant)
 	if len(stormService.Name) > 63 {
@@ -209,13 +219,22 @@ func (r *StormServiceCustomDefaulter) ValidateCreate(ctx context.Context, obj ru
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *StormServiceCustomDefaulter) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
+func (r *StormServiceCustomDefaulter) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	stormService, ok := newObj.(*orchestrationv1alpha1.StormService)
 	if !ok {
 		return nil, fmt.Errorf("expected a StormService object but got %T", newObj)
 	}
 	if err := validateStormServiceMode(stormService); err != nil {
 		return nil, err
+	}
+	// Re-validate the scheduling strategy only when the RoleSet template changed. Objects that
+	// predate this validation must keep accepting metadata-only updates, in particular the
+	// controller's finalizer removal, or they could never be deleted.
+	oldStormService, ok := oldObj.(*orchestrationv1alpha1.StormService)
+	if !ok || !equality.Semantic.DeepEqual(oldStormService.Spec.Template.Spec, stormService.Spec.Template.Spec) {
+		if err := validateStormServiceSchedulingStrategy(stormService); err != nil {
+			return nil, err
+		}
 	}
 	return nil, nil
 }
@@ -231,6 +250,105 @@ func validateStormServiceMode(stormService *orchestrationv1alpha1.StormService) 
 			orchestrationv1alpha1.StormServicePooledMode, *stormService.Spec.Replicas)
 	}
 	return nil
+}
+
+// validateStormServiceSchedulingStrategy rejects gang scheduling configurations in the RoleSet
+// template that the RoleSet controller or Volcano cannot honour.
+func validateStormServiceSchedulingStrategy(stormService *orchestrationv1alpha1.StormService) error {
+	allErrs := validateRoleSetSchedulingStrategy(stormService.Spec.Template.Spec, field.NewPath("spec", "template", "spec"))
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: orchestrationv1alpha1.GroupVersion.Group, Kind: orchestrationv1alpha1.StormServiceKind},
+		stormService.Name,
+		allErrs,
+	)
+}
+
+// validateRoleSetSchedulingStrategy validates the scheduling strategies declared on a RoleSet spec.
+// It takes the RoleSetSpec and its field path rather than the StormService so that a RoleSet
+// webhook can reuse it.
+//
+// The RoleSet-level strategy and the Role-level strategies are mutually exclusive: the RoleSet
+// controller points every pod at the RoleSet-level PodGroup and then re-points PodSet pods at the
+// Role-level PodGroup, so setting both splits one gang across two PodGroups that can never both
+// be satisfied.
+func validateRoleSetSchedulingStrategy(spec *orchestrationv1alpha1.RoleSetSpec, specPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if spec == nil {
+		return allErrs
+	}
+
+	roleNames := sets.New[string]()
+	for _, role := range spec.Roles {
+		roleNames.Insert(role.Name)
+	}
+
+	roleSetStrategyPath := specPath.Child("schedulingStrategy")
+	if spec.SchedulingStrategy != nil {
+		allErrs = append(allErrs, validateVolcanoSchedulingStrategy(
+			spec.SchedulingStrategy.VolcanoSchedulingStrategy, roleNames, roleSetStrategyPath.Child("volcanoSchedulingStrategy"))...)
+	}
+
+	for i, role := range spec.Roles {
+		if role.SchedulingStrategy == nil {
+			continue
+		}
+		roleStrategyPath := specPath.Child("roles").Index(i).Child("schedulingStrategy")
+		if spec.SchedulingStrategy != nil {
+			allErrs = append(allErrs, field.Forbidden(roleStrategyPath,
+				fmt.Sprintf("must not be set together with %s; RoleSet-level and Role-level scheduling strategies are mutually exclusive", roleSetStrategyPath)))
+		}
+		// A Role-level PodGroup only ever contains pods of that role.
+		allErrs = append(allErrs, validateVolcanoSchedulingStrategy(
+			role.SchedulingStrategy.VolcanoSchedulingStrategy, sets.New(role.Name), roleStrategyPath.Child("volcanoSchedulingStrategy"))...)
+	}
+	return allErrs
+}
+
+// validateVolcanoSchedulingStrategy checks the Volcano PodGroup fields that Volcano itself does not
+// validate. taskNames holds the role names that minTaskMember keys may refer to.
+func validateVolcanoSchedulingStrategy(strategy *orchestrationv1alpha1.VolcanoSchedulingStrategySpec, taskNames sets.Set[string], path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if strategy == nil {
+		return allErrs
+	}
+
+	minMemberPath := path.Child("minMember")
+	if strategy.MinMember <= 0 {
+		allErrs = append(allErrs, field.Invalid(minMemberPath, strategy.MinMember, "must be greater than 0 when Volcano gang scheduling is configured"))
+	}
+
+	taskKeys := make([]string, 0, len(strategy.MinTaskMember))
+	for key := range strategy.MinTaskMember {
+		taskKeys = append(taskKeys, key)
+	}
+	sort.Strings(taskKeys) // deterministic error ordering
+
+	var minTaskMemberSum int64
+	taskMembersValid := true
+	for _, key := range taskKeys {
+		value := strategy.MinTaskMember[key]
+		keyPath := path.Child("minTaskMember").Key(key)
+		if value <= 0 {
+			taskMembersValid = false
+			allErrs = append(allErrs, field.Invalid(keyPath, value, "must be greater than 0"))
+		}
+		if !taskNames.Has(key) {
+			allErrs = append(allErrs, field.Invalid(keyPath, key,
+				fmt.Sprintf("must match a role name; valid names are: %s", strings.Join(sets.List(taskNames), ", "))))
+		}
+		minTaskMemberSum += int64(value)
+	}
+
+	// Volcano skips every per-task check when minMember is smaller than the sum of minTaskMember,
+	// which silently disables the per-role guarantees the user asked for.
+	if strategy.MinMember > 0 && taskMembersValid && int64(strategy.MinMember) < minTaskMemberSum {
+		allErrs = append(allErrs, field.Invalid(minMemberPath, strategy.MinMember,
+			fmt.Sprintf("must not be smaller than the sum of minTaskMember values (%d); Volcano ignores minTaskMember otherwise", minTaskMemberSum)))
+	}
+	return allErrs
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/pkg/webhook/stormservice_webhook_test.go
+++ b/pkg/webhook/stormservice_webhook_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
 	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
@@ -109,6 +111,208 @@ func TestStormServiceValidateUpdate_ModeReplicas(t *testing.T) {
 			_, err := validator.ValidateUpdate(context.Background(), oldSS, newSS)
 			if tc.expectError {
 				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func volcanoStrategy(minMember int32, minTaskMember map[string]int32) *orchestrationv1alpha1.SchedulingStrategy {
+	return &orchestrationv1alpha1.SchedulingStrategy{
+		VolcanoSchedulingStrategy: &orchestrationv1alpha1.VolcanoSchedulingStrategySpec{
+			MinMember:     minMember,
+			MinTaskMember: minTaskMember,
+		},
+	}
+}
+
+func roleWithStrategy(name string, strategy *orchestrationv1alpha1.SchedulingStrategy) orchestrationv1alpha1.RoleSpec {
+	return orchestrationv1alpha1.RoleSpec{Name: name, SchedulingStrategy: strategy}
+}
+
+func stormServiceWithTemplate(roleSetStrategy *orchestrationv1alpha1.SchedulingStrategy, roles ...orchestrationv1alpha1.RoleSpec) *orchestrationv1alpha1.StormService {
+	ss := &orchestrationv1alpha1.StormService{
+		Spec: orchestrationv1alpha1.StormServiceSpec{
+			Template: orchestrationv1alpha1.RoleSetTemplateSpec{
+				Spec: &orchestrationv1alpha1.RoleSetSpec{
+					Roles:              roles,
+					SchedulingStrategy: roleSetStrategy,
+				},
+			},
+		},
+	}
+	ss.Name = "test"
+	return ss
+}
+
+func TestStormServiceValidateCreate_SchedulingStrategy(t *testing.T) {
+	validator := &StormServiceCustomDefaulter{}
+	prefill := roleWithStrategy("prefill", nil)
+	decode := roleWithStrategy("decode", nil)
+	const roleSetVolcanoPath = "spec.template.spec.schedulingStrategy.volcanoSchedulingStrategy"
+
+	tests := map[string]struct {
+		roleSetStrategy *orchestrationv1alpha1.SchedulingStrategy
+		roles           []orchestrationv1alpha1.RoleSpec
+		// wantErrs lists substrings that must all appear in the error; empty means the object is valid.
+		wantErrs []string
+	}{
+		"no scheduling strategy": {
+			roles: []orchestrationv1alpha1.RoleSpec{prefill, decode},
+		},
+		"valid volcano gang with minTaskMember": {
+			roleSetStrategy: volcanoStrategy(6, map[string]int32{"prefill": 4, "decode": 2}),
+			roles:           []orchestrationv1alpha1.RoleSpec{prefill, decode},
+		},
+		"valid volcano gang without minTaskMember": {
+			roleSetStrategy: volcanoStrategy(2, nil),
+			roles:           []orchestrationv1alpha1.RoleSpec{prefill, decode},
+		},
+		"minMember above minTaskMember sum is allowed": {
+			roleSetStrategy: volcanoStrategy(8, map[string]int32{"prefill": 4, "decode": 2}),
+			roles:           []orchestrationv1alpha1.RoleSpec{prefill, decode},
+		},
+		"minMember zero is rejected": {
+			roleSetStrategy: volcanoStrategy(0, nil),
+			roles:           []orchestrationv1alpha1.RoleSpec{prefill},
+			wantErrs:        []string{roleSetVolcanoPath + ".minMember", "must be greater than 0"},
+		},
+		"minMember negative is rejected": {
+			roleSetStrategy: volcanoStrategy(-1, nil),
+			roles:           []orchestrationv1alpha1.RoleSpec{prefill},
+			wantErrs:        []string{roleSetVolcanoPath + ".minMember", "must be greater than 0"},
+		},
+		"minTaskMember zero is rejected": {
+			roleSetStrategy: volcanoStrategy(4, map[string]int32{"prefill": 0, "decode": 4}),
+			roles:           []orchestrationv1alpha1.RoleSpec{prefill, decode},
+			wantErrs:        []string{roleSetVolcanoPath + ".minTaskMember[prefill]", "must be greater than 0"},
+		},
+		"minTaskMember negative is rejected": {
+			roleSetStrategy: volcanoStrategy(4, map[string]int32{"prefill": -2}),
+			roles:           []orchestrationv1alpha1.RoleSpec{prefill},
+			wantErrs:        []string{roleSetVolcanoPath + ".minTaskMember[prefill]", "must be greater than 0"},
+		},
+		"minTaskMember key not matching a role is rejected": {
+			roleSetStrategy: volcanoStrategy(4, map[string]int32{"worker": 4}),
+			roles:           []orchestrationv1alpha1.RoleSpec{prefill, decode},
+			wantErrs:        []string{roleSetVolcanoPath + ".minTaskMember[worker]", "must match a role name", "decode, prefill"},
+		},
+		"minMember below minTaskMember sum is rejected": {
+			roleSetStrategy: volcanoStrategy(4, map[string]int32{"prefill": 4, "decode": 2}),
+			roles:           []orchestrationv1alpha1.RoleSpec{prefill, decode},
+			wantErrs:        []string{roleSetVolcanoPath + ".minMember", "sum of minTaskMember values (6)"},
+		},
+		"roleset-level and role-level strategies together are rejected": {
+			roleSetStrategy: volcanoStrategy(2, nil),
+			roles:           []orchestrationv1alpha1.RoleSpec{roleWithStrategy("prefill", volcanoStrategy(1, nil))},
+			wantErrs:        []string{"spec.template.spec.roles[0].schedulingStrategy", "Forbidden", "mutually exclusive"},
+		},
+		"roleset-level and role-level strategies together are rejected for non-volcano schedulers": {
+			roleSetStrategy: &orchestrationv1alpha1.SchedulingStrategy{
+				GodelSchedulingStrategy: &orchestrationv1alpha1.GodelSchedulingStrategySpec{MinMember: 2},
+			},
+			roles: []orchestrationv1alpha1.RoleSpec{
+				prefill,
+				roleWithStrategy("decode", &orchestrationv1alpha1.SchedulingStrategy{
+					CoschedulingSchedulingStrategy: &orchestrationv1alpha1.CoschedulingSchedulingStrategySpec{MinMember: 1},
+				}),
+			},
+			wantErrs: []string{"spec.template.spec.roles[1].schedulingStrategy", "Forbidden"},
+		},
+		"role-level volcano keyed by its own role is allowed": {
+			roles: []orchestrationv1alpha1.RoleSpec{prefill, roleWithStrategy("decode", volcanoStrategy(2, map[string]int32{"decode": 2}))},
+		},
+		"role-level volcano keyed by another role is rejected": {
+			roles:    []orchestrationv1alpha1.RoleSpec{prefill, roleWithStrategy("decode", volcanoStrategy(2, map[string]int32{"prefill": 2}))},
+			wantErrs: []string{"spec.template.spec.roles[1].schedulingStrategy.volcanoSchedulingStrategy.minTaskMember[prefill]", "valid names are: decode"},
+		},
+		"non-volcano strategies are not checked": {
+			roleSetStrategy: &orchestrationv1alpha1.SchedulingStrategy{
+				GodelSchedulingStrategy: &orchestrationv1alpha1.GodelSchedulingStrategySpec{MinMember: 0},
+			},
+			roles: []orchestrationv1alpha1.RoleSpec{prefill},
+		},
+		"all errors are reported together": {
+			roleSetStrategy: volcanoStrategy(0, map[string]int32{"worker": 0}),
+			roles:           []orchestrationv1alpha1.RoleSpec{prefill},
+			wantErrs: []string{
+				roleSetVolcanoPath + ".minMember: Invalid value: 0",
+				roleSetVolcanoPath + ".minTaskMember[worker]: Invalid value: 0",
+				roleSetVolcanoPath + ".minTaskMember[worker]: Invalid value: \"worker\"",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ss := stormServiceWithTemplate(tc.roleSetStrategy, tc.roles...)
+			_, err := validator.ValidateCreate(context.Background(), ss)
+			if len(tc.wantErrs) == 0 {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.True(t, apierrors.IsInvalid(err), "expected an Invalid error, got %v", err)
+			for _, want := range tc.wantErrs {
+				assert.Contains(t, err.Error(), want)
+			}
+		})
+	}
+}
+
+func TestValidateRoleSetSchedulingStrategy_NilSpec(t *testing.T) {
+	assert.Empty(t, validateRoleSetSchedulingStrategy(nil, field.NewPath("spec")))
+}
+
+// Objects created before the scheduling validation existed must keep accepting updates that do
+// not touch the RoleSet template, otherwise the controller's finalizer removal would be rejected
+// and the object could never be deleted.
+func TestStormServiceValidateUpdate_SchedulingStrategy(t *testing.T) {
+	validator := &StormServiceCustomDefaulter{}
+	prefill := roleWithStrategy("prefill", nil)
+	invalid := func() *orchestrationv1alpha1.StormService {
+		return stormServiceWithTemplate(volcanoStrategy(0, nil), prefill)
+	}
+	valid := func() *orchestrationv1alpha1.StormService {
+		return stormServiceWithTemplate(volcanoStrategy(1, nil), prefill)
+	}
+
+	tests := map[string]struct {
+		old         *orchestrationv1alpha1.StormService
+		new         *orchestrationv1alpha1.StormService
+		expectError bool
+	}{
+		"unchanged invalid template is allowed": {old: invalid(), new: invalid(), expectError: false},
+		"metadata-only update on invalid template is allowed": {
+			old: invalid(),
+			new: func() *orchestrationv1alpha1.StormService {
+				ss := invalid()
+				ss.Finalizers = []string{"orchestration.aibrix.ai/stormservice-finalizer"}
+				ss.Spec.Replicas = ptr.To[int32](3)
+				return ss
+			}(),
+			expectError: false,
+		},
+		"template change introducing invalid config is rejected": {old: valid(), new: invalid(), expectError: true},
+		"template change that keeps invalid config is rejected": {
+			old: invalid(),
+			new: func() *orchestrationv1alpha1.StormService {
+				ss := invalid()
+				ss.Spec.Template.Spec.Roles[0].Replicas = ptr.To[int32](2)
+				return ss
+			}(),
+			expectError: true,
+		},
+		"template change fixing invalid config is allowed": {old: invalid(), new: valid(), expectError: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := validator.ValidateUpdate(context.Background(), tc.old, tc.new)
+			if tc.expectError {
+				require.Error(t, err)
+				assert.True(t, apierrors.IsInvalid(err), "expected an Invalid error, got %v", err)
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/webhook/stormservice_webhook_test.go
+++ b/pkg/webhook/stormservice_webhook_test.go
@@ -266,8 +266,8 @@ func TestValidateRoleSetSchedulingStrategy_NilSpec(t *testing.T) {
 }
 
 // Objects created before the scheduling validation existed must keep accepting updates that do
-// not touch the RoleSet template, otherwise the controller's finalizer removal would be rejected
-// and the object could never be deleted.
+// not touch the scheduling configuration, otherwise the controller's finalizer removal would be
+// rejected and the object could never be deleted.
 func TestStormServiceValidateUpdate_SchedulingStrategy(t *testing.T) {
 	validator := &StormServiceCustomDefaulter{}
 	prefill := roleWithStrategy("prefill", nil)
@@ -295,13 +295,28 @@ func TestStormServiceValidateUpdate_SchedulingStrategy(t *testing.T) {
 			expectError: false,
 		},
 		"template change introducing invalid config is rejected": {old: valid(), new: invalid(), expectError: true},
-		"template change that keeps invalid config is rejected": {
+		"unrelated template change on invalid config is allowed": {
 			old: invalid(),
 			new: func() *orchestrationv1alpha1.StormService {
 				ss := invalid()
 				ss.Spec.Template.Spec.Roles[0].Replicas = ptr.To[int32](2)
+				ss.Spec.Template.Spec.Roles[0].Template.Spec.SchedulerName = "custom"
 				return ss
 			}(),
+			expectError: false,
+		},
+		"role rename with invalid config is rejected": {
+			old: invalid(),
+			new: func() *orchestrationv1alpha1.StormService {
+				ss := invalid()
+				ss.Spec.Template.Spec.Roles[0].Name = "decode"
+				return ss
+			}(),
+			expectError: true,
+		},
+		"role-level strategy change is validated": {
+			old:         stormServiceWithTemplate(nil, prefill),
+			new:         stormServiceWithTemplate(nil, roleWithStrategy("prefill", volcanoStrategy(0, nil))),
 			expectError: true,
 		},
 		"template change fixing invalid config is allowed": {old: invalid(), new: valid(), expectError: false},
@@ -318,4 +333,71 @@ func TestStormServiceValidateUpdate_SchedulingStrategy(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The defaulter may inject the sidecar into an object that was stored without it (for example
+// because the mutating webhook was unavailable when it was created). That must not count as a
+// scheduling change, or such an object with a pre-existing invalid gang config could never have
+// its finalizer removed.
+func TestStormServiceValidateUpdate_SidecarInjectionDoesNotTriggerSchedulingValidation(t *testing.T) {
+	webhook := &StormServiceCustomDefaulter{}
+
+	stored := stormServiceWithTemplate(volcanoStrategy(0, nil), roleWithStrategy("prefill", nil))
+	stored.Annotations = map[string]string{SidecarInjectionAnnotation: "true"}
+	stored.Finalizers = []string{"orchestration.aibrix.ai/stormservice-finalizer"}
+
+	updated := stored.DeepCopy()
+	updated.Finalizers = nil
+	// The API server runs the defaulter on the new object only.
+	require.NoError(t, webhook.Default(context.Background(), updated))
+	require.NotEqual(t, stored.Spec.Template.Spec, updated.Spec.Template.Spec, "defaulter should have injected the sidecar")
+
+	_, err := webhook.ValidateUpdate(context.Background(), stored, updated)
+	require.NoError(t, err)
+}
+
+func TestSchedulingConfigChanged(t *testing.T) {
+	base := func() *orchestrationv1alpha1.RoleSetSpec {
+		return &orchestrationv1alpha1.RoleSetSpec{
+			SchedulingStrategy: volcanoStrategy(2, nil),
+			Roles: []orchestrationv1alpha1.RoleSpec{
+				roleWithStrategy("prefill", nil),
+				roleWithStrategy("decode", nil),
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		mutate  func(spec *orchestrationv1alpha1.RoleSetSpec)
+		changed bool
+	}{
+		"identical":         {mutate: func(*orchestrationv1alpha1.RoleSetSpec) {}, changed: false},
+		"role replicas":     {mutate: func(s *orchestrationv1alpha1.RoleSetSpec) { s.Roles[0].Replicas = ptr.To[int32](3) }, changed: false},
+		"role pod template": {mutate: func(s *orchestrationv1alpha1.RoleSetSpec) { s.Roles[0].Template.Spec.SchedulerName = "x" }, changed: false},
+		"roleset update strategy": {mutate: func(s *orchestrationv1alpha1.RoleSetSpec) {
+			s.UpdateStrategy = orchestrationv1alpha1.ParallelRoleSetUpdateStrategyType
+		}, changed: false},
+		"roleset strategy minMember": {mutate: func(s *orchestrationv1alpha1.RoleSetSpec) {
+			s.SchedulingStrategy.VolcanoSchedulingStrategy.MinMember = 3
+		}, changed: true},
+		"roleset strategy removed": {mutate: func(s *orchestrationv1alpha1.RoleSetSpec) { s.SchedulingStrategy = nil }, changed: true},
+		"role added":               {mutate: func(s *orchestrationv1alpha1.RoleSetSpec) { s.Roles = append(s.Roles, roleWithStrategy("worker", nil)) }, changed: true},
+		"role renamed":             {mutate: func(s *orchestrationv1alpha1.RoleSetSpec) { s.Roles[1].Name = "worker" }, changed: true},
+		"role strategy added":      {mutate: func(s *orchestrationv1alpha1.RoleSetSpec) { s.Roles[1].SchedulingStrategy = volcanoStrategy(1, nil) }, changed: true},
+		"roles reordered errs on the side of validating": {mutate: func(s *orchestrationv1alpha1.RoleSetSpec) { s.Roles[0], s.Roles[1] = s.Roles[1], s.Roles[0] }, changed: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldSpec, newSpec := base(), base()
+			tc.mutate(newSpec)
+			assert.Equal(t, tc.changed, schedulingConfigChanged(oldSpec, newSpec))
+		})
+	}
+
+	t.Run("nil specs", func(t *testing.T) {
+		assert.False(t, schedulingConfigChanged(nil, nil))
+		assert.True(t, schedulingConfigChanged(nil, base()))
+		assert.True(t, schedulingConfigChanged(base(), nil))
+	})
 }

--- a/test/integration/webhook/stormservice_webhook_test.go
+++ b/test/integration/webhook/stormservice_webhook_test.go
@@ -137,6 +137,8 @@ var _ = ginkgo.Describe("stormservice default webhook", func() {
 		stormservice  func() *orchestrationapi.StormService
 		failed        bool
 		expectInvalid bool
+		// wantErr, when set, must appear in the admission error message.
+		wantErr string
 	}
 	ginkgo.DescribeTable("test validating",
 		func(tc *testValidatingCase) {
@@ -146,6 +148,9 @@ var _ = ginkgo.Describe("stormservice default webhook", func() {
 				if tc.expectInvalid {
 					gomega.Expect(apierrors.IsInvalid(err)).To(gomega.BeTrue(),
 						"expected schema validation error, got %v", err)
+				}
+				if tc.wantErr != "" {
+					gomega.Expect(err.Error()).To(gomega.ContainSubstring(tc.wantErr))
 				}
 			} else {
 				gomega.Expect(err).To(gomega.Succeed())
@@ -264,6 +269,82 @@ var _ = ginkgo.Describe("stormservice default webhook", func() {
 			},
 			failed: false,
 		}),
+
+		// Volcano gang scheduling: the webhook rejects configurations that the RoleSet controller
+		// or Volcano cannot honour. The default roles are "worker" (roles[0]) and "master" (roles[1]).
+		ginkgo.Entry("accepts a valid Volcano gang", &testValidatingCase{
+			stormservice: func() *orchestrationapi.StormService {
+				return gangStormService("gang-valid", ns.Name,
+					volcanoStrategy(3, map[string]int32{"master": 1, "worker": 2}), nil)
+			},
+			failed: false,
+		}),
+		ginkgo.Entry("accepts a Volcano gang without minTaskMember", &testValidatingCase{
+			stormservice: func() *orchestrationapi.StormService {
+				return gangStormService("gang-no-task-member", ns.Name, volcanoStrategy(2, nil), nil)
+			},
+			failed: false,
+		}),
+		ginkgo.Entry("rejects Volcano minMember of zero", &testValidatingCase{
+			stormservice: func() *orchestrationapi.StormService {
+				return gangStormService("gang-min-member-zero", ns.Name, volcanoStrategy(0, nil), nil)
+			},
+			failed:        true,
+			expectInvalid: true,
+			wantErr:       "spec.template.spec.schedulingStrategy.volcanoSchedulingStrategy.minMember",
+		}),
+		ginkgo.Entry("rejects a Volcano minTaskMember value of zero", &testValidatingCase{
+			stormservice: func() *orchestrationapi.StormService {
+				return gangStormService("gang-task-member-zero", ns.Name,
+					volcanoStrategy(2, map[string]int32{"master": 0, "worker": 2}), nil)
+			},
+			failed:        true,
+			expectInvalid: true,
+			wantErr:       "volcanoSchedulingStrategy.minTaskMember[master]",
+		}),
+		ginkgo.Entry("rejects a Volcano minTaskMember key that is not a role name", &testValidatingCase{
+			stormservice: func() *orchestrationapi.StormService {
+				return gangStormService("gang-unknown-role", ns.Name,
+					volcanoStrategy(2, map[string]int32{"prefill": 2}), nil)
+			},
+			failed:        true,
+			expectInvalid: true,
+			wantErr:       "volcanoSchedulingStrategy.minTaskMember[prefill]",
+		}),
+		ginkgo.Entry("rejects Volcano minMember below the sum of minTaskMember", &testValidatingCase{
+			stormservice: func() *orchestrationapi.StormService {
+				return gangStormService("gang-min-member-low", ns.Name,
+					volcanoStrategy(2, map[string]int32{"master": 1, "worker": 2}), nil)
+			},
+			failed:        true,
+			expectInvalid: true,
+			wantErr:       "sum of minTaskMember values (3)",
+		}),
+		ginkgo.Entry("rejects RoleSet-level and Role-level scheduling strategies together", &testValidatingCase{
+			stormservice: func() *orchestrationapi.StormService {
+				return gangStormService("gang-both-levels", ns.Name, volcanoStrategy(2, nil),
+					map[string]*orchestrationapi.SchedulingStrategy{"worker": volcanoStrategy(1, nil)})
+			},
+			failed:        true,
+			expectInvalid: true,
+			wantErr:       "spec.template.spec.roles[0].schedulingStrategy: Forbidden",
+		}),
+		ginkgo.Entry("accepts a Role-level Volcano gang keyed by its own role", &testValidatingCase{
+			stormservice: func() *orchestrationapi.StormService {
+				return gangStormService("gang-role-level", ns.Name, nil,
+					map[string]*orchestrationapi.SchedulingStrategy{"worker": volcanoStrategy(1, map[string]int32{"worker": 1})})
+			},
+			failed: false,
+		}),
+		ginkgo.Entry("rejects a Role-level Volcano gang keyed by another role", &testValidatingCase{
+			stormservice: func() *orchestrationapi.StormService {
+				return gangStormService("gang-role-level-wrong-key", ns.Name, nil,
+					map[string]*orchestrationapi.SchedulingStrategy{"worker": volcanoStrategy(1, map[string]int32{"master": 1})})
+			},
+			failed:        true,
+			expectInvalid: true,
+			wantErr:       "spec.template.spec.roles[0].schedulingStrategy.volcanoSchedulingStrategy.minTaskMember[master]",
+		}),
 	)
 
 	ginkgo.It("rejects scaling an explicit Pooled StormService above one replica", func() {
@@ -277,4 +358,50 @@ var _ = ginkgo.Describe("stormservice default webhook", func() {
 		stormService.Spec.Replicas = ptr.To(int32(3))
 		gomega.Expect(k8sClient.Update(ctx, stormService)).ShouldNot(gomega.Succeed())
 	})
+
+	ginkgo.It("rejects an update that makes the Volcano gang invalid", func() {
+		stormService := gangStormService("gang-update-invalid", ns.Name,
+			volcanoStrategy(3, map[string]int32{"master": 1, "worker": 2}), nil)
+		gomega.Expect(k8sClient.Create(ctx, stormService)).To(gomega.Succeed())
+
+		stormService.Spec.Template.Spec.SchedulingStrategy.VolcanoSchedulingStrategy.MinMember = 0
+		err := k8sClient.Update(ctx, stormService)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(apierrors.IsInvalid(err)).To(gomega.BeTrue(), "expected an Invalid error, got %v", err)
+	})
+
+	ginkgo.It("accepts an update that keeps the Volcano gang valid", func() {
+		stormService := gangStormService("gang-update-valid", ns.Name,
+			volcanoStrategy(3, map[string]int32{"master": 1, "worker": 2}), nil)
+		gomega.Expect(k8sClient.Create(ctx, stormService)).To(gomega.Succeed())
+
+		stormService.Spec.Template.Spec.SchedulingStrategy.VolcanoSchedulingStrategy.MinMember = 4
+		gomega.Expect(k8sClient.Update(ctx, stormService)).To(gomega.Succeed())
+	})
 })
+
+// volcanoStrategy returns a scheduling strategy that gang schedules through Volcano.
+func volcanoStrategy(minMember int32, minTaskMember map[string]int32) *orchestrationapi.SchedulingStrategy {
+	return &orchestrationapi.SchedulingStrategy{
+		VolcanoSchedulingStrategy: &orchestrationapi.VolcanoSchedulingStrategySpec{
+			MinMember:     minMember,
+			MinTaskMember: minTaskMember,
+		},
+	}
+}
+
+// gangStormService builds a StormService with the default "worker" (roles[0]) and "master"
+// (roles[1]) roles, a RoleSet-level strategy, and per-role strategies keyed by role name.
+func gangStormService(name, namespace string, roleSetStrategy *orchestrationapi.SchedulingStrategy,
+	roleStrategies map[string]*orchestrationapi.SchedulingStrategy) *orchestrationapi.StormService {
+	stormService := wrapper.MakeStormService(name).
+		Namespace(namespace).
+		WithDefaultConfiguration().
+		Obj()
+	stormService.Spec.Template.Spec.SchedulingStrategy = roleSetStrategy
+	for i := range stormService.Spec.Template.Spec.Roles {
+		role := &stormService.Spec.Template.Spec.Roles[i]
+		role.SchedulingStrategy = roleStrategies[role.Name]
+	}
+	return stormService
+}


### PR DESCRIPTION
## Pull Request Description
The StormService webhook now rejects Volcano gang scheduling configurations that the controller or Volcano cannot accept, instead of silently accepting them:

- `volcanoSchedulingStrategy.minMember` must be greater than 0.
- Every `minTaskMember` value must be greater than 0.
- Every `minTaskMember` key must match a role name (for a Role-level strategy, only that role's own name).
- `minMember` must not be smaller than the sum of `minTaskMember` values, since Volcano skips all per-task checks otherwise.
- `spec.template.spec.schedulingStrategy` and `roles[].schedulingStrategy` cannot be set together; the controller treats them as mutually exclusive.

All violations are returned in one `Invalid` error with field paths. On update, the check only runs when the RoleSet template changed, so objects created before this validation can still be updated and deleted.

Testing: unit tests in `pkg/webhook/stormservice_webhook_test.go` cover every rule and the update ratcheting; `golangci-lint` and `go build ./...` pass.


## Related Issues
Resolves: #2619 scope 1

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[x] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>