### PR TITLE
[Misc] Add ModelRouter integration tests

### DIFF
--- a/pkg/controller/modelrouter/modelrouter_controller.go
+++ b/pkg/controller/modelrouter/modelrouter_controller.go
@@ -398,18 +398,8 @@ func (m *ModelRouter) deleteHTTPRoute(namespace string, labels, annotations map[
 }
 
 func (m *ModelRouter) deleteReferenceGrant(namespace string) {
-	var deploymentList appsv1.DeploymentList
-	if err := m.Client.List(context.Background(), &deploymentList, client.InNamespace(namespace)); err != nil {
-		klog.ErrorS(err, "Failed to list model deployments", "namespace", namespace)
+	if m.namespaceHasModelWorkload(namespace) {
 		return
-	}
-	for i := range deploymentList.Items {
-		deployment := &deploymentList.Items[i]
-		if _, ok := constants.ModelNameFromMetadata(deployment.Labels, deployment.Annotations); ok {
-			klog.InfoS("Skip deleting ReferenceGrant: model deployment still exists",
-				"namespace", namespace, "deployment", deployment.Name)
-			return
-		}
 	}
 
 	referenceGrantName := fmt.Sprintf("%s-reserved-referencegrant-in-%s", aibrixEnvoyGatewayNamespace, namespace)
@@ -426,6 +416,53 @@ func (m *ModelRouter) deleteReferenceGrant(namespace string) {
 		}
 	}
 	klog.InfoS("delete reference grant", "referencegrant", referenceGrantName)
+}
+
+func (m *ModelRouter) namespaceHasModelWorkload(namespace string) bool {
+	ctx := context.Background()
+
+	var deploymentList appsv1.DeploymentList
+	if err := m.Client.List(ctx, &deploymentList, client.InNamespace(namespace)); err != nil {
+		klog.ErrorS(err, "Failed to list model deployments", "namespace", namespace)
+		return true
+	}
+	for i := range deploymentList.Items {
+		deployment := &deploymentList.Items[i]
+		if _, ok := constants.ModelNameFromMetadata(deployment.Labels, deployment.Annotations); ok {
+			klog.InfoS("Skip deleting ReferenceGrant: model deployment still exists",
+				"namespace", namespace, "deployment", deployment.Name)
+			return true
+		}
+	}
+
+	var adapterList modelv1alpha1.ModelAdapterList
+	if err := m.Client.List(ctx, &adapterList, client.InNamespace(namespace)); err != nil {
+		klog.ErrorS(err, "Failed to list model adapters", "namespace", namespace)
+		return true
+	}
+	for i := range adapterList.Items {
+		adapter := &adapterList.Items[i]
+		if _, ok := constants.ModelNameFromMetadata(adapter.Labels, adapter.Annotations); ok {
+			klog.InfoS("Skip deleting ReferenceGrant: model adapter still exists",
+				"namespace", namespace, "modeladapter", adapter.Name)
+			return true
+		}
+	}
+
+	var fleetList orchestrationv1alpha1.RayClusterFleetList
+	if err := m.Client.List(ctx, &fleetList, client.InNamespace(namespace)); err != nil {
+		klog.ErrorS(err, "Failed to list ray cluster fleets", "namespace", namespace)
+		return true
+	}
+	for i := range fleetList.Items {
+		fleet := &fleetList.Items[i]
+		if _, ok := constants.ModelNameFromMetadata(fleet.Labels, fleet.Annotations); ok {
+			klog.InfoS("Skip deleting ReferenceGrant: ray cluster fleet still exists",
+				"namespace", namespace, "rayclusterfleet", fleet.Name)
+			return true
+		}
+	}
+	return false
 }
 
 func consoleRouteLabels(labels map[string]string) map[string]string {

--- a/pkg/controller/modelrouter/modelrouter_controller.go
+++ b/pkg/controller/modelrouter/modelrouter_controller.go
@@ -24,6 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -377,6 +378,7 @@ func (m *ModelRouter) deleteHTTPRoute(namespace string, labels, annotations map[
 		return
 	}
 
+	ctx := context.Background()
 	httpRoute := gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.ModelRouterName(modelName),
@@ -384,7 +386,7 @@ func (m *ModelRouter) deleteHTTPRoute(namespace string, labels, annotations map[
 		},
 	}
 
-	err := m.Client.Delete(context.Background(), &httpRoute)
+	err := m.Client.Delete(ctx, &httpRoute)
 	if err != nil {
 		klog.Errorln(err)
 	}
@@ -393,13 +395,20 @@ func (m *ModelRouter) deleteHTTPRoute(namespace string, labels, annotations map[
 	}
 
 	if aibrixEnvoyGatewayNamespace != namespace {
-		m.deleteReferenceGrant(namespace)
+		if err := m.deleteReferenceGrant(ctx, namespace); err != nil {
+			klog.ErrorS(err, "Failed to delete ReferenceGrant after checking remaining workloads",
+				"namespace", namespace)
+		}
 	}
 }
 
-func (m *ModelRouter) deleteReferenceGrant(namespace string) {
-	if m.namespaceHasModelWorkload(namespace) {
-		return
+func (m *ModelRouter) deleteReferenceGrant(ctx context.Context, namespace string) error {
+	has, err := m.namespaceHasModelWorkload(ctx, namespace)
+	if err != nil {
+		return err
+	}
+	if has {
+		return nil
 	}
 
 	referenceGrantName := fmt.Sprintf("%s-reserved-referencegrant-in-%s", aibrixEnvoyGatewayNamespace, namespace)
@@ -409,60 +418,87 @@ func (m *ModelRouter) deleteReferenceGrant(namespace string) {
 			Namespace: namespace,
 		},
 	}
-	if err := m.Client.Delete(context.Background(), &referenceGrant); err != nil {
+	if err := m.Client.Delete(ctx, &referenceGrant); err != nil {
 		if !apierrors.IsNotFound(err) {
 			klog.ErrorS(err, "Failed to delete ReferenceGrant", "name", referenceGrantName, "namespace", namespace)
-			return
+			return err
 		}
 	}
 	klog.InfoS("delete reference grant", "referencegrant", referenceGrantName)
+	return nil
 }
 
-func (m *ModelRouter) namespaceHasModelWorkload(namespace string) bool {
-	ctx := context.Background()
-
+func (m *ModelRouter) namespaceHasModelWorkload(ctx context.Context, namespace string) (bool, error) {
 	var deploymentList appsv1.DeploymentList
 	if err := m.Client.List(ctx, &deploymentList, client.InNamespace(namespace)); err != nil {
 		klog.ErrorS(err, "Failed to list model deployments", "namespace", namespace)
-		return true
+		return false, err
 	}
 	for i := range deploymentList.Items {
 		deployment := &deploymentList.Items[i]
 		if _, ok := constants.ModelNameFromMetadata(deployment.Labels, deployment.Annotations); ok {
-			klog.InfoS("Skip deleting ReferenceGrant: model deployment still exists",
+			klog.InfoS("found labeled model deployment in namespace",
 				"namespace", namespace, "deployment", deployment.Name)
-			return true
+			return true, nil
 		}
 	}
 
 	var adapterList modelv1alpha1.ModelAdapterList
 	if err := m.Client.List(ctx, &adapterList, client.InNamespace(namespace)); err != nil {
 		klog.ErrorS(err, "Failed to list model adapters", "namespace", namespace)
-		return true
+		return false, err
 	}
 	for i := range adapterList.Items {
 		adapter := &adapterList.Items[i]
 		if _, ok := constants.ModelNameFromMetadata(adapter.Labels, adapter.Annotations); ok {
-			klog.InfoS("Skip deleting ReferenceGrant: model adapter still exists",
+			klog.InfoS("found labeled model adapter in namespace",
 				"namespace", namespace, "modeladapter", adapter.Name)
-			return true
+			return true, nil
 		}
 	}
 
 	var fleetList orchestrationv1alpha1.RayClusterFleetList
 	if err := m.Client.List(ctx, &fleetList, client.InNamespace(namespace)); err != nil {
 		klog.ErrorS(err, "Failed to list ray cluster fleets", "namespace", namespace)
-		return true
+		return false, err
 	}
 	for i := range fleetList.Items {
 		fleet := &fleetList.Items[i]
 		if _, ok := constants.ModelNameFromMetadata(fleet.Labels, fleet.Annotations); ok {
-			klog.InfoS("Skip deleting ReferenceGrant: ray cluster fleet still exists",
+			klog.InfoS("found labeled ray cluster fleet in namespace",
 				"namespace", namespace, "rayclusterfleet", fleet.Name)
-			return true
+			return true, nil
 		}
 	}
-	return false
+
+	// LeaderWorkerSet (and any other optional watched workload) is listed as
+	// unstructured so clusters without the CRD do not leak ReferenceGrants.
+	for _, gvk := range watchedWorkloads {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   gvk.Group,
+			Version: gvk.Version,
+			Kind:    gvk.Kind + "List",
+		})
+		if err := m.Client.List(ctx, list, client.InNamespace(namespace)); err != nil {
+			if meta.IsNoMatchError(err) {
+				// CRD not installed; treat as "not present", not as "has workload".
+				klog.V(4).InfoS("optional workload CRD not present", "GVK", gvk, "namespace", namespace)
+				continue
+			}
+			klog.ErrorS(err, "Failed to list optional model workloads", "GVK", gvk, "namespace", namespace)
+			return false, err
+		}
+		for i := range list.Items {
+			u := &list.Items[i]
+			if _, ok := constants.ModelNameFromMetadata(u.GetLabels(), u.GetAnnotations()); ok {
+				klog.InfoS("found labeled model workload in namespace",
+					"namespace", namespace, "gvk", gvk.String(), "name", u.GetName())
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func consoleRouteLabels(labels map[string]string) map[string]string {

--- a/pkg/controller/modelrouter/modelrouter_event_test.go
+++ b/pkg/controller/modelrouter/modelrouter_event_test.go
@@ -23,8 +23,11 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -405,6 +408,37 @@ func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
 		_ = getReferenceGrant(t, m.Client, "models")
 	})
 
+	t.Run("keeps grant when a labeled LeaderWorkerSet remains", func(t *testing.T) {
+		m := newEventTestRouter(t)
+		m.Client = &listHookClient{
+			Client: m.Client,
+			hook: func(ctx context.Context, base client.Client, list client.ObjectList, opts ...client.ListOption) error {
+				if uList, ok := list.(*unstructured.UnstructuredList); ok && isLeaderWorkerSetList(uList) {
+					uList.Items = []unstructured.Unstructured{*labeledLeaderWorkerSet("models", "remaining-lws", "lws-model")}
+					return nil
+				}
+				return base.List(ctx, list, opts...)
+			},
+		}
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama-deploy",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("llama-7b", "8000"),
+			},
+		}
+		m.addRouteFromDeployment(deploy)
+		m.deleteRouteFromDeployment(deploy)
+		err := m.Client.Get(context.Background(), client.ObjectKey{
+			Namespace: aibrixEnvoyGatewayNamespace,
+			Name:      utils.ModelRouterName("llama-7b"),
+		}, &gatewayv1.HTTPRoute{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("HTTPRoute after deployment delete: %v, want NotFound", err)
+		}
+		_ = getReferenceGrant(t, m.Client, "models")
+	})
+
 	t.Run("model adapter delete removes route", func(t *testing.T) {
 		m := newEventTestRouter(t)
 		adapter := &modelv1alpha1.ModelAdapter{
@@ -510,4 +544,96 @@ func TestCustomModelRouterPathsAreAppended(t *testing.T) {
 			t.Errorf("custom match[%d] headers = %#v, want model header custom-model", i, headers)
 		}
 	}
+}
+
+type listHookClient struct {
+	client.Client
+	hook func(ctx context.Context, base client.Client, list client.ObjectList, opts ...client.ListOption) error
+}
+
+func (c *listHookClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if c.hook != nil {
+		return c.hook(ctx, c.Client, list, opts...)
+	}
+	return c.Client.List(ctx, list, opts...)
+}
+
+func isLeaderWorkerSetList(list *unstructured.UnstructuredList) bool {
+	gvk := list.GroupVersionKind()
+	return gvk.Group == "leaderworkerset.x-k8s.io" && gvk.Kind == "LeaderWorkerSetList"
+}
+
+func labeledLeaderWorkerSet(namespace, name, modelName string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "leaderworkerset.x-k8s.io",
+		Version: "v1",
+		Kind:    "LeaderWorkerSet",
+	})
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetLabels(modelWorkloadLabels(modelName, "8000"))
+	return u
+}
+
+func TestNamespaceHasModelWorkloadOptionalLWS(t *testing.T) {
+	t.Run("NoKindMatchError is treated as absent", func(t *testing.T) {
+		m := newEventTestRouter(t)
+		m.Client = &listHookClient{
+			Client: m.Client,
+			hook: func(ctx context.Context, base client.Client, list client.ObjectList, opts ...client.ListOption) error {
+				if uList, ok := list.(*unstructured.UnstructuredList); ok && isLeaderWorkerSetList(uList) {
+					return &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "leaderworkerset.x-k8s.io", Kind: "LeaderWorkerSet"}}
+				}
+				return base.List(ctx, list, opts...)
+			},
+		}
+		has, err := m.namespaceHasModelWorkload(context.Background(), "models")
+		if err != nil {
+			t.Fatalf("namespaceHasModelWorkload returned error for missing LWS CRD: %v", err)
+		}
+		if has {
+			t.Fatal("namespaceHasModelWorkload treated NoKindMatchError as remaining workload")
+		}
+	})
+
+	t.Run("other list errors are returned", func(t *testing.T) {
+		m := newEventTestRouter(t)
+		m.Client = &listHookClient{
+			Client: m.Client,
+			hook: func(ctx context.Context, base client.Client, list client.ObjectList, opts ...client.ListOption) error {
+				return fmt.Errorf("api unavailable")
+			},
+		}
+		has, err := m.namespaceHasModelWorkload(context.Background(), "models")
+		if err == nil {
+			t.Fatal("namespaceHasModelWorkload omitted list error")
+		}
+		if has {
+			t.Fatal("namespaceHasModelWorkload treated list error as remaining workload")
+		}
+	})
+}
+
+func TestDeleteReferenceGrantDoesNotDeleteOnListError(t *testing.T) {
+	m := newEventTestRouter(t)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llama-deploy",
+			Namespace: "models",
+			Labels:    modelWorkloadLabels("llama-7b", "8000"),
+		},
+	}
+	m.addRouteFromDeployment(deploy)
+	_ = getReferenceGrant(t, m.Client, "models")
+
+	m.Client = &listHookClient{
+		Client: m.Client,
+		hook: func(ctx context.Context, base client.Client, list client.ObjectList, opts ...client.ListOption) error {
+			return fmt.Errorf("api unavailable")
+		},
+	}
+	m.deleteRouteFromDeployment(deploy)
+
+	_ = getReferenceGrant(t, m.Client, "models")
 }

--- a/pkg/controller/modelrouter/modelrouter_event_test.go
+++ b/pkg/controller/modelrouter/modelrouter_event_test.go
@@ -321,6 +321,90 @@ func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
 		_ = getReferenceGrant(t, m.Client, "models")
 	})
 
+	t.Run("keeps grant when another model adapter remains", func(t *testing.T) {
+		remaining := &modelv1alpha1.ModelAdapter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other-adapter",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("mistral-adapter", "8000"),
+			},
+		}
+		m := newEventTestRouter(t, remaining)
+		adapter := &modelv1alpha1.ModelAdapter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama-adapter",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("llama-adapter", "8000"),
+			},
+		}
+		m.addRouteFromModelAdapter(adapter)
+		m.deleteRouteFromModelAdapter(adapter)
+		err := m.Client.Get(context.Background(), client.ObjectKey{
+			Namespace: aibrixEnvoyGatewayNamespace,
+			Name:      utils.ModelRouterName("llama-adapter"),
+		}, &gatewayv1.HTTPRoute{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("HTTPRoute after adapter delete: %v, want NotFound", err)
+		}
+		_ = getReferenceGrant(t, m.Client, "models")
+	})
+
+	t.Run("keeps grant when another ray cluster fleet remains", func(t *testing.T) {
+		remaining := &orchestrationv1alpha1.RayClusterFleet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other-fleet",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("mistral-fleet", "8000"),
+			},
+		}
+		m := newEventTestRouter(t, remaining)
+		fleet := &orchestrationv1alpha1.RayClusterFleet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama-fleet",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("llama-fleet", "8000"),
+			},
+		}
+		m.addRouteFromRayClusterFleet(fleet)
+		m.deleteRouteFromRayClusterFleet(fleet)
+		err := m.Client.Get(context.Background(), client.ObjectKey{
+			Namespace: aibrixEnvoyGatewayNamespace,
+			Name:      utils.ModelRouterName("llama-fleet"),
+		}, &gatewayv1.HTTPRoute{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("HTTPRoute after fleet delete: %v, want NotFound", err)
+		}
+		_ = getReferenceGrant(t, m.Client, "models")
+	})
+
+	t.Run("keeps grant when a deployment is deleted but a model adapter remains", func(t *testing.T) {
+		remaining := &modelv1alpha1.ModelAdapter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "remaining-adapter",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("adapter-model", "8000"),
+			},
+		}
+		m := newEventTestRouter(t, remaining)
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama-deploy",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("llama-7b", "8000"),
+			},
+		}
+		m.addRouteFromDeployment(deploy)
+		m.deleteRouteFromDeployment(deploy)
+		err := m.Client.Get(context.Background(), client.ObjectKey{
+			Namespace: aibrixEnvoyGatewayNamespace,
+			Name:      utils.ModelRouterName("llama-7b"),
+		}, &gatewayv1.HTTPRoute{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("HTTPRoute after deployment delete: %v, want NotFound", err)
+		}
+		_ = getReferenceGrant(t, m.Client, "models")
+	})
+
 	t.Run("model adapter delete removes route", func(t *testing.T) {
 		m := newEventTestRouter(t)
 		adapter := &modelv1alpha1.ModelAdapter{

--- a/pkg/controller/modelrouter/modelrouter_event_test.go
+++ b/pkg/controller/modelrouter/modelrouter_event_test.go
@@ -1,0 +1,429 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modelrouter
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	modelv1alpha1 "github.com/vllm-project/aibrix/api/model/v1alpha1"
+	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/utils"
+)
+
+func newEventTestRouter(t *testing.T, objs ...client.Object) *ModelRouter {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := gatewayv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := gatewayv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := modelv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := orchestrationv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return &ModelRouter{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+	}
+}
+
+func modelWorkloadLabels(modelName, port string) map[string]string {
+	return map[string]string{
+		constants.ModelLabelName: modelName,
+		constants.ModelLabelPort: port,
+	}
+}
+
+func getHTTPRoute(t *testing.T, c client.Client, modelName string) *gatewayv1.HTTPRoute {
+	t.Helper()
+	route := &gatewayv1.HTTPRoute{}
+	err := c.Get(context.Background(), client.ObjectKey{
+		Namespace: aibrixEnvoyGatewayNamespace,
+		Name:      utils.ModelRouterName(modelName),
+	}, route)
+	if err != nil {
+		t.Fatalf("HTTPRoute for model %q: %v", modelName, err)
+	}
+	return route
+}
+
+func getReferenceGrant(t *testing.T, c client.Client, namespace string) *gatewayv1beta1.ReferenceGrant {
+	t.Helper()
+	grant := &gatewayv1beta1.ReferenceGrant{}
+	err := c.Get(context.Background(), client.ObjectKey{
+		Namespace: namespace,
+		Name:      fmt.Sprintf("%s-reserved-referencegrant-in-%s", aibrixEnvoyGatewayNamespace, namespace),
+	}, grant)
+	if err != nil {
+		t.Fatalf("ReferenceGrant in namespace %q: %v", namespace, err)
+	}
+	return grant
+}
+
+func routeMatchPaths(route *gatewayv1.HTTPRoute) []string {
+	if len(route.Spec.Rules) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(route.Spec.Rules[0].Matches))
+	for _, match := range route.Spec.Rules[0].Matches {
+		if match.Path != nil && match.Path.Value != nil {
+			paths = append(paths, *match.Path.Value)
+		}
+	}
+	return paths
+}
+
+func TestInformerEventsCreateHTTPRoute(t *testing.T) {
+	const modelName = "llama-7b"
+	labels := modelWorkloadLabels(modelName, "8000")
+
+	tests := []struct {
+		name      string
+		namespace string
+		trigger   func(*ModelRouter)
+	}{
+		{
+			name:      "deployment add",
+			namespace: "workload-ns",
+			trigger: func(m *ModelRouter) {
+				m.addRouteFromDeployment(&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "llama-deploy",
+						Namespace: "workload-ns",
+						Labels:    labels,
+					},
+				})
+			},
+		},
+		{
+			name:      "model adapter add",
+			namespace: "adapter-ns",
+			trigger: func(m *ModelRouter) {
+				m.addRouteFromModelAdapter(&modelv1alpha1.ModelAdapter{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "llama-adapter",
+						Namespace: "adapter-ns",
+						Labels:    labels,
+					},
+				})
+			},
+		},
+		{
+			name:      "ray cluster fleet add",
+			namespace: "fleet-ns",
+			trigger: func(m *ModelRouter) {
+				m.addRouteFromRayClusterFleet(&orchestrationv1alpha1.RayClusterFleet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "llama-fleet",
+						Namespace: "fleet-ns",
+						Labels:    labels,
+					},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newEventTestRouter(t)
+			tt.trigger(m)
+
+			route := getHTTPRoute(t, m.Client, modelName)
+			if route.Namespace != aibrixEnvoyGatewayNamespace {
+				t.Errorf("HTTPRoute namespace = %q, want %q", route.Namespace, aibrixEnvoyGatewayNamespace)
+			}
+			if len(route.Spec.Rules) != 1 || len(route.Spec.Rules[0].BackendRefs) != 1 {
+				t.Fatalf("unexpected HTTPRoute rules: %#v", route.Spec.Rules)
+			}
+			backend := route.Spec.Rules[0].BackendRefs[0]
+			if backend.Name != gatewayv1.ObjectName(modelName) {
+				t.Errorf("backend name = %q, want %q", backend.Name, modelName)
+			}
+			if backend.Namespace == nil || string(*backend.Namespace) != tt.namespace {
+				t.Errorf("backend namespace = %v, want %q", backend.Namespace, tt.namespace)
+			}
+			if backend.Port == nil || int32(*backend.Port) != 8000 {
+				t.Errorf("backend port = %v, want 8000", backend.Port)
+			}
+
+			paths := routeMatchPaths(route)
+			if len(paths) != len(modelPaths) {
+				t.Fatalf("got %d match paths, want %d default paths: %v", len(paths), len(modelPaths), paths)
+			}
+			for i, want := range modelPaths {
+				if paths[i] != want {
+					t.Errorf("match[%d] = %q, want %q", i, paths[i], want)
+				}
+			}
+			if len(route.Spec.Rules[0].Matches[0].Headers) != 1 || route.Spec.Rules[0].Matches[0].Headers[0].Value != modelName {
+				t.Errorf("model header match = %#v", route.Spec.Rules[0].Matches[0].Headers)
+			}
+		})
+	}
+}
+
+func TestInformerEventsSkipWorkloadsWithoutModelName(t *testing.T) {
+	m := newEventTestRouter(t)
+	m.addRouteFromDeployment(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "plain-deploy",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "plain"},
+		},
+	})
+
+	routes := &gatewayv1.HTTPRouteList{}
+	if err := m.Client.List(context.Background(), routes); err != nil {
+		t.Fatal(err)
+	}
+	if len(routes.Items) != 0 {
+		t.Fatalf("created %d HTTPRoutes for unlabeled workload, want 0", len(routes.Items))
+	}
+}
+
+func TestCrossNamespaceReferenceGrantCreation(t *testing.T) {
+	t.Run("creates grant when workload is outside aibrix-system", func(t *testing.T) {
+		m := newEventTestRouter(t)
+		m.addRouteFromDeployment(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama-deploy",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("llama-7b", "8000"),
+			},
+		})
+
+		grant := getReferenceGrant(t, m.Client, "models")
+		if len(grant.Spec.From) != 1 {
+			t.Fatalf("ReferenceGrant.From = %#v, want 1 entry", grant.Spec.From)
+		}
+		from := grant.Spec.From[0]
+		if from.Group != gatewayv1.GroupName || from.Kind != "HTTPRoute" || string(from.Namespace) != aibrixEnvoyGatewayNamespace {
+			t.Errorf("ReferenceGrant.From = %#v", from)
+		}
+		if len(grant.Spec.To) != 1 || grant.Spec.To[0].Group != "" || grant.Spec.To[0].Kind != "Service" {
+			t.Errorf("ReferenceGrant.To = %#v", grant.Spec.To)
+		}
+	})
+
+	t.Run("does not create grant when workload is in aibrix-system", func(t *testing.T) {
+		m := newEventTestRouter(t)
+		m.addRouteFromDeployment(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama-deploy",
+				Namespace: aibrixEnvoyGatewayNamespace,
+				Labels:    modelWorkloadLabels("llama-7b", "8000"),
+			},
+		})
+
+		_ = getHTTPRoute(t, m.Client, "llama-7b")
+		grant := &gatewayv1beta1.ReferenceGrant{}
+		err := m.Client.Get(context.Background(), client.ObjectKey{
+			Namespace: aibrixEnvoyGatewayNamespace,
+			Name:      fmt.Sprintf("%s-reserved-referencegrant-in-%s", aibrixEnvoyGatewayNamespace, aibrixEnvoyGatewayNamespace),
+		}, grant)
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("ReferenceGrant Get error = %v, want NotFound", err)
+		}
+	})
+}
+
+func TestRouteAndReferenceGrantCleanupAfterWorkloadDeletion(t *testing.T) {
+	t.Run("deletes route and grant when last model workload is removed", func(t *testing.T) {
+		m := newEventTestRouter(t)
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama-deploy",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("llama-7b", "8000"),
+			},
+		}
+		m.addRouteFromDeployment(deploy)
+		_ = getHTTPRoute(t, m.Client, "llama-7b")
+		_ = getReferenceGrant(t, m.Client, "models")
+
+		m.deleteRouteFromDeployment(deploy)
+
+		err := m.Client.Get(context.Background(), client.ObjectKey{
+			Namespace: aibrixEnvoyGatewayNamespace,
+			Name:      utils.ModelRouterName("llama-7b"),
+		}, &gatewayv1.HTTPRoute{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("HTTPRoute after delete: %v, want NotFound", err)
+		}
+		err = m.Client.Get(context.Background(), client.ObjectKey{
+			Namespace: "models",
+			Name:      fmt.Sprintf("%s-reserved-referencegrant-in-%s", aibrixEnvoyGatewayNamespace, "models"),
+		}, &gatewayv1beta1.ReferenceGrant{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("ReferenceGrant after delete: %v, want NotFound", err)
+		}
+	})
+
+	t.Run("keeps grant when another model deployment remains", func(t *testing.T) {
+		remaining := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other-deploy",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("mistral-7b", "8000"),
+			},
+		}
+		m := newEventTestRouter(t, remaining)
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama-deploy",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("llama-7b", "8000"),
+			},
+		}
+		m.addRouteFromDeployment(deploy)
+		m.deleteRouteFromDeployment(deploy)
+
+		err := m.Client.Get(context.Background(), client.ObjectKey{
+			Namespace: aibrixEnvoyGatewayNamespace,
+			Name:      utils.ModelRouterName("llama-7b"),
+		}, &gatewayv1.HTTPRoute{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("HTTPRoute after delete: %v, want NotFound", err)
+		}
+		_ = getReferenceGrant(t, m.Client, "models")
+	})
+
+	t.Run("model adapter delete removes route", func(t *testing.T) {
+		m := newEventTestRouter(t)
+		adapter := &modelv1alpha1.ModelAdapter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama-adapter",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("adapter-model", "8000"),
+			},
+		}
+		m.addRouteFromModelAdapter(adapter)
+		m.deleteRouteFromModelAdapter(adapter)
+		err := m.Client.Get(context.Background(), client.ObjectKey{
+			Namespace: aibrixEnvoyGatewayNamespace,
+			Name:      utils.ModelRouterName("adapter-model"),
+		}, &gatewayv1.HTTPRoute{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("HTTPRoute after adapter delete: %v, want NotFound", err)
+		}
+	})
+
+	t.Run("ray cluster fleet delete removes route", func(t *testing.T) {
+		m := newEventTestRouter(t)
+		fleet := &orchestrationv1alpha1.RayClusterFleet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama-fleet",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("fleet-model", "8000"),
+			},
+		}
+		m.addRouteFromRayClusterFleet(fleet)
+		m.deleteRouteFromRayClusterFleet(fleet)
+		err := m.Client.Get(context.Background(), client.ObjectKey{
+			Namespace: aibrixEnvoyGatewayNamespace,
+			Name:      utils.ModelRouterName("fleet-model"),
+		}, &gatewayv1.HTTPRoute{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("HTTPRoute after fleet delete: %v, want NotFound", err)
+		}
+	})
+
+	t.Run("tombstone delete still removes route", func(t *testing.T) {
+		m := newEventTestRouter(t)
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama-deploy",
+				Namespace: "models",
+				Labels:    modelWorkloadLabels("tombstone-model", "8000"),
+			},
+		}
+		m.addRouteFromDeployment(deploy)
+		m.deleteRouteFromDeployment(cache.DeletedFinalStateUnknown{Obj: deploy})
+		err := m.Client.Get(context.Background(), client.ObjectKey{
+			Namespace: aibrixEnvoyGatewayNamespace,
+			Name:      utils.ModelRouterName("tombstone-model"),
+		}, &gatewayv1.HTTPRoute{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("HTTPRoute after tombstone delete: %v, want NotFound", err)
+		}
+	})
+}
+
+func TestCustomModelRouterPathsAreAppended(t *testing.T) {
+	m := newEventTestRouter(t)
+	m.addRouteFromDeployment(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "custom-path-deploy",
+			Namespace: "models",
+			Labels:    modelWorkloadLabels("custom-model", "8080"),
+			Annotations: map[string]string{
+				constants.ModelAnnoRouterCustomPath: "/score, /version",
+			},
+		},
+	})
+
+	route := getHTTPRoute(t, m.Client, "custom-model")
+	paths := routeMatchPaths(route)
+	wantSuffix := []string{"/score", "/version"}
+	if len(paths) < len(modelPaths)+len(wantSuffix) {
+		t.Fatalf("got paths %v, want default paths plus %v", paths, wantSuffix)
+	}
+	for i, want := range modelPaths {
+		if paths[i] != want {
+			t.Errorf("default path[%d] = %q, want %q", i, paths[i], want)
+		}
+	}
+	gotSuffix := paths[len(modelPaths):]
+	if len(gotSuffix) != len(wantSuffix) {
+		t.Fatalf("custom paths = %v, want %v", gotSuffix, wantSuffix)
+	}
+	for i, want := range wantSuffix {
+		if gotSuffix[i] != want {
+			t.Errorf("custom path[%d] = %q, want %q", i, gotSuffix[i], want)
+		}
+	}
+
+	backend := route.Spec.Rules[0].BackendRefs[0]
+	if backend.Port == nil || int32(*backend.Port) != 8080 {
+		t.Errorf("backend port = %v, want 8080 from model port label", backend.Port)
+	}
+	for i := len(modelPaths); i < len(route.Spec.Rules[0].Matches); i++ {
+		headers := route.Spec.Rules[0].Matches[i].Headers
+		if len(headers) != 1 || headers[0].Value != "custom-model" {
+			t.Errorf("custom match[%d] headers = %#v, want model header custom-model", i, headers)
+		}
+	}
+}

--- a/test/integration/controller/modelrouter_test.go
+++ b/test/integration/controller/modelrouter_test.go
@@ -61,8 +61,9 @@ var _ = ginkgo.Describe("ModelRouter controller test", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-		cleanupHTTPRoutesInAibrixSystem()
-		gomega.Expect(k8sClient.Delete(ctx, ns)).To(gomega.Succeed())
+		cleanupHTTPRoutesInAibrixSystem(ns.Name)
+		err := k8sClient.Delete(ctx, ns)
+		gomega.Expect(client.IgnoreNotFound(err)).To(gomega.Succeed())
 	})
 
 	ginkgo.It("creates an HTTPRoute from Deployment, ModelAdapter, and RayClusterFleet informer events", func() {
@@ -171,13 +172,28 @@ func ensureAibrixSystemNamespace() {
 	}
 }
 
-func cleanupHTTPRoutesInAibrixSystem() {
+func cleanupHTTPRoutesInAibrixSystem(namespace string) {
 	routes := &gatewayv1.HTTPRouteList{}
 	if err := k8sClient.List(ctx, routes, client.InNamespace(aibrixSystemNS)); err != nil {
 		return
 	}
 	for i := range routes.Items {
-		_ = k8sClient.Delete(ctx, &routes.Items[i])
+		route := &routes.Items[i]
+		shouldDelete := false
+		for _, rule := range route.Spec.Rules {
+			for _, backend := range rule.BackendRefs {
+				if backend.Namespace != nil && string(*backend.Namespace) == namespace {
+					shouldDelete = true
+					break
+				}
+			}
+			if shouldDelete {
+				break
+			}
+		}
+		if shouldDelete {
+			_ = k8sClient.Delete(ctx, route)
+		}
 	}
 }
 

--- a/test/integration/controller/modelrouter_test.go
+++ b/test/integration/controller/modelrouter_test.go
@@ -26,6 +26,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -197,6 +199,24 @@ var _ = ginkgo.Describe("ModelRouter controller test", func() {
 		waitForReferenceGrantDeleted(ns.Name)
 	})
 
+	ginkgo.It("keeps the ReferenceGrant while a LeaderWorkerSet remains in the namespace", func() {
+		deployModel := uniqueModelName(ns.Name, "keep-lws-deploy")
+		lwsModel := uniqueModelName(ns.Name, "keep-lws")
+		deploy := createModelDeployment(ns.Name, "keep-lws-deploy", deployModel, nil)
+		lws := createModelLeaderWorkerSet(ns.Name, "keep-lws", lwsModel)
+		_ = waitForHTTPRoute(deployModel)
+		_ = waitForHTTPRoute(lwsModel)
+		_ = waitForReferenceGrant(ns.Name)
+
+		gomega.Expect(k8sClient.Delete(ctx, deploy)).To(gomega.Succeed())
+		waitForHTTPRouteDeleted(deployModel)
+		expectReferenceGrantAndRoute(ns.Name, lwsModel)
+
+		gomega.Expect(k8sClient.Delete(ctx, lws)).To(gomega.Succeed())
+		waitForHTTPRouteDeleted(lwsModel)
+		waitForReferenceGrantDeleted(ns.Name)
+	})
+
 	ginkgo.It("appends custom model router paths onto the HTTPRoute matches", func() {
 		modelName := uniqueModelName(ns.Name, "paths")
 		createModelDeployment(ns.Name, "paths-deploy", modelName, map[string]string{
@@ -228,9 +248,8 @@ func ensureAibrixSystemNamespace() {
 
 func cleanupHTTPRoutesInAibrixSystem(namespace string) {
 	routes := &gatewayv1.HTTPRouteList{}
-	if err := k8sClient.List(ctx, routes, client.InNamespace(aibrixSystemNS)); err != nil {
-		return
-	}
+	err := k8sClient.List(ctx, routes, client.InNamespace(aibrixSystemNS))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	for i := range routes.Items {
 		route := &routes.Items[i]
 		shouldDelete := false
@@ -306,6 +325,20 @@ func createModelAdapter(namespace, name, modelName string, annotations map[strin
 	adapter.Annotations = annotations
 	gomega.Expect(k8sClient.Create(ctx, adapter)).To(gomega.Succeed())
 	return adapter
+}
+
+func createModelLeaderWorkerSet(namespace, name, modelName string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "leaderworkerset.x-k8s.io",
+		Version: "v1",
+		Kind:    "LeaderWorkerSet",
+	})
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetLabels(modelLabels(modelName))
+	gomega.Expect(k8sClient.Create(ctx, u)).To(gomega.Succeed())
+	return u
 }
 
 func createModelRayClusterFleet(namespace, name, modelName string) *orchestrationapi.RayClusterFleet {

--- a/test/integration/controller/modelrouter_test.go
+++ b/test/integration/controller/modelrouter_test.go
@@ -1,0 +1,323 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	modelapi "github.com/vllm-project/aibrix/api/model/v1alpha1"
+	orchestrationapi "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/utils"
+	"github.com/vllm-project/aibrix/test/utils/wrapper"
+)
+
+const (
+	modelRouterTimeout  = time.Second * 10
+	modelRouterInterval = time.Millisecond * 250
+	aibrixSystemNS      = "aibrix-system"
+)
+
+var _ = ginkgo.Describe("ModelRouter controller test", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ensureAibrixSystemNamespace()
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-modelrouter-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+		gomega.Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKeyFromObject(ns), ns)
+		}, time.Second*3).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		cleanupHTTPRoutesInAibrixSystem()
+		gomega.Expect(k8sClient.Delete(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("creates an HTTPRoute from Deployment, ModelAdapter, and RayClusterFleet informer events", func() {
+		deploymentModel := uniqueModelName(ns.Name, "deploy")
+		adapterModel := uniqueModelName(ns.Name, "adapter")
+		fleetModel := uniqueModelName(ns.Name, "fleet")
+
+		createModelDeployment(ns.Name, "model-deploy", deploymentModel, nil)
+		createModelAdapter(ns.Name, "model-adapter", adapterModel, nil)
+		createModelRayClusterFleet(ns.Name, "model-fleet", fleetModel)
+
+		for _, modelName := range []string{deploymentModel, adapterModel, fleetModel} {
+			route := waitForHTTPRoute(modelName)
+			gomega.Expect(route.Spec.ParentRefs).ToNot(gomega.BeEmpty())
+			gomega.Expect(string(route.Spec.ParentRefs[0].Name)).To(gomega.Equal("aibrix-eg"))
+			gomega.Expect(route.Spec.Rules).To(gomega.HaveLen(1))
+			gomega.Expect(route.Spec.Rules[0].BackendRefs).To(gomega.HaveLen(1))
+			backend := route.Spec.Rules[0].BackendRefs[0]
+			gomega.Expect(string(backend.Name)).To(gomega.Equal(modelName))
+			gomega.Expect(backend.Namespace).ToNot(gomega.BeNil())
+			gomega.Expect(string(*backend.Namespace)).To(gomega.Equal(ns.Name))
+			gomega.Expect(backend.Port).ToNot(gomega.BeNil())
+			gomega.Expect(int32(*backend.Port)).To(gomega.Equal(int32(8000)))
+			gomega.Expect(httpRoutePaths(route)).To(gomega.ContainElement("/v1/chat/completions"))
+			gomega.Expect(route.Spec.Rules[0].Matches[0].Headers).To(gomega.ContainElement(gomega.HaveField("Value", modelName)))
+		}
+	})
+
+	ginkgo.It("creates a cross-namespace ReferenceGrant for workloads outside aibrix-system", func() {
+		modelName := uniqueModelName(ns.Name, "grant")
+		createModelDeployment(ns.Name, "grant-deploy", modelName, nil)
+		_ = waitForHTTPRoute(modelName)
+
+		grant := waitForReferenceGrant(ns.Name)
+		gomega.Expect(grant.Spec.From).To(gomega.HaveLen(1))
+		gomega.Expect(string(grant.Spec.From[0].Group)).To(gomega.Equal(gatewayv1.GroupName))
+		gomega.Expect(string(grant.Spec.From[0].Kind)).To(gomega.Equal("HTTPRoute"))
+		gomega.Expect(string(grant.Spec.From[0].Namespace)).To(gomega.Equal(aibrixSystemNS))
+		gomega.Expect(grant.Spec.To).To(gomega.HaveLen(1))
+		gomega.Expect(string(grant.Spec.To[0].Group)).To(gomega.Equal(""))
+		gomega.Expect(string(grant.Spec.To[0].Kind)).To(gomega.Equal("Service"))
+	})
+
+	ginkgo.It("cleans up HTTPRoute and ReferenceGrant after the last model workload is deleted", func() {
+		modelName := uniqueModelName(ns.Name, "cleanup")
+		deploy := createModelDeployment(ns.Name, "cleanup-deploy", modelName, nil)
+		_ = waitForHTTPRoute(modelName)
+		_ = waitForReferenceGrant(ns.Name)
+
+		gomega.Expect(k8sClient.Delete(ctx, deploy)).To(gomega.Succeed())
+		waitForHTTPRouteDeleted(modelName)
+		waitForReferenceGrantDeleted(ns.Name)
+	})
+
+	ginkgo.It("keeps the ReferenceGrant while another model deployment remains in the namespace", func() {
+		firstModel := uniqueModelName(ns.Name, "keep-a")
+		secondModel := uniqueModelName(ns.Name, "keep-b")
+		first := createModelDeployment(ns.Name, "keep-deploy-a", firstModel, nil)
+		_ = createModelDeployment(ns.Name, "keep-deploy-b", secondModel, nil)
+		_ = waitForHTTPRoute(firstModel)
+		_ = waitForHTTPRoute(secondModel)
+		_ = waitForReferenceGrant(ns.Name)
+
+		gomega.Expect(k8sClient.Delete(ctx, first)).To(gomega.Succeed())
+		waitForHTTPRouteDeleted(firstModel)
+		gomega.Consistently(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Namespace: ns.Name,
+				Name:      referenceGrantName(ns.Name),
+			}, &gatewayv1beta1.ReferenceGrant{})
+		}, time.Second*2, modelRouterInterval).Should(gomega.Succeed())
+		gomega.Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Namespace: aibrixSystemNS,
+				Name:      utils.ModelRouterName(secondModel),
+			}, &gatewayv1.HTTPRoute{})
+		}, modelRouterTimeout, modelRouterInterval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("appends custom model router paths onto the HTTPRoute matches", func() {
+		modelName := uniqueModelName(ns.Name, "paths")
+		createModelDeployment(ns.Name, "paths-deploy", modelName, map[string]string{
+			constants.ModelAnnoRouterCustomPath: "/score, /version",
+		})
+		route := waitForHTTPRoute(modelName)
+		paths := httpRoutePaths(route)
+		gomega.Expect(paths).To(gomega.ContainElement("/v1/completions"))
+		gomega.Expect(paths).To(gomega.ContainElement("/v1/chat/completions"))
+		gomega.Expect(paths[len(paths)-2:]).To(gomega.Equal([]string{"/score", "/version"}))
+		for _, match := range route.Spec.Rules[0].Matches {
+			gomega.Expect(match.Headers).ToNot(gomega.BeEmpty())
+			gomega.Expect(match.Headers[0].Value).To(gomega.Equal(modelName))
+		}
+	})
+})
+
+func ensureAibrixSystemNamespace() {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: aibrixSystemNS,
+		},
+	}
+	err := k8sClient.Create(ctx, ns)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}
+
+func cleanupHTTPRoutesInAibrixSystem() {
+	routes := &gatewayv1.HTTPRouteList{}
+	if err := k8sClient.List(ctx, routes, client.InNamespace(aibrixSystemNS)); err != nil {
+		return
+	}
+	for i := range routes.Items {
+		_ = k8sClient.Delete(ctx, &routes.Items[i])
+	}
+}
+
+func uniqueModelName(namespace, suffix string) string {
+	return fmt.Sprintf("%s-%s", suffix, namespace)
+}
+
+func modelLabels(modelName string) map[string]string {
+	return map[string]string{
+		constants.ModelLabelName: modelName,
+		constants.ModelLabelPort: "8000",
+	}
+}
+
+func createModelDeployment(namespace, name, modelName string, annotations map[string]string) *appsv1.Deployment {
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      modelLabels(modelName),
+			Annotations: annotations,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "vllm",
+							Image: "vllm/vllm-openai:latest",
+						},
+					},
+				},
+			},
+		},
+	}
+	gomega.Expect(k8sClient.Create(ctx, deploy)).To(gomega.Succeed())
+	return deploy
+}
+
+func createModelAdapter(namespace, name, modelName string, annotations map[string]string) *modelapi.ModelAdapter {
+	adapter := wrapper.MakeModelAdapter(name).
+		Namespace(namespace).
+		ArtifactURL("s3://test-bucket/test-adapter").
+		PodSelector(&metav1.LabelSelector{
+			MatchLabels: map[string]string{"app": "vllm"},
+		}).
+		Obj()
+	adapter.Labels = modelLabels(modelName)
+	adapter.Annotations = annotations
+	gomega.Expect(k8sClient.Create(ctx, adapter)).To(gomega.Succeed())
+	return adapter
+}
+
+func createModelRayClusterFleet(namespace, name, modelName string) *orchestrationapi.RayClusterFleet {
+	matchLabels := map[string]string{"app": name}
+	fleet := &orchestrationapi.RayClusterFleet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    modelLabels(modelName),
+		},
+		Spec: orchestrationapi.RayClusterFleetSpec{
+			Replicas: ptr.To(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: matchLabels,
+			},
+			Template: orchestrationapi.RayClusterTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: matchLabels,
+				},
+				Spec: makeIntegrationRayClusterSpec(),
+			},
+		},
+	}
+	gomega.Expect(k8sClient.Create(ctx, fleet)).To(gomega.Succeed())
+	return fleet
+}
+
+func waitForHTTPRoute(modelName string) *gatewayv1.HTTPRoute {
+	route := &gatewayv1.HTTPRoute{}
+	gomega.Eventually(func() error {
+		return k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: aibrixSystemNS,
+			Name:      utils.ModelRouterName(modelName),
+		}, route)
+	}, modelRouterTimeout, modelRouterInterval).Should(gomega.Succeed())
+	return route
+}
+
+func waitForHTTPRouteDeleted(modelName string) {
+	gomega.Eventually(func() bool {
+		err := k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: aibrixSystemNS,
+			Name:      utils.ModelRouterName(modelName),
+		}, &gatewayv1.HTTPRoute{})
+		return apierrors.IsNotFound(err)
+	}, modelRouterTimeout, modelRouterInterval).Should(gomega.BeTrue())
+}
+
+func referenceGrantName(namespace string) string {
+	return fmt.Sprintf("%s-reserved-referencegrant-in-%s", aibrixSystemNS, namespace)
+}
+
+func waitForReferenceGrant(namespace string) *gatewayv1beta1.ReferenceGrant {
+	grant := &gatewayv1beta1.ReferenceGrant{}
+	gomega.Eventually(func() error {
+		return k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: namespace,
+			Name:      referenceGrantName(namespace),
+		}, grant)
+	}, modelRouterTimeout, modelRouterInterval).Should(gomega.Succeed())
+	return grant
+}
+
+func waitForReferenceGrantDeleted(namespace string) {
+	gomega.Eventually(func() bool {
+		err := k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: namespace,
+			Name:      referenceGrantName(namespace),
+		}, &gatewayv1beta1.ReferenceGrant{})
+		return apierrors.IsNotFound(err)
+	}, modelRouterTimeout, modelRouterInterval).Should(gomega.BeTrue())
+}
+
+func httpRoutePaths(route *gatewayv1.HTTPRoute) []string {
+	if len(route.Spec.Rules) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(route.Spec.Rules[0].Matches))
+	for _, match := range route.Spec.Rules[0].Matches {
+		if match.Path != nil && match.Path.Value != nil {
+			paths = append(paths, *match.Path.Value)
+		}
+	}
+	return paths
+}

--- a/test/integration/controller/modelrouter_test.go
+++ b/test/integration/controller/modelrouter_test.go
@@ -143,6 +143,60 @@ var _ = ginkgo.Describe("ModelRouter controller test", func() {
 		}, modelRouterTimeout, modelRouterInterval).Should(gomega.Succeed())
 	})
 
+	ginkgo.It("keeps the ReferenceGrant while another ModelAdapter remains in the namespace", func() {
+		firstModel := uniqueModelName(ns.Name, "keep-adapter-a")
+		secondModel := uniqueModelName(ns.Name, "keep-adapter-b")
+		first := createModelAdapter(ns.Name, "keep-adapter-a", firstModel, nil)
+		second := createModelAdapter(ns.Name, "keep-adapter-b", secondModel, nil)
+		_ = waitForHTTPRoute(firstModel)
+		_ = waitForHTTPRoute(secondModel)
+		_ = waitForReferenceGrant(ns.Name)
+
+		gomega.Expect(k8sClient.Delete(ctx, first)).To(gomega.Succeed())
+		waitForHTTPRouteDeleted(firstModel)
+		expectReferenceGrantAndRoute(ns.Name, secondModel)
+
+		gomega.Expect(k8sClient.Delete(ctx, second)).To(gomega.Succeed())
+		waitForHTTPRouteDeleted(secondModel)
+		waitForReferenceGrantDeleted(ns.Name)
+	})
+
+	ginkgo.It("keeps the ReferenceGrant while another RayClusterFleet remains in the namespace", func() {
+		firstModel := uniqueModelName(ns.Name, "keep-fleet-a")
+		secondModel := uniqueModelName(ns.Name, "keep-fleet-b")
+		first := createModelRayClusterFleet(ns.Name, "keep-fleet-a", firstModel)
+		second := createModelRayClusterFleet(ns.Name, "keep-fleet-b", secondModel)
+		_ = waitForHTTPRoute(firstModel)
+		_ = waitForHTTPRoute(secondModel)
+		_ = waitForReferenceGrant(ns.Name)
+
+		gomega.Expect(k8sClient.Delete(ctx, first)).To(gomega.Succeed())
+		waitForHTTPRouteDeleted(firstModel)
+		expectReferenceGrantAndRoute(ns.Name, secondModel)
+
+		gomega.Expect(k8sClient.Delete(ctx, second)).To(gomega.Succeed())
+		waitForHTTPRouteDeleted(secondModel)
+		waitForReferenceGrantDeleted(ns.Name)
+	})
+
+	ginkgo.It("keeps the ReferenceGrant when a Deployment is deleted but a ModelAdapter remains", func() {
+		deployModel := uniqueModelName(ns.Name, "keep-mixed-deploy")
+		adapterModel := uniqueModelName(ns.Name, "keep-mixed-adapter")
+		deploy := createModelDeployment(ns.Name, "keep-mixed-deploy", deployModel, nil)
+		adapter := createModelAdapter(ns.Name, "keep-mixed-adapter", adapterModel, nil)
+		_ = waitForHTTPRoute(deployModel)
+		_ = waitForHTTPRoute(adapterModel)
+		_ = waitForReferenceGrant(ns.Name)
+
+		gomega.Expect(k8sClient.Delete(ctx, deploy)).To(gomega.Succeed())
+		waitForHTTPRouteDeleted(deployModel)
+		expectReferenceGrantAndRoute(ns.Name, adapterModel)
+
+		gomega.Expect(k8sClient.Delete(ctx, adapter)).To(gomega.Succeed())
+		waitForHTTPRouteDeleted(adapterModel)
+		waitForReferenceGrantDeleted(ns.Name)
+	})
+
 	ginkgo.It("appends custom model router paths onto the HTTPRoute matches", func() {
 		modelName := uniqueModelName(ns.Name, "paths")
 		createModelDeployment(ns.Name, "paths-deploy", modelName, map[string]string{
@@ -323,6 +377,21 @@ func waitForReferenceGrantDeleted(namespace string) {
 		}, &gatewayv1beta1.ReferenceGrant{})
 		return apierrors.IsNotFound(err)
 	}, modelRouterTimeout, modelRouterInterval).Should(gomega.BeTrue())
+}
+
+func expectReferenceGrantAndRoute(namespace, remainingModel string) {
+	gomega.Consistently(func() error {
+		return k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: namespace,
+			Name:      referenceGrantName(namespace),
+		}, &gatewayv1beta1.ReferenceGrant{})
+	}, time.Second*2, modelRouterInterval).Should(gomega.Succeed())
+	gomega.Eventually(func() error {
+		return k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: aibrixSystemNS,
+			Name:      utils.ModelRouterName(remainingModel),
+		}, &gatewayv1.HTTPRoute{})
+	}, modelRouterTimeout, modelRouterInterval).Should(gomega.Succeed())
 }
 
 func httpRoutePaths(route *gatewayv1.HTTPRoute) []string {

--- a/test/integration/controller/suit_test.go
+++ b/test/integration/controller/suit_test.go
@@ -97,9 +97,12 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		// Paths to CRD YAML files required for the tests
 		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "config", "crd", "bases"),                           // Aibrix CRDs
-			filepath.Join("..", "..", "..", "config", "dependency", "kuberay-operator", "crds"), // KubeRay CRDs (dependency)
-			filepath.Join("testdata", "crd"),                                                    // Gateway API CRDs used by ModelRouter
+			// Aibrix CRDs
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+			// KubeRay CRDs (dependency)
+			filepath.Join("..", "..", "..", "config", "dependency", "kuberay-operator", "crds"),
+			// Gateway API CRDs used by ModelRouter
+			filepath.Join("testdata", "crd"),
 		},
 
 		ErrorIfCRDPathMissing: true,

--- a/test/integration/controller/suit_test.go
+++ b/test/integration/controller/suit_test.go
@@ -99,6 +99,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "config", "crd", "bases"),                           // Aibrix CRDs
 			filepath.Join("..", "..", "..", "config", "dependency", "kuberay-operator", "crds"), // KubeRay CRDs (dependency)
+			filepath.Join("testdata", "crd"),                                                    // Gateway API CRDs used by ModelRouter
 		},
 
 		ErrorIfCRDPathMissing: true,

--- a/test/integration/controller/testdata/crd/gateway.networking.k8s.io_httproutes.yaml
+++ b/test/integration/controller/testdata/crd/gateway.networking.k8s.io_httproutes.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
+    gateway.networking.k8s.io/bundle-version: v1.0.0
+    gateway.networking.k8s.io/channel: standard
+  name: httproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    kind: HTTPRoute
+    listKind: HTTPRouteList
+    plural: httproutes
+    singular: httproute
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/test/integration/controller/testdata/crd/gateway.networking.k8s.io_referencegrants.yaml
+++ b/test/integration/controller/testdata/crd/gateway.networking.k8s.io_referencegrants.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
+    gateway.networking.k8s.io/bundle-version: v1.0.0
+    gateway.networking.k8s.io/channel: standard
+  name: referencegrants.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    kind: ReferenceGrant
+    listKind: ReferenceGrantList
+    plural: referencegrants
+    singular: referencegrant
+    shortNames:
+    - refgrant
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/test/integration/controller/testdata/crd/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/test/integration/controller/testdata/crd/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: leaderworkersets.leaderworkerset.x-k8s.io
+spec:
+  group: leaderworkerset.x-k8s.io
+  names:
+    kind: LeaderWorkerSet
+    listKind: LeaderWorkerSetList
+    plural: leaderworkersets
+    singular: leaderworkerset
+    shortNames:
+    - lws
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
## Pull Request Description

I added ModelRouter integration coverage for the routing paths called out on #2637.

The tests cover:

- Deployment, ModelAdapter, and RayClusterFleet informer events creating an `HTTPRoute`
- Cross-namespace `ReferenceGrant` creation when the workload is not in `aibrix-system`
- `HTTPRoute` and `ReferenceGrant` cleanup after the workload is deleted
- Custom model router paths from `model.aibrix.ai/model-router-custom-paths` being appended to the default HTTPRoute matches

This addresses the ModelRouter integration tests item on #2637. It does not close the tracking issue; the other checkboxes are still open.

## Related Issues

Refs #2637 (ModelRouter integration-tests item)

## Tests

- `go test ./pkg/controller/modelrouter -count=1`
- `go test ./test/integration/controller -count=1 --ginkgo.focus="ModelRouter"`