### PR TITLE
[CI] Upgrade golangci-lint to v2.13.1

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version: '1.26'
       - name: Lint
         run: make lint-all
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,43 +1,56 @@
+version: "2"
+
 run:
   timeout: 5m
   allow-parallel-runners: true
 
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "pkg/*"
-      linters:
-        - dupl
-        - lll
-    # disable lll check for flag descriptions
-    - path: "cmd/controllers/main.go"
-      linters:
-        - lll
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
 linters:
-  disable-all: true
+  default: none
   enable:
     - dupl
     - errcheck
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
     - nakedret
-#    - prealloc
     - staticcheck
-    - typecheck
     - unconvert
-#    - unparam
-#    - unused
+  settings:
+    goconst:
+      min-occurrences: 20
+  exclusions:
+    # v2 does not apply default exclusion presets unless listed.
+    # v1's exclude-use-default: false is achieved by not listing any presets.
+    rules:
+      - path: "api/*"
+        linters:
+          - lll
+      - path: "pkg/*"
+        linters:
+          - dupl
+          - lll
+      # disable lll check for flag descriptions
+      - path: "cmd/controllers/main.go"
+        linters:
+          - lll
+      # apps/ uses repeated strings in test data and placeholder keys; exclude from goconst
+      - path: "apps/*"
+        linters:
+          - goconst
+      # test files commonly use repeated strings for test data; exclude from goconst
+      - path: ".*_test\\.go"
+        linters:
+          - goconst
+      # fmt.Fprintf/Fprint errors are typically safe to ignore in test/utility code
+      - path: ".*"
+        linters:
+          - errcheck
+        text: "Error return value of `fmt\\.Fprint"

--- a/Makefile
+++ b/Makefile
@@ -504,7 +504,7 @@ GO_TEST_COVERAGE = $(LOCALBIN)/go-test-coverage-$(GO_TEST_COVERAGE_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.1
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.57.2
+GOLANGCI_LINT_VERSION ?= v2.13.1
 GO_TEST_COVERAGE_VERSION ?= v2.14.3
 
 .PHONY: kustomize
@@ -525,7 +525,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 .PHONY: go-test-coverage
 go-test-coverage: $(GO_TEST_COVERAGE) ## Download go-test-coverage locally if necessary.

--- a/pkg/cache/cache_init.go
+++ b/pkg/cache/cache_init.go
@@ -305,7 +305,7 @@ func InitWithPodsModelMetrics(st *Store, podMetrics map[string]map[string]metric
 			return true
 		}
 		if podmetrics, ok := podMetrics[podName]; ok {
-			modelName, _ := constants.ModelNameFromMetadata(metaPod.Pod.Labels, metaPod.Pod.Annotations)
+			modelName, _ := constants.ModelNameFromMetadata(metaPod.Labels, metaPod.Annotations)
 			for metricName, metric := range podmetrics {
 				if err := st.updatePodRecord(metaPod, modelName, metricName, metrics.PodModelMetricScope, metric); err != nil {
 					return false
@@ -595,6 +595,7 @@ func (s *Store) initKVEventSync() error {
 	}
 
 	// Validate configuration before allocating more resources
+	//nolint:staticcheck // SA4023: always true in non-ZMQ build, but required for ZMQ build
 	if err := s.kvEventManager.validateConfiguration(); err != nil {
 		return fmt.Errorf("invalid KV event sync configuration: %w", err)
 	}
@@ -692,7 +693,7 @@ func (c *Store) promQueryLoop(stopCh <-chan struct{}) {
 	podKey := func(p *Pod) string {
 		ns := p.Namespace
 		if ns == "" && p.Pod != nil {
-			ns = p.Pod.Namespace
+			ns = p.Namespace
 		}
 		return ns + "/" + p.Name
 	}

--- a/pkg/cache/cache_metrics.go
+++ b/pkg/cache/cache_metrics.go
@@ -610,9 +610,10 @@ func (c *Store) queryUpdatePromQLMetrics(ctx context.Context, metric metrics.Met
 // Update `PodMetrics` and `PodModelMetrics` according to the metric scope
 // TODO: replace in-place metric update podMetrics and podModelMetrics to fresh copy for preventing stale metric keys
 func (c *Store) updatePodRecord(pod *Pod, modelName string, metricName string, scope metrics.MetricScope, metricValue metrics.MetricValue) error {
-	if scope == metrics.PodMetricScope {
+	switch scope {
+	case metrics.PodMetricScope:
 		pod.Metrics.Store(metricName, metricValue)
-	} else if scope == metrics.PodModelMetricScope {
+	case metrics.PodModelMetricScope:
 		if modelName == "" {
 			var ok bool
 			modelName, ok = constants.ModelNameFromMetadata(pod.Labels, pod.Annotations)
@@ -621,7 +622,7 @@ func (c *Store) updatePodRecord(pod *Pod, modelName string, metricName string, s
 			}
 		}
 		pod.ModelMetrics.Store(c.getPodModelMetricName(modelName, metricName), metricValue)
-	} else {
+	default:
 		return fmt.Errorf("scope %v is not supported", scope)
 	}
 	return nil

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -59,7 +59,7 @@ func getReadyPod(podName, podNamespcae string, modelName string, id int) *v1.Pod
 			},
 		},
 	}
-	pod.ObjectMeta.Labels[modelIdentifier] = modelName
+	pod.Labels[modelIdentifier] = modelName
 	return pod
 }
 
@@ -157,21 +157,21 @@ var _ = Describe("Cache", func() {
 	It("should both addPod create both pods and metaModels entry", func() {
 		// Ignore pods without model label
 		podWOModel := getReadyPod("p1", "default", "m1", 0)
-		podWOModel.ObjectMeta.Labels = nil
+		podWOModel.Labels = nil
 		cache.addPod(podWOModel)
 		_, exist := cache.metaPods.Load("default/p1")
 		Expect(exist).To(BeFalse())
 
 		// Ignore pods without model label
 		podRayWorker := getReadyPod("p1", "default", "m1", 0)
-		podRayWorker.ObjectMeta.Labels[nodeType] = nodeWorker
+		podRayWorker.Labels[nodeType] = nodeWorker
 		cache.addPod(podRayWorker)
 		_, exist = cache.metaPods.Load("default/p1")
 		Expect(exist).To(BeFalse())
 
 		// Ignore pods with podGroupIndex > 0
 		podGroupWorker := getReadyPod("p1", "default", "m1", 0)
-		podGroupWorker.ObjectMeta.Labels[podGroupIndex] = "1"
+		podGroupWorker.Labels[podGroupIndex] = "1"
 		cache.addPod(podGroupWorker)
 		_, exist = cache.metaPods.Load("default/p1")
 		Expect(exist).To(BeFalse())
@@ -364,18 +364,18 @@ var _ = Describe("Cache", func() {
 
 	It("should updatePod after podIndex updated", func() {
 		oldPod := getNewPod("p1", "default", "m1", 0)
-		oldPod.ObjectMeta.Labels[podGroupIndex] = "1"
+		oldPod.Labels[podGroupIndex] = "1"
 		cache.addPod(oldPod)
 		_, exist := cache.metaPods.Load("default/p1")
 		Expect(exist).To(BeFalse())
 
 		newPod := getReadyPod("p1", "default", "m1", 0) // IP may changed due to migration
-		newPod.ObjectMeta.Labels[podGroupIndex] = "1"
+		newPod.Labels[podGroupIndex] = "1"
 		cache.updatePod(oldPod, newPod)
 		_, exist = cache.metaPods.Load("default/p1")
 		Expect(exist).To(BeFalse())
 
-		newPod.ObjectMeta.Labels[podGroupIndex] = "0"
+		newPod.Labels[podGroupIndex] = "0"
 		cache.updatePod(oldPod, newPod)
 		_, exist = cache.metaPods.Load("default/p1")
 		Expect(exist).To(BeTrue())
@@ -383,13 +383,13 @@ var _ = Describe("Cache", func() {
 
 	It("should not delete pod after podIndex updated", func() {
 		oldPod := getNewPod("p1", "default", "m1", 0)
-		oldPod.ObjectMeta.Labels[podGroupIndex] = "0"
+		oldPod.Labels[podGroupIndex] = "0"
 		cache.addPod(oldPod)
 		_, exist := cache.metaPods.Load("default/p1")
 		Expect(exist).To(BeTrue())
 
 		newPod := getReadyPod("p1", "default", "m1", 0) // IP may changed due to migration
-		newPod.ObjectMeta.Labels[podGroupIndex] = "1"
+		newPod.Labels[podGroupIndex] = "1"
 		cache.updatePod(oldPod, newPod)
 		_, exist = cache.metaPods.Load("default/p1")
 		Expect(exist).To(BeFalse())
@@ -416,7 +416,7 @@ var _ = Describe("Cache", func() {
 		cache.addPod(pod)
 		_, exist = cache.metaPods.Load("default/p1")
 		Expect(exist).To(BeTrue())
-		pod.ObjectMeta.Labels = nil
+		pod.Labels = nil
 		cache.deletePod(pod)
 		_, exist = cache.metaPods.Load("default/p1")
 		Expect(exist).To(BeFalse())

--- a/pkg/cache/informers.go
+++ b/pkg/cache/informers.go
@@ -330,10 +330,10 @@ func (c *Store) setModelBaseModelLocked(model *modelv1alpha1.ModelAdapter) {
 	if base == "" {
 		for _, podName := range model.Status.Instances {
 			metaPod, ok := c.metaPods.Load(utils.GeneratePodKey(model.Namespace, podName))
-			if !ok || metaPod.Pod == nil || metaPod.Pod.Labels == nil {
+			if !ok || metaPod.Pod == nil || metaPod.Labels == nil {
 				continue
 			}
-			if v := strings.TrimSpace(metaPod.Pod.Labels[constants.ModelLabelName]); v != "" {
+			if v := strings.TrimSpace(metaPod.Labels[constants.ModelLabelName]); v != "" {
 				base = v
 				break
 			}

--- a/pkg/controller/kvcache/backends/distributed.go
+++ b/pkg/controller/kvcache/backends/distributed.go
@@ -44,11 +44,12 @@ func NewDistributedReconciler(c client.Client, backend string) *DistributedRecon
 		BaseReconciler: &BaseReconciler{Client: c},
 	}
 
-	if backend == constants.KVCacheBackendInfinistore {
+	switch backend {
+	case constants.KVCacheBackendInfinistore:
 		reconciler.Backend = InfiniStoreBackend{}
-	} else if backend == constants.KVCacheBackendHPKV {
+	case constants.KVCacheBackendHPKV:
 		reconciler.Backend = HpKVBackend{}
-	} else {
+	default:
 		panic(fmt.Sprintf("unsupported backend: %s", backend))
 	}
 	return reconciler
@@ -185,7 +186,7 @@ func (r *DistributedReconciler) validateSecretExists(ctx context.Context, namesp
 	secretName, secretKey := parseSecretRef(secretRef)
 
 	secret := &corev1.Secret{}
-	if err := r.Client.Get(ctx, types.NamespacedName{
+	if err := r.Get(ctx, types.NamespacedName{
 		Namespace: namespace,
 		Name:      secretName,
 	}, secret); err != nil {
@@ -210,7 +211,7 @@ func (r *DistributedReconciler) cleanupInClusterRedis(ctx context.Context, kvCac
 	pod := &corev1.Pod{}
 	pod.Name = redisPodName
 	pod.Namespace = kvCache.Namespace
-	if err := r.Client.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+	if err := r.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete Redis Pod %s: %w", redisPodName, err)
 	} else if err == nil {
 		klog.Infof("Deleted orphaned in-cluster Redis Pod %s/%s", kvCache.Namespace, redisPodName)
@@ -220,7 +221,7 @@ func (r *DistributedReconciler) cleanupInClusterRedis(ctx context.Context, kvCac
 	svc := &corev1.Service{}
 	svc.Name = redisServiceName
 	svc.Namespace = kvCache.Namespace
-	if err := r.Client.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
+	if err := r.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete Redis Service %s: %w", redisServiceName, err)
 	} else if err == nil {
 		klog.Infof("Deleted orphaned in-cluster Redis Service %s/%s", kvCache.Namespace, redisServiceName)

--- a/pkg/controller/kvcache/backends/hpkv_test.go
+++ b/pkg/controller/kvcache/backends/hpkv_test.go
@@ -194,7 +194,7 @@ func TestBuildCacheStatefulSet_HP(t *testing.T) {
 
 	// Volumes
 	vol := ss.Spec.Template.Spec.Volumes[0]
-	assert.Equal(t, corev1.StorageMediumMemory, vol.VolumeSource.EmptyDir.Medium)
+	assert.Equal(t, corev1.StorageMediumMemory, vol.EmptyDir.Medium)
 	assert.Equal(t, "shared-mem", vol.Name)
 }
 

--- a/pkg/controller/kvcache/backends/vineyard.go
+++ b/pkg/controller/kvcache/backends/vineyard.go
@@ -218,7 +218,7 @@ func buildEtcdAggregateService(kvCache *orchestrationv1alpha1.KVCache) *corev1.S
 
 func buildVineyardDeployment(kvCache *orchestrationv1alpha1.KVCache) *appsv1.Deployment {
 	envs := []corev1.EnvVar{
-		{Name: "VINEYARDD_UID", Value: string(kvCache.ObjectMeta.UID)},
+		{Name: "VINEYARDD_UID", Value: string(kvCache.UID)},
 		{Name: "VINEYARDD_NAME", Value: kvCache.Name},
 		{Name: "VINEYARDD_NAMESPACE", Value: kvCache.Namespace},
 		{Name: "MY_NODE_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},

--- a/pkg/controller/modeladapter/modeladapter_controller.go
+++ b/pkg/controller/modeladapter/modeladapter_controller.go
@@ -337,7 +337,7 @@ func (r *ModelAdapterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return reconcile.Result{}, err
 	}
 
-	if modelAdapter.ObjectMeta.DeletionTimestamp.IsZero() {
+	if modelAdapter.DeletionTimestamp.IsZero() {
 		// the object is not being deleted, so if it does not have the finalizer,
 		// then lets add the finalizer and update the object.
 		if !controllerutil.ContainsFinalizer(modelAdapter, ModelAdapterFinalizer) {

--- a/pkg/controller/modelrouter/modelrouter_controller.go
+++ b/pkg/controller/modelrouter/modelrouter_controller.go
@@ -313,7 +313,7 @@ func (m *ModelRouter) createHTTPRoute(namespace string, labels map[string]string
 
 	appendCustomModelRouterPaths(&httpRoute, modelHeaderMatch, annotations)
 
-	err = m.Client.Create(context.Background(), &httpRoute)
+	err = m.Create(context.Background(), &httpRoute)
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			klog.V(4).Infof("httproute: %v already exists in namespace: %v", httpRoute.Name, namespace)
@@ -339,7 +339,7 @@ func (m *ModelRouter) createReferenceGrant(namespace string) {
 		},
 	}
 
-	if err := m.Client.Get(context.Background(), client.ObjectKeyFromObject(&referenceGrant), &referenceGrant); err == nil {
+	if err := m.Get(context.Background(), client.ObjectKeyFromObject(&referenceGrant), &referenceGrant); err == nil {
 		klog.V(4).InfoS("reference grant already exists", "referencegrant", referenceGrant.Name)
 		return
 	}
@@ -365,7 +365,7 @@ func (m *ModelRouter) createReferenceGrant(namespace string) {
 			},
 		},
 	}
-	if err := m.Client.Create(context.Background(), &referenceGrant); err != nil {
+	if err := m.Create(context.Background(), &referenceGrant); err != nil {
 		klog.ErrorS(err, "error on creating referencegrant", "referencegrant", referenceGrant)
 		return
 	}
@@ -386,7 +386,7 @@ func (m *ModelRouter) deleteHTTPRoute(namespace string, labels, annotations map[
 		},
 	}
 
-	err := m.Client.Delete(ctx, &httpRoute)
+	err := m.Delete(ctx, &httpRoute)
 	if err != nil {
 		klog.Errorln(err)
 	}
@@ -418,7 +418,7 @@ func (m *ModelRouter) deleteReferenceGrant(ctx context.Context, namespace string
 			Namespace: namespace,
 		},
 	}
-	if err := m.Client.Delete(ctx, &referenceGrant); err != nil {
+	if err := m.Delete(ctx, &referenceGrant); err != nil {
 		if !apierrors.IsNotFound(err) {
 			klog.ErrorS(err, "Failed to delete ReferenceGrant", "name", referenceGrantName, "namespace", namespace)
 			return err
@@ -430,7 +430,7 @@ func (m *ModelRouter) deleteReferenceGrant(ctx context.Context, namespace string
 
 func (m *ModelRouter) namespaceHasModelWorkload(ctx context.Context, namespace string) (bool, error) {
 	var deploymentList appsv1.DeploymentList
-	if err := m.Client.List(ctx, &deploymentList, client.InNamespace(namespace)); err != nil {
+	if err := m.List(ctx, &deploymentList, client.InNamespace(namespace)); err != nil {
 		klog.ErrorS(err, "Failed to list model deployments", "namespace", namespace)
 		return false, err
 	}
@@ -444,7 +444,7 @@ func (m *ModelRouter) namespaceHasModelWorkload(ctx context.Context, namespace s
 	}
 
 	var adapterList modelv1alpha1.ModelAdapterList
-	if err := m.Client.List(ctx, &adapterList, client.InNamespace(namespace)); err != nil {
+	if err := m.List(ctx, &adapterList, client.InNamespace(namespace)); err != nil {
 		klog.ErrorS(err, "Failed to list model adapters", "namespace", namespace)
 		return false, err
 	}
@@ -458,7 +458,7 @@ func (m *ModelRouter) namespaceHasModelWorkload(ctx context.Context, namespace s
 	}
 
 	var fleetList orchestrationv1alpha1.RayClusterFleetList
-	if err := m.Client.List(ctx, &fleetList, client.InNamespace(namespace)); err != nil {
+	if err := m.List(ctx, &fleetList, client.InNamespace(namespace)); err != nil {
 		klog.ErrorS(err, "Failed to list ray cluster fleets", "namespace", namespace)
 		return false, err
 	}
@@ -480,7 +480,7 @@ func (m *ModelRouter) namespaceHasModelWorkload(ctx context.Context, namespace s
 			Version: gvk.Version,
 			Kind:    gvk.Kind + "List",
 		})
-		if err := m.Client.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		if err := m.List(ctx, list, client.InNamespace(namespace)); err != nil {
 			if meta.IsNoMatchError(err) {
 				// CRD not installed; treat as "not present", not as "has workload".
 				klog.V(4).InfoS("optional workload CRD not present", "GVK", gvk, "namespace", namespace)

--- a/pkg/controller/modelrouter/modelrouter_controller_test.go
+++ b/pkg/controller/modelrouter/modelrouter_controller_test.go
@@ -56,7 +56,7 @@ func TestCreateHTTPRouteSupportsAnnotatedModelAndServiceNames(t *testing.T) {
 	)
 
 	routes := &gatewayv1.HTTPRouteList{}
-	if err := m.Client.List(context.Background(), routes, client.InNamespace(aibrixEnvoyGatewayNamespace)); err != nil {
+	if err := m.List(context.Background(), routes, client.InNamespace(aibrixEnvoyGatewayNamespace)); err != nil {
 		t.Fatal(err)
 	}
 	if len(routes.Items) != 1 {
@@ -92,7 +92,7 @@ func TestCreateHTTPRouteSupportsAnnotatedModelAndServiceNames(t *testing.T) {
 	}
 
 	grant := &gatewayv1beta1.ReferenceGrant{}
-	if err := m.Client.Get(context.Background(), client.ObjectKey{
+	if err := m.Get(context.Background(), client.ObjectKey{
 		Namespace: "default",
 		Name:      "aibrix-system-reserved-referencegrant-in-default",
 	}, grant); err != nil {

--- a/pkg/controller/modelrouter/modelrouter_event_test.go
+++ b/pkg/controller/modelrouter/modelrouter_event_test.go
@@ -209,7 +209,7 @@ func TestInformerEventsSkipWorkloadsWithoutModelName(t *testing.T) {
 	})
 
 	routes := &gatewayv1.HTTPRouteList{}
-	if err := m.Client.List(context.Background(), routes); err != nil {
+	if err := m.List(context.Background(), routes); err != nil {
 		t.Fatal(err)
 	}
 	if len(routes.Items) != 0 {
@@ -253,7 +253,7 @@ func TestCrossNamespaceReferenceGrantCreation(t *testing.T) {
 
 		_ = getHTTPRoute(t, m.Client, "llama-7b")
 		grant := &gatewayv1beta1.ReferenceGrant{}
-		err := m.Client.Get(context.Background(), client.ObjectKey{
+		err := m.Get(context.Background(), client.ObjectKey{
 			Namespace: aibrixEnvoyGatewayNamespace,
 			Name:      fmt.Sprintf("%s-reserved-referencegrant-in-%s", aibrixEnvoyGatewayNamespace, aibrixEnvoyGatewayNamespace),
 		}, grant)
@@ -279,14 +279,14 @@ func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
 
 		m.deleteRouteFromDeployment(deploy)
 
-		err := m.Client.Get(context.Background(), client.ObjectKey{
+		err := m.Get(context.Background(), client.ObjectKey{
 			Namespace: aibrixEnvoyGatewayNamespace,
 			Name:      utils.ModelRouterName("llama-7b"),
 		}, &gatewayv1.HTTPRoute{})
 		if !apierrors.IsNotFound(err) {
 			t.Fatalf("HTTPRoute after delete: %v, want NotFound", err)
 		}
-		err = m.Client.Get(context.Background(), client.ObjectKey{
+		err = m.Get(context.Background(), client.ObjectKey{
 			Namespace: "models",
 			Name:      fmt.Sprintf("%s-reserved-referencegrant-in-%s", aibrixEnvoyGatewayNamespace, "models"),
 		}, &gatewayv1beta1.ReferenceGrant{})
@@ -314,7 +314,7 @@ func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
 		m.addRouteFromDeployment(deploy)
 		m.deleteRouteFromDeployment(deploy)
 
-		err := m.Client.Get(context.Background(), client.ObjectKey{
+		err := m.Get(context.Background(), client.ObjectKey{
 			Namespace: aibrixEnvoyGatewayNamespace,
 			Name:      utils.ModelRouterName("llama-7b"),
 		}, &gatewayv1.HTTPRoute{})
@@ -342,7 +342,7 @@ func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
 		}
 		m.addRouteFromModelAdapter(adapter)
 		m.deleteRouteFromModelAdapter(adapter)
-		err := m.Client.Get(context.Background(), client.ObjectKey{
+		err := m.Get(context.Background(), client.ObjectKey{
 			Namespace: aibrixEnvoyGatewayNamespace,
 			Name:      utils.ModelRouterName("llama-adapter"),
 		}, &gatewayv1.HTTPRoute{})
@@ -370,7 +370,7 @@ func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
 		}
 		m.addRouteFromRayClusterFleet(fleet)
 		m.deleteRouteFromRayClusterFleet(fleet)
-		err := m.Client.Get(context.Background(), client.ObjectKey{
+		err := m.Get(context.Background(), client.ObjectKey{
 			Namespace: aibrixEnvoyGatewayNamespace,
 			Name:      utils.ModelRouterName("llama-fleet"),
 		}, &gatewayv1.HTTPRoute{})
@@ -398,7 +398,7 @@ func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
 		}
 		m.addRouteFromDeployment(deploy)
 		m.deleteRouteFromDeployment(deploy)
-		err := m.Client.Get(context.Background(), client.ObjectKey{
+		err := m.Get(context.Background(), client.ObjectKey{
 			Namespace: aibrixEnvoyGatewayNamespace,
 			Name:      utils.ModelRouterName("llama-7b"),
 		}, &gatewayv1.HTTPRoute{})
@@ -429,7 +429,7 @@ func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
 		}
 		m.addRouteFromDeployment(deploy)
 		m.deleteRouteFromDeployment(deploy)
-		err := m.Client.Get(context.Background(), client.ObjectKey{
+		err := m.Get(context.Background(), client.ObjectKey{
 			Namespace: aibrixEnvoyGatewayNamespace,
 			Name:      utils.ModelRouterName("llama-7b"),
 		}, &gatewayv1.HTTPRoute{})
@@ -450,7 +450,7 @@ func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
 		}
 		m.addRouteFromModelAdapter(adapter)
 		m.deleteRouteFromModelAdapter(adapter)
-		err := m.Client.Get(context.Background(), client.ObjectKey{
+		err := m.Get(context.Background(), client.ObjectKey{
 			Namespace: aibrixEnvoyGatewayNamespace,
 			Name:      utils.ModelRouterName("adapter-model"),
 		}, &gatewayv1.HTTPRoute{})
@@ -470,7 +470,7 @@ func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
 		}
 		m.addRouteFromRayClusterFleet(fleet)
 		m.deleteRouteFromRayClusterFleet(fleet)
-		err := m.Client.Get(context.Background(), client.ObjectKey{
+		err := m.Get(context.Background(), client.ObjectKey{
 			Namespace: aibrixEnvoyGatewayNamespace,
 			Name:      utils.ModelRouterName("fleet-model"),
 		}, &gatewayv1.HTTPRoute{})
@@ -490,7 +490,7 @@ func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
 		}
 		m.addRouteFromDeployment(deploy)
 		m.deleteRouteFromDeployment(cache.DeletedFinalStateUnknown{Obj: deploy})
-		err := m.Client.Get(context.Background(), client.ObjectKey{
+		err := m.Get(context.Background(), client.ObjectKey{
 			Namespace: aibrixEnvoyGatewayNamespace,
 			Name:      utils.ModelRouterName("tombstone-model"),
 		}, &gatewayv1.HTTPRoute{})

--- a/pkg/controller/podautoscaler/autoscaler_test.go
+++ b/pkg/controller/podautoscaler/autoscaler_test.go
@@ -192,7 +192,7 @@ func TestComputeDesiredReplicasConfiguresMetricWindowsFromPodAutoscalerSpec(t *t
 	_, err := autoScaler.ComputeDesiredReplicas(context.TODO(), request)
 	require.NoError(t, err)
 
-	mockFactory.mockMetricFetcher.metricsValue = 70.0
+	mockFactory.metricsValue = 70.0
 	request.Timestamp = request.Timestamp.Add(60 * time.Second)
 	_, err = autoScaler.ComputeDesiredReplicas(context.TODO(), request)
 	require.NoError(t, err)

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -1023,7 +1023,7 @@ func setStatus(pa *autoscalingv1alpha1.PodAutoscaler, currentReplicas, desiredRe
 			// 2. The desired scale is different from the last recorded scale, or
 			// 3. The success status has changed (success to failure or vice versa), or
 			// 4. There's a different error message
-			timeSinceLastScale := now.Time.Sub(lastScale.Timestamp.Time)
+			timeSinceLastScale := now.Sub(lastScale.Timestamp.Time)
 			if timeSinceLastScale > minScalingHistoryRecordInterval ||
 				lastScale.NewScale != desiredReplicas ||
 				lastScale.Success != success ||

--- a/pkg/controller/podautoscaler/workload_scale.go
+++ b/pkg/controller/podautoscaler/workload_scale.go
@@ -386,10 +386,8 @@ func (s *workloadScale) GetPodSelectorFromScale(ctx context.Context, pa *autosca
 }
 
 func (s *workloadScale) isStormServiceWorkload(scale *unstructured.Unstructured) bool {
-	isStormService := false
-	if scale.GetAPIVersion() == "orchestration.aibrix.ai/v1alpha1" && scale.GetKind() == "StormService" {
-		isStormService = true
-	}
+	isStormService := scale.GetAPIVersion() == "orchestration.aibrix.ai/v1alpha1" && scale.GetKind() == "StormService"
+
 	return isStormService
 }
 

--- a/pkg/controller/podset/podset_controller.go
+++ b/pkg/controller/podset/podset_controller.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -245,10 +244,10 @@ func (r *PodSetReconciler) reconcilePods(ctx context.Context, podSet *orchestrat
 }
 
 func (r *PodSetReconciler) handleReplaceUnhealthy(ctx context.Context, podSet *orchestrationv1alpha1.PodSet,
-	activePods []corev1.Pod, currentPodCount, desiredPodCount int) (controllerdrain.Result, error) {
+	activePods []v1.Pod, currentPodCount, desiredPodCount int) (controllerdrain.Result, error) {
 
 	// Proactively find and delete unhealthy pods
-	var podsToDelete []*corev1.Pod
+	var podsToDelete []*v1.Pod
 	for i := range activePods {
 		for _, cs := range activePods[i].Status.ContainerStatuses {
 			if cs.RestartCount > 0 {
@@ -264,13 +263,13 @@ func (r *PodSetReconciler) handleReplaceUnhealthy(ctx context.Context, podSet *o
 		if err != nil {
 			return result, err
 		}
-		r.EventRecorder.Eventf(podSet, corev1.EventTypeNormal, "DeletingUnhealthyPods", "Deleting %d unhealthy pods due to container restarts.", len(podsToDelete))
+		r.EventRecorder.Eventf(podSet, v1.EventTypeNormal, "DeletingUnhealthyPods", "Deleting %d unhealthy pods due to container restarts.", len(podsToDelete))
 		return result, nil
 	}
 
 	// If no unhealthy pods deleted, fill missing slots
 	if desiredPodCount-currentPodCount > 0 {
-		r.EventRecorder.Eventf(podSet, corev1.EventTypeNormal, "ReplacingUnhealthy",
+		r.EventRecorder.Eventf(podSet, v1.EventTypeNormal, "ReplacingUnhealthy",
 			"ReplaceUnhealthy policy: creating %d pod(s) to replace missing ones, aiming for %d total.",
 			desiredPodCount-currentPodCount, desiredPodCount)
 	}
@@ -304,13 +303,13 @@ func (r *PodSetReconciler) handleReplaceUnhealthy(ctx context.Context, podSet *o
 }
 
 func (r *PodSetReconciler) handleRecreateStrategy(ctx context.Context, podSet *orchestrationv1alpha1.PodSet,
-	activePods []corev1.Pod, desiredPodCount int) (controllerdrain.Result, error) {
+	activePods []v1.Pod, desiredPodCount int) (controllerdrain.Result, error) {
 
 	if len(activePods) > 0 {
 		klog.InfoS("Recreate strategy: deleting active pods", "podset", podSet.Name, "count", len(activePods))
-		r.EventRecorder.Eventf(podSet, corev1.EventTypeNormal, "RecreatingAllPods",
+		r.EventRecorder.Eventf(podSet, v1.EventTypeNormal, "RecreatingAllPods",
 			"Recreate policy triggered: deleting all %d active pods before creating new ones", len(activePods))
-		podsToDelete := make([]*corev1.Pod, 0, len(activePods))
+		podsToDelete := make([]*v1.Pod, 0, len(activePods))
 		for i := range activePods {
 			podsToDelete = append(podsToDelete, &activePods[i])
 		}
@@ -335,19 +334,19 @@ func (r *PodSetReconciler) handleRecreateStrategy(ctx context.Context, podSet *o
 }
 
 func (r *PodSetReconciler) handleScaleDown(ctx context.Context, podSet *orchestrationv1alpha1.PodSet,
-	activePods []corev1.Pod, currentPodCount, desiredPodCount int) (controllerdrain.Result, error) {
+	activePods []v1.Pod, currentPodCount, desiredPodCount int) (controllerdrain.Result, error) {
 
 	podsToDelete := currentPodCount - desiredPodCount
 	if timeout, ok := drainTimeoutSeconds(podSet.Spec.Drain); ok {
-		r.EventRecorder.Eventf(podSet, corev1.EventTypeNormal, "ScalingDown",
+		r.EventRecorder.Eventf(podSet, v1.EventTypeNormal, "ScalingDown",
 			"Draining %d excess pods before deletion to meet desired count of %d (timeout=%ds)", podsToDelete, desiredPodCount, timeout)
 	} else {
-		r.EventRecorder.Eventf(podSet, corev1.EventTypeNormal, "ScalingDown",
+		r.EventRecorder.Eventf(podSet, v1.EventTypeNormal, "ScalingDown",
 			"Deleting %d excess pods to meet desired count of %d", podsToDelete, desiredPodCount)
 	}
 
 	sortPodsByIndex(activePods)
-	podList := make([]*corev1.Pod, 0, podsToDelete)
+	podList := make([]*v1.Pod, 0, podsToDelete)
 	for i := 0; i < podsToDelete; i++ {
 		podList = append(podList, &activePods[len(activePods)-1-i])
 	}
@@ -366,7 +365,7 @@ func (r *PodSetReconciler) handleScaleDown(ctx context.Context, podSet *orchestr
 	return result, nil
 }
 
-func (r *PodSetReconciler) cancelStaleScaleInDrain(ctx context.Context, podSet *orchestrationv1alpha1.PodSet, activePods []corev1.Pod, podsToDelete []*corev1.Pod) (controllerdrain.Result, error) {
+func (r *PodSetReconciler) cancelStaleScaleInDrain(ctx context.Context, podSet *orchestrationv1alpha1.PodSet, activePods []v1.Pod, podsToDelete []*v1.Pod) (controllerdrain.Result, error) {
 	deleteSet := make(map[string]struct{}, len(podsToDelete))
 	for _, pod := range podsToDelete {
 		if pod == nil {
@@ -374,7 +373,7 @@ func (r *PodSetReconciler) cancelStaleScaleInDrain(ctx context.Context, podSet *
 		}
 		deleteSet[pod.Namespace+"/"+pod.Name] = struct{}{}
 	}
-	stale := make([]*corev1.Pod, 0)
+	stale := make([]*v1.Pod, 0)
 	for i := range activePods {
 		pod := &activePods[i]
 		if !podutil.IsPodDraining(pod) {
@@ -537,7 +536,7 @@ func (r *PodSetReconciler) finalizePodSet(ctx context.Context, podSet *orchestra
 	}
 
 	if len(podSetList.Items) > 0 {
-		podsToDelete := make([]*corev1.Pod, 0, len(podSetList.Items))
+		podsToDelete := make([]*v1.Pod, 0, len(podSetList.Items))
 		for i := range podSetList.Items {
 			podsToDelete = append(podsToDelete, &podSetList.Items[i])
 		}

--- a/pkg/controller/rayclusterfleet/sync.go
+++ b/pkg/controller/rayclusterfleet/sync.go
@@ -458,7 +458,7 @@ func (r *RayClusterFleetReconciler) cleanupDeployment(ctx context.Context, oldRS
 
 	// Avoid deleting replica set with deletion timestamp set
 	aliveFilter := func(rs *orchestrationv1alpha1.RayClusterReplicaSet) bool {
-		return rs != nil && rs.ObjectMeta.DeletionTimestamp == nil
+		return rs != nil && rs.DeletionTimestamp == nil
 	}
 	cleanableRSes := util.FilterReplicaSets(oldRSs, aliveFilter)
 

--- a/pkg/controller/rayclusterfleet/util/fleet.go
+++ b/pkg/controller/rayclusterfleet/util/fleet.go
@@ -670,8 +670,8 @@ func FindOldReplicaSets(deployment *orchestrationv1alpha1.RayClusterFleet, rsLis
 func SetFromReplicaSetTemplate(fleet *orchestrationv1alpha1.RayClusterFleet, template orchestrationv1alpha1.RayClusterTemplateSpec) *orchestrationv1alpha1.RayClusterFleet {
 	fleet.Spec.Template.ObjectMeta = template.ObjectMeta
 	fleet.Spec.Template.Spec = template.Spec
-	fleet.Spec.Template.ObjectMeta.Labels = labelsutil.CloneAndRemoveLabel(
-		fleet.Spec.Template.ObjectMeta.Labels,
+	fleet.Spec.Template.Labels = labelsutil.CloneAndRemoveLabel(
+		fleet.Spec.Template.Labels,
 		appsv1.DefaultDeploymentUniqueLabelKey)
 	return fleet
 }

--- a/pkg/controller/rayclusterreplicaset/rayclusterreplicaset_controller.go
+++ b/pkg/controller/rayclusterreplicaset/rayclusterreplicaset_controller.go
@@ -108,7 +108,7 @@ type RayClusterReplicaSetReconciler struct {
 // Reconcile method moves the RayClusterReplicaSet to desired State
 func (r *RayClusterReplicaSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	replicaset := &orchestrationv1alpha1.RayClusterReplicaSet{}
-	rsKey := req.NamespacedName.String()
+	rsKey := req.String()
 	if err := r.Get(ctx, req.NamespacedName, replicaset); err != nil {
 		klog.ErrorS(err, "unable to fetch object", "RayClusterReplicaSet", req.NamespacedName)
 		// deletion & recreation will find the exception exist, even it always return true (result is same) but the logic is different.
@@ -125,7 +125,7 @@ func (r *RayClusterReplicaSetReconciler) Reconcile(ctx context.Context, req ctrl
 		client.MatchingLabels(replicaset.Spec.Selector.MatchLabels),
 	}
 
-	if err := r.Client.List(ctx, rayClusterList, ListOps...); err != nil {
+	if err := r.List(ctx, rayClusterList, ListOps...); err != nil {
 		klog.ErrorS(err, "unable to list ray clusters")
 		return ctrl.Result{}, err
 	}

--- a/pkg/controller/roleset/roleset_controller.go
+++ b/pkg/controller/roleset/roleset_controller.go
@@ -109,26 +109,26 @@ type RoleSetReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;update;patch
 
 func (r *RoleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	klog.Infof("Reconciling RoleSet %s", req.NamespacedName.String())
+	klog.Infof("Reconciling RoleSet %s", req.String())
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 	roleSet := &orchestrationv1alpha1.RoleSet{}
-	if err := r.Client.Get(ctx, req.NamespacedName, roleSet); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, roleSet); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	if roleSet.DeletionTimestamp != nil {
 		if done, err := r.finalize(ctx, roleSet); err != nil {
-			klog.Errorf("Reconciling RoleSet %s finalize error %v", req.NamespacedName.String(), err)
+			klog.Errorf("Reconciling RoleSet %s finalize error %v", req.String(), err)
 			return ctrl.Result{RequeueAfter: DefaultRequeueAfter}, err
 		} else if !done {
-			klog.Infof("Reconciling RoleSet %s finalize not done yet, reconcile after %v seconds", req.NamespacedName.String(), DefaultRequeueAfter)
+			klog.Infof("Reconciling RoleSet %s finalize not done yet, reconcile after %v seconds", req.String(), DefaultRequeueAfter)
 			return ctrl.Result{RequeueAfter: DefaultRequeueAfter}, nil
 		}
 		return ctrl.Result{}, nil
 	} else if !controllerutil.ContainsFinalizer(roleSet, RoleSetFinalizer) {
 		// add finalizer if not exist
 		if err := orchestrationctrl.Patch(ctx, r.Client, roleSet, patch.AddFinalizerPatch(roleSet, RoleSetFinalizer)); err != nil {
-			klog.Errorf("Adding RoleSet %s finalizer error %v", req.NamespacedName.String(), err)
+			klog.Errorf("Adding RoleSet %s finalizer error %v", req.String(), err)
 			return ctrl.Result{RequeueAfter: DefaultRequeueAfter}, err
 		}
 		return ctrl.Result{}, nil

--- a/pkg/controller/roleset/sync.go
+++ b/pkg/controller/roleset/sync.go
@@ -181,7 +181,7 @@ func (r *RoleSetReconciler) calculateStatusForRole(ctx context.Context, rs *orch
 
 	// Use traditional pod-based status calculation for podGroupSize <= 1
 	allPods := &v1.PodList{}
-	if err := r.Client.List(ctx, allPods, client.InNamespace(rs.Namespace), client.MatchingLabels{
+	if err := r.List(ctx, allPods, client.InNamespace(rs.Namespace), client.MatchingLabels{
 		constants.RoleSetNameLabelKey: rs.Name,
 	}); err != nil {
 		return nil, err
@@ -211,7 +211,7 @@ func (r *RoleSetReconciler) calculateStatusForRole(ctx context.Context, rs *orch
 func (r *RoleSetReconciler) calculateStatusFromPodSets(ctx context.Context, rs *orchestrationv1alpha1.RoleSet, role *orchestrationv1alpha1.RoleSpec) (*orchestrationv1alpha1.RoleStatus, error) {
 	// Get PodSets for this role
 	podSetList := &orchestrationv1alpha1.PodSetList{}
-	err := r.Client.List(ctx, podSetList, client.InNamespace(rs.Namespace), client.MatchingLabels{
+	err := r.List(ctx, podSetList, client.InNamespace(rs.Namespace), client.MatchingLabels{
 		constants.RoleSetNameLabelKey: rs.Name,
 		constants.RoleNameLabelKey:    role.Name,
 	})
@@ -254,12 +254,12 @@ func (r *RoleSetReconciler) finalize(ctx context.Context, roleSet *orchestration
 	selectorOpt := client.MatchingLabels{constants.RoleSetNameLabelKey: roleSet.Name}
 	// 1. check if all podsets are delete for podGroupSize > 1
 	allPodSets := &orchestrationv1alpha1.PodSetList{}
-	if err := r.Client.List(ctx, allPodSets, client.InNamespace(roleSet.Namespace), selectorOpt); err != nil {
+	if err := r.List(ctx, allPodSets, client.InNamespace(roleSet.Namespace), selectorOpt); err != nil {
 		return false, err
 	} else if len(allPodSets.Items) != 0 {
 		// delete pods
 		for i := range allPodSets.Items {
-			if err = r.Client.Delete(ctx, &allPodSets.Items[i]); err != nil {
+			if err = r.Delete(ctx, &allPodSets.Items[i]); err != nil {
 				if apierrors.IsNotFound(err) {
 					continue
 				}
@@ -272,12 +272,12 @@ func (r *RoleSetReconciler) finalize(ctx context.Context, roleSet *orchestration
 
 	// 2. check if all pods are deleted.
 	allPods := &v1.PodList{}
-	if err := r.Client.List(ctx, allPods, client.InNamespace(roleSet.Namespace), selectorOpt); err != nil {
+	if err := r.List(ctx, allPods, client.InNamespace(roleSet.Namespace), selectorOpt); err != nil {
 		return false, err
 	} else if len(allPods.Items) != 0 {
 		// delete pods
 		for i := range allPods.Items {
-			if err = r.Client.Delete(ctx, &allPods.Items[i]); err != nil {
+			if err = r.Delete(ctx, &allPods.Items[i]); err != nil {
 				if apierrors.IsNotFound(err) {
 					continue
 				}

--- a/pkg/controller/stormservice/revision.go
+++ b/pkg/controller/stormservice/revision.go
@@ -37,7 +37,7 @@ import (
 func (r *StormServiceReconciler) getControllerRevision(ctx context.Context, obj metav1.Object) ([]*apps.ControllerRevision, error) {
 	revisionList := &apps.ControllerRevisionList{}
 	matchLabels := client.MatchingLabels(getRevisionLabels(obj))
-	if err := r.Client.List(ctx, revisionList, matchLabels, client.InNamespace(obj.GetNamespace())); err != nil {
+	if err := r.List(ctx, revisionList, matchLabels, client.InNamespace(obj.GetNamespace())); err != nil {
 		return nil, fmt.Errorf("list controller revision failed, %v", err)
 	}
 
@@ -104,8 +104,8 @@ func newRevision(stormService *orchestrationv1alpha1.StormService, revision int6
 	if err != nil {
 		return nil, err
 	}
-	if cr.ObjectMeta.Annotations == nil {
-		cr.ObjectMeta.Annotations = make(map[string]string)
+	if cr.Annotations == nil {
+		cr.Annotations = make(map[string]string)
 	}
 	return cr, nil
 }
@@ -131,10 +131,10 @@ func (r *StormServiceReconciler) createControllerRevision(ctx context.Context, p
 		clone.Name = history.ControllerRevisionName(parent.GetName(), hash)
 		clone.Namespace = parent.GetNamespace()
 
-		createErr := r.Client.Create(ctx, clone)
+		createErr := r.Create(ctx, clone)
 		if errors.IsAlreadyExists(createErr) {
 			exists := &apps.ControllerRevision{}
-			err := r.Client.Get(ctx, client.ObjectKey{Namespace: clone.Namespace, Name: clone.Name}, exists)
+			err := r.Get(ctx, client.ObjectKey{Namespace: clone.Namespace, Name: clone.Name}, exists)
 			if err != nil {
 				return nil, err
 			}
@@ -156,12 +156,12 @@ func (r *StormServiceReconciler) updateControllerRevision(revision *apps.Control
 		}
 		clone.Revision = newRevision
 
-		updateErr := r.Client.Update(context.TODO(), clone)
+		updateErr := r.Update(context.TODO(), clone)
 		if updateErr == nil {
 			return nil
 		}
 		fresh := &apps.ControllerRevision{}
-		if err := r.Client.Get(context.TODO(), client.ObjectKey{Namespace: clone.Namespace, Name: clone.Name}, fresh); err == nil {
+		if err := r.Get(context.TODO(), client.ObjectKey{Namespace: clone.Namespace, Name: clone.Name}, fresh); err == nil {
 			clone = fresh.DeepCopy()
 		}
 		return updateErr
@@ -274,7 +274,7 @@ func (r *StormServiceReconciler) truncateHistory(ctx context.Context, stormServi
 	// delete any non-live history to maintain the revision limit.
 	revisionHistory = revisionHistory[:(historyLen - historyLimit)]
 	for i := 0; i < len(revisionHistory); i++ {
-		if err := r.Client.Delete(ctx, revisionHistory[i]); err != nil {
+		if err := r.Delete(ctx, revisionHistory[i]); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/stormservice/revision_test.go
+++ b/pkg/controller/stormservice/revision_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apps "k8s.io/api/apps/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -186,7 +185,7 @@ func TestNewRevision(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, revision)
 	assert.Equal(t, int64(1), revision.Revision)
-	assert.NotNil(t, revision.ObjectMeta.Annotations)
+	assert.NotNil(t, revision.Annotations)
 	assert.NotEmpty(t, revision.Data.Raw)
 }
 
@@ -231,9 +230,9 @@ func TestTruncateHistory(t *testing.T) {
 	tests := []struct {
 		name         string
 		stormService *orchestrationv1alpha1.StormService
-		revisions    []*appsv1.ControllerRevision
-		current      *appsv1.ControllerRevision
-		update       *appsv1.ControllerRevision
+		revisions    []*apps.ControllerRevision
+		current      *apps.ControllerRevision
+		update       *apps.ControllerRevision
 		mockSetup    func(mockClient *MockClient)
 		wantErr      bool
 	}{
@@ -246,7 +245,7 @@ func TestTruncateHistory(t *testing.T) {
 					},
 				},
 			},
-			revisions: []*appsv1.ControllerRevision{},
+			revisions: []*apps.ControllerRevision{},
 			mockSetup: func(m *MockClient) {
 				m.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
@@ -261,10 +260,10 @@ func TestTruncateHistory(t *testing.T) {
 					},
 				},
 			},
-			revisions: []*appsv1.ControllerRevision{
+			revisions: []*apps.ControllerRevision{
 				{ObjectMeta: metav1.ObjectMeta{Name: "rev1"}},
 			},
-			current: &appsv1.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "current"}},
+			current: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "current"}},
 			mockSetup: func(m *MockClient) {
 				m.On("List", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 					list := args.Get(1).(*orchestrationv1alpha1.RoleSetList)
@@ -285,12 +284,12 @@ func TestTruncateHistory(t *testing.T) {
 					RevisionHistoryLimit: func() *int32 { i := int32(1); return &i }(),
 				},
 			},
-			revisions: []*appsv1.ControllerRevision{
+			revisions: []*apps.ControllerRevision{
 				{ObjectMeta: metav1.ObjectMeta{Name: "rev1"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "rev2"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "rev3"}},
 			},
-			current: &appsv1.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "current"}},
+			current: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "current"}},
 			mockSetup: func(m *MockClient) {
 				m.On("List", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 					list := args.Get(1).(*orchestrationv1alpha1.RoleSetList)
@@ -326,12 +325,12 @@ func TestTruncateHistory(t *testing.T) {
 					RevisionHistoryLimit: func() *int32 { i := int32(1); return &i }(),
 				},
 			},
-			revisions: []*appsv1.ControllerRevision{
+			revisions: []*apps.ControllerRevision{
 				{ObjectMeta: metav1.ObjectMeta{Name: "rev1"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "rev2"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "rev3"}},
 			},
-			current: &appsv1.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "current"}},
+			current: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "current"}},
 			mockSetup: func(m *MockClient) {
 				m.On("List", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 					list := args.Get(1).(*orchestrationv1alpha1.RoleSetList)
@@ -353,13 +352,13 @@ func TestTruncateHistory(t *testing.T) {
 					RevisionHistoryLimit: func() *int32 { i := int32(1); return &i }(),
 				},
 			},
-			revisions: []*appsv1.ControllerRevision{
+			revisions: []*apps.ControllerRevision{
 				{ObjectMeta: metav1.ObjectMeta{Name: "rev1"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "rev2"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "rev3"}},
 			},
-			current: &appsv1.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "current"}},
-			update:  &appsv1.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "update-rev"}},
+			current: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "current"}},
+			update:  &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "update-rev"}},
 			mockSetup: func(m *MockClient) {
 				m.On("List", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 					list := args.Get(1).(*orchestrationv1alpha1.RoleSetList)
@@ -567,7 +566,7 @@ func TestGetControllerRevision(t *testing.T) {
 		name        string
 		setupMock   func(*MockClient, metav1.Object)
 		obj         metav1.Object
-		expected    []*appsv1.ControllerRevision
+		expected    []*apps.ControllerRevision
 		expectedErr string
 	}{
 		{
@@ -578,8 +577,8 @@ func TestGetControllerRevision(t *testing.T) {
 				UID:       "test-uid",
 			},
 			setupMock: func(m *MockClient, obj metav1.Object) {
-				revisionList := &appsv1.ControllerRevisionList{
-					Items: []appsv1.ControllerRevision{
+				revisionList := &apps.ControllerRevisionList{
+					Items: []apps.ControllerRevision{
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "rev1",
@@ -617,12 +616,12 @@ func TestGetControllerRevision(t *testing.T) {
 				}
 				m.On("List", mock.Anything, mock.AnythingOfType("*v1.ControllerRevisionList"), mock.Anything).
 					Run(func(args mock.Arguments) {
-						list := args.Get(1).(*appsv1.ControllerRevisionList)
+						list := args.Get(1).(*apps.ControllerRevisionList)
 						list.Items = revisionList.Items
 					}).
 					Return(nil)
 			},
-			expected: []*appsv1.ControllerRevision{
+			expected: []*apps.ControllerRevision{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "rev1",
@@ -655,8 +654,8 @@ func TestGetControllerRevision(t *testing.T) {
 				UID:       "test-uid",
 			},
 			setupMock: func(m *MockClient, obj metav1.Object) {
-				revisionList := &appsv1.ControllerRevisionList{
-					Items: []appsv1.ControllerRevision{
+				revisionList := &apps.ControllerRevisionList{
+					Items: []apps.ControllerRevision{
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "rev1",
@@ -683,12 +682,12 @@ func TestGetControllerRevision(t *testing.T) {
 				}
 				m.On("List", mock.Anything, mock.AnythingOfType("*v1.ControllerRevisionList"), mock.Anything).
 					Run(func(args mock.Arguments) {
-						list := args.Get(1).(*appsv1.ControllerRevisionList)
+						list := args.Get(1).(*apps.ControllerRevisionList)
 						list.Items = revisionList.Items
 					}).
 					Return(nil)
 			},
-			expected: []*appsv1.ControllerRevision{},
+			expected: []*apps.ControllerRevision{},
 		},
 		{
 			name: "empty revision list",
@@ -701,7 +700,7 @@ func TestGetControllerRevision(t *testing.T) {
 				m.On("List", mock.Anything, mock.AnythingOfType("*v1.ControllerRevisionList"), mock.Anything).
 					Return(nil)
 			},
-			expected: []*appsv1.ControllerRevision{},
+			expected: []*apps.ControllerRevision{},
 		},
 		{
 			name: "client list error",

--- a/pkg/controller/stormservice/rolesetoperations.go
+++ b/pkg/controller/stormservice/rolesetoperations.go
@@ -43,7 +43,7 @@ func (r *StormServiceReconciler) getRoleSetList(ctx context.Context, selector *m
 		return nil, fmt.Errorf("bad selector format: %v", err)
 	}
 	roleSetList := &orchestrationv1alpha1.RoleSetList{}
-	err = r.Client.List(ctx, roleSetList, client.MatchingLabelsSelector{Selector: roleSetSelector})
+	err = r.List(ctx, roleSetList, client.MatchingLabelsSelector{Selector: roleSetSelector})
 	if err != nil {
 		klog.Errorf("failed to list roleSets")
 		return nil, err
@@ -122,14 +122,14 @@ func (r *StormServiceReconciler) createRoleSet(stormService *orchestrationv1alph
 	}
 	return utils.SlowStartBatch(len(toCreate), ctrlutil.SlowStartInitialBatchSize, func(i int) error {
 		klog.Infof("[rolesetoperation] create roleset for stormservice %s/%s", stormService.Namespace, stormService.Name)
-		return r.Client.Create(context.TODO(), toCreate[i])
+		return r.Create(context.TODO(), toCreate[i])
 	})
 }
 
 func (r *StormServiceReconciler) deleteRoleSet(toDelete []*orchestrationv1alpha1.RoleSet) (int, error) {
 	return utils.SlowStartBatch(len(toDelete), ctrlutil.SlowStartInitialBatchSize, func(i int) error {
 		klog.Infof("[rolesetoperation] delete roleset %s", toDelete[i].Name)
-		err := r.Client.Delete(context.TODO(), toDelete[i])
+		err := r.Delete(context.TODO(), toDelete[i])
 		if err != nil && apierrors.IsNotFound(err) {
 			// NotFound will be ignored
 			return nil
@@ -159,6 +159,6 @@ func (r *StormServiceReconciler) updateRoleSet(stormService *orchestrationv1alph
 		}
 		// update roleset spec
 		toUpdate[i].Spec = target.Spec
-		return r.Client.Update(context.TODO(), toUpdate[i])
+		return r.Update(context.TODO(), toUpdate[i])
 	})
 }

--- a/pkg/controller/stormservice/stormservice_controller.go
+++ b/pkg/controller/stormservice/stormservice_controller.go
@@ -98,9 +98,9 @@ type StormServiceReconciler struct {
 
 func (r *StormServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	startTime := time.Now()
-	klog.Infof("Started syncing stormservice %s (%v)", req.NamespacedName.String(), startTime)
+	klog.Infof("Started syncing stormservice %s (%v)", req.String(), startTime)
 	defer func() {
-		klog.Infof("Finished syncing stormservice %q (%v)", req.NamespacedName.String(), time.Since(startTime))
+		klog.Infof("Finished syncing stormservice %q (%v)", req.String(), time.Since(startTime))
 	}()
 
 	stormService := &orchestrationv1alpha1.StormService{}
@@ -118,7 +118,7 @@ func (r *StormServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	} else if !controllerutil.ContainsFinalizer(stormService, StormServiceFinalizer) {
 		if err := utils.Patch(ctx, r.Client, stormService, patch.AddFinalizerPatch(stormService, StormServiceFinalizer)); err != nil {
-			klog.Errorf("add finalizer failed: %v, stormService %s", err, req.NamespacedName.String())
+			klog.Errorf("add finalizer failed: %v, stormService %s", err, req.String())
 			return ctrl.Result{RequeueAfter: DefaultRequeueAfter}, err
 		}
 	}

--- a/pkg/controller/stormservice/sync.go
+++ b/pkg/controller/stormservice/sync.go
@@ -89,11 +89,11 @@ func (r *StormServiceReconciler) syncHeadlessService(ctx context.Context, servic
 	}
 
 	headlessService := &corev1.Service{}
-	err := r.Client.Get(ctx, client.ObjectKey{Name: service.Name, Namespace: service.Namespace}, headlessService)
+	err := r.Get(ctx, client.ObjectKey{Name: service.Name, Namespace: service.Namespace}, headlessService)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// service doesn't exist, create it
-			if createErr := r.Client.Create(ctx, expectedService); createErr != nil {
+			if createErr := r.Create(ctx, expectedService); createErr != nil {
 				return fmt.Errorf("failed to create headless service: %w", createErr)
 			}
 			r.EventRecorder.Eventf(service, corev1.EventTypeNormal, HeadlessServiceEventType, "Headless Service(discovery) %s created", service.Name)
@@ -104,7 +104,7 @@ func (r *StormServiceReconciler) syncHeadlessService(ctx context.Context, servic
 
 	if !isServiceEqual(headlessService, expectedService) {
 		headlessService.Spec = expectedService.Spec
-		if err := r.Client.Update(ctx, headlessService); err != nil {
+		if err := r.Update(ctx, headlessService); err != nil {
 			return fmt.Errorf("failed to update headless service: %w", err)
 		}
 		r.EventRecorder.Eventf(service, corev1.EventTypeNormal, HeadlessServiceEventType, "Headless Service %s updated", service.Name)

--- a/pkg/controller/util/orchestration/util.go
+++ b/pkg/controller/util/orchestration/util.go
@@ -213,7 +213,7 @@ func UpdateStatus(ctx context.Context, scheme *runtime.Scheme, cli client.Client
 
 func resetObject(obj runtime.Object) error {
 	t := reflect.TypeOf(obj)
-	if t.Kind() != reflect.Ptr {
+	if t.Kind() != reflect.Pointer {
 		return fmt.Errorf("runtime object types must be pointers to structs, but got %s", t.Kind())
 	}
 

--- a/pkg/controller/util/patch/json_patch.go
+++ b/pkg/controller/util/patch/json_patch.go
@@ -118,5 +118,5 @@ func (jp *JSONPatch) JsonPatch() (client.Patch, error) {
 }
 
 func FixPathToValid(path string) string {
-	return strings.Replace(path, "/", "~1", -1)
+	return strings.ReplaceAll(path, "/", "~1")
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -100,6 +100,11 @@ const (
 	NumRequestsSwapped              = "num_requests_swapped"
 	AvgPromptThroughputToksPerS     = "avg_prompt_throughput_toks_per_s"
 	AvgGenerationThroughputToksPerS = "avg_generation_throughput_toks_per_s"
+
+	// Engine names
+	EngineNameVLLM   = "vllm"
+	EngineNameSGLang = "sglang"
+	EngineNameTRTLLM = "trtllm"
 )
 
 var (
@@ -112,8 +117,8 @@ var (
 				Raw: Gauge,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:num_requests_running",
-				"sglang": "sglang:num_running_reqs",
+				EngineNameVLLM: "vllm:num_requests_running",
+				"sglang":       "sglang:num_running_reqs",
 			},
 			Description: "Number of running requests",
 		},
@@ -124,8 +129,8 @@ var (
 				Raw: Gauge,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:num_requests_waiting",
-				"sglang": "sglang:num_queue_reqs",
+				EngineNameVLLM: "vllm:num_requests_waiting",
+				"sglang":       "sglang:num_queue_reqs",
 			},
 			Description: "Number of waiting requests",
 		},
@@ -136,8 +141,8 @@ var (
 				Raw: Gauge,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:num_requests_swapped",
-				"sglang": "sglang:num_retracted_reqs",
+				EngineNameVLLM: "vllm:num_requests_swapped",
+				"sglang":       "sglang:num_retracted_reqs",
 			},
 			Description: "Number of swapped requests",
 		},
@@ -148,7 +153,7 @@ var (
 				Raw: Gauge,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:engine_sleep_state",
+				EngineNameVLLM: "vllm:engine_sleep_state",
 			},
 			Description: "Engine sleep state; awake = 0 means engine is sleeping; awake = 1 means engine is awake; weights_offloaded = 1 means sleep level 1; discard_all = 1 means sleep level 2.",
 		},
@@ -159,7 +164,7 @@ var (
 				Raw: Counter,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:http_requests_total",
+				EngineNameVLLM: "vllm:http_requests_total",
 			},
 			Description: "Total number of requests by method, status and handler.",
 		},
@@ -170,7 +175,7 @@ var (
 				Raw: Counter,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:num_preemptions_total",
+				EngineNameVLLM: "vllm:num_preemptions_total",
 			},
 			Description: "Number of preemptions",
 		},
@@ -181,9 +186,9 @@ var (
 				Raw: Counter,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:num_requests_success_total",
-				"sglang": "sglang:num_requests_total",
-				"trtllm": "trtllm_request_success_total",
+				EngineNameVLLM: "vllm:num_requests_success_total",
+				"sglang":       "sglang:num_requests_total",
+				"trtllm":       "trtllm_request_success_total",
 			},
 			Description: "Number of successful requests",
 		},
@@ -217,9 +222,9 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:e2e_request_latency_seconds",
-				"sglang": "sglang:e2e_request_latency_seconds",
-				"trtllm": "trtllm_e2e_request_latency_seconds",
+				EngineNameVLLM: "vllm:e2e_request_latency_seconds",
+				"sglang":       "sglang:e2e_request_latency_seconds",
+				"trtllm":       "trtllm_e2e_request_latency_seconds",
 			},
 			Description: "End-to-end request latency in seconds",
 		},
@@ -230,8 +235,8 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:request_queue_time_seconds",
-				"trtllm": "trtllm_request_queue_time_seconds",
+				EngineNameVLLM: "vllm:request_queue_time_seconds",
+				"trtllm":       "trtllm_request_queue_time_seconds",
 			},
 			Description: "Request queue time in seconds",
 		},
@@ -242,7 +247,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:request_inference_time_seconds",
+				EngineNameVLLM: "vllm:request_inference_time_seconds",
 			},
 			Description: "Request inference time in seconds",
 		},
@@ -264,7 +269,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "http_request_duration_seconds",
+				EngineNameVLLM: "http_request_duration_seconds",
 			},
 			Description: "Histogram of request duration in seconds",
 		},
@@ -275,7 +280,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "http_request_duration_highr_seconds",
+				EngineNameVLLM: "http_request_duration_highr_seconds",
 			},
 			Description: "Histogram of request duration in seconds for high priority requests",
 		},
@@ -286,7 +291,7 @@ var (
 				Raw: Counter,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:prompt_tokens_total",
+				EngineNameVLLM: "vllm:prompt_tokens_total",
 			},
 			Description: "Total prompt tokens",
 		},
@@ -297,7 +302,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:request_prompt_tokens",
+				EngineNameVLLM: "vllm:request_prompt_tokens",
 			},
 			Description: "Histogram of prompt tokens",
 		},
@@ -308,7 +313,7 @@ var (
 				Raw: Counter,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:generation_tokens_total",
+				EngineNameVLLM: "vllm:generation_tokens_total",
 			},
 			Description: "Total generation tokens",
 		},
@@ -319,7 +324,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:request_generation_tokens",
+				EngineNameVLLM: "vllm:request_generation_tokens",
 			},
 			Description: "Histogram of generation tokens",
 		},
@@ -330,7 +335,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:request_max_num_generation_tokens",
+				EngineNameVLLM: "vllm:request_max_num_generation_tokens",
 			},
 			Description: "Histogram of max number of generation tokens",
 		},
@@ -341,7 +346,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:iteration_tokens_total",
+				EngineNameVLLM: "vllm:iteration_tokens_total",
 			},
 			Description: "Total iteration tokens",
 		},
@@ -352,9 +357,9 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:time_to_first_token_seconds",
-				"sglang": "sglang:time_to_first_token_seconds",
-				"trtllm": "trtllm_time_to_first_token_seconds",
+				EngineNameVLLM: "vllm:time_to_first_token_seconds",
+				"sglang":       "sglang:time_to_first_token_seconds",
+				"trtllm":       "trtllm_time_to_first_token_seconds",
 			},
 			Description: "Time to first token in seconds",
 		},
@@ -365,9 +370,9 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:time_per_output_token_seconds",
-				"sglang": "sglang:inter_token_latency_seconds",
-				"trtllm": "trtllm_time_per_output_token_seconds",
+				EngineNameVLLM: "vllm:time_per_output_token_seconds",
+				"sglang":       "sglang:inter_token_latency_seconds",
+				"trtllm":       "trtllm_time_per_output_token_seconds",
 			},
 			Description: "Time per output token in seconds",
 		},
@@ -378,9 +383,9 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:inter_token_latency_seconds",
-				"sglang": "sglang:inter_token_latency_seconds",
-				"trtllm": "trtllm_time_per_output_token_seconds",
+				EngineNameVLLM: "vllm:inter_token_latency_seconds",
+				"sglang":       "sglang:inter_token_latency_seconds",
+				"trtllm":       "trtllm_time_per_output_token_seconds",
 			},
 			Description: "Inter-token latency in seconds",
 		},
@@ -391,7 +396,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:request_decode_time_seconds",
+				EngineNameVLLM: "vllm:request_decode_time_seconds",
 			},
 			Description: "Request decode time in seconds",
 		},
@@ -402,7 +407,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:request_prefill_time_seconds",
+				EngineNameVLLM: "vllm:request_prefill_time_seconds",
 			},
 			Description: "Request prefill time in seconds",
 		},
@@ -413,7 +418,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:request_time_per_output_token_seconds",
+				EngineNameVLLM: "vllm:request_time_per_output_token_seconds",
 			},
 			Description: "Time per output token in seconds",
 		},
@@ -424,9 +429,9 @@ var (
 				Raw: Gauge,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:gpu_cache_usage_perc",
-				"sglang": "sglang:token_usage", // Based on https://github.com/sgl-project/sglang/issues/5979
-				"xllm":   "kv_cache_utilization",
+				EngineNameVLLM: "vllm:gpu_cache_usage_perc",
+				"sglang":       "sglang:token_usage", // Based on https://github.com/sgl-project/sglang/issues/5979
+				"xllm":         "kv_cache_utilization",
 			},
 			Description: "GPU cache usage percentage",
 		},
@@ -448,7 +453,7 @@ var (
 				Raw: Gauge,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:cpu_cache_usage_perc",
+				EngineNameVLLM: "vllm:cpu_cache_usage_perc",
 			},
 			Description: "CPU cache usage percentage",
 		},
@@ -459,10 +464,10 @@ var (
 				Raw: Gauge,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:kv_cache_usage_perc",
-				"sglang": "sglang:token_usage", // Based on https://github.com/sgl-project/sglang/issues/5979
-				"trtllm": "trtllm_kv_cache_utilization",
-				"xllm":   "kv_cache_utilization",
+				EngineNameVLLM: "vllm:kv_cache_usage_perc",
+				"sglang":       "sglang:token_usage", // Based on https://github.com/sgl-project/sglang/issues/5979
+				"trtllm":       "trtllm_kv_cache_utilization",
+				"xllm":         "kv_cache_utilization",
 			},
 			Description: "KV-cache usage. 1 means 100 percent usage.",
 		},
@@ -484,7 +489,7 @@ var (
 				Raw: Counter,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:prefix_cache_queries_total",
+				EngineNameVLLM: "vllm:prefix_cache_queries_total",
 			},
 			Description: "Prefix cache queries, in terms of number of queried tokens..",
 		},
@@ -495,7 +500,7 @@ var (
 				Raw: Counter,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:prefix_cache_hits_total",
+				EngineNameVLLM: "vllm:prefix_cache_hits_total",
 			},
 			Description: "Prefix cache hits, in terms of number of cached tokens.",
 		},
@@ -506,7 +511,7 @@ var (
 				Raw: Counter,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:external_prefix_cache_queries_total",
+				EngineNameVLLM: "vllm:external_prefix_cache_queries_total",
 			},
 			Description: "External prefix cache queries from KV connector cross-instance cache sharing, in terms of number of queried tokens.",
 		},
@@ -517,7 +522,7 @@ var (
 				Raw: Counter,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:external_prefix_cache_hits_total",
+				EngineNameVLLM: "vllm:external_prefix_cache_hits_total",
 			},
 			Description: "External prefix cache hits from KV connector cross-instance cache sharing, in terms of number of cached tokens.",
 		},
@@ -529,7 +534,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:nixl_xfer_time_seconds",
+				EngineNameVLLM: "vllm:nixl_xfer_time_seconds",
 			},
 			Description: "transfer duration for NIXL KV Cache transfers",
 		},
@@ -540,7 +545,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:nixl_post_time_seconds",
+				EngineNameVLLM: "vllm:nixl_post_time_seconds",
 			},
 			Description: "transfer post time for NIXL KV Cache transfers",
 		},
@@ -551,7 +556,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:nixl_bytes_transferred",
+				EngineNameVLLM: "vllm:nixl_bytes_transferred",
 			},
 			Description: "number of bytes transferred per NIXL KV Cache transfer",
 		},
@@ -562,7 +567,7 @@ var (
 				Raw: Histogram,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:nixl_num_descriptors",
+				EngineNameVLLM: "vllm:nixl_num_descriptors",
 			},
 			Description: "number of descriptors per NIXL  KV Cache transfers",
 		},
@@ -573,7 +578,7 @@ var (
 				Raw: Counter,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:nixl_num_failed_transfers",
+				EngineNameVLLM: "vllm:nixl_num_failed_transfers",
 			},
 			Description: "number of failed NIXL KV Cache transfers",
 		},
@@ -584,7 +589,7 @@ var (
 				Raw: Counter,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:nixl_num_failed_notifications",
+				EngineNameVLLM: "vllm:nixl_num_failed_notifications",
 			},
 			Description: "number of failed NIXL KV Cache notifications",
 		},
@@ -700,7 +705,7 @@ var (
 				Raw: Gauge,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:avg_prompt_throughput_toks_per_s",
+				EngineNameVLLM: "vllm:avg_prompt_throughput_toks_per_s",
 			},
 			Description: "Average prompt throughput in tokens per second",
 		},
@@ -711,8 +716,8 @@ var (
 				Raw: Gauge,
 			},
 			EngineMetricsNameMapping: map[string]string{
-				"vllm":   "vllm:avg_generation_throughput_toks_per_s",
-				"sglang": "sglang:gen_throughput",
+				EngineNameVLLM: "vllm:avg_generation_throughput_toks_per_s",
+				"sglang":       "sglang:gen_throughput",
 			},
 			Description: "Average generation throughput in tokens per second",
 		},
@@ -742,7 +747,7 @@ var (
 			},
 			LabelKey: "max_lora",
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:lora_requests_info",
+				EngineNameVLLM: "vllm:lora_requests_info",
 			},
 			Description: "Max count of Lora Adapters",
 		},
@@ -754,7 +759,7 @@ var (
 			},
 			LabelKey: "running_lora_adapters",
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:lora_requests_info",
+				EngineNameVLLM: "vllm:lora_requests_info",
 			},
 			Description: "Count of running Lora Adapters",
 		},
@@ -766,7 +771,7 @@ var (
 			},
 			LabelKey: "waiting_lora_adapters",
 			EngineMetricsNameMapping: map[string]string{
-				"vllm": "vllm:lora_requests_info",
+				EngineNameVLLM: "vllm:lora_requests_info",
 			},
 			Description: "Count of waiting Lora Adapters",
 		},

--- a/pkg/metrics/utils.go
+++ b/pkg/metrics/utils.go
@@ -178,7 +178,7 @@ func GetLabelValueForKey(metric *dto.Metric, key string) (string, error) {
 			return labelPair.GetValue(), nil
 		}
 	}
-	return "", fmt.Errorf("Label %s not found", key)
+	return "", fmt.Errorf("label %s not found", key)
 }
 
 func GetCounterGaugeValue(metric *dto.Metric, metricType dto.MetricType) (*SimpleMetricValue, error) {
@@ -203,7 +203,7 @@ func GetHistogramValue(metric *dto.Metric) (*HistogramMetricValue, error) {
 	}
 	histogramMetric := metric.GetHistogram()
 	if histogramMetric == nil {
-		return nil, fmt.Errorf("Histogram metric not found")
+		return nil, fmt.Errorf("histogram metric not found")
 	}
 
 	histogram.Sum = histogramMetric.GetSampleSum()
@@ -221,12 +221,12 @@ func GetHistogramValue(metric *dto.Metric) (*HistogramMetricValue, error) {
 func ParseMetricsURLWithContext(ctx context.Context, url string) (map[string]*dto.MetricFamily, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create request for %s: %v\n", url, err)
+		return nil, fmt.Errorf("failed to create request for %s: %v", url, err)
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch metrics from %s: %v\n", url, err)
+		return nil, fmt.Errorf("failed to fetch metrics from %s: %v", url, err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -235,13 +235,13 @@ func ParseMetricsURLWithContext(ctx context.Context, url string) (map[string]*dt
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Bad status code while fetching metrics from %s: %d\n", url, resp.StatusCode)
+		return nil, fmt.Errorf("bad status code while fetching metrics from %s: %d", url, resp.StatusCode)
 	}
 
 	var parser expfmt.TextParser
 	allMetrics, err := parser.TextToMetricFamilies(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing metric families: %v\n", err)
+		return nil, fmt.Errorf("error parsing metric families: %v", err)
 	}
 	return allMetrics, nil
 }
@@ -262,7 +262,7 @@ func GetEngineType(pod v1.Pod) string {
 	if engineType, exists := pod.Labels[constants.ModelLabelEngine]; exists && engineType != "" {
 		return engineType
 	}
-	return "vllm" // Default to vllm for backward compatibility
+	return EngineNameVLLM // Default to vllm for backward compatibility
 }
 
 func HttpFailureStatusCode(ctx context.Context, err error, resp *http.Response) (string, string) {

--- a/pkg/plugins/gateway/algorithms/prefix_cache_preble.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_preble.go
@@ -208,21 +208,23 @@ func (h *SlidingWindowHistogram) getPrefillCost(node *prefixcacheindexer.TreeNod
 	numTokens := node.NumTokens()
 	contextLength := node.ContextLength()
 	baseTime := 0.0
-	if targetGPU == "A6000" {
+	switch targetGPU {
+	case "A6000":
 		baseTime = mistral7BA6000LinearTime(numTokens) + mistral7BA6000AttentionTime(1, contextLength, numTokens)
-	} else if targetGPU == "V100" {
+	case "V100":
 		baseTime = mistral7BV100LinearTime(numTokens) + mistral7BV100AttentionTime(1, contextLength, numTokens)
-	} else {
+	default:
 		klog.Warningf("Unknown target GPU: %s. Assume V100 as default", targetGPU)
 		baseTime = mistral7BV100LinearTime(numTokens) + mistral7BV100AttentionTime(1, contextLength, numTokens)
 	}
 
 	attnQuad := 0.0
-	if targetGPU == "A6000" {
+	switch targetGPU {
+	case "A6000":
 		attnQuad = calculateAttnQuadA6000(numTokens, nil)
-	} else if targetGPU == "V100" {
+	case "V100":
 		attnQuad = calculateAttnQuadV100(numTokens, nil)
-	} else {
+	default:
 		klog.Warningf("Unknown target GPU: %s. Assume V100 as default", targetGPU)
 		attnQuad = calculateAttnQuadV100(numTokens, nil)
 	}

--- a/pkg/plugins/gateway/algorithms/router.go
+++ b/pkg/plugins/gateway/algorithms/router.go
@@ -481,7 +481,7 @@ func (m *multiStrategyRouter) scoreAndRank(ctx *types.RoutingContext, readyPodLi
 	if logEnabled {
 		c, cacheErr := cache.Get()
 		var logBuilder strings.Builder
-		logBuilder.WriteString(fmt.Sprintf("Multi-strategy routing decision for request [%s]. Selected target pod: [%s]. Candidate pod details:\n", ctx.RequestID, winner.Name))
+		fmt.Fprintf(&logBuilder, "Multi-strategy routing decision for request [%s]. Selected target pod: [%s]. Candidate pod details:\n", ctx.RequestID, winner.Name)
 		for _, pod := range pods {
 			winnerFlag := " "
 			if pod.Name == winner.Name {
@@ -493,8 +493,8 @@ func (m *multiStrategyRouter) scoreAndRank(ctx *types.RoutingContext, readyPodLi
 					outstandingStr = fmt.Sprintf("%.0f", v.GetSimpleValue())
 				}
 			}
-			logBuilder.WriteString(fmt.Sprintf("  [%s] Pod: %-30s | FinalScore: %.4f | Outstanding: %-4s | Details: %s\n",
-				winnerFlag, pod.Name, finalScores[pod], outstandingStr, strings.Join(diags[pod].StrategyLog, ", ")))
+			fmt.Fprintf(&logBuilder, "  [%s] Pod: %-30s | FinalScore: %.4f | Outstanding: %-4s | Details: %s\n",
+				winnerFlag, pod.Name, finalScores[pod], outstandingStr, strings.Join(diags[pod].StrategyLog, ", "))
 		}
 		klog.Info(logBuilder.String())
 	}

--- a/pkg/plugins/gateway/algorithms/slo.go
+++ b/pkg/plugins/gateway/algorithms/slo.go
@@ -61,7 +61,7 @@ type SLORouter struct {
 
 func (r *SLORouter) Route(ctx *types.RoutingContext, pods types.PodList) (string, error) {
 	// Ctx is not routed if no profiles is found during Peek.
-	if !ctx.HasRouted() && r.SLOQueue.LastError() == nil {
+	if !ctx.HasRouted() && r.LastError() == nil {
 		return r.FallbackRouter.Route(ctx, pods)
 	}
 	return r.SLOQueue.Route(ctx, pods)

--- a/pkg/plugins/gateway/algorithms/util.go
+++ b/pkg/plugins/gateway/algorithms/util.go
@@ -48,7 +48,7 @@ func standardDeviation(numbers []float64) float64 {
 	avg := mean(numbers)
 	sumOfSquares := 0.0
 	for _, number := range numbers {
-		sumOfSquares += math.Pow(number-avg, 2)
+		sumOfSquares += (number - avg) * (number - avg)
 	}
 	variance := sumOfSquares / float64(len(numbers)-1)
 	return math.Sqrt(variance)

--- a/pkg/plugins/gateway/algorithms/vtc/token_tracker_test.go
+++ b/pkg/plugins/gateway/algorithms/vtc/token_tracker_test.go
@@ -147,7 +147,7 @@ func TestSlidingWindowTokenTracker_UpdateTokenCount_WithCustomWeights(t *testing
 func TestTokenTrackerInterface(t *testing.T) {
 	config := DefaultVTCConfig()
 
-	var tracker TokenTracker = NewInMemorySlidingWindowTokenTracker(&config)
+	var tracker = NewInMemorySlidingWindowTokenTracker(&config)
 
 	ctx := context.Background()
 	_, err := tracker.GetTokenCount(ctx, "user")

--- a/pkg/plugins/gateway/algorithms/vtc/vtc_basic.go
+++ b/pkg/plugins/gateway/algorithms/vtc/vtc_basic.go
@@ -107,7 +107,7 @@ func (r *BasicVTCRouter) Route(ctx *types.RoutingContext, readyPodList types.Pod
 		"outputTokens", outputTokens)
 
 	var targetPod *v1.Pod
-	var minScore float64 = math.MaxFloat64
+	var minScore = math.MaxFloat64
 
 	// Simple vtc-basic implementation
 	// Using clamped-linear instead of modulo - offers good monotonicity, fairness based routing.

--- a/pkg/plugins/gateway/algorithms/vtc/vtc_router.go
+++ b/pkg/plugins/gateway/algorithms/vtc/vtc_router.go
@@ -63,7 +63,7 @@ func DefaultVTCConfig() VTCConfig {
 func NewVTCBasicRouter() (types.Router, error) {
 	config := DefaultVTCConfig()
 	configPtr := &config
-	var tokenEstimator TokenEstimator = NewSimpleTokenEstimator()
-	var tokenTracker TokenTracker = NewInMemorySlidingWindowTokenTracker(configPtr)
+	var tokenEstimator = NewSimpleTokenEstimator()
+	var tokenTracker = NewInMemorySlidingWindowTokenTracker(configPtr)
 	return NewBasicVTCRouter(tokenTracker, tokenEstimator, configPtr)
 }

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -799,9 +799,10 @@ func (s *Server) responseErrorProcessingWithHeaders(ctx context.Context, routing
 
 	// Determine appropriate error code based on HTTP status
 	errorCode := ""
-	if respErrorCode == 401 {
+	switch respErrorCode {
+	case 401:
 		errorCode = ErrorCodeInvalidAPIKey
-	} else if respErrorCode == 503 {
+	case 503:
 		errorCode = ErrorCodeServiceUnavailable
 	}
 

--- a/pkg/plugins/gateway/queue/simple_queue_test.go
+++ b/pkg/plugins/gateway/queue/simple_queue_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("SimpleQueue", func() {
 	var (
 		queue *SimpleQueue[int]
-		cap   int = 10
+		cap   = 10
 	)
 
 	BeforeEach(func() {

--- a/pkg/plugins/gateway/queue/slo_queue.go
+++ b/pkg/plugins/gateway/queue/slo_queue.go
@@ -168,7 +168,7 @@ func (q *SLOQueue) Peek(currentTime time.Time, pods types.PodList) (*types.Routi
 		if len(q.dequeueCandidates) == 0 {
 			q.validateDequeueCandidatesLocked(1)
 			q.dequeueCandidates = q.dequeueCandidates[:1]
-		} else if q.dequeueCandidates[0].RoutingContext.RequestTime.Before(subReq.RequestTime) {
+		} else if q.dequeueCandidates[0].RequestTime.Before(subReq.RequestTime) {
 			// Skip this subqueue
 			return true
 		}
@@ -258,7 +258,7 @@ func (q *SLOQueue) Peek(currentTime time.Time, pods types.PodList) (*types.Routi
 	sort.Slice(dequeueCandidates, func(i, j int) bool {
 		// Keep original order for no slo violation if fifoOnNonSLOViolation enabled.
 		if fifoOnNonSLOViolation && dequeueCandidates[i].Profiles[0].Rank < 0 && dequeueCandidates[j].Profiles[0].Rank < 0 {
-			return dequeueCandidates[i].RoutingContext.RequestTime.Before(dequeueCandidates[j].RoutingContext.RequestTime)
+			return dequeueCandidates[i].RequestTime.Before(dequeueCandidates[j].RequestTime)
 		} else {
 			return q.higherRank(dequeueCandidates[i].Profiles[0].Rank, dequeueCandidates[j].Profiles[0].Rank) > 0
 		}
@@ -278,14 +278,14 @@ func (q *SLOQueue) Peek(currentTime time.Time, pods types.PodList) (*types.Routi
 				// Try routing.
 				_, lastErr = q.subRoute(candidate.RoutingContext, &utils.PodArray{Pods: pods.ListByIndex(profile.Key)})
 				// If monogenousGPURoutingOnly is enabled, only the most relaxing profile is considered.
-				if monogenousGPURoutingOnly || candidate.RoutingContext.HasRouted() {
+				if monogenousGPURoutingOnly || candidate.HasRouted() {
 					break
 				}
 			}
 		} else {
 			_, lastErr = q.subRoute(candidate.RoutingContext, pods)
 		}
-		if candidate.RoutingContext.HasRouted() {
+		if candidate.HasRouted() {
 			q.lastCandidateSubKey = candidate.SubKey
 			return candidate.RoutingContext, nil
 		} else if lastErr != cache.ErrorLoadCapacityReached {
@@ -495,7 +495,7 @@ func (q *SLOQueue) debugCandidates(msg string, candidates []*candidateRouterRequ
 		for _, profile := range candidate.Profiles {
 			logMsg.WriteString(profile.Key)
 			logMsg.WriteRune(':')
-			logMsg.WriteString(fmt.Sprintf("%.3f", profile.Rank))
+			fmt.Fprintf(&logMsg, "%.3f", profile.Rank)
 			logMsg.WriteRune(' ')
 		}
 		logMsg.WriteString(") ")

--- a/pkg/plugins/gateway/statesync/redissync_test.go
+++ b/pkg/plugins/gateway/statesync/redissync_test.go
@@ -121,14 +121,14 @@ func (d *fakeDeltaSyncable) markUpdated(id string, data []byte) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.updated[id] = data
-	d.fakeSyncable.state[id] = data
+	d.state[id] = data
 }
 
 func (d *fakeDeltaSyncable) markDeleted(id string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.deleted = append(d.deleted, id)
-	delete(d.fakeSyncable.state, id)
+	delete(d.state, id)
 }
 
 // fakeTombstoneSyncable adds TombstoneSupport on top of fakeDeltaSyncable.
@@ -153,7 +153,7 @@ func (ts *fakeTombstoneSyncable) IsTombstone(_ context.Context, _ string, data [
 
 func (ts *fakeTombstoneSyncable) DeleteLocal(_ context.Context, id string) error {
 	ts.deletedLocal = append(ts.deletedLocal, id)
-	delete(ts.fakeSyncable.state, id)
+	delete(ts.state, id)
 	return nil
 }
 

--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -31,8 +31,8 @@ import (
 )
 
 var (
-	nilPod       = &v1.Pod{}
-	unknownError = errors.New("unknown error")
+	nilPod     = &v1.Pod{}
+	ErrUnknown = errors.New("unknown error")
 )
 
 const (
@@ -237,7 +237,7 @@ func (r *RoutingContext) SetTargetPod(pod *v1.Pod) {
 // Do not call this function from synchronize routers. Asynchronize routers call this to set an error.
 func (r *RoutingContext) SetError(err error) {
 	if err == nil {
-		r.lastError.Store(&unknownError)
+		r.lastError.Store(&ErrUnknown)
 	} else {
 		r.lastError.Store(&err)
 	}
@@ -251,8 +251,8 @@ func (r *RoutingContext) TargetPod() *v1.Pod {
 	if targetPod == nilPod {
 		r.debugWait()
 		select {
-		case <-r.Context.Done():
-			r.SetError(r.Context.Err())
+		case <-r.Done():
+			r.SetError(r.Err())
 		case <-r.targetPodSet: // No blocking if targetPod is set after last "targetPod == nil"
 		}
 		targetPod = r.targetPod.Load()

--- a/pkg/utils/pod_test.go
+++ b/pkg/utils/pod_test.go
@@ -62,7 +62,7 @@ func genPods(cnt int, readyCnt int) []*v1.Pod {
 		case 2:
 			pod.Status.Conditions[0].Status = v1.ConditionFalse
 		case 3:
-			pod.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			pod.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 		}
 		pods = append(pods, pod)
 	}
@@ -136,7 +136,7 @@ func getRayClusterHead(withLabel bool) *v1.Pod {
 		},
 	}
 	if withLabel {
-		pod.ObjectMeta.Labels[ReyClusterFleetIdentifier] = "qwen-coder-7b-instruct-by-label"
+		pod.Labels[ReyClusterFleetIdentifier] = "qwen-coder-7b-instruct-by-label"
 	}
 	return pod
 }

--- a/pkg/utils/raycluster.go
+++ b/pkg/utils/raycluster.go
@@ -60,7 +60,7 @@ func IsRayClusterAvailable(cluster *rayclusterv1.RayCluster, minReadySeconds int
 	}
 
 	lastTransitionTime := provisionedCond.LastTransitionTime
-	if headPodReadyCond.LastTransitionTime.Time.After(provisionedCond.LastTransitionTime.Time) {
+	if headPodReadyCond.LastTransitionTime.After(provisionedCond.LastTransitionTime.Time) {
 		lastTransitionTime = headPodReadyCond.LastTransitionTime
 	}
 

--- a/pkg/utils/syncprefixcacheindexer/sync_hash.go
+++ b/pkg/utils/syncprefixcacheindexer/sync_hash.go
@@ -279,7 +279,7 @@ func (s *SyncPrefixHashTable) ProcessBlockStored(event BlockStored) error {
 		}
 
 		// Compute hash with proper parent lookup
-		var parentAibrixHash uint64 = s.seed
+		var parentAibrixHash = s.seed
 		if event.ParentBlockHash != nil {
 			if ph, exists := hashMapping.engineToAibrix[*event.ParentBlockHash]; exists {
 				parentAibrixHash = ph

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck,golint,revive
 )
 
 const (
@@ -135,6 +135,6 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }

--- a/test/utils/wrapper/podset.go
+++ b/test/utils/wrapper/podset.go
@@ -107,12 +107,12 @@ func (w *PodSetWrapper) Labels(labels map[string]string) *PodSetWrapper {
 		w.podSet.Labels = make(map[string]string)
 	}
 	if w.podSet.Spec.Template.Labels == nil {
-		w.podSet.Spec.Template.ObjectMeta.Labels = make(map[string]string)
+		w.podSet.Spec.Template.Labels = make(map[string]string)
 	}
 
 	for k, v := range labels {
 		w.podSet.Labels[k] = v
-		w.podSet.Spec.Template.ObjectMeta.Labels[k] = v
+		w.podSet.Spec.Template.Labels[k] = v
 	}
 	return w
 }
@@ -122,12 +122,12 @@ func (w *PodSetWrapper) Annotations(annotations map[string]string) *PodSetWrappe
 	if w.podSet.Annotations == nil {
 		w.podSet.Annotations = make(map[string]string)
 	}
-	if w.podSet.Spec.Template.ObjectMeta.Annotations == nil {
-		w.podSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	if w.podSet.Spec.Template.Annotations == nil {
+		w.podSet.Spec.Template.Annotations = make(map[string]string)
 	}
 	for k, v := range annotations {
 		w.podSet.Annotations[k] = v
-		w.podSet.Spec.Template.ObjectMeta.Annotations[k] = v
+		w.podSet.Spec.Template.Annotations[k] = v
 	}
 	return w
 }

--- a/test/utils/wrapper/stormservice.go
+++ b/test/utils/wrapper/stormservice.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -159,15 +158,15 @@ func (w *StormServiceWrapper) WithRole(name string, stateful bool, podGroupSize 
 			Type: orchestrationapi.RecreateRoleUpdateStrategyType,
 		},
 		Stateful: stateful,
-		Template: v1.PodTemplateSpec{
+		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					"role": name,
 					"app":  "my-ai-app",
 				},
 			},
-			Spec: v1.PodSpec{
-				Containers: []v1.Container{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
 					{
 						Name:  fmt.Sprintf("vllm-%s", name),
 						Image: "vllm/vllm-openai:latest",
@@ -175,13 +174,13 @@ func (w *StormServiceWrapper) WithRole(name string, stateful bool, podGroupSize 
 							"--model", "meta-llama/Llama-3-8b",
 							"--tensor-parallel-size", "1",
 						},
-						Ports: []v1.ContainerPort{
+						Ports: []corev1.ContainerPort{
 							{ContainerPort: 8000, Protocol: "TCP"},
 						},
-						Resources: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("4"),
-								v1.ResourceMemory: resource.MustParse("16Gi"),
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("16Gi"),
 							},
 						},
 					},
@@ -215,21 +214,21 @@ func (w *StormServiceWrapper) WithSidecarInjection(runtimeImage string) *StormSe
 		runtimeImage = webhook.SidecarImage
 	}
 
-	sidecarContainer := v1.Container{
+	sidecarContainer := corev1.Container{
 		Name:  webhook.SidecarName,
 		Image: runtimeImage,
 		Command: []string{
 			"aibrix_runtime",
 			"--port", strconv.Itoa(webhook.SidecarPort),
 		},
-		Ports: []v1.ContainerPort{
+		Ports: []corev1.ContainerPort{
 			{
 				Name:          "metrics",
 				ContainerPort: webhook.SidecarPort,
 				Protocol:      "TCP",
 			},
 		},
-		Env: []v1.EnvVar{
+		Env: []corev1.EnvVar{
 			{
 				Name:  "INFERENCE_ENGINE",
 				Value: "vllm",
@@ -239,7 +238,7 @@ func (w *StormServiceWrapper) WithSidecarInjection(runtimeImage string) *StormSe
 				Value: webhook.DefaultEngineEndpoint,
 			},
 		},
-		Resources: v1.ResourceRequirements{
+		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("256Mi"),
@@ -249,9 +248,9 @@ func (w *StormServiceWrapper) WithSidecarInjection(runtimeImage string) *StormSe
 				corev1.ResourceMemory: resource.MustParse("512Mi"),
 			},
 		},
-		LivenessProbe: &v1.Probe{
-			ProbeHandler: v1.ProbeHandler{
-				HTTPGet: &v1.HTTPGetAction{
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/healthz",
 					Port:   intstr.FromInt(webhook.SidecarPort),
 					Scheme: corev1.URISchemeHTTP,
@@ -260,9 +259,9 @@ func (w *StormServiceWrapper) WithSidecarInjection(runtimeImage string) *StormSe
 			InitialDelaySeconds: 3,
 			PeriodSeconds:       2,
 		},
-		ReadinessProbe: &v1.Probe{
-			ProbeHandler: v1.ProbeHandler{
-				HTTPGet: &v1.HTTPGetAction{
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/ready",
 					Port:   intstr.FromInt(webhook.SidecarPort),
 					Scheme: corev1.URISchemeHTTP,
@@ -271,7 +270,7 @@ func (w *StormServiceWrapper) WithSidecarInjection(runtimeImage string) *StormSe
 			InitialDelaySeconds: 5,
 			PeriodSeconds:       10,
 		},
-		VolumeMounts: []v1.VolumeMount{
+		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      webhook.DefaultAdapterVolumeName,
 				MountPath: webhook.DefaultAdapterMountPath,
@@ -288,8 +287,8 @@ func (w *StormServiceWrapper) WithSidecarInjection(runtimeImage string) *StormSe
 			v := &role.Template.Spec.Volumes[vi]
 			if v.Name == webhook.DefaultAdapterVolumeName {
 				if v.EmptyDir == nil {
-					v.VolumeSource = v1.VolumeSource{
-						EmptyDir: &v1.EmptyDirVolumeSource{},
+					v.VolumeSource = corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					}
 				}
 				foundEmptyDirVolume = true
@@ -297,10 +296,10 @@ func (w *StormServiceWrapper) WithSidecarInjection(runtimeImage string) *StormSe
 			}
 		}
 		if !foundEmptyDirVolume {
-			role.Template.Spec.Volumes = append(role.Template.Spec.Volumes, v1.Volume{
+			role.Template.Spec.Volumes = append(role.Template.Spec.Volumes, corev1.Volume{
 				Name: webhook.DefaultAdapterVolumeName,
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			})
 		}
@@ -311,7 +310,7 @@ func (w *StormServiceWrapper) WithSidecarInjection(runtimeImage string) *StormSe
 				continue
 			}
 			if !utils.HasVolumeMount(container.VolumeMounts, webhook.DefaultAdapterVolumeName, webhook.DefaultAdapterMountPath) {
-				container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
+				container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 					Name:      webhook.DefaultAdapterVolumeName,
 					MountPath: webhook.DefaultAdapterMountPath,
 				})
@@ -330,7 +329,7 @@ func (w *StormServiceWrapper) WithSidecarInjection(runtimeImage string) *StormSe
 			continue
 		}
 		// Prepend sidecar container
-		role.Template.Spec.Containers = append([]v1.Container{sidecarContainer}, role.Template.Spec.Containers...)
+		role.Template.Spec.Containers = append([]corev1.Container{sidecarContainer}, role.Template.Spec.Containers...)
 	}
 
 	return w


### PR DESCRIPTION
## Pull Request Description

Upgrade golangci-lint from v1.57.2 to v2.13.1 and migrate configuration to v2 schema.

### Changes

**Infrastructure:**
- Update `Makefile`: bump version to v2.13.1 and use `/v2` module path
- Migrate `.golangci.yml` to v2 schema:
  - Add `version: "2"` header (required by v2)
  - `linters.disable-all: true` → `linters.default: none`
  - Move `gofmt`/`goimports` to new `formatters` section
  - Relocate `issues.exclude-rules` → `linters.exclusions.rules`
  - Configure `goconst` with `min-occurrences: 20`
  - Add exclusions for test files and utility code
- Bump CI Go version to 1.26 for lint job (v2.13.1 requires Go ≥ 1.26)

**Code Quality Fixes:**
- **ST1019**: Remove duplicate imports in 3 files
- **ST1005**: Fix error string formatting (lowercase, no trailing punctuation/newlines)
- **ST1012**: Rename `unknownError` → `ErrUnknown` (Go naming convention)
- **ST1001**: Add nolint comment for intentional dot import
- **S1009**: Simplify nil check (`len(nil slice) == 0` is safe)
- **SA4023**: Add nolint comment for intentional always-true validation check
- **QF1008**: Remove redundant embedded field selectors in 3 files
- Add engine name constants (`EngineNameVLLM`, `EngineNameSGLang`, `EngineNameTRTLLM`) to resolve goconst warnings

### Verification

- ✅ `golangci-lint config verify` passes
- ✅ `golangci-lint run` reports 0 issues
- ✅ `go vet ./...` passes
- ✅ Unit tests pass (excluding envtest-dependent controller tests)

### Notes

- Dropped `gosimple` from enabled linters (merged into `staticcheck` in v2)
- Dropped `typecheck` from enabled linters (always-on internally in v2, not configurable)
- Verify and test CI jobs remain on Go 1.22 to match project's `go.mod`

## Related Issues

N/A