### PR TITLE
[Cache] Back off pod metrics fetch failures

### DIFF
--- a/pkg/cache/cache_init.go
+++ b/pkg/cache/cache_init.go
@@ -112,6 +112,9 @@ type Store struct {
 	// podMetricsJobs Channel for sending Pod metrics update jobs to workers
 	podMetricsJobs chan *Pod
 
+	// podMetricsBackoff tracks per-pod fetch failure backoff for metrics collection.
+	podMetricsBackoff utils.SyncMap[string, *podMetricsBackoffState]
+
 	// Sync prefix indexer - only created when KV sync is enabled
 	syncPrefixIndexer *syncindexer.SyncPrefixHashTable
 
@@ -155,6 +158,8 @@ func Get() (Cache, error) {
 //
 //	Store: Initialized cache store instance
 func New(redisClient *redis.Client, prometheusApi prometheusv1.API, modelRouterProvider ModelRouterProviderFunc) *Store {
+	podMetricsWorkerCount := loadPodMetricsWorkerCount()
+	podMetricsJobQueueSize := loadPodMetricsJobQueueSize(podMetricsWorkerCount)
 
 	store = &Store{
 		initialized:           true,
@@ -163,8 +168,8 @@ func New(redisClient *redis.Client, prometheusApi prometheusv1.API, modelRouterP
 		enableTracing:         enableGPUOptimizerTracing,
 		requestTrace:          &utils.SyncMap[string, *RequestTrace]{},
 		modelRouterProvider:   modelRouterProvider,
-		podMetricsWorkerCount: defaultPodMetricsWorkerCount,
-		podMetricsJobs:        make(chan *Pod, 100),              // Initialize the job channel with a buffer size of 100
+		podMetricsWorkerCount: podMetricsWorkerCount,
+		podMetricsJobs:        make(chan *Pod, podMetricsJobQueueSize),
 		engineMetricsFetcher:  metrics.NewEngineMetricsFetcher(), // Initialize centralized typed metrics fetcher
 		enableProfileCaching:  enableModelGPUProfileCaching,
 	}

--- a/pkg/cache/cache_init.go
+++ b/pkg/cache/cache_init.go
@@ -115,6 +115,9 @@ type Store struct {
 	// podMetricsBackoff tracks per-pod fetch failure backoff for metrics collection.
 	podMetricsBackoff utils.SyncMap[string, *podMetricsBackoffState]
 
+	// podMetricsScheduling tracks queued or in-flight pod metrics jobs.
+	podMetricsScheduling utils.SyncMap[string, *podMetricsSchedulingState]
+
 	// Sync prefix indexer - only created when KV sync is enabled
 	syncPrefixIndexer *syncindexer.SyncPrefixHashTable
 

--- a/pkg/cache/cache_metrics.go
+++ b/pkg/cache/cache_metrics.go
@@ -46,6 +46,7 @@ const (
 	defaultPodMetricRefreshIntervalInMS = 1000
 	defaultPodMetricsWorkerCount        = 10
 	defaultPodMetricsQueuePerWorker     = 10
+	defaultPodMetricsFetchTimeoutInMS   = 5000
 	defaultPromQueryIntervalInMS        = 200
 	defaultPromQueryTimeoutInMS         = 2000
 	undefinedMetricLabelValue           = "undefined"
@@ -123,6 +124,7 @@ var (
 		metrics.RunningLoraAdapters,
 	}
 	podMetricRefreshInterval = loadPodMetricRefreshInterval()
+	podMetricsFetchTimeout   = loadPodMetricsFetchTimeout()
 	promQueryInterval        = time.Duration(utils.LoadEnvInt("AIBRIX_PROMETHEUS_QUERY_INTERVAL_MS", defaultPromQueryIntervalInMS)) * time.Millisecond
 	promQueryTimeout         = time.Duration(utils.LoadEnvInt("AIBRIX_PROMETHEUS_QUERY_TIMEOUT_MS", defaultPromQueryTimeoutInMS)) * time.Millisecond
 )
@@ -133,6 +135,19 @@ type podMetricsBackoffState struct {
 	failures    int
 	nextFetchAt time.Time
 }
+
+type podMetricsSchedulingState struct {
+	mu     sync.Mutex
+	uid    string
+	status podMetricsSchedulingStatus
+}
+
+type podMetricsSchedulingStatus string
+
+const (
+	podMetricsQueued   podMetricsSchedulingStatus = "queued"
+	podMetricsInFlight podMetricsSchedulingStatus = "in_flight"
+)
 
 func loadPodMetricRefreshInterval() time.Duration {
 	return time.Duration(utils.LoadEnvInt("AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS", defaultPodMetricRefreshIntervalInMS)) * time.Millisecond
@@ -153,6 +168,14 @@ func loadPodMetricsJobQueueSize(workerCount int) int {
 		return defaultQueueSize
 	}
 	return queueSize
+}
+
+func loadPodMetricsFetchTimeout() time.Duration {
+	timeout := utils.LoadEnvInt("AIBRIX_POD_METRICS_FETCH_TIMEOUT_MS", defaultPodMetricsFetchTimeoutInMS)
+	if timeout <= 0 {
+		timeout = defaultPodMetricsFetchTimeoutInMS
+	}
+	return time.Duration(timeout) * time.Millisecond
 }
 
 func podMetricsBackoffKey(pod *Pod) string {
@@ -302,6 +325,12 @@ func (c *Store) updatePodMetrics() {
 				"pod", metaPod.Name, "namespace", metaPod.Namespace)
 			return true
 		}
+		if !c.tryMarkPodMetricsQueued(metaPod) {
+			metrics.IncrementPodMetricsEnqueueDropped(metrics.PodMetricsDropReasonAlreadyQueued)
+			klog.V(4).InfoS("Pod metrics fetch is already queued or in flight, skipping duplicate pod metrics update",
+				"pod", metaPod.Name, "namespace", metaPod.Namespace)
+			return true
+		}
 		// Non-blocking send: if the worker pool is saturated (all workers busy
 		// and channel buffer full), skip this pod. It will be retried on the
 		// next refresh cycle. This prevents the metrics refresh
@@ -310,6 +339,7 @@ func (c *Store) updatePodMetrics() {
 		select {
 		case c.podMetricsJobs <- metaPod:
 		default:
+			c.finishPodMetricsScheduling(metaPod)
 			metrics.IncrementPodMetricsEnqueueDropped(metrics.PodMetricsDropReasonQueueFull)
 			klog.V(4).InfoS("Metrics worker pool saturated, skipping pod metrics update",
 				"pod", metaPod.Name)
@@ -320,74 +350,128 @@ func (c *Store) updatePodMetrics() {
 
 func (c *Store) worker(jobs <-chan *Pod) {
 	for pod := range jobs {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		c.markPodMetricsInFlight(pod)
+		ctx, cancel := context.WithTimeout(context.Background(), podMetricsFetchTimeout)
 		podMetricPort := getPodMetricPort(pod)
+		func() {
+			defer c.finishPodMetricsScheduling(pod)
+			defer cancel()
 
-		// Use centralized typed metrics fetcher for better engine abstraction and error handling
-		metricsToFetch := c.getAllAvailableMetrics()
-		endpoint := fmt.Sprintf("%s:%d", pod.Status.PodIP, podMetricPort)
-		engineType := metrics.GetEngineType(*pod.Pod)
-		identifier := pod.Name
-		result, err := c.engineMetricsFetcher.FetchAllTypedMetrics(ctx, endpoint, engineType, identifier, metricsToFetch)
-		if err != nil {
-			metrics.IncrementPodMetricsFetchFailure(engineType, metrics.PodMetricsFetchFailureReasonFetchError)
-			c.recordPodMetricsFetchFailure(pod, time.Now())
-			klog.V(4).InfoS("Failed to fetch typed metrics from engine pod",
-				"pod", pod.Name, "podIP", pod.Status.PodIP, "port", podMetricPort, "error", err)
-			cancel()
-			continue
-		}
-		c.recordPodMetricsFetchSuccess(pod)
-
-		for metricName, metricValue := range result.Metrics {
-			sanitizeMetricValueLabels(pod, metricValue)
-			if shouldSkipMetric(pod.Name, metricName) {
-				continue
+			// Use centralized typed metrics fetcher for better engine abstraction and error handling
+			metricsToFetch := c.getAllAvailableMetrics()
+			endpoint := fmt.Sprintf("%s:%d", pod.Status.PodIP, podMetricPort)
+			engineType := metrics.GetEngineType(*pod.Pod)
+			identifier := pod.Name
+			result, err := c.engineMetricsFetcher.FetchAllTypedMetrics(ctx, endpoint, engineType, identifier, metricsToFetch)
+			if err != nil {
+				metrics.IncrementPodMetricsFetchFailure(engineType, metrics.PodMetricsFetchFailureReasonFetchError)
+				c.recordPodMetricsFetchFailure(pod, time.Now())
+				klog.V(4).InfoS("Failed to fetch typed metrics from engine pod",
+					"pod", pod.Name, "podIP", pod.Status.PodIP, "port", podMetricPort, "error", err)
+				return
 			}
-			metrics.EmitMetricToPrometheus(&types.RoutingContext{Model: ""}, pod.Pod, metricName, metricValue, metricValue.GetLabelValues())
-		}
+			c.recordPodMetricsFetchSuccess(pod)
 
-		for metricName, metricValue := range result.ModelMetrics {
-			sanitizeMetricValueLabels(pod, metricValue)
-			parts := strings.SplitN(metricName, "/", 2)
-			if len(parts) != 2 {
-				continue
-			}
-			model := parts[0]
-			metric := parts[1]
-
-			model = resolveMetricModelName(pod, model)
-
-			if shouldSkipMetric(pod.Name, metric) {
-				continue
+			for metricName, metricValue := range result.Metrics {
+				sanitizeMetricValueLabels(pod, metricValue)
+				if shouldSkipMetric(pod.Name, metricName) {
+					continue
+				}
+				metrics.EmitMetricToPrometheus(&types.RoutingContext{Model: ""}, pod.Pod, metricName, metricValue, metricValue.GetLabelValues())
 			}
 
-			c.updateThroughputToksPerS(pod, model, metric, metricValue)
-			metrics.EmitMetricToPrometheus(&types.RoutingContext{Model: model}, pod.Pod, metric, metricValue, metricValue.GetLabelValues())
-		}
-		// Update pod metrics using typed results
-		c.updatePodMetricsFromTypedResult(pod, result)
+			for metricName, metricValue := range result.ModelMetrics {
+				sanitizeMetricValueLabels(pod, metricValue)
+				parts := strings.SplitN(metricName, "/", 2)
+				if len(parts) != 2 {
+					continue
+				}
+				model := parts[0]
+				metric := parts[1]
 
-		c.syncRunningRequestsGlobally(pod)
+				model = resolveMetricModelName(pod, model)
 
-		c.updateRealtimeRunningRequestsDrainRate1m(pod)
+				if shouldSkipMetric(pod.Name, metric) {
+					continue
+				}
 
-		// Handle Prometheus-based metrics separately (these require PromQL queries)
-		if c.prometheusApi != nil {
-			c.enqueuePromQL(pod)
-		} else {
-			klog.V(4).InfoS("Prometheus API not initialized, skipping PromQL metrics", "pod", pod.Name)
-		}
+				c.updateThroughputToksPerS(pod, model, metric, metricValue)
+				metrics.EmitMetricToPrometheus(&types.RoutingContext{Model: model}, pod.Pod, metric, metricValue, metricValue.GetLabelValues())
+			}
+			// Update pod metrics using typed results
+			c.updatePodMetricsFromTypedResult(pod, result)
 
-		// Log successful processing
-		klog.V(5).InfoS("Successfully processed metrics for pod",
-			"pod", pod.Name,
-			"podMetrics", len(result.Metrics),
-			"modelMetrics", len(result.ModelMetrics),
-			"errors", len(result.Errors))
+			c.syncRunningRequestsGlobally(pod)
 
-		cancel()
+			c.updateRealtimeRunningRequestsDrainRate1m(pod)
+
+			// Handle Prometheus-based metrics separately (these require PromQL queries)
+			if c.prometheusApi != nil {
+				c.enqueuePromQL(pod)
+			} else {
+				klog.V(4).InfoS("Prometheus API not initialized, skipping PromQL metrics", "pod", pod.Name)
+			}
+
+			// Log successful processing
+			klog.V(5).InfoS("Successfully processed metrics for pod",
+				"pod", pod.Name,
+				"podMetrics", len(result.Metrics),
+				"modelMetrics", len(result.ModelMetrics),
+				"errors", len(result.Errors))
+		}()
 	}
+}
+
+func (c *Store) tryMarkPodMetricsQueued(pod *Pod) bool {
+	key := podMetricsBackoffKey(pod)
+	state, loaded := c.podMetricsScheduling.LoadOrStore(key, &podMetricsSchedulingState{
+		uid:    string(pod.UID),
+		status: podMetricsQueued,
+	})
+	if !loaded {
+		return true
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.uid != string(pod.UID) {
+		c.podMetricsScheduling.Store(key, &podMetricsSchedulingState{
+			uid:    string(pod.UID),
+			status: podMetricsQueued,
+		})
+		return true
+	}
+	return false
+}
+
+func (c *Store) markPodMetricsInFlight(pod *Pod) {
+	key := podMetricsBackoffKey(pod)
+	state, ok := c.podMetricsScheduling.Load(key)
+	if !ok {
+		return
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.uid == string(pod.UID) {
+		state.status = podMetricsInFlight
+	}
+}
+
+func (c *Store) finishPodMetricsScheduling(pod *Pod) {
+	key := podMetricsBackoffKey(pod)
+	state, ok := c.podMetricsScheduling.Load(key)
+	if !ok {
+		return
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.uid == string(pod.UID) {
+		c.podMetricsScheduling.CompareAndDelete(key, state)
+	}
+}
+
+func (c *Store) clearPodMetricsScheduling(namespace, name string) {
+	c.podMetricsScheduling.Delete(utils.GeneratePodKey(namespace, name))
 }
 
 func (c *Store) shouldSkipPodMetricsFetch(pod *Pod, now time.Time) bool {

--- a/pkg/cache/cache_metrics.go
+++ b/pkg/cache/cache_metrics.go
@@ -43,11 +43,14 @@ const (
 	engineLabel                         = constants.ModelLabelEngine
 	defaultMetricPort                   = 8000
 	defaultEngineLabelValue             = "vllm"
-	defaultPodMetricRefreshIntervalInMS = 50
+	defaultPodMetricRefreshIntervalInMS = 1000
 	defaultPodMetricsWorkerCount        = 10
+	defaultPodMetricsQueuePerWorker     = 10
 	defaultPromQueryIntervalInMS        = 200
 	defaultPromQueryTimeoutInMS         = 2000
 	undefinedMetricLabelValue           = "undefined"
+	podMetricsBackoffBaseDelay          = time.Second
+	podMetricsBackoffMaxDelay           = 30 * time.Second
 )
 
 var (
@@ -119,10 +122,56 @@ var (
 		metrics.WaitingLoraAdapters,
 		metrics.RunningLoraAdapters,
 	}
-	podMetricRefreshInterval = time.Duration(utils.LoadEnvInt("AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS", defaultPodMetricRefreshIntervalInMS)) * time.Millisecond
+	podMetricRefreshInterval = loadPodMetricRefreshInterval()
 	promQueryInterval        = time.Duration(utils.LoadEnvInt("AIBRIX_PROMETHEUS_QUERY_INTERVAL_MS", defaultPromQueryIntervalInMS)) * time.Millisecond
 	promQueryTimeout         = time.Duration(utils.LoadEnvInt("AIBRIX_PROMETHEUS_QUERY_TIMEOUT_MS", defaultPromQueryTimeoutInMS)) * time.Millisecond
 )
+
+type podMetricsBackoffState struct {
+	mu          sync.Mutex
+	uid         string
+	failures    int
+	nextFetchAt time.Time
+}
+
+func loadPodMetricRefreshInterval() time.Duration {
+	return time.Duration(utils.LoadEnvInt("AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS", defaultPodMetricRefreshIntervalInMS)) * time.Millisecond
+}
+
+func loadPodMetricsWorkerCount() int {
+	workerCount := utils.LoadEnvInt("AIBRIX_POD_METRICS_WORKER_COUNT", defaultPodMetricsWorkerCount)
+	if workerCount <= 0 {
+		return defaultPodMetricsWorkerCount
+	}
+	return workerCount
+}
+
+func loadPodMetricsJobQueueSize(workerCount int) int {
+	defaultQueueSize := workerCount * defaultPodMetricsQueuePerWorker
+	queueSize := utils.LoadEnvInt("AIBRIX_POD_METRICS_JOB_QUEUE_SIZE", defaultQueueSize)
+	if queueSize <= 0 {
+		return defaultQueueSize
+	}
+	return queueSize
+}
+
+func podMetricsBackoffKey(pod *Pod) string {
+	return utils.GeneratePodKey(pod.Namespace, pod.Name)
+}
+
+func podMetricsBackoffDelay(failures int) time.Duration {
+	if failures <= 0 {
+		return podMetricsBackoffBaseDelay
+	}
+	if failures >= 6 {
+		return podMetricsBackoffMaxDelay
+	}
+	delay := podMetricsBackoffBaseDelay
+	for i := 1; i < failures; i++ {
+		delay *= 2
+	}
+	return delay
+}
 
 // MetricSnapshot represents a metric value at a specific timestamp
 type MetricSnapshot struct {
@@ -241,19 +290,27 @@ func (c *Store) getPodModelMetricName(modelName string, metricName string) strin
 }
 
 func (c *Store) updatePodMetrics() {
+	now := time.Now()
 	c.metaPods.Range(func(key string, metaPod *Pod) bool {
 		if !utils.FilterReadyPod(metaPod.Pod) {
 			// Skip unready pod
 			return true
 		}
+		if c.shouldSkipPodMetricsFetch(metaPod, now) {
+			metrics.IncrementPodMetricsEnqueueDropped(metrics.PodMetricsDropReasonBackoff)
+			klog.V(4).InfoS("Pod metrics fetch is in backoff, skipping pod metrics update",
+				"pod", metaPod.Name, "namespace", metaPod.Namespace)
+			return true
+		}
 		// Non-blocking send: if the worker pool is saturated (all workers busy
 		// and channel buffer full), skip this pod. It will be retried on the
-		// next refresh cycle (every 50ms). This prevents the metrics refresh
+		// next refresh cycle. This prevents the metrics refresh
 		// goroutine from blocking indefinitely when workers are stuck on slow
 		// or unreachable engine pods.
 		select {
 		case c.podMetricsJobs <- metaPod:
 		default:
+			metrics.IncrementPodMetricsEnqueueDropped(metrics.PodMetricsDropReasonQueueFull)
 			klog.V(4).InfoS("Metrics worker pool saturated, skipping pod metrics update",
 				"pod", metaPod.Name)
 		}
@@ -273,11 +330,14 @@ func (c *Store) worker(jobs <-chan *Pod) {
 		identifier := pod.Name
 		result, err := c.engineMetricsFetcher.FetchAllTypedMetrics(ctx, endpoint, engineType, identifier, metricsToFetch)
 		if err != nil {
+			metrics.IncrementPodMetricsFetchFailure(engineType, metrics.PodMetricsFetchFailureReasonFetchError)
+			c.recordPodMetricsFetchFailure(pod, time.Now())
 			klog.V(4).InfoS("Failed to fetch typed metrics from engine pod",
 				"pod", pod.Name, "podIP", pod.Status.PodIP, "port", podMetricPort, "error", err)
 			cancel()
 			continue
 		}
+		c.recordPodMetricsFetchSuccess(pod)
 
 		for metricName, metricValue := range result.Metrics {
 			sanitizeMetricValueLabels(pod, metricValue)
@@ -328,6 +388,46 @@ func (c *Store) worker(jobs <-chan *Pod) {
 
 		cancel()
 	}
+}
+
+func (c *Store) shouldSkipPodMetricsFetch(pod *Pod, now time.Time) bool {
+	key := podMetricsBackoffKey(pod)
+	state, ok := c.podMetricsBackoff.Load(key)
+	if !ok {
+		return false
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.uid != string(pod.UID) {
+		c.podMetricsBackoff.Delete(key)
+		return false
+	}
+	return now.Before(state.nextFetchAt)
+}
+
+func (c *Store) recordPodMetricsFetchFailure(pod *Pod, now time.Time) {
+	key := podMetricsBackoffKey(pod)
+	state, ok := c.podMetricsBackoff.Load(key)
+	if !ok {
+		state, _ = c.podMetricsBackoff.LoadOrStore(key, &podMetricsBackoffState{uid: string(pod.UID)})
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.uid != string(pod.UID) {
+		state.uid = string(pod.UID)
+		state.failures = 0
+	}
+	state.failures++
+	state.nextFetchAt = now.Add(podMetricsBackoffDelay(state.failures))
+}
+
+func (c *Store) recordPodMetricsFetchSuccess(pod *Pod) {
+	c.clearPodMetricsBackoff(pod.Namespace, pod.Name)
+}
+
+func (c *Store) clearPodMetricsBackoff(namespace, name string) {
+	c.podMetricsBackoff.Delete(utils.GeneratePodKey(namespace, name))
 }
 
 func (c *Store) updateMetricFromPromQL(ctx context.Context, pod *Pod) (queryErr error) {

--- a/pkg/cache/cache_metrics.go
+++ b/pkg/cache/cache_metrics.go
@@ -483,7 +483,7 @@ func (c *Store) shouldSkipPodMetricsFetch(pod *Pod, now time.Time) bool {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 	if state.uid != string(pod.UID) {
-		c.podMetricsBackoff.Delete(key)
+		c.podMetricsBackoff.CompareAndDelete(key, state)
 		return false
 	}
 	return now.Before(state.nextFetchAt)
@@ -498,6 +498,12 @@ func (c *Store) recordPodMetricsFetchFailure(pod *Pod, now time.Time) {
 
 	state.mu.Lock()
 	defer state.mu.Unlock()
+	if !c.isCurrentPodMetricsPod(pod) {
+		if state.uid == string(pod.UID) {
+			c.podMetricsBackoff.CompareAndDelete(key, state)
+		}
+		return
+	}
 	if state.uid != string(pod.UID) {
 		state.uid = string(pod.UID)
 		state.failures = 0
@@ -507,11 +513,29 @@ func (c *Store) recordPodMetricsFetchFailure(pod *Pod, now time.Time) {
 }
 
 func (c *Store) recordPodMetricsFetchSuccess(pod *Pod) {
-	c.clearPodMetricsBackoff(pod.Namespace, pod.Name)
+	c.clearPodMetricsBackoffForPod(pod)
+}
+
+func (c *Store) clearPodMetricsBackoffForPod(pod *Pod) {
+	key := podMetricsBackoffKey(pod)
+	state, ok := c.podMetricsBackoff.Load(key)
+	if !ok {
+		return
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.uid == string(pod.UID) {
+		c.podMetricsBackoff.CompareAndDelete(key, state)
+	}
 }
 
 func (c *Store) clearPodMetricsBackoff(namespace, name string) {
 	c.podMetricsBackoff.Delete(utils.GeneratePodKey(namespace, name))
+}
+
+func (c *Store) isCurrentPodMetricsPod(pod *Pod) bool {
+	current, ok := c.metaPods.Load(utils.GeneratePodKey(pod.Namespace, pod.Name))
+	return ok && string(current.UID) == string(pod.UID)
 }
 
 func (c *Store) updateMetricFromPromQL(ctx context.Context, pod *Pod) (queryErr error) {

--- a/pkg/cache/cache_metrics_test.go
+++ b/pkg/cache/cache_metrics_test.go
@@ -28,8 +28,10 @@ import (
 	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 )
 
@@ -448,9 +450,6 @@ func TestInitPrometheusAPI_EndpointSet(t *testing.T) {
 	require.NotNil(t, api)
 }
 
-// TestUpdatePodMetricsNonBlocking verifies that updatePodMetrics does not block
-// when the worker pool is saturated (channel buffer full). This prevents the
-// metrics refresh goroutine from stalling when workers are stuck on slow pods.
 func TestUpdateModelReplicaMetrics(t *testing.T) {
 	t.Setenv("POD_NAME", "gateway-0")
 
@@ -533,43 +532,270 @@ func TestUpdateModelReplicaMetrics(t *testing.T) {
 }
 
 func TestUpdatePodMetricsNonBlocking(t *testing.T) {
-	// Create a store with a tiny channel buffer and NO workers draining it
+	var counters []counterCall
+	restore := captureCounterCalls(&counters)
+	defer restore()
+
 	store := &Store{
 		podMetricsJobs: make(chan *Pod, 2),
 	}
 
-	// Add 5 ready pods — more than the channel buffer can hold
 	for i := range 5 {
 		name := fmt.Sprintf("pod-%d", i)
-		store.metaPods.Store(name, &Pod{
-			Pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: name},
-				Status: v1.PodStatus{
-					Phase: v1.PodRunning,
-					PodIP: fmt.Sprintf("10.0.0.%d", i+1),
-					Conditions: []v1.PodCondition{
-						{Type: v1.PodReady, Status: v1.ConditionTrue},
-					},
-				},
-			},
+		pod := newReadyMetricsPod(name, "uid-"+name)
+		pod.Status.PodIP = fmt.Sprintf("10.0.0.%d", i+1)
+		store.metaPods.Store(utils.GeneratePodKey(pod.Namespace, pod.Name), pod)
+	}
+
+	store.updatePodMetrics()
+
+	require.Equal(t, 2, len(store.podMetricsJobs))
+	require.Equal(t, 3, countCounterCalls(counters, metrics.PodMetricsEnqueueDroppedTotal, "reason", metrics.PodMetricsDropReasonQueueFull))
+}
+
+func TestPodMetricsConfigDefaultsAndOverrides(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		t.Setenv("AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS", "")
+		t.Setenv("AIBRIX_POD_METRICS_WORKER_COUNT", "")
+		t.Setenv("AIBRIX_POD_METRICS_JOB_QUEUE_SIZE", "")
+
+		require.Equal(t, time.Second, loadPodMetricRefreshInterval())
+		workerCount := loadPodMetricsWorkerCount()
+		require.Equal(t, 10, workerCount)
+		require.Equal(t, 100, loadPodMetricsJobQueueSize(workerCount))
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		t.Setenv("AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS", "2500")
+		t.Setenv("AIBRIX_POD_METRICS_WORKER_COUNT", "20")
+		t.Setenv("AIBRIX_POD_METRICS_JOB_QUEUE_SIZE", "55")
+
+		require.Equal(t, 2500*time.Millisecond, loadPodMetricRefreshInterval())
+		workerCount := loadPodMetricsWorkerCount()
+		require.Equal(t, 20, workerCount)
+		require.Equal(t, 55, loadPodMetricsJobQueueSize(workerCount))
+	})
+
+	t.Run("invalid values", func(t *testing.T) {
+		t.Setenv("AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS", "0")
+		t.Setenv("AIBRIX_POD_METRICS_WORKER_COUNT", "-1")
+		t.Setenv("AIBRIX_POD_METRICS_JOB_QUEUE_SIZE", "bad")
+
+		require.Equal(t, time.Second, loadPodMetricRefreshInterval())
+		workerCount := loadPodMetricsWorkerCount()
+		require.Equal(t, 10, workerCount)
+		require.Equal(t, 100, loadPodMetricsJobQueueSize(workerCount))
+	})
+}
+
+func TestPodMetricsBackoffTransitions(t *testing.T) {
+	store := &Store{}
+	pod := newReadyMetricsPod("pod-0", "uid-0")
+	now := time.Date(2026, 8, 29, 1, 2, 3, 0, time.UTC)
+
+	require.False(t, store.shouldSkipPodMetricsFetch(pod, now))
+
+	store.recordPodMetricsFetchFailure(pod, now)
+	state, ok := store.podMetricsBackoff.Load(podMetricsBackoffKey(pod))
+	require.True(t, ok)
+	require.Equal(t, 1, state.failures)
+	require.Equal(t, now.Add(time.Second), state.nextFetchAt)
+	require.True(t, store.shouldSkipPodMetricsFetch(pod, now.Add(500*time.Millisecond)))
+	require.False(t, store.shouldSkipPodMetricsFetch(pod, now.Add(time.Second)))
+
+	store.recordPodMetricsFetchFailure(pod, now.Add(time.Second))
+	state, ok = store.podMetricsBackoff.Load(podMetricsBackoffKey(pod))
+	require.True(t, ok)
+	require.Equal(t, 2, state.failures)
+	require.Equal(t, now.Add(3*time.Second), state.nextFetchAt)
+
+	store.recordPodMetricsFetchSuccess(pod)
+	require.Equal(t, 0, store.podMetricsBackoff.Len())
+}
+
+func TestPodMetricsBackoffCapsAtMaxDelay(t *testing.T) {
+	store := &Store{}
+	pod := newReadyMetricsPod("pod-0", "uid-0")
+	now := time.Date(2026, 8, 29, 1, 2, 3, 0, time.UTC)
+
+	for range 10 {
+		store.recordPodMetricsFetchFailure(pod, now)
+	}
+
+	state, ok := store.podMetricsBackoff.Load(podMetricsBackoffKey(pod))
+	require.True(t, ok)
+	require.Equal(t, now.Add(30*time.Second), state.nextFetchAt)
+}
+
+func TestPodMetricsBackoffConcurrentFailuresDoNotLoseUpdates(t *testing.T) {
+	store := &Store{}
+	pod := newReadyMetricsPod("pod-0", "uid-0")
+	now := time.Date(2026, 8, 29, 1, 2, 3, 0, time.UTC)
+	const failureCount = 100
+
+	var wg sync.WaitGroup
+	wg.Add(failureCount)
+	for range failureCount {
+		go func() {
+			defer wg.Done()
+			store.recordPodMetricsFetchFailure(pod, now)
+		}()
+	}
+	wg.Wait()
+
+	state, ok := store.podMetricsBackoff.Load(podMetricsBackoffKey(pod))
+	require.True(t, ok)
+	require.Equal(t, failureCount, state.failures)
+	require.Equal(t, now.Add(30*time.Second), state.nextFetchAt)
+}
+
+func TestPodMetricsBackoffUIDChangeClearsState(t *testing.T) {
+	store := &Store{}
+	pod := newReadyMetricsPod("pod-0", "uid-0")
+	now := time.Date(2026, 8, 29, 1, 2, 3, 0, time.UTC)
+
+	store.recordPodMetricsFetchFailure(pod, now)
+	recreated := newReadyMetricsPod("pod-0", "uid-1")
+
+	require.False(t, store.shouldSkipPodMetricsFetch(recreated, now.Add(500*time.Millisecond)))
+	require.Equal(t, 0, store.podMetricsBackoff.Len())
+}
+
+func TestUpdatePodMetricsSkipsBackoffPods(t *testing.T) {
+	var counters []counterCall
+	restore := captureCounterCalls(&counters)
+	defer restore()
+
+	store := &Store{
+		podMetricsJobs: make(chan *Pod, 2),
+	}
+	backoffPod := newReadyMetricsPod("pod-backoff", "uid-backoff")
+	readyPod := newReadyMetricsPod("pod-ready", "uid-ready")
+	store.metaPods.Store(utils.GeneratePodKey(backoffPod.Namespace, backoffPod.Name), backoffPod)
+	store.metaPods.Store(utils.GeneratePodKey(readyPod.Namespace, readyPod.Name), readyPod)
+	store.recordPodMetricsFetchFailure(backoffPod, time.Now())
+
+	store.updatePodMetrics()
+
+	require.Equal(t, 1, len(store.podMetricsJobs))
+	require.Equal(t, 1, countCounterCalls(counters, metrics.PodMetricsEnqueueDroppedTotal, "reason", metrics.PodMetricsDropReasonBackoff))
+}
+
+func TestDeletePodClearsPodMetricsBackoff(t *testing.T) {
+	store := &Store{}
+	pod := newReadyMetricsPod("pod-0", "uid-0")
+	store.metaPods.Store(utils.GeneratePodKey(pod.Namespace, pod.Name), pod)
+	store.recordPodMetricsFetchFailure(pod, time.Now())
+	require.Equal(t, 1, store.podMetricsBackoff.Len())
+
+	store.deletePod(pod.Pod)
+
+	require.Equal(t, 0, store.podMetricsBackoff.Len())
+}
+
+func BenchmarkUpdatePodMetricsEnqueue(b *testing.B) {
+	scenarios := []struct {
+		name         string
+		pods         int
+		queueSize    int
+		backoffEvery int
+	}{
+		{name: "pods_100_no_backoff", pods: 100, queueSize: 100},
+		{name: "pods_1000_no_backoff", pods: 1000, queueSize: 1000},
+		{name: "pods_1000_queue_full", pods: 1000, queueSize: 10},
+		{name: "pods_1000_50pct_backoff", pods: 1000, queueSize: 1000, backoffEvery: 2},
+		{name: "pods_1000_90pct_backoff", pods: 1000, queueSize: 1000, backoffEvery: 10},
+	}
+
+	for _, scenario := range scenarios {
+		b.Run(scenario.name, func(b *testing.B) {
+			var counters []counterCall
+			restore := captureCounterCalls(&counters)
+			defer restore()
+
+			store := &Store{
+				podMetricsJobs: make(chan *Pod, scenario.queueSize),
+			}
+			now := time.Now()
+			for i := range scenario.pods {
+				pod := newReadyMetricsPod(fmt.Sprintf("pod-%d", i), fmt.Sprintf("uid-%d", i))
+				store.metaPods.Store(utils.GeneratePodKey(pod.Namespace, pod.Name), pod)
+				if scenario.backoffEvery > 0 && i%scenario.backoffEvery != 0 {
+					store.recordPodMetricsFetchFailure(pod, now)
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			var enqueuedTotal int
+			for range b.N {
+				store.podMetricsJobs = make(chan *Pod, scenario.queueSize)
+				store.updatePodMetrics()
+				enqueuedTotal += len(store.podMetricsJobs)
+			}
+			b.StopTimer()
+
+			b.ReportMetric(float64(enqueuedTotal)/float64(b.N), "jobs_enqueued/op")
+			b.ReportMetric(float64(countCounterCalls(counters, metrics.PodMetricsEnqueueDroppedTotal, "reason", metrics.PodMetricsDropReasonQueueFull))/float64(b.N), "queue_full_drops/op")
+			b.ReportMetric(float64(countCounterCalls(counters, metrics.PodMetricsEnqueueDroppedTotal, "reason", metrics.PodMetricsDropReasonBackoff))/float64(b.N), "backoff_drops/op")
 		})
 	}
+}
 
-	// updatePodMetrics must return promptly without blocking.
-	// With the old blocking send, this would deadlock since no worker is reading.
-	done := make(chan struct{})
-	go func() {
-		store.updatePodMetrics()
-		close(done)
-	}()
+type counterCall struct {
+	name        string
+	labelNames  []string
+	labelValues []string
+}
 
-	select {
-	case <-done:
-		// Success: updatePodMetrics returned without blocking
-	case <-time.After(2 * time.Second):
-		t.Fatal("updatePodMetrics blocked — channel send is not non-blocking")
+func captureCounterCalls(calls *[]counterCall) func() {
+	originalFn := metrics.IncrementCounterMetricFnForTest
+	metrics.IncrementCounterMetricFnForTest = func(name string, help string, value float64, labelNames []string, labelValues ...string) {
+		*calls = append(*calls, counterCall{
+			name:        name,
+			labelNames:  append([]string(nil), labelNames...),
+			labelValues: append([]string(nil), labelValues...),
+		})
 	}
+	return func() {
+		metrics.IncrementCounterMetricFnForTest = originalFn
+	}
+}
 
-	// Exactly 2 pods should have been enqueued (channel buffer size)
-	require.Equal(t, 2, len(store.podMetricsJobs))
+func countCounterCalls(calls []counterCall, name, labelName, labelValue string) int {
+	count := 0
+	for _, call := range calls {
+		if call.name != name {
+			continue
+		}
+		for i, ln := range call.labelNames {
+			if ln == labelName && i < len(call.labelValues) && call.labelValues[i] == labelValue {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func newReadyMetricsPod(name, uid string) *Pod {
+	return &Pod{
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				UID:       k8stypes.UID(uid),
+				Labels: map[string]string{
+					constants.ModelLabelName: "model",
+				},
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+				PodIP: "10.0.0.1",
+				Conditions: []v1.PodCondition{
+					{Type: v1.PodReady, Status: v1.ConditionTrue},
+				},
+			},
+		},
+		Models: utils.NewRegistry[string](),
+	}
 }

--- a/pkg/cache/cache_metrics_test.go
+++ b/pkg/cache/cache_metrics_test.go
@@ -547,7 +547,17 @@ func TestUpdatePodMetricsNonBlocking(t *testing.T) {
 		store.metaPods.Store(utils.GeneratePodKey(pod.Namespace, pod.Name), pod)
 	}
 
-	store.updatePodMetrics()
+	done := make(chan struct{})
+	go func() {
+		store.updatePodMetrics()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("updatePodMetrics blocked while pod metrics queue was full")
+	}
 
 	require.Equal(t, 2, len(store.podMetricsJobs))
 	require.Equal(t, 3, countCounterCalls(counters, metrics.PodMetricsEnqueueDroppedTotal, "reason", metrics.PodMetricsDropReasonQueueFull))
@@ -645,6 +655,7 @@ func TestPodMetricsSchedulingCompletesAndAllowsRequeue(t *testing.T) {
 func TestPodMetricsBackoffTransitions(t *testing.T) {
 	store := &Store{}
 	pod := newReadyMetricsPod("pod-0", "uid-0")
+	store.metaPods.Store(utils.GeneratePodKey(pod.Namespace, pod.Name), pod)
 	now := time.Date(2026, 8, 29, 1, 2, 3, 0, time.UTC)
 
 	require.False(t, store.shouldSkipPodMetricsFetch(pod, now))
@@ -670,6 +681,7 @@ func TestPodMetricsBackoffTransitions(t *testing.T) {
 func TestPodMetricsBackoffCapsAtMaxDelay(t *testing.T) {
 	store := &Store{}
 	pod := newReadyMetricsPod("pod-0", "uid-0")
+	store.metaPods.Store(utils.GeneratePodKey(pod.Namespace, pod.Name), pod)
 	now := time.Date(2026, 8, 29, 1, 2, 3, 0, time.UTC)
 
 	for range 10 {
@@ -684,6 +696,7 @@ func TestPodMetricsBackoffCapsAtMaxDelay(t *testing.T) {
 func TestPodMetricsBackoffConcurrentFailuresDoNotLoseUpdates(t *testing.T) {
 	store := &Store{}
 	pod := newReadyMetricsPod("pod-0", "uid-0")
+	store.metaPods.Store(utils.GeneratePodKey(pod.Namespace, pod.Name), pod)
 	now := time.Date(2026, 8, 29, 1, 2, 3, 0, time.UTC)
 	const failureCount = 100
 
@@ -706,6 +719,7 @@ func TestPodMetricsBackoffConcurrentFailuresDoNotLoseUpdates(t *testing.T) {
 func TestPodMetricsBackoffUIDChangeClearsState(t *testing.T) {
 	store := &Store{}
 	pod := newReadyMetricsPod("pod-0", "uid-0")
+	store.metaPods.Store(utils.GeneratePodKey(pod.Namespace, pod.Name), pod)
 	now := time.Date(2026, 8, 29, 1, 2, 3, 0, time.UTC)
 
 	store.recordPodMetricsFetchFailure(pod, now)
@@ -735,6 +749,34 @@ func TestUpdatePodMetricsSkipsBackoffPods(t *testing.T) {
 	require.Equal(t, 1, countCounterCalls(counters, metrics.PodMetricsEnqueueDroppedTotal, "reason", metrics.PodMetricsDropReasonBackoff))
 }
 
+func TestPodMetricsFetchSuccessDoesNotClearRecreatedPodBackoff(t *testing.T) {
+	store := &Store{}
+	stalePod := newReadyMetricsPod("pod-0", "uid-0")
+	recreatedPod := newReadyMetricsPod("pod-0", "uid-1")
+	now := time.Date(2026, 8, 29, 1, 2, 3, 0, time.UTC)
+	store.metaPods.Store(utils.GeneratePodKey(recreatedPod.Namespace, recreatedPod.Name), recreatedPod)
+	store.podMetricsBackoff.Store(podMetricsBackoffKey(recreatedPod), &podMetricsBackoffState{
+		uid:         string(recreatedPod.UID),
+		failures:    1,
+		nextFetchAt: now.Add(time.Second),
+	})
+
+	store.recordPodMetricsFetchSuccess(stalePod)
+
+	state, ok := store.podMetricsBackoff.Load(podMetricsBackoffKey(recreatedPod))
+	require.True(t, ok)
+	require.Equal(t, string(recreatedPod.UID), state.uid)
+}
+
+func TestPodMetricsFailureDoesNotRecordBackoffForDeletedPod(t *testing.T) {
+	store := &Store{}
+	pod := newReadyMetricsPod("pod-0", "uid-0")
+
+	store.recordPodMetricsFetchFailure(pod, time.Now())
+
+	require.Equal(t, 0, store.podMetricsBackoff.Len())
+}
+
 func TestDeletePodClearsPodMetricsBackoff(t *testing.T) {
 	store := &Store{}
 	pod := newReadyMetricsPod("pod-0", "uid-0")
@@ -757,6 +799,40 @@ func TestDeletePodClearsPodMetricsScheduling(t *testing.T) {
 	store.deletePod(pod.Pod)
 
 	require.Equal(t, 0, store.podMetricsScheduling.Len())
+}
+
+func TestUpdatePodClearsPodMetricsStateWhenModelInfoIsRemoved(t *testing.T) {
+	store := &Store{}
+	oldPod := newReadyMetricsPod("pod-0", "uid-0")
+	newPod := oldPod.DeepCopy()
+	newPod.Labels = map[string]string{}
+	metaPod := &Pod{Pod: oldPod.Pod, Models: utils.NewRegistry[string]()}
+	metaPod.Models.Store("model", "model")
+	store.metaPods.Store(utils.GeneratePodKey(oldPod.Namespace, oldPod.Name), metaPod)
+	store.recordPodMetricsFetchFailure(metaPod, time.Now())
+	require.True(t, store.tryMarkPodMetricsQueued(metaPod))
+
+	store.updatePod(oldPod.Pod, newPod)
+
+	require.Equal(t, 0, store.podMetricsBackoff.Len())
+	require.Equal(t, 0, store.podMetricsScheduling.Len())
+}
+
+func TestUpdatePodPreservesPodMetricsStateWhenPodRemainsTracked(t *testing.T) {
+	store := &Store{}
+	oldPod := newReadyMetricsPod("pod-0", "uid-0")
+	newPod := oldPod.DeepCopy()
+	newPod.Status.PodIP = "10.0.0.2"
+	metaPod := &Pod{Pod: oldPod.Pod, Models: utils.NewRegistry[string]()}
+	metaPod.Models.Store("model", "model")
+	store.metaPods.Store(utils.GeneratePodKey(oldPod.Namespace, oldPod.Name), metaPod)
+	store.recordPodMetricsFetchFailure(metaPod, time.Now())
+	require.True(t, store.tryMarkPodMetricsQueued(metaPod))
+
+	store.updatePod(oldPod.Pod, newPod)
+
+	require.Equal(t, 1, store.podMetricsBackoff.Len())
+	require.Equal(t, 1, store.podMetricsScheduling.Len())
 }
 
 func BenchmarkUpdatePodMetricsEnqueue(b *testing.B) {

--- a/pkg/cache/cache_metrics_test.go
+++ b/pkg/cache/cache_metrics_test.go
@@ -558,34 +558,88 @@ func TestPodMetricsConfigDefaultsAndOverrides(t *testing.T) {
 		t.Setenv("AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS", "")
 		t.Setenv("AIBRIX_POD_METRICS_WORKER_COUNT", "")
 		t.Setenv("AIBRIX_POD_METRICS_JOB_QUEUE_SIZE", "")
+		t.Setenv("AIBRIX_POD_METRICS_FETCH_TIMEOUT_MS", "")
 
 		require.Equal(t, time.Second, loadPodMetricRefreshInterval())
 		workerCount := loadPodMetricsWorkerCount()
 		require.Equal(t, 10, workerCount)
 		require.Equal(t, 100, loadPodMetricsJobQueueSize(workerCount))
+		require.Equal(t, 5*time.Second, loadPodMetricsFetchTimeout())
 	})
 
 	t.Run("overrides", func(t *testing.T) {
 		t.Setenv("AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS", "2500")
 		t.Setenv("AIBRIX_POD_METRICS_WORKER_COUNT", "20")
 		t.Setenv("AIBRIX_POD_METRICS_JOB_QUEUE_SIZE", "55")
+		t.Setenv("AIBRIX_POD_METRICS_FETCH_TIMEOUT_MS", "1500")
 
 		require.Equal(t, 2500*time.Millisecond, loadPodMetricRefreshInterval())
 		workerCount := loadPodMetricsWorkerCount()
 		require.Equal(t, 20, workerCount)
 		require.Equal(t, 55, loadPodMetricsJobQueueSize(workerCount))
+		require.Equal(t, 1500*time.Millisecond, loadPodMetricsFetchTimeout())
 	})
 
 	t.Run("invalid values", func(t *testing.T) {
 		t.Setenv("AIBRIX_POD_METRIC_REFRESH_INTERVAL_MS", "0")
 		t.Setenv("AIBRIX_POD_METRICS_WORKER_COUNT", "-1")
 		t.Setenv("AIBRIX_POD_METRICS_JOB_QUEUE_SIZE", "bad")
+		t.Setenv("AIBRIX_POD_METRICS_FETCH_TIMEOUT_MS", "0")
 
 		require.Equal(t, time.Second, loadPodMetricRefreshInterval())
 		workerCount := loadPodMetricsWorkerCount()
 		require.Equal(t, 10, workerCount)
 		require.Equal(t, 100, loadPodMetricsJobQueueSize(workerCount))
+		require.Equal(t, 5*time.Second, loadPodMetricsFetchTimeout())
 	})
+}
+
+func TestUpdatePodMetricsDedupesQueuedPods(t *testing.T) {
+	var counters []counterCall
+	restore := captureCounterCalls(&counters)
+	defer restore()
+
+	store := &Store{
+		podMetricsJobs: make(chan *Pod, 10),
+	}
+	pod := newReadyMetricsPod("pod-0", "uid-0")
+	store.metaPods.Store(utils.GeneratePodKey(pod.Namespace, pod.Name), pod)
+
+	store.updatePodMetrics()
+	store.updatePodMetrics()
+
+	require.Equal(t, 1, len(store.podMetricsJobs))
+	require.Equal(t, 1, store.podMetricsScheduling.Len())
+	require.Equal(t, 1, countCounterCalls(counters, metrics.PodMetricsEnqueueDroppedTotal, "reason", metrics.PodMetricsDropReasonAlreadyQueued))
+}
+
+func TestPodMetricsSchedulingUIDChangeClearsState(t *testing.T) {
+	store := &Store{
+		podMetricsJobs: make(chan *Pod, 10),
+	}
+	pod := newReadyMetricsPod("pod-0", "uid-0")
+	recreated := newReadyMetricsPod("pod-0", "uid-1")
+	store.metaPods.Store(utils.GeneratePodKey(pod.Namespace, pod.Name), pod)
+
+	require.True(t, store.tryMarkPodMetricsQueued(pod))
+	require.True(t, store.tryMarkPodMetricsQueued(recreated))
+	require.Equal(t, 1, store.podMetricsScheduling.Len())
+}
+
+func TestPodMetricsSchedulingCompletesAndAllowsRequeue(t *testing.T) {
+	store := &Store{
+		podMetricsJobs: make(chan *Pod, 10),
+	}
+	pod := newReadyMetricsPod("pod-0", "uid-0")
+
+	require.True(t, store.tryMarkPodMetricsQueued(pod))
+	require.False(t, store.tryMarkPodMetricsQueued(pod))
+
+	store.markPodMetricsInFlight(pod)
+	require.False(t, store.tryMarkPodMetricsQueued(pod))
+
+	store.finishPodMetricsScheduling(pod)
+	require.True(t, store.tryMarkPodMetricsQueued(pod))
 }
 
 func TestPodMetricsBackoffTransitions(t *testing.T) {
@@ -693,6 +747,18 @@ func TestDeletePodClearsPodMetricsBackoff(t *testing.T) {
 	require.Equal(t, 0, store.podMetricsBackoff.Len())
 }
 
+func TestDeletePodClearsPodMetricsScheduling(t *testing.T) {
+	store := &Store{}
+	pod := newReadyMetricsPod("pod-0", "uid-0")
+	store.metaPods.Store(utils.GeneratePodKey(pod.Namespace, pod.Name), pod)
+	require.True(t, store.tryMarkPodMetricsQueued(pod))
+	require.Equal(t, 1, store.podMetricsScheduling.Len())
+
+	store.deletePod(pod.Pod)
+
+	require.Equal(t, 0, store.podMetricsScheduling.Len())
+}
+
 func BenchmarkUpdatePodMetricsEnqueue(b *testing.B) {
 	scenarios := []struct {
 		name         string
@@ -732,6 +798,9 @@ func BenchmarkUpdatePodMetricsEnqueue(b *testing.B) {
 				store.podMetricsJobs = make(chan *Pod, scenario.queueSize)
 				store.updatePodMetrics()
 				enqueuedTotal += len(store.podMetricsJobs)
+				for len(store.podMetricsJobs) > 0 {
+					store.finishPodMetricsScheduling(<-store.podMetricsJobs)
+				}
 			}
 			b.StopTimer()
 

--- a/pkg/cache/informers.go
+++ b/pkg/cache/informers.go
@@ -268,6 +268,7 @@ func (c *Store) deletePod(obj interface{}) {
 	}
 	c.modelClaims.clearPod(utils.GeneratePodKey(namespace, name))
 
+	c.clearPodMetricsBackoff(namespace, name)
 	rateCalculator.PurgeEntriesForPod(name)
 
 	klog.V(4).Infof("POD DELETED: %s/%s", namespace, name)

--- a/pkg/cache/informers.go
+++ b/pkg/cache/informers.go
@@ -164,8 +164,9 @@ func (c *Store) updatePod(oldObj interface{}, newObj interface{}) {
 	_, existed := c.metaPods.Load(utils.GeneratePodKey(oldPod.Namespace, oldPod.Name)) // Make sure nothing left.
 	newModelName, newOk := getModelNameFromPod(newPod)
 	newModelClaims := utils.ModelClaimBindingsFromPod(newPod)
+	newHasModelInfo := newOk || len(newModelClaims) > 0
 
-	if !oldOk && !existed && !newOk && len(newModelClaims) == 0 {
+	if !oldOk && !existed && !newHasModelInfo {
 		return // No model information to track in either old or new pod
 	}
 
@@ -189,12 +190,14 @@ func (c *Store) updatePod(oldObj interface{}, newObj interface{}) {
 	oldNodeType := oldPod.Labels[nodeType]
 	newNodeType := newPod.Labels[nodeType]
 	if oldNodeType == nodeWorker || newNodeType == nodeWorker {
+		c.clearPodMetricsBackoff(oldPod.Namespace, oldPod.Name)
+		c.clearPodMetricsScheduling(oldPod.Namespace, oldPod.Name)
 		klog.InfoS("ignored ray worker pod", "old pod", oldPod.Name, "new pod", newPod.Name)
 		return
 	}
 
 	// Add new mappings if present
-	if (newOk || len(newModelClaims) > 0) && !newIsWorker {
+	if newHasModelInfo && !newIsWorker {
 		metaPod := c.addPodLocked(newPod)
 		if newOk {
 			c.addPodAndModelMappingLocked(metaPod, newModelName)
@@ -206,6 +209,9 @@ func (c *Store) updatePod(oldObj interface{}, newObj interface{}) {
 				c.addPodAndModelMappingLocked(metaPod, servedModel)
 			}
 		}
+	} else {
+		c.clearPodMetricsBackoff(oldPod.Namespace, oldPod.Name)
+		c.clearPodMetricsScheduling(oldPod.Namespace, oldPod.Name)
 	}
 
 	klog.V(4).Infof("POD UPDATED: %s/%s %s", newPod.Namespace, newPod.Name, newPod.Status.Phase)

--- a/pkg/cache/informers.go
+++ b/pkg/cache/informers.go
@@ -269,6 +269,7 @@ func (c *Store) deletePod(obj interface{}) {
 	c.modelClaims.clearPod(utils.GeneratePodKey(namespace, name))
 
 	c.clearPodMetricsBackoff(namespace, name)
+	c.clearPodMetricsScheduling(namespace, name)
 	rateCalculator.PurgeEntriesForPod(name)
 
 	klog.V(4).Infof("POD DELETED: %s/%s", namespace, name)

--- a/pkg/cache/utils.go
+++ b/pkg/cache/utils.go
@@ -228,7 +228,7 @@ func (c *Store) calculatePerSecondRate(pod *Pod, modelName, metricName string, c
 // over an approximate 1-minute window. It is designed for gateway-tracked counters
 // (e.g. completedRequests) that are available even when engine metrics are not.
 //
-// Snapshots are throttled to ~5-second intervals so the 50ms metric refresh loop
+// Snapshots are throttled to ~5-second intervals so the metric refresh loop
 // does not flood the history buffer. The baseline is the snapshot closest to
 // 1 minute ago; if less than 1 minute of history exists, the oldest available
 // snapshot is used. Returns -1 when insufficient data is available.

--- a/pkg/metrics/custom_metrics.go
+++ b/pkg/metrics/custom_metrics.go
@@ -54,6 +54,7 @@ const (
 
 	PodMetricsDropReasonQueueFull            = "queue_full"
 	PodMetricsDropReasonBackoff              = "backoff"
+	PodMetricsDropReasonAlreadyQueued        = "already_queued"
 	PodMetricsFetchFailureReasonFetchError   = "fetch_error"
 	podMetricsEnqueueDroppedTotalDescription = "Total number of pod metrics enqueue attempts dropped by the gateway cache."
 	podMetricsFetchFailuresTotalDescription  = "Total number of pod metrics fetch failures observed by the gateway cache."

--- a/pkg/metrics/custom_metrics.go
+++ b/pkg/metrics/custom_metrics.go
@@ -48,9 +48,41 @@ var (
 	IncrementCounterMetricFnForTest = defaultIncrementCounterMetric
 )
 
+const (
+	PodMetricsEnqueueDroppedTotal = "aibrix_pod_metrics_enqueue_dropped_total"
+	PodMetricsFetchFailuresTotal  = "aibrix_pod_metrics_fetch_failures_total"
+
+	PodMetricsDropReasonQueueFull            = "queue_full"
+	PodMetricsDropReasonBackoff              = "backoff"
+	PodMetricsFetchFailureReasonFetchError   = "fetch_error"
+	podMetricsEnqueueDroppedTotalDescription = "Total number of pod metrics enqueue attempts dropped by the gateway cache."
+	podMetricsFetchFailuresTotalDescription  = "Total number of pod metrics fetch failures observed by the gateway cache."
+)
+
 // GatewayPodName returns the gateway pod name used as the gateway_pod metric label.
 func GatewayPodName() string {
 	return gatewayPodName
+}
+
+func IncrementPodMetricsEnqueueDropped(reason string) {
+	IncrementCounterMetric(
+		PodMetricsEnqueueDroppedTotal,
+		podMetricsEnqueueDroppedTotalDescription,
+		1,
+		[]string{"reason"},
+		reason,
+	)
+}
+
+func IncrementPodMetricsFetchFailure(engineType, reason string) {
+	IncrementCounterMetric(
+		PodMetricsFetchFailuresTotal,
+		podMetricsFetchFailuresTotalDescription,
+		1,
+		[]string{"engine_type", "reason"},
+		engineType,
+		reason,
+	)
 }
 
 func SetGaugeMetric(name string, help string, value float64, labelNames []string, labelValues ...string) {


### PR DESCRIPTION
## Summary

This is Part 1 for #2569.

It reduces the aggressiveness of gateway pod metrics collection and adds cache-layer scheduling controls for slow or failing pod metrics fetches:

- change the default pod metrics refresh interval from 50ms to 1000ms
- add configurable worker count via `AIBRIX_POD_METRICS_WORKER_COUNT` with default 10
- add configurable job queue size via `AIBRIX_POD_METRICS_JOB_QUEUE_SIZE` with default `10 * workerCount`
- add configurable per-fetch timeout via `AIBRIX_POD_METRICS_FETCH_TIMEOUT_MS` with default 5000ms
- add per-pod UID-scoped backoff for whole `FetchAllTypedMetrics()` errors using 1s, 2s, 4s, ... capped at 30s
- keep `result.Errors` inside a successful fetch from triggering backoff
- clear backoff on successful fetch, UID change, and pod delete
- dedupe pod metrics jobs by namespace/name + UID while a pod is already queued or in flight
- clear queued/in-flight scheduling state when the worker finishes, enqueue fails due to a full queue, pod UID changes, or pod deletion
- add counters for dropped enqueue attempts and whole-fetch failures
- add a focused enqueue benchmark for no-backoff, queue-full, and backoff-heavy scenarios

References #2569.

## Part 1 scope

This PR intentionally does not change routing behavior, Prometheus label behavior, histogram percentile behavior, or engine fetch retry behavior.

## Benchmark

Added `BenchmarkUpdatePodMetricsEnqueue` covering:

- `pods_100_no_backoff`
- `pods_1000_no_backoff`
- `pods_1000_queue_full`
- `pods_1000_50pct_backoff`
- `pods_1000_90pct_backoff`

Latest local run with `-benchtime=1x` showed:

- 1000 no-backoff pods enqueue 1000 jobs/op
- queue-full scenario enqueues 10 jobs/op and records 990 `queue_full` drops/op
- 50% backoff scenario enqueues 500 jobs/op and records 500 `backoff` drops/op
- 90% backoff scenario enqueues 100 jobs/op and records 900 `backoff` drops/op

## Tests

```bash
GOCACHE=/private/tmp/aibrix-go-build-cache go test ./pkg/cache ./pkg/metrics ./pkg/plugins/gateway/algorithms
GOCACHE=/private/tmp/aibrix-go-build-cache go test ./pkg/cache -run '^$' -bench BenchmarkUpdatePodMetricsEnqueue -benchtime=1x
```