### PR TITLE
[Misc] Add KVCache controller integration tests

### DIFF
--- a/pkg/controller/kvcache/kvcache_controller.go
+++ b/pkg/controller/kvcache/kvcache_controller.go
@@ -96,6 +96,23 @@ func podWithLabelFilter(labelKey string) predicate.Predicate {
 	}
 }
 
+// kvCacheRequestsForPod maps a Pod labeled with KVCacheLabelKeyIdentifier to the matching KVCache.
+func kvCacheRequestsForPod(_ context.Context, obj client.Object) []reconcile.Request {
+	cacheName, ok := obj.GetLabels()[constants.KVCacheLabelKeyIdentifier]
+	if !ok {
+		return nil
+	}
+
+	return []ctrl.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Namespace: obj.GetNamespace(),
+				Name:      cacheName,
+			},
+		},
+	}
+}
+
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// use the builder fashion. If we need more fine grain control later, we can switch to `controller.New()`
@@ -105,21 +122,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		Owns(&corev1.Service{}).
 		Owns(&appsv1.Deployment{}).
 		Watches(&corev1.Pod{},
-			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-				cacheName, ok := obj.GetLabels()[constants.KVCacheLabelKeyIdentifier]
-				if !ok {
-					return nil
-				}
-
-				return []ctrl.Request{
-					{
-						NamespacedName: types.NamespacedName{
-							Namespace: obj.GetNamespace(),
-							Name:      cacheName,
-						},
-					},
-				}
-			}),
+			handler.EnqueueRequestsFromMapFunc(kvCacheRequestsForPod),
 			builder.WithPredicates(podWithLabelFilter(constants.KVCacheLabelKeyIdentifier))).
 		Complete(r)
 	if err != nil {

--- a/pkg/controller/kvcache/kvcache_controller_test.go
+++ b/pkg/controller/kvcache/kvcache_controller_test.go
@@ -17,12 +17,26 @@ limitations under the License.
 package kvcache
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
 	"github.com/vllm-project/aibrix/pkg/constants"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/vllm-project/aibrix/pkg/controller/kvcache/backends"
 )
 
 func Test_getKVCacheBackendFromMetadata(t *testing.T) {
@@ -46,6 +60,30 @@ func Test_getKVCacheBackendFromMetadata(t *testing.T) {
 			},
 			expected: constants.KVCacheBackendInfinistore,
 		},
+		{
+			name: "valid backend annotation - hpkv",
+			annotations: map[string]string{
+				constants.KVCacheLabelKeyBackend: constants.KVCacheBackendHPKV,
+			},
+			expected: constants.KVCacheBackendHPKV,
+		},
+		{
+			name:        "empty annotations uses default backend",
+			annotations: map[string]string{},
+			expected:    constants.KVCacheBackendDefault,
+		},
+		{
+			name:        "missing annotations uses default backend",
+			annotations: nil,
+			expected:    constants.KVCacheBackendDefault,
+		},
+		{
+			name: "empty backend annotation uses default backend",
+			annotations: map[string]string{
+				constants.KVCacheLabelKeyBackend: "",
+			},
+			expected: constants.KVCacheBackendDefault,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -57,6 +95,201 @@ func Test_getKVCacheBackendFromMetadata(t *testing.T) {
 			}
 			result := getKVCacheBackendFromAnnotations(kv)
 			assert.Equal(t, tc.expected, result)
+			if tc.expected == constants.KVCacheBackendDefault {
+				assert.Equal(t, constants.KVCacheBackendVineyard, result)
+			}
 		})
+	}
+}
+
+func TestKVCacheReconciler_UnsupportedBackend(t *testing.T) {
+	scheme := newKVCacheTestScheme(t)
+	kv := newUnitTestKVCache("unsupported-cache", "default")
+	kv.Annotations = map[string]string{
+		constants.KVCacheLabelKeyBackend: "not-a-backend",
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kv).Build()
+	r := newUnitTestReconciler(c, scheme)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: kv.Name, Namespace: kv.Namespace},
+	})
+	require.Error(t, err)
+	assert.EqualError(t, err, "unsupported backend: not-a-backend")
+
+	assertNoOwnedWorkloads(t, c, kv.Namespace, kv.Name)
+}
+
+func TestKVCacheReconciler_DefaultBackendCreatesOwnedResources(t *testing.T) {
+	scheme := newKVCacheTestScheme(t)
+	kv := newUnitTestKVCache("default-cache", "default")
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kv).Build()
+	r := newUnitTestReconciler(c, scheme)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: kv.Name, Namespace: kv.Namespace},
+	})
+	require.NoError(t, err)
+
+	deploy := &appsv1.Deployment{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: kv.Name, Namespace: kv.Namespace}, deploy))
+	assertControllerOwnerRef(t, deploy, kv)
+
+	svc := &corev1.Service{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: kv.Name + "-rpc", Namespace: kv.Namespace}, svc))
+	assertControllerOwnerRef(t, svc, kv)
+
+	sts := &appsv1.StatefulSet{}
+	err = c.Get(context.Background(), types.NamespacedName{Name: kv.Name, Namespace: kv.Namespace}, sts)
+	assert.True(t, apierrors.IsNotFound(err), "default vineyard backend should not create a StatefulSet")
+}
+
+func TestKVCacheRequestsForPod(t *testing.T) {
+	t.Run("maps identifier label to KVCache request", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cache-member",
+				Namespace: "kv-ns",
+				Labels: map[string]string{
+					constants.KVCacheLabelKeyIdentifier: "my-kvcache",
+				},
+			},
+		}
+
+		reqs := kvCacheRequestsForPod(context.Background(), pod)
+		require.Equal(t, []reconcile.Request{{
+			NamespacedName: types.NamespacedName{Namespace: "kv-ns", Name: "my-kvcache"},
+		}}, reqs)
+	})
+
+	t.Run("returns nil without identifier label", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "unrelated",
+				Namespace: "kv-ns",
+				Labels: map[string]string{
+					"app": "other",
+				},
+			},
+		}
+		assert.Nil(t, kvCacheRequestsForPod(context.Background(), pod))
+	})
+
+	t.Run("returns nil when labels are empty", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "unlabeled",
+				Namespace: "kv-ns",
+			},
+		}
+		assert.Nil(t, kvCacheRequestsForPod(context.Background(), pod))
+	})
+}
+
+func TestPodWithLabelFilter(t *testing.T) {
+	pred := podWithLabelFilter(constants.KVCacheLabelKeyIdentifier)
+	labeled := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labeled",
+			Labels: map[string]string{
+				constants.KVCacheLabelKeyIdentifier: "my-kvcache",
+			},
+		},
+	}
+	unlabeled := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "unlabeled",
+			Labels: map[string]string{
+				"app": "other",
+			},
+		},
+	}
+
+	assert.True(t, pred.Create(event.CreateEvent{Object: labeled}))
+	assert.False(t, pred.Create(event.CreateEvent{Object: unlabeled}))
+	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: unlabeled, ObjectNew: labeled}))
+	assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: unlabeled, ObjectNew: unlabeled}))
+	assert.True(t, pred.Delete(event.DeleteEvent{Object: labeled}))
+	assert.False(t, pred.Delete(event.DeleteEvent{Object: unlabeled}))
+	assert.True(t, pred.Generic(event.GenericEvent{Object: labeled}))
+	assert.False(t, pred.Generic(event.GenericEvent{Object: unlabeled}))
+}
+
+func newKVCacheTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, orchestrationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	return scheme
+}
+
+func newUnitTestReconciler(c client.Client, scheme *runtime.Scheme) *KVCacheReconciler {
+	return &KVCacheReconciler{
+		Client: c,
+		Scheme: scheme,
+		Backends: map[string]backends.BackendReconciler{
+			constants.KVCacheBackendVineyard:    backends.NewVineyardReconciler(c),
+			constants.KVCacheBackendHPKV:        backends.NewDistributedReconciler(c, constants.KVCacheBackendHPKV),
+			constants.KVCacheBackendInfinistore: backends.NewDistributedReconciler(c, constants.KVCacheBackendInfinistore),
+		},
+	}
+}
+
+func newUnitTestKVCache(name, namespace string) *orchestrationv1alpha1.KVCache {
+	return &orchestrationv1alpha1.KVCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID(name + "-uid"),
+		},
+		Spec: orchestrationv1alpha1.KVCacheSpec{
+			Cache: orchestrationv1alpha1.RuntimeSpec{
+				Replicas:        1,
+				Image:           "aibrix/vineyardd:20241120",
+				ImagePullPolicy: "IfNotPresent",
+			},
+			Service: orchestrationv1alpha1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "rpc",
+						Port:       9600,
+						TargetPort: intstr.FromInt32(9600),
+						Protocol:   corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}
+}
+
+func assertControllerOwnerRef(t *testing.T, obj metav1.Object, kv *orchestrationv1alpha1.KVCache) {
+	t.Helper()
+	require.True(t, metav1.IsControlledBy(obj, kv))
+	require.NotEmpty(t, obj.GetOwnerReferences())
+	assert.Equal(t, "KVCache", obj.GetOwnerReferences()[0].Kind)
+	assert.Equal(t, kv.Name, obj.GetOwnerReferences()[0].Name)
+	assert.Equal(t, kv.UID, obj.GetOwnerReferences()[0].UID)
+}
+
+func assertNoOwnedWorkloads(t *testing.T, c client.Client, namespace, name string) {
+	t.Helper()
+	ctx := context.Background()
+
+	deploy := &appsv1.Deployment{}
+	err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, deploy)
+	assert.True(t, apierrors.IsNotFound(err), "expected no Deployment for unsupported backend")
+
+	sts := &appsv1.StatefulSet{}
+	err = c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, sts)
+	assert.True(t, apierrors.IsNotFound(err), "expected no StatefulSet for unsupported backend")
+
+	for _, svcName := range []string{name + "-rpc", name + "-headless-service"} {
+		svc := &corev1.Service{}
+		err = c.Get(ctx, types.NamespacedName{Name: svcName, Namespace: namespace}, svc)
+		assert.True(t, apierrors.IsNotFound(err), "expected no Service %s for unsupported backend", svcName)
 	}
 }

--- a/test/integration/controller/kvcache_test.go
+++ b/test/integration/controller/kvcache_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	orchestrationapi "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/constants"
+)
+
+const (
+	kvcacheTimeout  = time.Second * 10
+	kvcacheInterval = time.Millisecond * 250
+)
+
+var _ = ginkgo.Describe("KVCache controller test", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-kvcache-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+		gomega.Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKeyFromObject(ns), ns)
+		}, time.Second*3).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(k8sClient.Delete(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("uses the default vineyard backend when the backend annotation is omitted", func() {
+		kv := newIntegrationKVCache("default-backend", ns.Name, "")
+		gomega.Expect(k8sClient.Create(ctx, kv)).To(gomega.Succeed())
+		kv = waitForKVCache(kv)
+
+		deploy := waitForDeployment(ns.Name, kv.Name)
+		expectControlledByKVCache(deploy, kv)
+		gomega.Expect(deploy.Labels[constants.KVCacheLabelKeyIdentifier]).To(gomega.Equal(kv.Name))
+		gomega.Expect(deploy.Labels[constants.KVCacheLabelKeyRole]).To(gomega.Equal(constants.KVCacheLabelValueRoleCache))
+		gomega.Expect(deploy.Spec.Replicas).ToNot(gomega.BeNil())
+		gomega.Expect(*deploy.Spec.Replicas).To(gomega.Equal(int32(1)))
+
+		svc := waitForService(ns.Name, fmt.Sprintf("%s-rpc", kv.Name))
+		expectControlledByKVCache(svc, kv)
+		gomega.Expect(svc.Spec.Selector[constants.KVCacheLabelKeyIdentifier]).To(gomega.Equal(kv.Name))
+
+		gomega.Consistently(func() bool {
+			return isNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: kv.Name}, &appsv1.StatefulSet{}))
+		}, time.Second*2, kvcacheInterval).Should(gomega.BeTrue())
+	})
+
+	ginkgo.It("does not create owned workloads for an unsupported backend", func() {
+		kv := newIntegrationKVCache("unsupported-backend", ns.Name, "not-a-backend")
+		gomega.Expect(k8sClient.Create(ctx, kv)).To(gomega.Succeed())
+		_ = waitForKVCache(kv)
+
+		gomega.Consistently(func(g gomega.Gomega) {
+			g.Expect(isNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: kv.Name}, &appsv1.Deployment{}))).To(gomega.BeTrue())
+			g.Expect(isNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: kv.Name}, &appsv1.StatefulSet{}))).To(gomega.BeTrue())
+			g.Expect(isNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: kv.Name + "-rpc"}, &corev1.Service{}))).To(gomega.BeTrue())
+			g.Expect(isNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: kv.Name + "-headless-service"}, &corev1.Service{}))).To(gomega.BeTrue())
+		}, time.Second*3, kvcacheInterval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("creates owned Service, Deployment, and StatefulSet resources with controller owner references", func() {
+		vineyard := newIntegrationKVCache("owned-vineyard", ns.Name, constants.KVCacheBackendVineyard)
+		gomega.Expect(k8sClient.Create(ctx, vineyard)).To(gomega.Succeed())
+		vineyard = waitForKVCache(vineyard)
+
+		vineyardDeploy := waitForDeployment(ns.Name, vineyard.Name)
+		expectControlledByKVCache(vineyardDeploy, vineyard)
+		vineyardSvc := waitForService(ns.Name, vineyard.Name+"-rpc")
+		expectControlledByKVCache(vineyardSvc, vineyard)
+
+		hpkv := newIntegrationKVCache("owned-hpkv", ns.Name, constants.KVCacheBackendHPKV)
+		gomega.Expect(k8sClient.Create(ctx, hpkv)).To(gomega.Succeed())
+		hpkv = waitForKVCache(hpkv)
+
+		sts := waitForStatefulSet(ns.Name, hpkv.Name)
+		expectControlledByKVCache(sts, hpkv)
+		gomega.Expect(sts.Labels[constants.KVCacheLabelKeyIdentifier]).To(gomega.Equal(hpkv.Name))
+		gomega.Expect(sts.Labels[constants.KVCacheLabelKeyRole]).To(gomega.Equal(constants.KVCacheLabelValueRoleCache))
+
+		headless := waitForService(ns.Name, hpkv.Name+"-headless-service")
+		expectControlledByKVCache(headless, hpkv)
+		gomega.Expect(headless.Spec.ClusterIP).To(gomega.Equal(corev1.ClusterIPNone))
+		gomega.Expect(headless.Spec.Selector[constants.KVCacheLabelKeyIdentifier]).To(gomega.Equal(hpkv.Name))
+	})
+
+	ginkgo.It("reconciles the matching KVCache when a labeled Pod is created or deleted", func() {
+		kv := newIntegrationKVCache("pod-events", ns.Name, constants.KVCacheBackendVineyard)
+		kv.Spec.Metadata = &orchestrationapi.MetadataSpec{
+			Etcd: &orchestrationapi.MetadataConfig{
+				Runtime: &orchestrationapi.RuntimeSpec{
+					Replicas:        1,
+					Image:           "etcd:3.5",
+					ImagePullPolicy: "IfNotPresent",
+				},
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, kv)).To(gomega.Succeed())
+		kv = waitForKVCache(kv)
+
+		deploy := waitForDeployment(ns.Name, kv.Name)
+		expectControlledByKVCache(deploy, kv)
+		rpc := waitForService(ns.Name, kv.Name+"-rpc")
+		expectControlledByKVCache(rpc, kv)
+
+		etcdPodName := fmt.Sprintf("%s-etcd-0", kv.Name)
+		etcdPod := waitForPod(ns.Name, etcdPodName)
+		gomega.Expect(etcdPod.Labels[constants.KVCacheLabelKeyIdentifier]).To(gomega.Equal(kv.Name))
+		expectControlledByKVCache(etcdPod, kv)
+
+		gomega.Expect(k8sClient.Delete(ctx, etcdPod)).To(gomega.Succeed())
+		gomega.Eventually(func() bool {
+			return isNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: etcdPodName}, &corev1.Pod{}))
+		}, kvcacheTimeout, kvcacheInterval).Should(gomega.BeTrue())
+
+		recreated := waitForPod(ns.Name, etcdPodName)
+		gomega.Expect(recreated.Labels[constants.KVCacheLabelKeyIdentifier]).To(gomega.Equal(kv.Name))
+		expectControlledByKVCache(recreated, kv)
+
+		rpcCopy := rpc.DeepCopy()
+		gomega.Expect(k8sClient.Delete(ctx, rpcCopy)).To(gomega.Succeed())
+		gomega.Eventually(func() bool {
+			return isNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: rpc.Name}, &corev1.Service{}))
+		}, kvcacheTimeout, kvcacheInterval).Should(gomega.BeTrue())
+
+		trigger := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "labeled-trigger",
+				Namespace: ns.Name,
+				Labels: map[string]string{
+					constants.KVCacheLabelKeyIdentifier: kv.Name,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "pause",
+						Image: "registry.k8s.io/pause:3.9",
+					},
+				},
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, trigger)).To(gomega.Succeed())
+
+		recreatedSvc := waitForService(ns.Name, rpc.Name)
+		expectControlledByKVCache(recreatedSvc, kv)
+		gomega.Expect(recreatedSvc.Spec.Selector[constants.KVCacheLabelKeyIdentifier]).To(gomega.Equal(kv.Name))
+	})
+})
+
+func newIntegrationKVCache(name, namespace, backend string) *orchestrationapi.KVCache {
+	kv := &orchestrationapi.KVCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: orchestrationapi.KVCacheSpec{
+			Cache: orchestrationapi.RuntimeSpec{
+				Replicas:        1,
+				Image:           "aibrix/vineyardd:20241120",
+				ImagePullPolicy: "IfNotPresent",
+			},
+			Service: orchestrationapi.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "rpc",
+						Port:       9600,
+						TargetPort: intstr.FromInt32(9600),
+						Protocol:   corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}
+	if backend != "" {
+		kv.Annotations = map[string]string{
+			constants.KVCacheLabelKeyBackend: backend,
+		}
+	}
+	return kv
+}
+
+func waitForKVCache(kv *orchestrationapi.KVCache) *orchestrationapi.KVCache {
+	fetched := &orchestrationapi.KVCache{}
+	gomega.Eventually(func() error {
+		return k8sClient.Get(ctx, client.ObjectKeyFromObject(kv), fetched)
+	}, kvcacheTimeout, kvcacheInterval).Should(gomega.Succeed())
+	return fetched
+}
+
+func waitForDeployment(namespace, name string) *appsv1.Deployment {
+	deploy := &appsv1.Deployment{}
+	gomega.Eventually(func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, deploy)
+	}, kvcacheTimeout, kvcacheInterval).Should(gomega.Succeed())
+	return deploy
+}
+
+func waitForStatefulSet(namespace, name string) *appsv1.StatefulSet {
+	sts := &appsv1.StatefulSet{}
+	gomega.Eventually(func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, sts)
+	}, kvcacheTimeout, kvcacheInterval).Should(gomega.Succeed())
+	return sts
+}
+
+func waitForService(namespace, name string) *corev1.Service {
+	svc := &corev1.Service{}
+	gomega.Eventually(func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, svc)
+	}, kvcacheTimeout, kvcacheInterval).Should(gomega.Succeed())
+	return svc
+}
+
+func waitForPod(namespace, name string) *corev1.Pod {
+	pod := &corev1.Pod{}
+	gomega.Eventually(func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, pod)
+	}, kvcacheTimeout, kvcacheInterval).Should(gomega.Succeed())
+	return pod
+}
+
+func expectControlledByKVCache(obj metav1.Object, kv *orchestrationapi.KVCache) {
+	gomega.Expect(obj.GetOwnerReferences()).ToNot(gomega.BeEmpty())
+	gomega.Expect(metav1.IsControlledBy(obj, kv)).To(gomega.BeTrue())
+	gomega.Expect(obj.GetOwnerReferences()[0].Kind).To(gomega.Equal("KVCache"))
+	gomega.Expect(obj.GetOwnerReferences()[0].Name).To(gomega.Equal(kv.Name))
+	gomega.Expect(obj.GetOwnerReferences()[0].UID).To(gomega.Equal(kv.UID))
+	gomega.Expect(obj.GetOwnerReferences()[0].APIVersion).To(gomega.Equal(orchestrationapi.GroupVersion.String()))
+}
+
+func isNotFound(err error) bool {
+	return apierrors.IsNotFound(err)
+}


### PR DESCRIPTION
## Summary
I added KVCache controller coverage for the **KVCache controller integration tests** item on #2637:

- Default backend: omitting the backend annotation selects vineyard and creates the cache Deployment plus RPC Service.
- Unsupported backend: reconcile returns `unsupported backend: %s` and does not create owned Service/Deployment/StatefulSet objects.
- Owned resources: vineyard creates a Deployment and Service, hpkv creates a StatefulSet and headless Service, each with a controller owner reference pointing at the KVCache.
- Pod label events: pods labeled with `kvcache.orchestration.aibrix.ai/name` map to the matching KVCache; deleting a labeled etcd pod (or creating a labeled pod after the RPC Service is removed) retriggers reconcile so owned objects are restored.

This does **not** close #2637. It only covers the KVCache integration-tests item. ModelRouter tests and controller registration are handled in other PRs.

## Test plan
- [x] `go test ./pkg/controller/kvcache -count=1`
- [x] `go test ./test/integration/controller -count=1 --ginkgo.focus="KVCache"`

Refs #2637