### PR TITLE
[Bug] Batch: validate scheduled jobs concurrently

### DIFF
--- a/python/aibrix/aibrix/batch/batch_scheduler.py
+++ b/python/aibrix/aibrix/batch/batch_scheduler.py
@@ -25,7 +25,7 @@ like an OS scheduler); the per-job execution itself lives in the JobDriver.
 
 import asyncio
 import time
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional
 
 import aibrix.batch.constant as constant
 from aibrix.batch.job_entity import BatchJobState
@@ -56,8 +56,8 @@ class BatchScheduler:
         the scheduler keeps no duplicated due-time / inactive bookkeeping — the
         registry is the single source of truth for job state.
 
-        ``pool_size`` caps the number of concurrently executing jobs while the
-        policy still decides which pending job is admitted next.
+        ``pool_size`` caps the number of jobs being admitted or executed while
+        the policy still decides which pending job is admitted next.
         """
         self._context = context
         self._job_progress_manager = job_progress_manager
@@ -78,29 +78,38 @@ class BatchScheduler:
         # derived from the registry's pending pool, so no due-time is tracked.
         self._policy.add(job_id)
 
-    async def schedule_next_job(self) -> Optional[Tuple[str, "JobDriver"]]:
-        # Pick the next job in policy order and admit it (skipping expired /
-        # un-admittable jobs). Returns the admitted (job_id, driver) for the
-        # loop to dispatch, or None if the queue drains.
+    async def schedule_next_job(self) -> Optional[str]:
+        # Pop the next job without awaiting admission so validation can run in
+        # the pool alongside other jobs.
         if self._policy.empty():
             logger.debug("Job scheduler is waiting jobs coming")
             await asyncio.sleep(self._idle_interval)
 
         job_id = self._policy.next()
-        while job_id is not None:
+        if job_id is not None:
             logger.info("Job scheduler is scheduling job", job_id=job_id)  # type: ignore[call-arg]
+        return job_id
+
+    async def _admit_and_execute_scheduled_job(self, job_id: str) -> None:
+        try:
             driver = await self._job_progress_manager.admit(job_id)
-            if driver is not None:
-                return (job_id, driver)
-            # admit() returns None for an expired / no-longer-pending job, so an
-            # expired job is skipped here without a separate "inactive" set.
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(
+                "Failed to admit job",
+                job_id=job_id,
+                error=str(e),
+            )  # type: ignore[call-arg]
+            return
+
+        if driver is None:
             logger.warning(
                 "Scheduler skipped job: admit() declined (expired or no longer pending)",
                 job_id=job_id,
             )  # type: ignore[call-arg]
-            job_id = self._policy.next()
-
-        return None
+            return
+        await self._execute_scheduled_job(job_id, driver)
 
     async def expire_jobs(self):
         # Derive past-due jobs from schedulable pools rather than a duplicated
@@ -168,21 +177,26 @@ class BatchScheduler:
                 )
                 continue
 
-            scheduled: Optional[Tuple[str, "JobDriver"]] = None
+            job_id: Optional[str] = None
             try:
-                scheduled = await self.schedule_next_job()
+                job_id = await self.schedule_next_job()
             except Exception as e:
                 logger.error(
                     "Failed to schedule job",
                     error=str(e),
                 )  # type: ignore[call-arg]
 
-            if scheduled:
-                one_job, job_driver = scheduled
-                task = self._serve_loop.create_task(
-                    self._execute_scheduled_job(one_job, job_driver)
-                )
-                self._job_execution_tasks[one_job] = task
+            if job_id is not None:
+                if job_id in self._job_execution_tasks:
+                    logger.warning(
+                        "Job is already being admitted or executed, skipping duplicate scheduling",
+                        job_id=job_id,
+                    )  # type: ignore[call-arg]
+                else:
+                    task = self._serve_loop.create_task(
+                        self._admit_and_execute_scheduled_job(job_id)
+                    )
+                    self._job_execution_tasks[job_id] = task
             # yield loop
             await asyncio.sleep(0)
 

--- a/python/aibrix/tests/batch/job_driver/test_deployment_driver.py
+++ b/python/aibrix/tests/batch/job_driver/test_deployment_driver.py
@@ -707,14 +707,15 @@ async def test_scheduler_uses_create_job_driver_for_deployment_jobs(monkeypatch)
         created["kwargs"] = kwargs
         return _Driver()
 
+    scheduled_job_ids = [job.job_id]
+
     async def _one_job():
-        return (job.job_id, driver)
+        return scheduled_job_ids.pop(0) if scheduled_job_ids else None
 
     monkeypatch.setattr(
         "aibrix.batch.batch_manager.create_job_driver",
         _create_job_driver,
     )
-    driver = await progress_manager.admit(job.job_id)
     scheduler = BatchScheduler(context, progress_manager, 1)
     monkeypatch.setattr(scheduler, "schedule_next_job", _one_job)
 

--- a/python/aibrix/tests/batch/test_scheduler.py
+++ b/python/aibrix/tests/batch/test_scheduler.py
@@ -93,7 +93,7 @@ def _make_scheduler(progress_manager, pool_size=1):
 
 
 @pytest.mark.asyncio
-async def test_schedule_next_job_pops_fifo_and_validates():
+async def test_schedule_next_job_pops_fifo_without_admitting():
     progress_manager = FakeProgressManager(
         {
             "job-1": BatchJobState.CREATED,
@@ -106,24 +106,19 @@ async def test_schedule_next_job_pops_fifo_and_validates():
 
     first = await scheduler.schedule_next_job()
     second = await scheduler.schedule_next_job()
-    assert first is not None and first[0] == "job-1"
-    assert second is not None and second[0] == "job-2"
-    assert progress_manager.validated_job_ids == ["job-1", "job-2"]
+    assert first == "job-1"
+    assert second == "job-2"
+    assert progress_manager.validated_job_ids == []
 
 
 @pytest.mark.asyncio
-async def test_schedule_next_job_skips_unadmittable_jobs():
-    # "gone-job" is not admittable (admit returns None, e.g. it expired); the
-    # scheduler must advance past it to the next admittable job.
-    progress_manager = FakeProgressManager({"good-job": BatchJobState.CREATED})
+async def test_admit_and_execute_skips_unadmittable_job():
+    progress_manager = FakeProgressManager()
     scheduler = _make_scheduler(progress_manager)
-    scheduler.append_job("gone-job")
-    scheduler.append_job("good-job")
 
-    result = await scheduler.schedule_next_job()
-    assert result is not None and result[0] == "good-job"
-    # admit() is the gate: attempted on the gone job (None) then the good one.
-    assert progress_manager.validated_job_ids == ["gone-job", "good-job"]
+    await scheduler._admit_and_execute_scheduled_job("gone-job")
+
+    assert progress_manager.validated_job_ids == ["gone-job"]
 
 
 @pytest.mark.asyncio
@@ -183,48 +178,82 @@ def test_fifo_scheduling_policy_order_and_empty():
 
 
 @pytest.mark.asyncio
-async def test_jobs_running_loop_dispatches_second_job_while_first_is_blocked(
-    monkeypatch,
-):
-    scheduler = _make_scheduler(FakeProgressManager(), pool_size=2)
-    first_job_entered = asyncio.Event()
-    release_first_job = asyncio.Event()
-    second_job_started = asyncio.Event()
-    scheduled = []
+async def test_jobs_running_loop_admits_up_to_pool_size_concurrently():
+    pool_size = 4
+    job_ids = [f"job-{index}" for index in range(pool_size)]
+    all_admits_started = asyncio.Event()
+    release_admits = asyncio.Event()
 
     class _Driver:
-        def __init__(self, job_id):
-            self.job_id = job_id
-
         async def execute(self, job_id):
-            assert job_id == self.job_id
-            if job_id == "job-1":
-                first_job_entered.set()
-                await release_first_job.wait()
-                return
-            second_job_started.set()
+            assert release_admits.is_set()
 
-    scheduled.extend(
-        [
-            ("job-1", _Driver("job-1")),
-            ("job-2", _Driver("job-2")),
-        ]
-    )
+    class _ProgressManager(FakeProgressManager):
+        async def admit(self, job_id):
+            self.validated_job_ids.append(job_id)
+            if len(self.validated_job_ids) == pool_size:
+                all_admits_started.set()
+            await release_admits.wait()
+            return _Driver()
 
-    async def _schedule_next_job():
-        if scheduled:
-            return scheduled.pop(0)
-        await asyncio.sleep(0)
-        return None
-
-    monkeypatch.setattr(scheduler, "schedule_next_job", _schedule_next_job)
+    progress_manager = _ProgressManager()
+    scheduler = _make_scheduler(progress_manager, pool_size=pool_size)
+    for job_id in job_ids:
+        scheduler.append_job(job_id)
 
     task = asyncio.create_task(scheduler.jobs_running_loop())
     try:
-        await asyncio.wait_for(first_job_entered.wait(), timeout=1)
-        await asyncio.wait_for(second_job_started.wait(), timeout=1)
+        await asyncio.wait_for(all_admits_started.wait(), timeout=1)
+        assert progress_manager.validated_job_ids == job_ids
+        assert len(scheduler._job_execution_tasks) == pool_size
     finally:
-        release_first_job.set()
+        release_admits.set()
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
+        await asyncio.gather(
+            *scheduler._job_execution_tasks.values(),
+            return_exceptions=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_jobs_running_loop_skips_duplicate_active_job():
+    job_id = "job-1"
+    first_admit_started = asyncio.Event()
+    release_admit = asyncio.Event()
+    admit_tasks = []
+
+    class _Driver:
+        async def execute(self, job_id):
+            pass
+
+    class _ProgressManager(FakeProgressManager):
+        async def admit(self, job_id):
+            current_task = asyncio.current_task()
+            assert current_task is not None
+            admit_tasks.append(current_task)
+            self.validated_job_ids.append(job_id)
+            first_admit_started.set()
+            await release_admit.wait()
+            return _Driver()
+
+    progress_manager = _ProgressManager()
+    scheduler = _make_scheduler(progress_manager, pool_size=2)
+    scheduler.append_job(job_id)
+    scheduler.append_job(job_id)
+
+    task = asyncio.create_task(scheduler.jobs_running_loop())
+    try:
+        await asyncio.wait_for(first_admit_started.wait(), timeout=1)
+        while not scheduler._policy.empty():
+            await asyncio.sleep(0)
+
+        assert progress_manager.validated_job_ids == [job_id]
+        assert scheduler._job_execution_tasks[job_id] is admit_tasks[0]
+    finally:
+        release_admit.set()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.gather(*admit_tasks, return_exceptions=True)


### PR DESCRIPTION
## Pull Request Description

Batch job admission currently runs inside the scheduling loop before the job is registered in the execution pool. A slow validation therefore blocks later jobs even when `pool_size` has available capacity.

This change moves admission into the tracked per-job task so that:
- independent jobs can validate concurrently;
- `pool_size` bounds the full admission and execution lifecycle;
- declined or failed admissions release their pool slot without blocking the scheduler;
- duplicate active job IDs are skipped instead of overwriting tracked tasks.

The concurrency regression test blocks four admissions simultaneously with `pool_size=4` and verifies that all four start before execution is released, matching the multi-job scheduling scenario shown in the PR discussion.

## Related Issues

N/A

## Testing

- `poetry run pytest -q tests/batch/test_scheduler.py tests/batch/test_batch_manager.py tests/batch/job_driver/test_deployment_driver.py` (70 passed)
- `poetry run pytest -q tests/batch/test_e2e_openai_batch_api.py -k "respects_default_job_pool_size or second_job_does_not_stay_validating_when_pool_has_capacity"` (2 passed)
- `poetry run ruff check .`
- `poetry run ruff format --check .`
- `poetry run mypy aibrix/batch/batch_scheduler.py`
- `poetry run pytest -q tests` (1040 passed, 25 skipped, 1 xfailed)