### PR TITLE
fix(batch): scale concurrency with live capacity

### DIFF
--- a/python/aibrix/aibrix/batch/client/concurrency.py
+++ b/python/aibrix/aibrix/batch/client/concurrency.py
@@ -68,6 +68,9 @@ class FixedConcurrencyController:
     def limit(self) -> int:
         return self._limit
 
+    def set_max_limit(self, max_limit: int) -> None:
+        self._limit = max(int(max_limit), 1)
+
     def admission_delay_seconds(self) -> float:
         return 0.0
 
@@ -171,6 +174,17 @@ class LLMAdaptiveConcurrencyController:
 
     def limit(self) -> int:
         return self._limit
+
+    def set_max_limit(self, max_limit: int) -> None:
+        next_max_limit = max(int(max_limit), self._settings.min_limit)
+        if next_max_limit == self._max_limit:
+            return
+        self._max_limit = next_max_limit
+        self._limit = min(self._limit, self._max_limit)
+        self._healthy = 0
+        self._overload_samples = 0
+        self._overload_errors = 0
+        self._overload_window_size = 0
 
     def admission_delay_seconds(self) -> float:
         if self._backoff_error_count < self._settings.failure_backoff_after:

--- a/python/aibrix/aibrix/batch/client/engine.py
+++ b/python/aibrix/aibrix/batch/client/engine.py
@@ -25,6 +25,7 @@ import asyncio
 from dataclasses import dataclass
 from math import ceil, isfinite
 from threading import Lock
+from time import time
 from typing import (
     Any,
     AsyncIterable,
@@ -40,6 +41,7 @@ from aibrix.batch.client.concurrency import (
     DEFAULT_ADAPTIVE_ADDITIVE_INCREASE,
     DEFAULT_ADAPTIVE_HEALTHY_WINDOW,
     ConcurrencyController,
+    ConcurrencyOutcome,
     FixedConcurrencyController,
     LLMAdaptiveConcurrencyController,
     LLMAdaptiveConcurrencySettings,
@@ -51,6 +53,10 @@ from aibrix.batch.client.source import CapacitySignal, EndpointSource
 from aibrix.logger import init_logger
 
 logger = init_logger(__name__)
+
+_CAPACITY_WATCH_RETRY_SECONDS = 1.0
+_NO_ENDPOINT_MIN_RETRY_DELAY_SECONDS = 1.0
+_NO_ENDPOINT_LOG_INTERVAL = 120
 
 # Called once per request with (request, response, error). Exactly one of
 # response / error is non-None. May be sync or async.
@@ -70,6 +76,7 @@ class RetryConfig:
     base_delay_seconds: float = 0.0
     max_delay_seconds: float = 5.0
     no_endpoint_max_retries: Optional[int] = None
+    no_endpoint_deadline_epoch_seconds: Optional[float] = None
 
     def __post_init__(self) -> None:
         if self.max_retries < 0:
@@ -83,11 +90,18 @@ class RetryConfig:
             and self.no_endpoint_max_retries < 0
         ):
             raise ValueError("no_endpoint_max_retries must be >= 0")
+        if (
+            self.no_endpoint_deadline_epoch_seconds is not None
+            and self.no_endpoint_deadline_epoch_seconds <= 0
+        ):
+            raise ValueError("no_endpoint_deadline_epoch_seconds must be > 0")
 
-    def no_endpoint_retries(self) -> int:
-        if self.no_endpoint_max_retries is None:
-            return self.max_retries
-        return self.no_endpoint_max_retries
+    def no_endpoint_retries(self) -> Optional[int]:
+        if self.no_endpoint_max_retries is not None:
+            return self.no_endpoint_max_retries
+        if self.no_endpoint_deadline_epoch_seconds is not None:
+            return None
+        return self.max_retries
 
 
 @dataclass(frozen=True, slots=True)
@@ -171,6 +185,66 @@ class DispatchStats:
             return snapshot
 
 
+class _CapacityScaledConcurrencyController:
+    """Clamp a controller to the fraction of configured capacity available."""
+
+    def __init__(
+        self,
+        controller: Union[
+            FixedConcurrencyController,
+            LLMAdaptiveConcurrencyController,
+        ],
+        *,
+        configured_capacity: int,
+        full_max_limit: int,
+        capacity: CapacitySignal,
+    ) -> None:
+        self._controller = controller
+        self._configured_capacity = max(int(configured_capacity), 1)
+        self._full_max_limit = max(int(full_max_limit), 1)
+        self._capacity = capacity
+        self._capacity_limit = 0
+        self._apply_capacity(capacity.count)
+
+    @property
+    def capacity(self) -> CapacitySignal:
+        return self._capacity
+
+    @property
+    def configured_capacity(self) -> int:
+        return self._configured_capacity
+
+    @property
+    def full_max_limit(self) -> int:
+        return self._full_max_limit
+
+    def limit(self) -> int:
+        return min(self._controller.limit(), self._capacity_limit)
+
+    def admission_delay_seconds(self) -> float:
+        return _admission_delay_seconds(self._controller)
+
+    def on_complete(self, outcome: ConcurrencyOutcome) -> None:
+        self._controller.on_complete(outcome)
+
+    def update_capacity(self, capacity: CapacitySignal) -> None:
+        self._capacity = capacity
+        self._apply_capacity(capacity.count)
+
+    def _apply_capacity(self, current_capacity: int) -> None:
+        available = min(
+            max(int(current_capacity), 0),
+            self._configured_capacity,
+        )
+        scaled_limit = max(
+            1,
+            (self._full_max_limit * available + self._configured_capacity - 1)
+            // self._configured_capacity,
+        )
+        self._capacity_limit = scaled_limit
+        self._controller.set_max_limit(scaled_limit)
+
+
 class DispatchEngine:
     def __init__(
         self,
@@ -181,6 +255,7 @@ class DispatchEngine:
         max_retries: int = 2,
         retry: Optional[RetryConfig] = None,
         job_id: Optional[str] = None,
+        configured_capacity: Optional[int] = None,
     ) -> None:
         self._source = source
         self._router: Router = router or RoundRobin()
@@ -189,6 +264,11 @@ class DispatchEngine:
         # One engine serves one job. Carrying the id lets every line this layer
         # emits be filtered per job, which the request ref alone cannot do.
         self._job_id = job_id
+        self._configured_capacity = (
+            max(int(configured_capacity), 1)
+            if configured_capacity is not None and configured_capacity > 0
+            else None
+        )
 
     @property
     def source(self) -> EndpointSource:
@@ -222,21 +302,27 @@ class DispatchEngine:
     ) -> None:
         """Drive ``requests`` to completion under a concurrency cap.
 
+        When the engine has configured capacity, explicit and adaptive maximums
+        apply at that full capacity and scale with the source's live capacity.
         A per-request inference failure is reported through ``on_result`` and
         never raised. Anything else -- a feeder error, or an ``on_result`` that
         itself raises (e.g. a caller's stop condition) -- stops scheduling,
         drains in-flight work, and re-raises the first such error.
         """
-        admission = _ConcurrencyAdmission(
-            await self._resolve_concurrency_controller(
-                max_concurrency=max_concurrency,
-                adaptive_concurrency=adaptive_concurrency,
-                adaptive_max_factor=adaptive_max_factor,
-                adaptive_max_concurrency=adaptive_max_concurrency,
-                adaptive_healthy_window=adaptive_healthy_window,
-                adaptive_additive_increase=adaptive_additive_increase,
-                concurrency_controller=concurrency_controller,
-            )
+        controller = await self._resolve_concurrency_controller(
+            max_concurrency=max_concurrency,
+            adaptive_concurrency=adaptive_concurrency,
+            adaptive_max_factor=adaptive_max_factor,
+            adaptive_max_concurrency=adaptive_max_concurrency,
+            adaptive_healthy_window=adaptive_healthy_window,
+            adaptive_additive_increase=adaptive_additive_increase,
+            concurrency_controller=concurrency_controller,
+        )
+        admission = _ConcurrencyAdmission(controller)
+        capacity_task = (
+            asyncio.create_task(self._watch_capacity(admission, controller))
+            if isinstance(controller, _CapacityScaledConcurrencyController)
+            else None
         )
         gate = _QpsGate(qps) if qps else None
         inflight: Set[asyncio.Task[None]] = set()
@@ -249,42 +335,56 @@ class DispatchEngine:
                 if exc is not None and not first_error:
                     first_error.append(exc)
 
-        scheduled = self._scheduler.schedule(requests).__aiter__()
         try:
-            while not first_error:
-                await admission.acquire()
-                if first_error:
-                    await admission.release()
-                    break
-                try:
-                    if gate is not None:
-                        await gate.wait()
-                    request = await scheduled.__anext__()
-                except StopAsyncIteration:
-                    await admission.release()
-                    break
-                except BaseException as exc:
-                    await admission.release()
-                    if not first_error:
-                        first_error.append(exc)
-                    break
+            scheduled = self._scheduler.schedule(requests).__aiter__()
+            try:
+                while not first_error:
+                    await admission.acquire()
+                    if first_error:
+                        await admission.release()
+                        break
+                    try:
+                        if gate is not None:
+                            await gate.wait()
+                        request = await scheduled.__anext__()
+                    except StopAsyncIteration:
+                        await admission.release()
+                        break
+                    except BaseException as exc:
+                        await admission.release()
+                        if not first_error:
+                            first_error.append(exc)
+                        break
 
-                if stats is not None:
-                    stats.record_start(
-                        limit=admission.limit(),
-                        inflight=admission.inflight(),
+                    if stats is not None:
+                        stats.record_start(
+                            limit=admission.limit(),
+                            inflight=admission.inflight(),
+                        )
+                    task = asyncio.create_task(
+                        self._process(
+                            request,
+                            on_result,
+                            admission,
+                            first_error,
+                            stats,
+                        )
                     )
-                task = asyncio.create_task(
-                    self._process(request, on_result, admission, first_error, stats)
-                )
-                inflight.add(task)
-                task.add_done_callback(_on_done)
-        except BaseException as exc:  # feeder raised; drain then re-raise
-            if not first_error:
-                first_error.append(exc)
+                    inflight.add(task)
+                    task.add_done_callback(_on_done)
+            except BaseException as exc:  # feeder raised; drain then re-raise
+                if not first_error:
+                    first_error.append(exc)
 
-        if inflight:
-            await asyncio.gather(*inflight, return_exceptions=True)
+            if inflight:
+                await asyncio.gather(*inflight, return_exceptions=True)
+        finally:
+            if capacity_task is not None:
+                capacity_task.cancel()
+                try:
+                    await capacity_task
+                except asyncio.CancelledError:
+                    pass
         if first_error:
             raise first_error[0]
 
@@ -343,14 +443,32 @@ class DispatchEngine:
     ) -> ConcurrencyController:
         if concurrency_controller is not None:
             return concurrency_controller
-        limit = await self._resolve_limit(max_concurrency)
+        normalized_capacity = self._configured_capacity
+        capacity = (
+            await self._source.capacity() if normalized_capacity is not None else None
+        )
+        limit = (
+            max(capacity.count, 1)
+            if capacity is not None and max_concurrency is None
+            else await self._resolve_limit(max_concurrency)
+        )
         if adaptive_concurrency:
             max_limit = (
                 max(int(adaptive_max_concurrency), 1)
                 if adaptive_max_concurrency is not None
-                else self._adaptive_max_limit(limit, adaptive_max_factor)
+                else self._adaptive_max_limit(
+                    (
+                        normalized_capacity
+                        if normalized_capacity is not None and max_concurrency is None
+                        else limit
+                    ),
+                    adaptive_max_factor,
+                )
             )
-            return LLMAdaptiveConcurrencyController(
+            controller: Union[
+                FixedConcurrencyController,
+                LLMAdaptiveConcurrencyController,
+            ] = LLMAdaptiveConcurrencyController(
                 initial_limit=min(limit, max_limit),
                 max_limit=max_limit,
                 settings=LLMAdaptiveConcurrencySettings(
@@ -358,7 +476,64 @@ class DispatchEngine:
                     additive_increase=adaptive_additive_increase,
                 ),
             )
-        return FixedConcurrencyController(limit)
+        else:
+            max_limit = (
+                normalized_capacity
+                if normalized_capacity is not None and max_concurrency is None
+                else limit
+            )
+            controller = FixedConcurrencyController(max_limit)
+
+        if normalized_capacity is None or capacity is None:
+            return controller
+        scaled_controller = _CapacityScaledConcurrencyController(
+            controller,
+            configured_capacity=normalized_capacity,
+            full_max_limit=max_limit,
+            capacity=capacity,
+        )
+        logger.info(
+            "Configured dispatch concurrency for endpoint capacity",
+            job_id=self._job_id,
+            current_capacity=capacity.count,
+            configured_capacity=normalized_capacity,
+            configured_max_concurrency=max_limit,
+            current_limit=scaled_controller.limit(),
+        )  # type: ignore[call-arg]
+        return scaled_controller
+
+    async def _watch_capacity(
+        self,
+        admission: "_ConcurrencyAdmission",
+        controller: _CapacityScaledConcurrencyController,
+    ) -> None:
+        previous = controller.capacity
+        while True:
+            try:
+                current = await self._source.wait_capacity_change(previous)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "Failed to watch endpoint capacity; retrying",
+                    job_id=self._job_id,
+                    error=str(exc),
+                )  # type: ignore[call-arg]
+                await asyncio.sleep(_CAPACITY_WATCH_RETRY_SECONDS)
+                continue
+
+            previous = current
+            previous_limit = admission.limit()
+            await admission.update_capacity(current)
+            logger.info(
+                "Updated dispatch concurrency for endpoint capacity",
+                job_id=self._job_id,
+                current_capacity=current.count,
+                configured_capacity=controller.configured_capacity,
+                configured_max_concurrency=controller.full_max_limit,
+                previous_limit=previous_limit,
+                current_limit=admission.limit(),
+            )  # type: ignore[call-arg]
 
     async def _send_with_failover(self, request: InferenceRequest) -> Response:
         try:
@@ -381,18 +556,40 @@ class DispatchEngine:
                     InferenceErrorCode.NO_ENDPOINT, "no reachable endpoint"
                 )
                 last_error = no_endpoint
-                causes.append(str(no_endpoint))
-                if endpoint_attempt < self._retry.no_endpoint_retries():
-                    if endpoint_attempt == 0 or endpoint_attempt % 20 == 0:
+                if endpoint_attempt == 0:
+                    causes.append(str(no_endpoint))
+                max_endpoint_retries = self._retry.no_endpoint_retries()
+                deadline_reached = (
+                    self._retry.no_endpoint_deadline_epoch_seconds is not None
+                    and time() >= self._retry.no_endpoint_deadline_epoch_seconds
+                )
+                retry_available = (
+                    max_endpoint_retries is None
+                    or endpoint_attempt < max_endpoint_retries
+                )
+                if retry_available and not deadline_reached:
+                    if (
+                        endpoint_attempt == 0
+                        or endpoint_attempt % _NO_ENDPOINT_LOG_INTERVAL == 0
+                    ):
                         logger.warning(
                             "No reachable endpoint; waiting for discovery",
                             job_id=self._job_id,
                             ref=request.ref,
                             attempt=endpoint_attempt + 1,
-                            max_retries=self._retry.no_endpoint_retries(),
+                            max_retries=max_endpoint_retries,
+                            deadline_epoch_seconds=(
+                                self._retry.no_endpoint_deadline_epoch_seconds
+                            ),
                         )  # type: ignore[call-arg]
                     await self._refresh_source()
-                    await self._sleep_before_retry(endpoint_attempt)
+                    await self._sleep_before_retry(
+                        endpoint_attempt,
+                        deadline_epoch_seconds=(
+                            self._retry.no_endpoint_deadline_epoch_seconds
+                        ),
+                        minimum_delay_seconds=_NO_ENDPOINT_MIN_RETRY_DELAY_SECONDS,
+                    )
                     endpoint_attempt += 1
                     continue
                 if not attempted_channel:
@@ -451,13 +648,35 @@ class DispatchEngine:
             return max(int(max_concurrency()), 1)
         return max(int(max_concurrency), 1)
 
-    async def _sleep_before_retry(self, attempt: int) -> None:
-        if self._retry.base_delay_seconds <= 0:
+    async def _sleep_before_retry(
+        self,
+        attempt: int,
+        *,
+        deadline_epoch_seconds: Optional[float] = None,
+        minimum_delay_seconds: float = 0.0,
+    ) -> None:
+        base_delay = max(
+            self._retry.base_delay_seconds,
+            minimum_delay_seconds,
+        )
+        max_delay = max(
+            self._retry.max_delay_seconds,
+            minimum_delay_seconds,
+        )
+        if base_delay <= 0:
             return
         delay = min(
-            self._retry.base_delay_seconds * (2**attempt),
-            self._retry.max_delay_seconds,
+            base_delay,
+            max_delay,
         )
+        for _ in range(attempt):
+            if delay >= max_delay:
+                break
+            delay = min(delay * 2, max_delay)
+        if deadline_epoch_seconds is not None:
+            delay = min(delay, max(deadline_epoch_seconds - time(), 0.0))
+        if delay <= 0:
+            return
         await asyncio.sleep(delay)
 
     async def _refresh_source(self) -> None:
@@ -509,7 +728,10 @@ class _ConcurrencyAdmission:
         while True:
             async with self._condition:
                 await self._condition.wait_for(
-                    lambda: self._inflight < max(int(self._controller.limit()), 1)
+                    lambda: (
+                        int(self._controller.limit()) > 0
+                        and self._inflight < int(self._controller.limit())
+                    )
                 )
                 delay = _admission_delay_seconds(self._controller)
                 if delay <= 0:
@@ -528,8 +750,17 @@ class _ConcurrencyAdmission:
             self._condition.notify_all()
             return self.limit(), self._inflight
 
+    async def update_capacity(self, capacity: CapacitySignal) -> None:
+        async with self._condition:
+            if isinstance(
+                self._controller,
+                _CapacityScaledConcurrencyController,
+            ):
+                self._controller.update_capacity(capacity)
+            self._condition.notify_all()
+
     def limit(self) -> int:
-        return max(int(self._controller.limit()), 1)
+        return max(int(self._controller.limit()), 0)
 
     def inflight(self) -> int:
         return self._inflight

--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -104,10 +104,6 @@ _OUTPUT_PERSISTENCE_FAILURE_BUCKET_SECONDS_ENV = (
 _DEFAULT_ADAPTIVE_MAX_FACTOR = 8.0
 _DEFAULT_TELEMETRY_INTERVAL_SECONDS = 5.0
 _DEFAULT_INFERENCE_MAX_RETRIES = 5
-# A no-endpoint attempt only re-queries service discovery,
-# so 120 tries against the 5s delay cap buys ~10 minutes of waiting out a
-# cold-starting deployment.
-_DEFAULT_NO_ENDPOINT_MAX_RETRIES = 120
 _DEFAULT_RETRY_BASE_DELAY_SECONDS = 0.5
 _DEFAULT_RETRY_MAX_DELAY_SECONDS = 5.0
 _DEFAULT_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD = 3
@@ -149,14 +145,19 @@ def _telemetry_interval_seconds() -> float:
     )
 
 
-def _no_endpoint_max_retries() -> int:
-    return max(
-        _int_env(
-            _NO_ENDPOINT_MAX_RETRIES_ENV,
-            _DEFAULT_NO_ENDPOINT_MAX_RETRIES,
-        ),
-        0,
-    )
+def _no_endpoint_max_retries() -> Optional[int]:
+    raw = os.environ.get(_NO_ENDPOINT_MAX_RETRIES_ENV)
+    if raw is None or raw == "":
+        return None
+    try:
+        return max(int(raw), 0)
+    except ValueError:
+        logger.warning(
+            "Invalid integer environment value; ignoring retry cap",
+            name=_NO_ENDPOINT_MAX_RETRIES_ENV,
+            value=raw,
+        )  # type: ignore[call-arg]
+        return None
 
 
 def _inference_max_retries() -> int:
@@ -1007,6 +1008,7 @@ class BaseJobDriver:
                 if policy is not None and policy.no_endpoint_max_retries is not None
                 else _no_endpoint_max_retries()
             ),
+            no_endpoint_deadline_epoch_seconds=job.expiration_timestamp(),
         )
 
     def _dispatch_run_kwargs_for_job(self, job: BatchJob) -> Dict[str, Any]:
@@ -1219,6 +1221,7 @@ class BaseJobDriver:
                     endpoint.source,
                     retry=self._retry_config_for_job(job),
                     job_id=job.job_id,
+                    configured_capacity=getattr(endpoint, "configured_capacity", None),
                 )
                 if endpoint.source is not None
                 else None

--- a/python/aibrix/aibrix/batch/job_driver/runtime/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/base.py
@@ -192,6 +192,8 @@ class Endpoint:
 
     source: Optional[EndpointSource]
     model_name: Optional[str] = None
+    # Desired backend width when all configured replicas are available.
+    configured_capacity: Optional[int] = None
 
 
 @runtime_checkable

--- a/python/aibrix/aibrix/batch/job_driver/runtime/k8s_deployment.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/k8s_deployment.py
@@ -262,7 +262,16 @@ class DeploymentRuntime(RuntimeBase):
 
     async def _connect(self, handle: DeploymentHandle) -> Endpoint:
         handle.source = self._build_endpoint_source(handle)
-        return Endpoint(source=handle.source, model_name=handle.model_name)
+        configured_capacity = (
+            max(handle.replicas, 1)
+            if isinstance(handle.source, DiscoveryEndpointSource)
+            else None
+        )
+        return Endpoint(
+            source=handle.source,
+            model_name=handle.model_name,
+            configured_capacity=configured_capacity,
+        )
 
     async def _teardown(self, handle: Optional[DeploymentHandle]) -> None:
         if handle is not None:

--- a/python/aibrix/tests/batch/job_driver/runtime/test_k8s_deployment.py
+++ b/python/aibrix/tests/batch/job_driver/runtime/test_k8s_deployment.py
@@ -21,6 +21,7 @@ import pytest
 from kubernetes.client import ApiException
 
 from aibrix.batch.client.sources import (
+    DiscoveryEndpointSource,
     InClusterEndpointSource,
     PortForwardEndpointSource,
 )
@@ -408,6 +409,31 @@ async def test_k8s_deployment_runtime_connect_uses_in_cluster_source(monkeypatch
 
     assert isinstance(endpoint.source, InClusterEndpointSource)
     assert endpoint.model_name == "rendered-model"
+    assert endpoint.configured_capacity is None
+
+
+@pytest.mark.asyncio
+async def test_k8s_deployment_runtime_exposes_configured_discovery_capacity(
+    monkeypatch,
+):
+    runtime = _make_runtime(renderer=FakeRenderer())
+    handle = DeploymentHandle(
+        namespace="default",
+        deployment_name="rendered-deployment",
+        service_name="rendered-service",
+        model_name="rendered-model",
+        base_url="http://rendered-service.default.svc.cluster.local:8000",
+        service_port=8000,
+        replicas=3,
+    )
+
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("AIBRIX_BATCH_K8S_ENDPOINT_SOURCE", "endpointslice")
+    monkeypatch.setattr(runtime, "_discovery_v1_api", lambda: object())
+    endpoint = await runtime._connect(handle)
+
+    assert isinstance(endpoint.source, DiscoveryEndpointSource)
+    assert endpoint.configured_capacity == 3
 
 
 @pytest.mark.asyncio
@@ -430,6 +456,7 @@ async def test_k8s_deployment_runtime_connect_uses_port_forward_source_outside_c
 
     assert isinstance(endpoint.source, PortForwardEndpointSource)
     assert endpoint.model_name == "rendered-model"
+    assert endpoint.configured_capacity is None
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/batch/job_driver/test_base_job_driver_concurrent.py
+++ b/python/aibrix/tests/batch/job_driver/test_base_job_driver_concurrent.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pytest
@@ -172,7 +172,47 @@ def test_retry_config_prefers_job_client_and_falls_back_to_env(monkeypatch):
     assert retry.no_endpoint_retries() == 11
     assert retry.base_delay_seconds == 2
     assert retry.max_delay_seconds == 6
+    expected_deadline = (
+        job.status.created_at.replace(tzinfo=timezone.utc).timestamp()
+        + job.spec.completion_window
+    )
+    assert retry.no_endpoint_deadline_epoch_seconds == expected_deadline
     assert base_module._inference_max_retries() == 9
+
+
+def test_no_endpoint_default_uses_job_deadline_without_retry_cap(monkeypatch):
+    monkeypatch.delenv("AIBRIX_BATCH_NO_ENDPOINT_MAX_RETRIES", raising=False)
+    job = _make_job(total=1)
+    driver = BaseJobDriver(
+        InfrastructureContext(),
+        SingleJobRunner(job),
+        ExternalRuntime(None),
+    )
+
+    retry = driver._retry_config_for_job(job)
+
+    assert retry.no_endpoint_retries() is None
+    assert retry.no_endpoint_deadline_epoch_seconds is not None
+
+
+def test_no_endpoint_deadline_prefers_provision_resource_deadline(monkeypatch):
+    monkeypatch.delenv("AIBRIX_BATCH_NO_ENDPOINT_MAX_RETRIES", raising=False)
+    job = _make_job(total=1)
+    provision_deadline = int(job.status.created_at.timestamp()) + 3600
+    job.spec.aibrix = AibrixMetadata(
+        resource_allocation={
+            "provision_resource_deadline": provision_deadline,
+        }
+    )
+    driver = BaseJobDriver(
+        InfrastructureContext(),
+        SingleJobRunner(job),
+        ExternalRuntime(None),
+    )
+
+    retry = driver._retry_config_for_job(job)
+
+    assert retry.no_endpoint_deadline_epoch_seconds == provision_deadline
 
 
 def test_retry_backoff_delays_are_configurable_from_env(monkeypatch):

--- a/python/aibrix/tests/batch/test_concurrency_controller.py
+++ b/python/aibrix/tests/batch/test_concurrency_controller.py
@@ -202,6 +202,23 @@ def test_llm_controller_recovers_after_healthy_window():
     assert controller.limit() == 4
 
 
+def test_llm_controller_clamps_to_updated_max_and_regrows():
+    settings = LLMAdaptiveConcurrencySettings(healthy_window=1)
+    controller = LLMAdaptiveConcurrencyController(
+        initial_limit=8,
+        max_limit=8,
+        settings=settings,
+    )
+
+    controller.set_max_limit(4)
+    assert controller.limit() == 4
+
+    controller.set_max_limit(8)
+    assert controller.limit() == 4
+    controller.on_complete(ConcurrencyOutcome(success=True))
+    assert controller.limit() == 5
+
+
 def test_llm_controller_waits_for_warmup_before_relative_slowdown():
     settings = LLMAdaptiveConcurrencySettings(
         relative_slowdown_warmup=2,

--- a/python/aibrix/tests/batch/test_dispatch_engine.py
+++ b/python/aibrix/tests/batch/test_dispatch_engine.py
@@ -17,6 +17,7 @@ import asyncio
 import pkgutil
 from dataclasses import dataclass
 from http import HTTPStatus
+from time import monotonic, time
 
 import httpx
 import pytest
@@ -79,6 +80,30 @@ class _FakeSource:
 
 class _ReadTimeout(Exception):
     pass
+
+
+class _MutableCapacitySource(_FakeSource):
+    def __init__(self, channels, capacity):
+        super().__init__(channels)
+        self._capacity = capacity
+        self._version = 0
+        self._changes = asyncio.Queue()
+
+    async def capacity(self):
+        return CapacitySignal(count=self._capacity, version=self._version)
+
+    async def wait_capacity_change(self, previous):
+        while True:
+            signal = await self._changes.get()
+            if signal != previous:
+                return signal
+
+    def set_capacity(self, capacity):
+        self._capacity = capacity
+        self._version += 1
+        self._changes.put_nowait(
+            CapacitySignal(count=self._capacity, version=self._version)
+        )
 
 
 class _ErrorChannel(_FakeChannel):
@@ -233,6 +258,8 @@ async def test_http_channel_truncates_large_error_body():
 def test_retry_config_rejects_invalid_values():
     with pytest.raises(ValueError):
         RetryConfig(max_retries=-1)
+    with pytest.raises(ValueError):
+        RetryConfig(no_endpoint_deadline_epoch_seconds=0)
 
 
 @pytest.mark.asyncio
@@ -392,6 +419,30 @@ async def test_no_endpoint_retry_budget_is_separate_from_send_retry_budget():
 
     assert result["by"] == "good"
     assert source.calls == 4
+
+
+@pytest.mark.asyncio
+async def test_no_endpoint_retries_until_job_deadline():
+    deadline = time() + 0.03
+    engine = DispatchEngine(
+        _FakeSource([]),
+        retry=RetryConfig(
+            max_retries=0,
+            base_delay_seconds=0.01,
+            max_delay_seconds=0.01,
+            no_endpoint_deadline_epoch_seconds=deadline,
+        ),
+    )
+
+    started = monotonic()
+    with pytest.raises(InferenceError) as excinfo:
+        await asyncio.wait_for(
+            engine.send_one(InferenceRequest("/test", {}, ref="r1")),
+            timeout=0.5,
+        )
+
+    assert excinfo.value.code == InferenceErrorCode.NO_ENDPOINT
+    assert monotonic() - started >= 0.02
 
 
 @pytest.mark.asyncio
@@ -763,6 +814,141 @@ async def test_explicit_concurrency_overrides_capacity():
     await engine.run(feed(), on_result, max_concurrency=4)
     assert len(results) == 10
     assert 1 < peak <= 4
+
+
+@pytest.mark.asyncio
+async def test_fixed_concurrency_scales_with_dynamic_source_capacity():
+    started = 0
+    initial_limit_reached = asyncio.Event()
+    expanded_limit_reached = asyncio.Event()
+    release = asyncio.Event()
+
+    class _BlockingChannel(_FakeChannel):
+        async def send(self, request):
+            nonlocal started
+            started += 1
+            if started == 2:
+                initial_limit_reached.set()
+            if started == 4:
+                expanded_limit_reached.set()
+            await release.wait()
+            return {"ok": True}
+
+    source = _MutableCapacitySource([_BlockingChannel("s")], capacity=1)
+    engine = DispatchEngine(
+        source,
+        max_retries=0,
+        configured_capacity=4,
+    )
+    results = []
+
+    async def feed():
+        for request in _reqs(6):
+            yield request
+
+    async def on_result(req, resp, err):
+        results.append((req.ref, resp, err))
+
+    task = asyncio.create_task(
+        engine.run(
+            feed(),
+            on_result,
+            max_concurrency=8,
+        )
+    )
+    try:
+        await asyncio.wait_for(initial_limit_reached.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        assert started == 2
+
+        source.set_capacity(2)
+        await asyncio.wait_for(expanded_limit_reached.wait(), timeout=1.0)
+        assert started == 4
+    finally:
+        release.set()
+        await task
+    assert len(results) == 6
+
+
+@pytest.mark.asyncio
+async def test_zero_capacity_keeps_one_recovery_probe():
+    channel = _FakeChannel("s")
+    source = _MutableCapacitySource([channel], capacity=0)
+    engine = DispatchEngine(
+        source,
+        max_retries=0,
+        configured_capacity=1,
+    )
+    pulled = []
+    results = []
+
+    async def feed():
+        for request in _reqs(1):
+            pulled.append(request.ref)
+            yield request
+
+    async def on_result(req, resp, err):
+        results.append((req.ref, resp, err))
+
+    task = asyncio.create_task(engine.run(feed(), on_result, adaptive_concurrency=True))
+    await asyncio.wait_for(task, timeout=1.0)
+    assert pulled == [0]
+    assert channel.calls == [0]
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_positive_capacity_never_scales_limit_to_zero():
+    source = _MutableCapacitySource([_FakeChannel("s")], capacity=9)
+    engine = DispatchEngine(
+        source,
+        max_retries=0,
+        configured_capacity=10,
+    )
+
+    controller = await engine._resolve_concurrency_controller(
+        max_concurrency=1,
+        adaptive_concurrency=False,
+        adaptive_max_factor=1,
+        adaptive_max_concurrency=None,
+        adaptive_healthy_window=8,
+        adaptive_additive_increase=1,
+        concurrency_controller=None,
+    )
+
+    assert controller.limit() == 1
+
+
+@pytest.mark.asyncio
+async def test_adaptive_concurrency_max_scales_with_source_capacity():
+    source = _MutableCapacitySource([_FakeChannel("s")], capacity=2)
+    engine = DispatchEngine(
+        source,
+        max_retries=0,
+        configured_capacity=10,
+    )
+    controller = await engine._resolve_concurrency_controller(
+        max_concurrency=None,
+        adaptive_concurrency=True,
+        adaptive_max_factor=1,
+        adaptive_max_concurrency=100,
+        adaptive_healthy_window=8,
+        adaptive_additive_increase=1,
+        concurrency_controller=None,
+    )
+    healthy = ConcurrencyOutcome(success=True)
+
+    for _ in range(200):
+        controller.on_complete(healthy)
+    assert controller.limit() == 20
+
+    controller.update_capacity(CapacitySignal(count=1, version=1))
+    assert controller.limit() == 10
+
+    controller.update_capacity(CapacitySignal(count=5, version=2))
+    for _ in range(8):
+        controller.on_complete(healthy)
+    assert controller.limit() == 13
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
+++ b/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
@@ -2585,11 +2585,11 @@ async def test_job_cancellation_in_finalizing(e2e_test_app, test_backend):
                 # Step 5: Cancellation should not interrupt finalization once it has started
                 cancel_response = client.post(f"/v1/batches/{batch_id}/cancel")
                 assert cancel_response.status_code == 409
-                assert cancel_response.json() == {
-                    "error": {
-                        "message": "Cannot cancel a batch with status 'finalized'.",
-                        "type": "invalid_request_error",
-                    }
+                cancel_error = cancel_response.json()["error"]
+                assert cancel_error["type"] == "invalid_request_error"
+                assert cancel_error["message"] in {
+                    "Cannot cancel a batch with status 'finalizing'.",
+                    "Cannot cancel a batch with status 'finalized'.",
                 }
 
                 # Step 6: Wait for final status and verify the job still completes


### PR DESCRIPTION
## Summary
- scale fixed and adaptive dispatch concurrency with live discovered capacity
- keep one recovery probe when live capacity reaches zero so EOF, errors, and deadlines still progress
- propagate configured runtime capacity for Kubernetes discovery backends and bound no-endpoint retries by the authoritative job deadline

## Validation
- 114 targeted pytest cases passed
- ruff format/check passed
- git diff --check passed