### PR TITLE
Surface Volcano gang scheduling status

### DIFF
--- a/api/orchestration/v1alpha1/roleset_types.go
+++ b/api/orchestration/v1alpha1/roleset_types.go
@@ -279,6 +279,10 @@ const (
 	RoleSetReady          ConditionType = "Ready"
 	RoleSetReplicaFailure ConditionType = "ReplicaFailure"
 	RoleSetProgressing    ConditionType = "Progressing"
+	// RoleSetPodGroupSynced means the scheduler PodGroup for this RoleSet has been reconciled.
+	RoleSetPodGroupSynced ConditionType = "PodGroupSynced"
+	// RoleSetGangSchedulingError means the RoleSet has an observed gang scheduling configuration or runtime error.
+	RoleSetGangSchedulingError ConditionType = "GangSchedulingError"
 )
 
 type RoleStatus struct {

--- a/api/orchestration/v1alpha1/stormservice_types.go
+++ b/api/orchestration/v1alpha1/stormservice_types.go
@@ -178,6 +178,10 @@ const (
 	// StormServiceReplicaFailure is added in a stormService when one of its workloads fails to be created
 	// or deleted.
 	StormServiceReplicaFailure ConditionType = "ReplicaFailure"
+	// StormServicePodGroupSynced summarizes scheduler PodGroup sync across owned RoleSets.
+	StormServicePodGroupSynced ConditionType = "PodGroupSynced"
+	// StormServiceGangSchedulingError summarizes gang scheduling errors across owned RoleSets.
+	StormServiceGangSchedulingError ConditionType = "GangSchedulingError"
 )
 
 type StormServiceUpdateStrategy struct {

--- a/pkg/controller/constants/stormservice.go
+++ b/pkg/controller/constants/stormservice.go
@@ -20,6 +20,7 @@ const (
 	GodelPodGroupNameAnnotationKey   = "godel.bytedance.com/pod-group-name"
 	CoschedulingPodGroupNameLabelKey = "scheduling.x-k8s.io/pod-group"
 	VolcanoPodGroupNameAnnotationKey = "scheduling.k8s.io/group-name" // Aligns with the standard Kubernetes PodGroup annotation for gang scheduling.
+	VolcanoTaskSpecKey               = "volcano.sh/task-spec"
 
 	RoleSetNameLabelKey          = "roleset-name"
 	StormServiceNameLabelKey     = "storm-service-name"

--- a/pkg/controller/podset/podset_controller.go
+++ b/pkg/controller/podset/podset_controller.go
@@ -364,6 +364,9 @@ func (r *PodSetReconciler) createPodFromTemplate(podSet *orchestrationv1alpha1.P
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
 	}
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
 	pod.Labels[constants.PodSetNameLabelKey] = podSet.Name
 	pod.Labels[constants.PodGroupIndexLabelKey] = strconv.Itoa(podIndex)
 
@@ -377,6 +380,9 @@ func (r *PodSetReconciler) createPodFromTemplate(podSet *orchestrationv1alpha1.P
 		if _, ok := pod.Annotations[k]; !ok {
 			pod.Annotations[k] = v
 		}
+	}
+	if pod.Spec.SchedulerName == "" && podHasVolcanoPodGroup(pod) {
+		pod.Spec.SchedulerName = "volcano"
 	}
 
 	// manually set the hostname and subdomain for FQDN
@@ -417,6 +423,19 @@ func (r *PodSetReconciler) createPodFromTemplate(podSet *orchestrationv1alpha1.P
 	}
 
 	return pod, nil
+}
+
+func podHasVolcanoPodGroup(pod *v1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	if _, ok := pod.Labels[constants.VolcanoPodGroupNameAnnotationKey]; ok {
+		return true
+	}
+	if _, ok := pod.Annotations[constants.VolcanoPodGroupNameAnnotationKey]; ok {
+		return true
+	}
+	return false
 }
 
 func (r *PodSetReconciler) getPodsForPodSet(ctx context.Context, podSet *orchestrationv1alpha1.PodSet) (*v1.PodList, error) {

--- a/pkg/controller/podset/podset_controller_test.go
+++ b/pkg/controller/podset/podset_controller_test.go
@@ -189,3 +189,45 @@ func TestCreatePodFromTemplate_EnvConflict(t *testing.T) {
 	assert.Equal(t, "USER_VAR", env.Name, "Only non-conflicting user-defined env var should be present")
 	assert.Equal(t, "value", env.Value, "User-defined env var value should be preserved")
 }
+
+func TestCreatePodFromTemplate_VolcanoSchedulingMetadata(t *testing.T) {
+	podSet := &orchestrationv1alpha1.PodSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-podset",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				constants.StormServiceNameLabelKey:         "test-service",
+				constants.VolcanoPodGroupNameAnnotationKey: "test-podset",
+				constants.VolcanoTaskSpecKey:               "prefill",
+			},
+			Annotations: map[string]string{
+				constants.VolcanoPodGroupNameAnnotationKey: "test-podset",
+				constants.VolcanoTaskSpecKey:               "prefill",
+			},
+		},
+		Spec: orchestrationv1alpha1.PodSetSpec{
+			PodGroupSize: 2,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+		},
+	}
+	scheme := runtime.NewScheme()
+	reconciler := &PodSetReconciler{
+		Client:        clientFake.NewClientBuilder().Build(),
+		Scheme:        scheme,
+		EventRecorder: &record.FakeRecorder{},
+		DynamicClient: dynamicFake.NewSimpleDynamicClient(scheme),
+	}
+
+	pod, err := reconciler.createPodFromTemplate(podSet, 0)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "volcano", pod.Spec.SchedulerName)
+	assert.Equal(t, "test-podset", pod.Labels[constants.VolcanoPodGroupNameAnnotationKey])
+	assert.Equal(t, "test-podset", pod.Annotations[constants.VolcanoPodGroupNameAnnotationKey])
+	assert.Equal(t, "prefill", pod.Labels[constants.VolcanoTaskSpecKey])
+	assert.Equal(t, "prefill", pod.Annotations[constants.VolcanoTaskSpecKey])
+}

--- a/pkg/controller/roleset/gang_status.go
+++ b/pkg/controller/roleset/gang_status.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roleset
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	volcanoschedv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
+	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	utils "github.com/vllm-project/aibrix/pkg/controller/util/orchestration"
+)
+
+var volcanoPodGroupGVR = schema.GroupVersionResource{
+	Group:    volcanoschedv1beta1.SchemeGroupVersion.Group,
+	Version:  volcanoschedv1beta1.SchemeGroupVersion.Version,
+	Resource: "podgroups",
+}
+
+const podGroupStatusMalformedReason = "PodGroupStatusMalformed"
+
+func (r *RoleSetReconciler) setVolcanoGangConditions(ctx context.Context, rs *orchestrationv1alpha1.RoleSet, status *orchestrationv1alpha1.RoleSetStatus, podGroupSyncErr error) error {
+	if rs.Spec.SchedulingStrategy == nil || rs.Spec.SchedulingStrategy.VolcanoSchedulingStrategy == nil {
+		RemoveRoleSetCondition(status, orchestrationv1alpha1.RoleSetPodGroupSynced)
+		RemoveRoleSetCondition(status, orchestrationv1alpha1.RoleSetGangSchedulingError)
+		return nil
+	}
+
+	if podGroupSyncErr != nil {
+		SetRoleSetCondition(status, *utils.NewCondition(
+			orchestrationv1alpha1.RoleSetPodGroupSynced,
+			corev1.ConditionFalse,
+			"PodGroupSyncFailed",
+			podGroupSyncErr.Error(),
+		))
+		SetRoleSetCondition(status, *utils.NewCondition(
+			orchestrationv1alpha1.RoleSetGangSchedulingError,
+			corev1.ConditionTrue,
+			"PodGroupSyncFailed",
+			podGroupSyncErr.Error(),
+		))
+		return nil
+	}
+
+	if r.DynamicClient == nil {
+		msg := "volcano scheduling is configured but PodGroup observation is disabled because the dynamic client is not initialized"
+		SetRoleSetCondition(status, *utils.NewCondition(
+			orchestrationv1alpha1.RoleSetPodGroupSynced,
+			corev1.ConditionUnknown,
+			"PodGroupObservationDisabled",
+			msg,
+		))
+		SetRoleSetCondition(status, *utils.NewCondition(
+			orchestrationv1alpha1.RoleSetGangSchedulingError,
+			corev1.ConditionUnknown,
+			"PodGroupObservationDisabled",
+			msg,
+		))
+		return nil
+	}
+
+	podGroup, err := r.getVolcanoPodGroup(ctx, rs)
+	if err != nil {
+		return err
+	}
+	if podGroup == nil {
+		msg := fmt.Sprintf("volcano scheduling is configured but PodGroup %s/%s is not observed", rs.Namespace, rs.Name)
+		SetRoleSetCondition(status, *utils.NewCondition(orchestrationv1alpha1.RoleSetPodGroupSynced, corev1.ConditionFalse, "PodGroupNotFound", msg))
+		SetRoleSetCondition(status, *utils.NewCondition(orchestrationv1alpha1.RoleSetGangSchedulingError, corev1.ConditionTrue, "PodGroupNotFound", msg))
+		return nil
+	}
+
+	SetRoleSetCondition(status, *utils.NewCondition(
+		orchestrationv1alpha1.RoleSetPodGroupSynced,
+		corev1.ConditionTrue,
+		"PodGroupSynced",
+		fmt.Sprintf("volcano PodGroup %s/%s is synced", rs.Namespace, rs.Name),
+	))
+
+	if reason, msg, hasError := volcanoPodGroupSchedulingError(podGroup); hasError {
+		SetRoleSetCondition(status, *utils.NewCondition(orchestrationv1alpha1.RoleSetGangSchedulingError, corev1.ConditionTrue, reason, msg))
+		return nil
+	}
+
+	if minMemberWarning := minTaskMemberWarning(rs.Spec.SchedulingStrategy.VolcanoSchedulingStrategy); minMemberWarning != "" {
+		SetRoleSetCondition(status, *utils.NewCondition(
+			orchestrationv1alpha1.RoleSetGangSchedulingError,
+			corev1.ConditionTrue,
+			"MinTaskMemberNotEnforced",
+			minMemberWarning,
+		))
+		return nil
+	}
+
+	SetRoleSetCondition(status, *utils.NewCondition(
+		orchestrationv1alpha1.RoleSetGangSchedulingError,
+		corev1.ConditionFalse,
+		"GangSchedulingHealthy",
+		"",
+	))
+	return nil
+}
+
+func (r *RoleSetReconciler) getVolcanoPodGroup(ctx context.Context, rs *orchestrationv1alpha1.RoleSet) (*unstructured.Unstructured, error) {
+	podGroup, err := r.DynamicClient.Resource(volcanoPodGroupGVR).Namespace(rs.Namespace).Get(ctx, rs.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return podGroup, nil
+}
+
+func volcanoPodGroupSchedulingError(podGroup *unstructured.Unstructured) (string, string, bool) {
+	phase, _, err := unstructured.NestedString(podGroup.Object, "status", "phase")
+	if err != nil {
+		return podGroupStatusMalformedReason, fmt.Sprintf("failed to parse volcano PodGroup status.phase: %v", err), true
+	}
+	if phase == string(volcanoschedv1beta1.PodGroupUnknown) {
+		return "PodGroupUnknown", "volcano PodGroup is Unknown", true
+	}
+
+	conditions, _, err := unstructured.NestedSlice(podGroup.Object, "status", "conditions")
+	if err != nil {
+		return podGroupStatusMalformedReason, fmt.Sprintf("failed to parse volcano PodGroup status.conditions: %v", err), true
+	}
+	for _, raw := range conditions {
+		condition, ok := raw.(map[string]interface{})
+		if !ok {
+			return podGroupStatusMalformedReason, "failed to parse volcano PodGroup status.conditions: condition entry is not an object", true
+		}
+		condType, _, err := unstructured.NestedString(condition, "type")
+		if err != nil {
+			return podGroupStatusMalformedReason, fmt.Sprintf("failed to parse volcano PodGroup condition type: %v", err), true
+		}
+		condStatus, _, err := unstructured.NestedString(condition, "status")
+		if err != nil {
+			return podGroupStatusMalformedReason, fmt.Sprintf("failed to parse volcano PodGroup condition status: %v", err), true
+		}
+		reason, _, err := unstructured.NestedString(condition, "reason")
+		if err != nil {
+			return podGroupStatusMalformedReason, fmt.Sprintf("failed to parse volcano PodGroup condition reason: %v", err), true
+		}
+		message, _, err := unstructured.NestedString(condition, "message")
+		if err != nil {
+			return podGroupStatusMalformedReason, fmt.Sprintf("failed to parse volcano PodGroup condition message: %v", err), true
+		}
+		if condType == string(volcanoschedv1beta1.PodGroupUnschedulableType) && condStatus == string(corev1.ConditionTrue) {
+			if reason == "" {
+				reason = "PodGroupUnschedulable"
+			}
+			if message == "" {
+				message = "volcano PodGroup is unschedulable"
+			}
+			return reason, message, true
+		}
+	}
+	return "", "", false
+}
+
+func minTaskMemberWarning(strategy *orchestrationv1alpha1.VolcanoSchedulingStrategySpec) string {
+	if strategy == nil || len(strategy.MinTaskMember) == 0 {
+		return ""
+	}
+	var total int32
+	for _, minMember := range strategy.MinTaskMember {
+		total += minMember
+	}
+	if strategy.MinMember < total {
+		return fmt.Sprintf("minMember %d is less than sum(minTaskMember) %d; Volcano skips task-level readiness checks in this configuration", strategy.MinMember, total)
+	}
+	return ""
+}

--- a/pkg/controller/roleset/gang_status_test.go
+++ b/pkg/controller/roleset/gang_status_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roleset
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	volcanoschedv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
+	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	ctrlutils "github.com/vllm-project/aibrix/pkg/controller/util/orchestration"
+)
+
+func TestSetVolcanoGangConditions(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reports missing PodGroup", func(t *testing.T) {
+		reconciler := &RoleSetReconciler{DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())}
+		status := &orchestrationv1alpha1.RoleSetStatus{}
+
+		err := reconciler.setVolcanoGangConditions(ctx, newVolcanoRoleSet(), status, nil)
+
+		assert.NoError(t, err)
+		assert.Equal(t, corev1.ConditionFalse, ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.RoleSetPodGroupSynced).Status)
+		assert.Equal(t, "PodGroupNotFound", ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.RoleSetGangSchedulingError).Reason)
+	})
+
+	t.Run("reports unknown when PodGroup observation is disabled", func(t *testing.T) {
+		reconciler := &RoleSetReconciler{}
+		status := &orchestrationv1alpha1.RoleSetStatus{}
+
+		err := reconciler.setVolcanoGangConditions(ctx, newVolcanoRoleSet(), status, nil)
+
+		assert.NoError(t, err)
+		assert.Equal(t, corev1.ConditionUnknown, ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.RoleSetPodGroupSynced).Status)
+		errCond := ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.RoleSetGangSchedulingError)
+		assert.Equal(t, corev1.ConditionUnknown, errCond.Status)
+		assert.Equal(t, "PodGroupObservationDisabled", errCond.Reason)
+	})
+
+	t.Run("reports synced and healthy PodGroup", func(t *testing.T) {
+		reconciler := &RoleSetReconciler{DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), newVolcanoPodGroup("test-roleset", "default", string(volcanoschedv1beta1.PodGroupRunning), nil))}
+		status := &orchestrationv1alpha1.RoleSetStatus{}
+
+		err := reconciler.setVolcanoGangConditions(ctx, newVolcanoRoleSet(), status, nil)
+
+		assert.NoError(t, err)
+		assert.Equal(t, corev1.ConditionTrue, ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.RoleSetPodGroupSynced).Status)
+		errCond := ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.RoleSetGangSchedulingError)
+		assert.Equal(t, corev1.ConditionFalse, errCond.Status)
+		assert.Equal(t, "GangSchedulingHealthy", errCond.Reason)
+	})
+
+	t.Run("reports unschedulable PodGroup condition", func(t *testing.T) {
+		conditions := []interface{}{
+			map[string]interface{}{
+				"type":    string(volcanoschedv1beta1.PodGroupUnschedulableType),
+				"status":  string(corev1.ConditionTrue),
+				"reason":  "NotEnoughPodsOfTask",
+				"message": "not enough pods of task prefill",
+			},
+		}
+		reconciler := &RoleSetReconciler{DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), newVolcanoPodGroup("test-roleset", "default", string(volcanoschedv1beta1.PodGroupInqueue), conditions))}
+		status := &orchestrationv1alpha1.RoleSetStatus{}
+
+		err := reconciler.setVolcanoGangConditions(ctx, newVolcanoRoleSet(), status, nil)
+
+		assert.NoError(t, err)
+		errCond := ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.RoleSetGangSchedulingError)
+		assert.Equal(t, corev1.ConditionTrue, errCond.Status)
+		assert.Equal(t, "NotEnoughPodsOfTask", errCond.Reason)
+		assert.Equal(t, "not enough pods of task prefill", errCond.Message)
+	})
+
+	t.Run("reports malformed PodGroup status", func(t *testing.T) {
+		podGroup := newVolcanoPodGroup("test-roleset", "default", string(volcanoschedv1beta1.PodGroupRunning), nil)
+		podGroup.Object["status"] = "malformed"
+		reconciler := &RoleSetReconciler{DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), podGroup)}
+		status := &orchestrationv1alpha1.RoleSetStatus{}
+
+		err := reconciler.setVolcanoGangConditions(ctx, newVolcanoRoleSet(), status, nil)
+
+		assert.NoError(t, err)
+		errCond := ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.RoleSetGangSchedulingError)
+		assert.Equal(t, corev1.ConditionTrue, errCond.Status)
+		assert.Equal(t, podGroupStatusMalformedReason, errCond.Reason)
+	})
+
+	t.Run("warns when minMember is lower than minTaskMember sum", func(t *testing.T) {
+		roleSet := newVolcanoRoleSet()
+		roleSet.Spec.SchedulingStrategy.VolcanoSchedulingStrategy.MinMember = 1
+		roleSet.Spec.SchedulingStrategy.VolcanoSchedulingStrategy.MinTaskMember = map[string]int32{"prefill": 1, "decode": 1}
+		reconciler := &RoleSetReconciler{DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), newVolcanoPodGroup("test-roleset", "default", string(volcanoschedv1beta1.PodGroupRunning), nil))}
+		status := &orchestrationv1alpha1.RoleSetStatus{}
+
+		err := reconciler.setVolcanoGangConditions(ctx, roleSet, status, nil)
+
+		assert.NoError(t, err)
+		errCond := ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.RoleSetGangSchedulingError)
+		assert.Equal(t, corev1.ConditionTrue, errCond.Status)
+		assert.Equal(t, "MinTaskMemberNotEnforced", errCond.Reason)
+	})
+}
+
+func newVolcanoRoleSet() *orchestrationv1alpha1.RoleSet {
+	return &orchestrationv1alpha1.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-roleset",
+			Namespace: "default",
+		},
+		Spec: orchestrationv1alpha1.RoleSetSpec{
+			SchedulingStrategy: &orchestrationv1alpha1.SchedulingStrategy{
+				VolcanoSchedulingStrategy: &orchestrationv1alpha1.VolcanoSchedulingStrategySpec{
+					MinMember: 2,
+				},
+			},
+		},
+	}
+}
+
+func newVolcanoPodGroup(name, namespace, phase string, conditions []interface{}) *unstructured.Unstructured {
+	podGroup := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "scheduling.volcano.sh/v1beta1",
+			"kind":       "PodGroup",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"status": map[string]interface{}{
+				"phase": phase,
+			},
+		},
+	}
+	if conditions != nil {
+		_ = unstructured.SetNestedSlice(podGroup.Object, conditions, "status", "conditions")
+	}
+	return podGroup
+}

--- a/pkg/controller/roleset/podset_rollsyncer.go
+++ b/pkg/controller/roleset/podset_rollsyncer.go
@@ -428,6 +428,7 @@ func (p *PodSetRoleSyncer) createPodSetForRole(roleSet *orchestrationv1alpha1.Ro
 		if roleSet.Spec.SchedulingStrategy.VolcanoSchedulingStrategy != nil {
 			podSet.Annotations[constants.VolcanoPodGroupNameAnnotationKey] = roleSet.Name
 			podSet.Labels[constants.VolcanoPodGroupNameAnnotationKey] = roleSet.Name
+			ensureVolcanoTaskSpec(podSet.Labels, podSet.Annotations, role.Name)
 		}
 	}
 	if role.SchedulingStrategy != nil { // note that roleSet.Spec.SchedulingStrategy and role.SchedulingStrategy should not be set concurrently
@@ -441,6 +442,7 @@ func (p *PodSetRoleSyncer) createPodSetForRole(roleSet *orchestrationv1alpha1.Ro
 		if role.SchedulingStrategy.VolcanoSchedulingStrategy != nil {
 			podSet.Annotations[constants.VolcanoPodGroupNameAnnotationKey] = podSet.Name
 			podSet.Labels[constants.VolcanoPodGroupNameAnnotationKey] = podSet.Name
+			ensureVolcanoTaskSpec(podSet.Labels, podSet.Annotations, role.Name)
 		}
 	}
 

--- a/pkg/controller/roleset/roleset_controller.go
+++ b/pkg/controller/roleset/roleset_controller.go
@@ -44,6 +44,7 @@ const (
 	RoleSetFinalizer          = "orchestration.aibrix.ai/roleset-finalizer"
 	DefaultRequeueAfter       = 15 * time.Second
 	DefaultRetryDelay         = 1 * time.Second
+	PodGroupStatusRefresh     = 1 * time.Minute
 	PodBurst                  = 500
 	PodOperationInitBatchSize = 16
 )
@@ -135,7 +136,9 @@ func (r *RoleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	var managedErrors []error
 
 	// 1. sync pod group
+	var podGroupSyncErr error
 	if err := r.syncPodGroup(ctx, roleSet, &roleSet.Spec); err != nil {
+		podGroupSyncErr = err
 		managedErrors = append(managedErrors, fmt.Errorf("sync pod group error %v", err))
 	}
 
@@ -149,7 +152,7 @@ func (r *RoleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// 3. update roleset status
-	status, err := r.calculateStatus(ctx, roleSet, managedErrors)
+	status, err := r.calculateStatus(ctx, roleSet, managedErrors, podGroupSyncErr)
 	if err != nil {
 		klog.Infof("roleset %s/%s calculate status error %v", roleSet.Namespace, roleSet.Name, err)
 		return ctrl.Result{RequeueAfter: 1 * time.Minute}, err
@@ -165,6 +168,10 @@ func (r *RoleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			klog.Infof("roleset %s/%s not ready, reconcile after %v seconds", roleSet.Namespace, roleSet.Name, DefaultRetryDelay)
 			return ctrl.Result{RequeueAfter: DefaultRetryDelay}, nil
 		}
+		if hasVolcanoScheduling(roleSet) {
+			klog.Infof("roleset %s/%s has volcano scheduling configured, refresh PodGroup status after %v", roleSet.Namespace, roleSet.Name, PodGroupStatusRefresh)
+			return ctrl.Result{RequeueAfter: PodGroupStatusRefresh}, nil
+		}
 		return ctrl.Result{}, nil
 	}
 	roleSet.Status = *status
@@ -178,5 +185,13 @@ func (r *RoleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		klog.Infof("roleset %s/%s has in-place update in progress, reconcile after %v seconds", roleSet.Namespace, roleSet.Name, DefaultRetryDelay)
 		return ctrl.Result{RequeueAfter: DefaultRetryDelay}, nil
 	}
+	if hasVolcanoScheduling(roleSet) {
+		klog.Infof("roleset %s/%s has volcano scheduling configured, refresh PodGroup status after %v", roleSet.Namespace, roleSet.Name, PodGroupStatusRefresh)
+		return ctrl.Result{RequeueAfter: PodGroupStatusRefresh}, nil
+	}
 	return ctrl.Result{}, nil
+}
+
+func hasVolcanoScheduling(roleSet *orchestrationv1alpha1.RoleSet) bool {
+	return roleSet.Spec.SchedulingStrategy != nil && roleSet.Spec.SchedulingStrategy.VolcanoSchedulingStrategy != nil
 }

--- a/pkg/controller/roleset/sync.go
+++ b/pkg/controller/roleset/sync.go
@@ -126,7 +126,7 @@ func (r *RoleSetReconciler) syncPods(ctx context.Context, roleSet *orchestration
 	return manager.Next(ctx, roleSet)
 }
 
-func (r *RoleSetReconciler) calculateStatus(ctx context.Context, rs *orchestrationv1alpha1.RoleSet, managedErrors []error) (*orchestrationv1alpha1.RoleSetStatus, error) {
+func (r *RoleSetReconciler) calculateStatus(ctx context.Context, rs *orchestrationv1alpha1.RoleSet, managedErrors []error, podGroupSyncErr error) (*orchestrationv1alpha1.RoleSetStatus, error) {
 	newStatus := rs.Status.DeepCopy()
 	newStatus.Roles = nil
 	var notReadyRoles []string
@@ -159,6 +159,9 @@ func (r *RoleSetReconciler) calculateStatus(ctx context.Context, rs *orchestrati
 		RemoveRoleSetCondition(newStatus, orchestrationv1alpha1.RoleSetReplicaFailure)
 	}
 	// TODO: what if new errors added and failureCond is not nil. can it reflect the new errors?
+	if err := r.setVolcanoGangConditions(ctx, rs, newStatus, podGroupSyncErr); err != nil {
+		return nil, err
+	}
 	return newStatus, nil
 }
 

--- a/pkg/controller/roleset/utils.go
+++ b/pkg/controller/roleset/utils.go
@@ -150,6 +150,7 @@ func renderStormServicePod(roleSet *orchestrationv1alpha1.RoleSet, role *orchest
 	if roleSet.Spec.SchedulingStrategy != nil {
 		if roleSet.Spec.SchedulingStrategy.VolcanoSchedulingStrategy != nil {
 			pod.Annotations[constants.VolcanoPodGroupNameAnnotationKey] = roleSet.Name
+			ensureVolcanoTaskSpec(pod.Labels, pod.Annotations, role.Name)
 		}
 		if roleSet.Spec.SchedulingStrategy.GodelSchedulingStrategy != nil {
 			pod.Annotations[constants.GodelPodGroupNameAnnotationKey] = roleSet.Name
@@ -242,6 +243,17 @@ func injectContainerEnvVars(
 	}
 
 	container.Env = envs
+}
+
+func ensureVolcanoTaskSpec(labels, annotations map[string]string, roleName string) {
+	if _, ok := annotations[constants.VolcanoTaskSpecKey]; ok {
+		return
+	}
+	if _, ok := labels[constants.VolcanoTaskSpecKey]; ok {
+		return
+	}
+	annotations[constants.VolcanoTaskSpecKey] = roleName
+	labels[constants.VolcanoTaskSpecKey] = roleName
 }
 
 // injectTopologyAffinityToPodSpec injects pod affinity into the given PodSpec

--- a/pkg/controller/roleset/utils.go
+++ b/pkg/controller/roleset/utils.go
@@ -246,14 +246,12 @@ func injectContainerEnvVars(
 }
 
 func ensureVolcanoTaskSpec(labels, annotations map[string]string, roleName string) {
-	if _, ok := annotations[constants.VolcanoTaskSpecKey]; ok {
-		return
+	if _, ok := annotations[constants.VolcanoTaskSpecKey]; !ok {
+		annotations[constants.VolcanoTaskSpecKey] = roleName
 	}
-	if _, ok := labels[constants.VolcanoTaskSpecKey]; ok {
-		return
+	if _, ok := labels[constants.VolcanoTaskSpecKey]; !ok {
+		labels[constants.VolcanoTaskSpecKey] = roleName
 	}
-	annotations[constants.VolcanoTaskSpecKey] = roleName
-	labels[constants.VolcanoTaskSpecKey] = roleName
 }
 
 // injectTopologyAffinityToPodSpec injects pod affinity into the given PodSpec

--- a/pkg/controller/roleset/utils_test.go
+++ b/pkg/controller/roleset/utils_test.go
@@ -53,12 +53,36 @@ func TestRenderStormServicePodVolcanoScheduler(t *testing.T) {
 		pod := &corev1.Pod{}
 		renderStormServicePod(roleSet, role, pod, nil)
 		assert.Equal(t, "volcano", pod.Spec.SchedulerName)
+		assert.Equal(t, "worker", pod.Labels[constants.VolcanoTaskSpecKey])
+		assert.Equal(t, "worker", pod.Annotations[constants.VolcanoTaskSpecKey])
 	})
 
 	t.Run("preserves an explicit scheduler", func(t *testing.T) {
 		pod := &corev1.Pod{Spec: corev1.PodSpec{SchedulerName: "custom"}}
 		renderStormServicePod(roleSet, role, pod, nil)
 		assert.Equal(t, "custom", pod.Spec.SchedulerName)
+	})
+
+	t.Run("preserves an explicit task spec annotation", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{constants.VolcanoTaskSpecKey: "explicit"},
+			},
+		}
+		renderStormServicePod(roleSet, role, pod, nil)
+		assert.Equal(t, "explicit", pod.Annotations[constants.VolcanoTaskSpecKey])
+		assert.NotContains(t, pod.Labels, constants.VolcanoTaskSpecKey)
+	})
+
+	t.Run("preserves an explicit task spec label", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{constants.VolcanoTaskSpecKey: "explicit"},
+			},
+		}
+		renderStormServicePod(roleSet, role, pod, nil)
+		assert.Equal(t, "explicit", pod.Labels[constants.VolcanoTaskSpecKey])
+		assert.NotContains(t, pod.Annotations, constants.VolcanoTaskSpecKey)
 	})
 }
 
@@ -308,6 +332,8 @@ func TestRenderStormServicePod_WithRoleSetVolcanoPodGroup(t *testing.T) {
 	// Verify pod group labels and annotations
 	assert.Equal(t, "test-role-set", pod.Labels[constants.VolcanoPodGroupNameAnnotationKey])
 	assert.Equal(t, "test-role-set", pod.Annotations[constants.VolcanoPodGroupNameAnnotationKey])
+	assert.Equal(t, "test-role", pod.Labels[constants.VolcanoTaskSpecKey])
+	assert.Equal(t, "test-role", pod.Annotations[constants.VolcanoTaskSpecKey])
 }
 
 func TestRenderStormServicePod_EmptyLabelsAndAnnotations(t *testing.T) {
@@ -849,6 +875,50 @@ func TestCreatePodSetForRole_TopologyPolicyDefaultsToPreferred(t *testing.T) {
 	assert.Equal(t, int32(100), preferred[0].Weight)
 	assert.Equal(t, "kubernetes.io/hostname", preferred[0].PodAffinityTerm.TopologyKey)
 	assert.Equal(t, "test-roleset", preferred[0].PodAffinityTerm.LabelSelector.MatchLabels[constants.RoleSetNameLabelKey])
+}
+
+func TestCreatePodSetForRole_VolcanoTaskSpec(t *testing.T) {
+	roleSet := &orchestrationv1alpha1.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-roleset",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				constants.StormServiceNameLabelKey: "test-stormservice",
+			},
+			Annotations: map[string]string{
+				constants.RoleSetIndexAnnotationKey: "0",
+			},
+		},
+		Spec: orchestrationv1alpha1.RoleSetSpec{
+			SchedulingStrategy: &orchestrationv1alpha1.SchedulingStrategy{
+				VolcanoSchedulingStrategy: &orchestrationv1alpha1.VolcanoSchedulingStrategySpec{
+					MinMember:     6,
+					MinTaskMember: map[string]int32{"prefill": 4, "decode": 2},
+				},
+			},
+		},
+	}
+	podGroupSize := int32(2)
+	roleIndex := 0
+	role := &orchestrationv1alpha1.RoleSpec{
+		Name:         "prefill",
+		PodGroupSize: &podGroupSize,
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "prefill"}},
+			},
+		},
+	}
+	syncer := &PodSetRoleSyncer{
+		computeHashFunc: fakeComputeHashFunc,
+	}
+
+	podSet := syncer.createPodSetForRole(roleSet, role, &roleIndex)
+
+	assert.Equal(t, "test-roleset", podSet.Labels[constants.VolcanoPodGroupNameAnnotationKey])
+	assert.Equal(t, "test-roleset", podSet.Annotations[constants.VolcanoPodGroupNameAnnotationKey])
+	assert.Equal(t, "prefill", podSet.Labels[constants.VolcanoTaskSpecKey])
+	assert.Equal(t, "prefill", podSet.Annotations[constants.VolcanoTaskSpecKey])
 }
 
 func TestInjectContainerEnvVars(t *testing.T) {

--- a/pkg/controller/roleset/utils_test.go
+++ b/pkg/controller/roleset/utils_test.go
@@ -71,7 +71,7 @@ func TestRenderStormServicePodVolcanoScheduler(t *testing.T) {
 		}
 		renderStormServicePod(roleSet, role, pod, nil)
 		assert.Equal(t, "explicit", pod.Annotations[constants.VolcanoTaskSpecKey])
-		assert.NotContains(t, pod.Labels, constants.VolcanoTaskSpecKey)
+		assert.Equal(t, "worker", pod.Labels[constants.VolcanoTaskSpecKey])
 	})
 
 	t.Run("preserves an explicit task spec label", func(t *testing.T) {
@@ -82,7 +82,7 @@ func TestRenderStormServicePodVolcanoScheduler(t *testing.T) {
 		}
 		renderStormServicePod(roleSet, role, pod, nil)
 		assert.Equal(t, "explicit", pod.Labels[constants.VolcanoTaskSpecKey])
-		assert.NotContains(t, pod.Annotations, constants.VolcanoTaskSpecKey)
+		assert.Equal(t, "worker", pod.Annotations[constants.VolcanoTaskSpecKey])
 	})
 }
 

--- a/pkg/controller/stormservice/gang_status.go
+++ b/pkg/controller/stormservice/gang_status.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stormservice
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	utils "github.com/vllm-project/aibrix/pkg/controller/util/orchestration"
+)
+
+func setGangSchedulingConditions(status *orchestrationv1alpha1.StormServiceStatus, roleSets []*orchestrationv1alpha1.RoleSet) {
+	volcanoRoleSets := volcanoRoleSetNames(roleSets)
+	if len(volcanoRoleSets) == 0 {
+		RemoveStormServiceCondition(status, orchestrationv1alpha1.StormServicePodGroupSynced)
+		RemoveStormServiceCondition(status, orchestrationv1alpha1.StormServiceGangSchedulingError)
+		return
+	}
+
+	errorRoleSets := conditionRoleSetNames(roleSets, orchestrationv1alpha1.RoleSetGangSchedulingError, corev1.ConditionTrue)
+	if len(errorRoleSets) > 0 {
+		SetStormServiceCondition(status, *utils.NewCondition(
+			orchestrationv1alpha1.StormServiceGangSchedulingError,
+			corev1.ConditionTrue,
+			"GangSchedulingError",
+			fmt.Sprintf("gang scheduling errors reported by RoleSets: %s", strings.Join(errorRoleSets, ",")),
+		))
+	} else {
+		SetStormServiceCondition(status, *utils.NewCondition(
+			orchestrationv1alpha1.StormServiceGangSchedulingError,
+			corev1.ConditionFalse,
+			"GangSchedulingHealthy",
+			"",
+		))
+	}
+
+	syncedRoleSets := conditionRoleSetNames(roleSets, orchestrationv1alpha1.RoleSetPodGroupSynced, corev1.ConditionTrue)
+	if len(syncedRoleSets) == len(volcanoRoleSets) {
+		SetStormServiceCondition(status, *utils.NewCondition(
+			orchestrationv1alpha1.StormServicePodGroupSynced,
+			corev1.ConditionTrue,
+			"PodGroupSynced",
+			fmt.Sprintf("PodGroup is synced for RoleSets: %s", strings.Join(syncedRoleSets, ",")),
+		))
+		return
+	}
+
+	incomplete := roleSetNamesWithout(volcanoRoleSets, syncedRoleSets)
+	SetStormServiceCondition(status, *utils.NewCondition(
+		orchestrationv1alpha1.StormServicePodGroupSynced,
+		corev1.ConditionFalse,
+		"PodGroupSyncIncomplete",
+		fmt.Sprintf("PodGroup sync is incomplete for RoleSets: %s", strings.Join(incomplete, ",")),
+	))
+}
+
+func volcanoRoleSetNames(roleSets []*orchestrationv1alpha1.RoleSet) []string {
+	names := map[string]struct{}{}
+	for _, rs := range roleSets {
+		if rs == nil {
+			continue
+		}
+		if rs.Spec.SchedulingStrategy != nil && rs.Spec.SchedulingStrategy.VolcanoSchedulingStrategy != nil {
+			names[rs.Name] = struct{}{}
+		}
+	}
+	return sortedRoleSetNames(names)
+}
+
+func conditionRoleSetNames(roleSets []*orchestrationv1alpha1.RoleSet, condType orchestrationv1alpha1.ConditionType, condStatus corev1.ConditionStatus) []string {
+	names := map[string]struct{}{}
+	for _, rs := range roleSets {
+		if rs == nil {
+			continue
+		}
+		cond := utils.GetCondition(rs.Status.Conditions, condType)
+		if cond != nil && cond.Status == condStatus {
+			names[rs.Name] = struct{}{}
+		}
+	}
+	return sortedRoleSetNames(names)
+}
+
+func roleSetNamesWithout(names, excluded []string) []string {
+	excludedSet := map[string]struct{}{}
+	for _, name := range excluded {
+		excludedSet[name] = struct{}{}
+	}
+	remaining := map[string]struct{}{}
+	for _, name := range names {
+		if _, ok := excludedSet[name]; !ok {
+			remaining[name] = struct{}{}
+		}
+	}
+	return sortedRoleSetNames(remaining)
+}
+
+func sortedRoleSetNames(nameSet map[string]struct{}) []string {
+	names := make([]string, 0, len(nameSet))
+	for name := range nameSet {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/controller/stormservice/gang_status.go
+++ b/pkg/controller/stormservice/gang_status.go
@@ -18,10 +18,10 @@ package stormservice
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
 	utils "github.com/vllm-project/aibrix/pkg/controller/util/orchestration"
@@ -36,12 +36,20 @@ func setGangSchedulingConditions(status *orchestrationv1alpha1.StormServiceStatu
 	}
 
 	errorRoleSets := conditionRoleSetNames(roleSets, orchestrationv1alpha1.RoleSetGangSchedulingError, corev1.ConditionTrue)
+	unknownRoleSets := conditionRoleSetNames(roleSets, orchestrationv1alpha1.RoleSetGangSchedulingError, corev1.ConditionUnknown)
 	if len(errorRoleSets) > 0 {
 		SetStormServiceCondition(status, *utils.NewCondition(
 			orchestrationv1alpha1.StormServiceGangSchedulingError,
 			corev1.ConditionTrue,
 			"GangSchedulingError",
 			fmt.Sprintf("gang scheduling errors reported by RoleSets: %s", strings.Join(errorRoleSets, ",")),
+		))
+	} else if len(unknownRoleSets) > 0 {
+		SetStormServiceCondition(status, *utils.NewCondition(
+			orchestrationv1alpha1.StormServiceGangSchedulingError,
+			corev1.ConditionUnknown,
+			"GangSchedulingUnknown",
+			fmt.Sprintf("gang scheduling state is unknown for RoleSets: %s", strings.Join(unknownRoleSets, ",")),
 		))
 	} else {
 		SetStormServiceCondition(status, *utils.NewCondition(
@@ -100,24 +108,9 @@ func conditionRoleSetNames(roleSets []*orchestrationv1alpha1.RoleSet, condType o
 }
 
 func roleSetNamesWithout(names, excluded []string) []string {
-	excludedSet := map[string]struct{}{}
-	for _, name := range excluded {
-		excludedSet[name] = struct{}{}
-	}
-	remaining := map[string]struct{}{}
-	for _, name := range names {
-		if _, ok := excludedSet[name]; !ok {
-			remaining[name] = struct{}{}
-		}
-	}
-	return sortedRoleSetNames(remaining)
+	return sets.NewString(names...).Difference(sets.NewString(excluded...)).List()
 }
 
 func sortedRoleSetNames(nameSet map[string]struct{}) []string {
-	names := make([]string, 0, len(nameSet))
-	for name := range nameSet {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
+	return sets.StringKeySet(nameSet).List()
 }

--- a/pkg/controller/stormservice/gang_status_test.go
+++ b/pkg/controller/stormservice/gang_status_test.go
@@ -110,6 +110,22 @@ func TestSetGangSchedulingConditions(t *testing.T) {
 		assert.Equal(t, "PodGroupSyncIncomplete", syncedCond.Reason)
 		assert.Contains(t, syncedCond.Message, "rs-1")
 	})
+
+	t.Run("aggregates unknown gang scheduling error", func(t *testing.T) {
+		status := &orchestrationv1alpha1.StormServiceStatus{}
+
+		setGangSchedulingConditions(status, []*orchestrationv1alpha1.RoleSet{
+			newVolcanoRoleSetWithConditions("rs-0",
+				condition(orchestrationv1alpha1.RoleSetGangSchedulingError, corev1.ConditionUnknown, "PodGroupObservationDisabled"),
+				condition(orchestrationv1alpha1.RoleSetPodGroupSynced, corev1.ConditionUnknown, "PodGroupObservationDisabled"),
+			),
+		})
+
+		errCond := ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.StormServiceGangSchedulingError)
+		assert.Equal(t, corev1.ConditionUnknown, errCond.Status)
+		assert.Equal(t, "GangSchedulingUnknown", errCond.Reason)
+		assert.Contains(t, errCond.Message, "rs-0")
+	})
 }
 
 func newRoleSetWithConditions(name string, conditions ...orchestrationv1alpha1.Condition) *orchestrationv1alpha1.RoleSet {

--- a/pkg/controller/stormservice/gang_status_test.go
+++ b/pkg/controller/stormservice/gang_status_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stormservice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	ctrlutils "github.com/vllm-project/aibrix/pkg/controller/util/orchestration"
+)
+
+func TestSetGangSchedulingConditions(t *testing.T) {
+	t.Run("does nothing when no RoleSet has gang conditions", func(t *testing.T) {
+		status := &orchestrationv1alpha1.StormServiceStatus{}
+
+		setGangSchedulingConditions(status, []*orchestrationv1alpha1.RoleSet{
+			newRoleSetWithConditions("rs-0"),
+		})
+
+		assert.Empty(t, status.Conditions)
+	})
+
+	t.Run("removes stale conditions when no RoleSet uses volcano scheduling", func(t *testing.T) {
+		status := &orchestrationv1alpha1.StormServiceStatus{
+			Conditions: []orchestrationv1alpha1.Condition{
+				condition(orchestrationv1alpha1.StormServiceGangSchedulingError, corev1.ConditionFalse, "GangSchedulingHealthy"),
+				condition(orchestrationv1alpha1.StormServicePodGroupSynced, corev1.ConditionTrue, "PodGroupSynced"),
+			},
+		}
+
+		setGangSchedulingConditions(status, []*orchestrationv1alpha1.RoleSet{
+			newRoleSetWithConditions("rs-0"),
+		})
+
+		assert.Empty(t, status.Conditions)
+	})
+
+	t.Run("aggregates healthy RoleSets", func(t *testing.T) {
+		status := &orchestrationv1alpha1.StormServiceStatus{}
+
+		setGangSchedulingConditions(status, []*orchestrationv1alpha1.RoleSet{
+			newVolcanoRoleSetWithConditions("rs-0",
+				condition(orchestrationv1alpha1.RoleSetGangSchedulingError, corev1.ConditionFalse, "Healthy"),
+				condition(orchestrationv1alpha1.RoleSetPodGroupSynced, corev1.ConditionTrue, "Synced"),
+			),
+			newVolcanoRoleSetWithConditions("rs-1",
+				condition(orchestrationv1alpha1.RoleSetGangSchedulingError, corev1.ConditionFalse, "Healthy"),
+				condition(orchestrationv1alpha1.RoleSetPodGroupSynced, corev1.ConditionTrue, "Synced"),
+			),
+		})
+
+		assert.Equal(t, corev1.ConditionFalse, ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.StormServiceGangSchedulingError).Status)
+		assert.Equal(t, corev1.ConditionTrue, ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.StormServicePodGroupSynced).Status)
+	})
+
+	t.Run("aggregates error and unsynced RoleSets", func(t *testing.T) {
+		status := &orchestrationv1alpha1.StormServiceStatus{}
+
+		setGangSchedulingConditions(status, []*orchestrationv1alpha1.RoleSet{
+			newVolcanoRoleSetWithConditions("rs-0",
+				condition(orchestrationv1alpha1.RoleSetGangSchedulingError, corev1.ConditionTrue, "PodGroupNotFound"),
+				condition(orchestrationv1alpha1.RoleSetPodGroupSynced, corev1.ConditionFalse, "PodGroupNotFound"),
+			),
+			newVolcanoRoleSetWithConditions("rs-1",
+				condition(orchestrationv1alpha1.RoleSetGangSchedulingError, corev1.ConditionFalse, "Healthy"),
+				condition(orchestrationv1alpha1.RoleSetPodGroupSynced, corev1.ConditionTrue, "Synced"),
+			),
+		})
+
+		errCond := ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.StormServiceGangSchedulingError)
+		assert.Equal(t, corev1.ConditionTrue, errCond.Status)
+		assert.Contains(t, errCond.Message, "rs-0")
+
+		syncedCond := ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.StormServicePodGroupSynced)
+		assert.Equal(t, corev1.ConditionFalse, syncedCond.Status)
+		assert.Contains(t, syncedCond.Message, "rs-0")
+	})
+
+	t.Run("reports incomplete when a volcano RoleSet has no synced condition yet", func(t *testing.T) {
+		status := &orchestrationv1alpha1.StormServiceStatus{}
+
+		setGangSchedulingConditions(status, []*orchestrationv1alpha1.RoleSet{
+			newVolcanoRoleSetWithConditions("rs-0",
+				condition(orchestrationv1alpha1.RoleSetGangSchedulingError, corev1.ConditionFalse, "Healthy"),
+				condition(orchestrationv1alpha1.RoleSetPodGroupSynced, corev1.ConditionTrue, "Synced"),
+			),
+			newVolcanoRoleSetWithConditions("rs-1"),
+		})
+
+		syncedCond := ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.StormServicePodGroupSynced)
+		assert.Equal(t, corev1.ConditionFalse, syncedCond.Status)
+		assert.Equal(t, "PodGroupSyncIncomplete", syncedCond.Reason)
+		assert.Contains(t, syncedCond.Message, "rs-1")
+	})
+}
+
+func newRoleSetWithConditions(name string, conditions ...orchestrationv1alpha1.Condition) *orchestrationv1alpha1.RoleSet {
+	return &orchestrationv1alpha1.RoleSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: orchestrationv1alpha1.RoleSetStatus{
+			Conditions: conditions,
+		},
+	}
+}
+
+func newVolcanoRoleSetWithConditions(name string, conditions ...orchestrationv1alpha1.Condition) *orchestrationv1alpha1.RoleSet {
+	roleSet := newRoleSetWithConditions(name, conditions...)
+	roleSet.Spec.SchedulingStrategy = &orchestrationv1alpha1.SchedulingStrategy{
+		VolcanoSchedulingStrategy: &orchestrationv1alpha1.VolcanoSchedulingStrategySpec{},
+	}
+	return roleSet
+}
+
+func condition(condType orchestrationv1alpha1.ConditionType, status corev1.ConditionStatus, reason string) orchestrationv1alpha1.Condition {
+	return orchestrationv1alpha1.Condition{
+		Type:   condType,
+		Status: status,
+		Reason: reason,
+	}
+}

--- a/pkg/controller/stormservice/sync.go
+++ b/pkg/controller/stormservice/sync.go
@@ -409,6 +409,7 @@ func (r *StormServiceReconciler) updateStatus(ctx context.Context, stormService 
 			*utils.NewCondition(orchestrationv1alpha1.StormServiceProgressing, corev1.ConditionTrue, "Processing", ""),
 		}
 	}
+	setGangSchedulingConditions(&stormService.Status, allRoleSets)
 	// support scale sub resources.
 	// TODO: add pod template hash to avoid errors during upgrade.
 	stormService.Status.ScalingTargetSelector = fmt.Sprintf("%s=%s", constants.StormServiceNameLabelKey, stormService.Name)

--- a/pkg/controller/stormservice/sync.go
+++ b/pkg/controller/stormservice/sync.go
@@ -400,15 +400,7 @@ func (r *StormServiceReconciler) updateStatus(ctx context.Context, stormService 
 		stormService.Status.UpdatedReplicas == *stormService.Spec.Replicas &&
 		stormService.Status.Replicas == *stormService.Spec.Replicas &&
 		stormService.Status.CurrentRevision == stormService.Status.UpdateRevision
-	if stormServiceReady {
-		stormService.Status.Conditions = []orchestrationv1alpha1.Condition{
-			*utils.NewCondition(orchestrationv1alpha1.StormServiceReady, corev1.ConditionTrue, "Ready", ""),
-		}
-	} else {
-		stormService.Status.Conditions = []orchestrationv1alpha1.Condition{
-			*utils.NewCondition(orchestrationv1alpha1.StormServiceProgressing, corev1.ConditionTrue, "Processing", ""),
-		}
-	}
+	setStormServiceAvailabilityCondition(&stormService.Status, stormServiceReady)
 	setGangSchedulingConditions(&stormService.Status, allRoleSets)
 	// support scale sub resources.
 	// TODO: add pod template hash to avoid errors during upgrade.
@@ -425,6 +417,16 @@ func (r *StormServiceReconciler) updateStatus(ctx context.Context, stormService 
 		}
 	}
 	return stormServiceReady, nil
+}
+
+func setStormServiceAvailabilityCondition(status *orchestrationv1alpha1.StormServiceStatus, ready bool) {
+	if ready {
+		RemoveStormServiceCondition(status, orchestrationv1alpha1.StormServiceProgressing)
+		SetStormServiceCondition(status, *utils.NewCondition(orchestrationv1alpha1.StormServiceReady, corev1.ConditionTrue, "Ready", ""))
+		return
+	}
+	RemoveStormServiceCondition(status, orchestrationv1alpha1.StormServiceReady)
+	SetStormServiceCondition(status, *utils.NewCondition(orchestrationv1alpha1.StormServiceProgressing, corev1.ConditionTrue, "Processing", ""))
 }
 
 func (r *StormServiceReconciler) finalize(ctx context.Context, stormService *orchestrationv1alpha1.StormService) (bool, error) {

--- a/pkg/controller/stormservice/sync_test.go
+++ b/pkg/controller/stormservice/sync_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,7 @@ import (
 
 	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
 	"github.com/vllm-project/aibrix/pkg/controller/constants"
+	ctrlutils "github.com/vllm-project/aibrix/pkg/controller/util/orchestration"
 )
 
 func TestCalculateReplicas(t *testing.T) {
@@ -124,6 +126,36 @@ func TestCalculateReplicas(t *testing.T) {
 		if c != test.desiredCurrent || u != test.desiredUpdated {
 			t.Errorf("failed %+v, current %d, updated %d", test, c, u)
 		}
+	}
+}
+
+func TestSetStormServiceAvailabilityConditionPreservesGangConditionTransitionTime(t *testing.T) {
+	oldTransition := metav1.NewTime(time.Now().Add(-time.Hour))
+	status := &orchestrationv1alpha1.StormServiceStatus{
+		Conditions: orchestrationv1alpha1.Conditions{
+			{
+				Type:               orchestrationv1alpha1.StormServiceGangSchedulingError,
+				Status:             corev1.ConditionFalse,
+				Reason:             "GangSchedulingHealthy",
+				LastTransitionTime: &oldTransition,
+			},
+		},
+	}
+
+	setStormServiceAvailabilityCondition(status, true)
+	SetStormServiceCondition(status, *ctrlutils.NewCondition(
+		orchestrationv1alpha1.StormServiceGangSchedulingError,
+		corev1.ConditionFalse,
+		"GangSchedulingHealthy",
+		"",
+	))
+
+	gangCondition := ctrlutils.GetCondition(status.Conditions, orchestrationv1alpha1.StormServiceGangSchedulingError)
+	if gangCondition == nil {
+		t.Fatal("expected gang scheduling condition to be preserved")
+	}
+	if gangCondition.LastTransitionTime == nil || !gangCondition.LastTransitionTime.Equal(&oldTransition) {
+		t.Fatalf("expected gang scheduling LastTransitionTime %v, got %v", oldTransition, gangCondition.LastTransitionTime)
 	}
 }
 

--- a/samples/disaggregation/vllm/volcano-gang-pd.yaml
+++ b/samples/disaggregation/vllm/volcano-gang-pd.yaml
@@ -1,0 +1,58 @@
+apiVersion: orchestration.aibrix.ai/v1alpha1
+kind: StormService
+metadata:
+  name: vllm-pd-volcano-gang
+spec:
+  replicas: 1
+  mode: Pooled
+  stateful: true
+  selector:
+    matchLabels:
+      app: vllm-pd-volcano-gang
+  template:
+    metadata:
+      labels:
+        app: vllm-pd-volcano-gang
+    spec:
+      schedulingStrategy:
+        volcanoSchedulingStrategy:
+          minMember: 6
+          minTaskMember:
+            prefill: 4
+            decode: 2
+          queue: default
+      roles:
+        # minTaskMember values are pod counts, not replica counts. With
+        # podGroupSize: 2, prefill: 4 means at least 2 prefill replicas.
+        # This is approximate role-level gang scheduling, not subgroup-level
+        # gang scheduling.
+        - name: prefill
+          replicas: 2
+          podGroupSize: 2
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: qwen3-8B
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+            spec:
+              containers:
+                - name: prefill
+                  image: busybox:1.36
+                  command: ["sh", "-c", "sleep 3600"]
+        - name: decode
+          replicas: 1
+          podGroupSize: 2
+          stateful: true
+          template:
+            metadata:
+              labels:
+                model.aibrix.ai/name: qwen3-8B
+                model.aibrix.ai/port: "8000"
+                model.aibrix.ai/engine: vllm
+            spec:
+              containers:
+                - name: decode
+                  image: busybox:1.36
+                  command: ["sh", "-c", "sleep 3600"]


### PR DESCRIPTION
## Summary
- Surface Volcano PodGroup sync and gang scheduling error status on RoleSet, and aggregate those conditions onto StormService.
- Default generated Volcano task spec metadata to the RoleSet role name while preserving user-provided scheduler/task-spec values.
- Add a PD-disaggregated Volcano gang scheduling sample using existing minTaskMember semantics.

## Test Plan
- `GOCACHE=/private/tmp/aibrix-go-build-cache go test ./pkg/controller/roleset -run 'Test(RenderStormServicePodVolcanoScheduler|RenderStormServicePod_WithRoleSetVolcanoPodGroup|CreatePodSetForRole_VolcanoTaskSpec|SetVolcanoGangConditions)$'` - 13 passed
- `GOCACHE=/private/tmp/aibrix-go-build-cache go test ./pkg/controller/podset -run 'TestCreatePodFromTemplate_VolcanoSchedulingMetadata$'` - 1 passed
- `GOCACHE=/private/tmp/aibrix-go-build-cache go test ./pkg/controller/stormservice -run 'TestSetGangSchedulingConditions$'` - 6 passed
- `GOCACHE=/private/tmp/aibrix-go-build-cache go test ./pkg/controller/roleset ./pkg/controller/podset ./pkg/controller/stormservice -run '^$'` - compile check passed
- `GOCACHE=/private/tmp/aibrix-go-build-cache go test ./api/orchestration/v1alpha1 -run '^$'` - compile check passed
- `kubectl apply --dry-run=client -f samples/disaggregation/vllm/volcano-gang-pd.yaml` - passed
- `git diff --check` - passed

Closes #2631
