### PR TITLE
docs: document PodAutoscaler support for Kubernetes external metrics

### DIFF
--- a/docs/source/features/autoscaling/metric-based-autoscaling.rst
+++ b/docs/source/features/autoscaling/metric-based-autoscaling.rst
@@ -157,6 +157,66 @@ Example APA yaml config
    :language: yaml
 
 
+Using Kubernetes external metrics
+---------------------------------
+
+Besides scraping a metrics endpoint directly, a ``PodAutoscaler`` can read its
+target metric from the Kubernetes ``external.metrics.k8s.io`` API. This lets you
+scale on any metric published by an external metrics adapter, such as Prometheus
+Adapter or an adapter of your own, without AiBrix having to reach the workload's
+metrics port itself.
+
+This is useful when the signal you want to scale on does not live on the pod, for
+example a queue depth held in a broker, or a metric already aggregated by an
+existing monitoring stack.
+
+Selecting the external metrics API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A metric source uses the Kubernetes external metrics API when
+``metricSourceType`` is ``external`` and ``endpoint`` is left unset. Setting
+``endpoint`` switches the same source type back to scraping that HTTP endpoint,
+in which case ``protocolType``, ``endpoint`` and ``path`` are all required.
+
+So for the external metrics API, specify only the metric and its target:
+
+.. code-block:: yaml
+
+    metricsSources:
+      - metricSourceType: external
+        targetMetric: aibrix_running_requests
+        targetValue: "100"
+
+Omitting ``endpoint``, ``path`` and ``protocolType`` is deliberate here, not an
+incomplete example.
+
+Requirements
+^^^^^^^^^^^^
+
+- An external metrics adapter must be installed and serving the
+  ``external.metrics.k8s.io`` API group in the cluster.
+- The adapter must expose the metric named in ``targetMetric``, in the same
+  namespace as the target workload.
+- The AiBrix controller needs ``get`` and ``list`` on
+  ``external.metrics.k8s.io``. The shipped RBAC already grants this.
+
+If the external metrics client cannot be constructed at controller startup, the
+controller logs a warning and continues with external metrics unavailable, so
+check the controller logs if a ``PodAutoscaler`` using this mode never scales.
+
+Example external metrics KPA config
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: ../../../../samples/autoscaling/external-metrics-kpa.yaml
+   :language: yaml
+
+Example external metrics APA config
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: ../../../../samples/autoscaling/external-metrics-apa.yaml
+   :language: yaml
+
+
 Supported PodAutoscaler annotations
 -----------------------------------
 


### PR DESCRIPTION
Fixes #2636.

The `PodAutoscaler` already supports reading its target metric from the Kubernetes
`external.metrics.k8s.io` API. The behaviour is exercised by
`test/e2e/external_metrics_autoscaler_test.go` and there are two working samples in
`samples/autoscaling/`, but `grep -rl "external.metrics.k8s.io" docs/` came back empty, so the
capability was undiscoverable from the docs and both samples were unreferenced.

This adds a "Using Kubernetes external metrics" section to
`docs/source/features/autoscaling/metric-based-autoscaling.rst`. It sits in that page rather than
in a new one because external metrics is a metric source for the existing autoscalers, not a
separate autoscaling mode.

What it covers:

- How a metric source selects the external metrics API. This is the part that is easy to get
  wrong from the samples alone: `metricSourceType: external` with `endpoint` unset uses the
  Kubernetes API, and setting `endpoint` switches the same source type back to HTTP scraping,
  where `protocolType`, `endpoint` and `path` all become required. That rule is
  `validateExternalMetricSource` in `pkg/controller/podautoscaler/podautoscaler_controller.go`.
  The docs now say explicitly that omitting those three fields is deliberate, since both samples
  look incomplete otherwise.
- What the cluster has to provide: an adapter serving the API group, the metric present in the
  same namespace as the workload, and the `get`/`list` RBAC that the shipped manifests already
  grant.
- The failure mode worth knowing about: if the external metrics client cannot be built at
  controller startup the controller logs a warning and carries on with external metrics
  unavailable, so a `PodAutoscaler` in this mode simply never scales. That is a quiet failure and
  the controller log is where it shows up.
- Both samples pulled in with `literalinclude`, matching how the HPA, KPA and APA examples on
  that page already work.

Docs only, no code change.
