### PR TITLE
[Misc] Add KVCache controller integration tests

### DIFF
--- a/pkg/controller/kvcache/kvcache_controller.go
+++ b/pkg/controller/kvcache/kvcache_controller.go
@@ -96,6 +96,24 @@ func podWithLabelFilter(labelKey string) predicate.Predicate {
 	}
 }
 
+// kvCacheRequestsForPod maps a Pod carrying the KVCache identifier label back to
+// the KVCache it belongs to. Pods without the label enqueue nothing.
+func kvCacheRequestsForPod(_ context.Context, obj client.Object) []reconcile.Request {
+	cacheName, ok := obj.GetLabels()[constants.KVCacheLabelKeyIdentifier]
+	if !ok {
+		return nil
+	}
+
+	return []ctrl.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Namespace: obj.GetNamespace(),
+				Name:      cacheName,
+			},
+		},
+	}
+}
+
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// use the builder fashion. If we need more fine grain control later, we can switch to `controller.New()`
@@ -105,21 +123,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		Owns(&corev1.Service{}).
 		Owns(&appsv1.Deployment{}).
 		Watches(&corev1.Pod{},
-			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-				cacheName, ok := obj.GetLabels()[constants.KVCacheLabelKeyIdentifier]
-				if !ok {
-					return nil
-				}
-
-				return []ctrl.Request{
-					{
-						NamespacedName: types.NamespacedName{
-							Namespace: obj.GetNamespace(),
-							Name:      cacheName,
-						},
-					},
-				}
-			}),
+			handler.EnqueueRequestsFromMapFunc(kvCacheRequestsForPod),
 			builder.WithPredicates(podWithLabelFilter(constants.KVCacheLabelKeyIdentifier))).
 		Complete(r)
 	if err != nil {

--- a/pkg/controller/kvcache/kvcache_controller_test.go
+++ b/pkg/controller/kvcache/kvcache_controller_test.go
@@ -17,12 +17,19 @@ limitations under the License.
 package kvcache
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
 	"github.com/vllm-project/aibrix/pkg/constants"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_getKVCacheBackendFromMetadata(t *testing.T) {
@@ -46,6 +53,31 @@ func Test_getKVCacheBackendFromMetadata(t *testing.T) {
 			},
 			expected: constants.KVCacheBackendInfinistore,
 		},
+		{
+			name: "valid backend annotation - hpkv",
+			annotations: map[string]string{
+				constants.KVCacheLabelKeyBackend: constants.KVCacheBackendHPKV,
+			},
+			expected: constants.KVCacheBackendHPKV,
+		},
+		{
+			name:        "nil annotations fall back to the default backend",
+			annotations: nil,
+			expected:    constants.KVCacheBackendDefault,
+		},
+		{
+			name:        "empty annotation map falls back to the default backend",
+			annotations: map[string]string{},
+			expected:    constants.KVCacheBackendDefault,
+		},
+		{
+			// Webhooks may be disabled, leaving the annotation present but blank.
+			name: "blank backend annotation falls back to the default backend",
+			annotations: map[string]string{
+				constants.KVCacheLabelKeyBackend: "",
+			},
+			expected: constants.KVCacheBackendDefault,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -59,4 +91,82 @@ func Test_getKVCacheBackendFromMetadata(t *testing.T) {
 			assert.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+func podWithLabels(name string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "kv-ns",
+			Labels:    labels,
+		},
+	}
+}
+
+func Test_kvCacheRequestsForPod(t *testing.T) {
+	testCases := []struct {
+		name     string
+		labels   map[string]string
+		expected []reconcile.Request
+	}{
+		{
+			name:   "identifier label maps to the named KVCache in the same namespace",
+			labels: map[string]string{constants.KVCacheLabelKeyIdentifier: "my-kvcache"},
+			expected: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "kv-ns", Name: "my-kvcache"}},
+			},
+		},
+		{
+			// A blank identifier still selects the KVCache name it names, which is
+			// empty; the reconciler then treats it as not found.
+			name:   "blank identifier label maps to an empty name",
+			labels: map[string]string{constants.KVCacheLabelKeyIdentifier: ""},
+			expected: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "kv-ns", Name: ""}},
+			},
+		},
+		{
+			name:     "unrelated labels enqueue nothing",
+			labels:   map[string]string{"app": "other"},
+			expected: nil,
+		},
+		{
+			name:     "nil labels enqueue nothing",
+			labels:   nil,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := kvCacheRequestsForPod(context.Background(), podWithLabels("pod", tc.labels))
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func Test_podWithLabelFilter(t *testing.T) {
+	pred := podWithLabelFilter(constants.KVCacheLabelKeyIdentifier)
+
+	labeled := podWithLabels("labeled", map[string]string{
+		constants.KVCacheLabelKeyIdentifier: "my-kvcache",
+	})
+	unlabeled := podWithLabels("unlabeled", map[string]string{"app": "other"})
+
+	// Every event type the controller subscribes to must gate on the label, and
+	// updates are judged on the new object so a Pod that gains the label passes.
+	assert.True(t, pred.Create(event.CreateEvent{Object: labeled}))
+	assert.False(t, pred.Create(event.CreateEvent{Object: unlabeled}))
+
+	assert.True(t, pred.Delete(event.DeleteEvent{Object: labeled}))
+	assert.False(t, pred.Delete(event.DeleteEvent{Object: unlabeled}))
+
+	assert.True(t, pred.Generic(event.GenericEvent{Object: labeled}))
+	assert.False(t, pred.Generic(event.GenericEvent{Object: unlabeled}))
+
+	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: unlabeled, ObjectNew: labeled}),
+		"a Pod that gains the label should pass")
+	assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: labeled, ObjectNew: unlabeled}),
+		"a Pod that loses the label should be filtered out")
+	assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: unlabeled, ObjectNew: unlabeled}))
 }

--- a/test/integration/controller/kvcache_test.go
+++ b/test/integration/controller/kvcache_test.go
@@ -1,0 +1,362 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	orchestrationapi "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/controller/kvcache"
+	"github.com/vllm-project/aibrix/pkg/controller/kvcache/backends"
+)
+
+const (
+	kvCacheTimeout  = time.Second * 15
+	kvCacheInterval = time.Millisecond * 250
+	// kvCacheQuietWindow is how long a resource must stay absent before we accept
+	// that nothing else re-triggered reconciliation. Reconciles in envtest land in
+	// milliseconds, so this leaves a wide margin without slowing the suite.
+	kvCacheQuietWindow = time.Second * 1
+)
+
+// makeKVCache builds a minimal KVCache. An empty backend leaves the annotation
+// unset, which exercises the controller's default-backend path.
+func makeKVCache(namespace, name, backend string) *orchestrationapi.KVCache {
+	kv := &orchestrationapi.KVCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: orchestrationapi.KVCacheSpec{
+			Cache: orchestrationapi.RuntimeSpec{
+				Replicas: 1,
+				Image:    "aibrix/kvcache:test",
+			},
+			// spec.service.ports is required by the CRD schema.
+			Service: orchestrationapi.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{Name: "service", Port: 9600, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		},
+	}
+	if backend != "" {
+		kv.Annotations = map[string]string{
+			constants.KVCacheLabelKeyBackend: backend,
+		}
+	}
+	return kv
+}
+
+// makePod builds a schedulable-looking Pod. When cacheName is non-empty the Pod
+// carries the KVCache identifier label the controller's Pod watch filters on.
+func makePod(namespace, name, cacheName string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Image: "busybox:stable"},
+			},
+		},
+	}
+	if cacheName != "" {
+		pod.Labels = map[string]string{
+			constants.KVCacheLabelKeyIdentifier: cacheName,
+		}
+	}
+	return pod
+}
+
+// newKVCacheReconciler mirrors the backend wiring the controller uses in
+// production, so error paths asserted here match what the manager would hit.
+func newKVCacheReconciler() *kvcache.KVCacheReconciler {
+	hpkv := backends.NewDistributedReconciler(k8sClient, constants.KVCacheBackendHPKV)
+	infinistore := backends.NewDistributedReconciler(k8sClient, constants.KVCacheBackendInfinistore)
+
+	return &kvcache.KVCacheReconciler{
+		Client: k8sClient,
+		Scheme: k8sClient.Scheme(),
+		Backends: map[string]backends.BackendReconciler{
+			constants.KVCacheBackendVineyard:    backends.NewVineyardReconciler(k8sClient),
+			constants.KVCacheBackendHPKV:        hpkv,
+			constants.KVCacheBackendInfinistore: infinistore,
+		},
+	}
+}
+
+var _ = ginkgo.Describe("KVCache controller test", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-kvcache-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+		gomega.Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKeyFromObject(ns), ns)
+		}, time.Second*3).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		// Tolerate NotFound so a failure in BeforeEach surfaces as itself rather
+		// than being masked by a cleanup error.
+		err := k8sClient.Delete(ctx, ns)
+		if err != nil && !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	})
+
+	// expectControllerOwnedBy asserts obj carries exactly one owner reference and
+	// that it is a controller reference back to the given KVCache.
+	expectControllerOwnedBy := func(obj metav1.Object, owner *orchestrationapi.KVCache) {
+		// Report failures at the caller's line rather than inside this helper.
+		ginkgo.GinkgoHelper()
+
+		refs := obj.GetOwnerReferences()
+		gomega.Expect(refs).To(gomega.HaveLen(1))
+
+		ref := refs[0]
+		gomega.Expect(ref.Kind).To(gomega.Equal("KVCache"))
+		gomega.Expect(ref.APIVersion).To(gomega.Equal(orchestrationapi.GroupVersion.String()))
+		gomega.Expect(ref.Name).To(gomega.Equal(owner.Name))
+		gomega.Expect(ref.UID).To(gomega.Equal(owner.UID))
+		gomega.Expect(ref.Controller).NotTo(gomega.BeNil())
+		gomega.Expect(*ref.Controller).To(gomega.BeTrue())
+		gomega.Expect(ref.BlockOwnerDeletion).NotTo(gomega.BeNil())
+		gomega.Expect(*ref.BlockOwnerDeletion).To(gomega.BeTrue())
+	}
+
+	// eventuallyGet waits until the named object exists.
+	eventuallyGet := func(name string, obj client.Object) {
+		ginkgo.GinkgoHelper()
+
+		gomega.Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: name}, obj)
+		}, kvCacheTimeout, kvCacheInterval).Should(gomega.Succeed())
+	}
+
+	// consistentlyAbsent asserts the named object is not (re)created for the
+	// duration of the quiet window.
+	consistentlyAbsent := func(name string, obj client.Object) {
+		ginkgo.GinkgoHelper()
+
+		gomega.Consistently(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: name}, obj)
+			return apierrors.IsNotFound(err)
+		}, kvCacheQuietWindow, kvCacheInterval).Should(gomega.BeTrue())
+	}
+
+	ginkgo.Context("backend selection", func() {
+		ginkgo.It("defaults to the vineyard backend when no backend annotation is set", func() {
+			kv := makeKVCache(ns.Name, "default-backend", "")
+			gomega.Expect(k8sClient.Create(ctx, kv)).To(gomega.Succeed())
+
+			// The vineyard backend is the configured default, so it must produce
+			// the vineyard deployment and its rpc service without any annotation.
+			deploy := &appsv1.Deployment{}
+			eventuallyGet(kv.Name, deploy)
+			gomega.Expect(deploy.Labels).To(gomega.HaveKeyWithValue(constants.KVCacheLabelKeyIdentifier, kv.Name))
+			gomega.Expect(deploy.Labels).To(gomega.HaveKeyWithValue(
+				constants.KVCacheLabelKeyRole, constants.KVCacheLabelValueRoleCache))
+			gomega.Expect(deploy.Spec.Replicas).NotTo(gomega.BeNil())
+			gomega.Expect(*deploy.Spec.Replicas).To(gomega.Equal(int32(1)))
+			gomega.Expect(deploy.Spec.Selector.MatchLabels).To(
+				gomega.HaveKeyWithValue(constants.KVCacheLabelKeyIdentifier, kv.Name))
+
+			svc := &corev1.Service{}
+			eventuallyGet(fmt.Sprintf("%s-rpc", kv.Name), svc)
+			// The rpc Service must select the cache pods this KVCache owns.
+			gomega.Expect(svc.Spec.Selector).To(gomega.HaveKeyWithValue(constants.KVCacheLabelKeyIdentifier, kv.Name))
+			gomega.Expect(svc.Spec.Selector).To(gomega.HaveKeyWithValue(
+				constants.KVCacheLabelKeyRole, constants.KVCacheLabelValueRoleCache))
+
+			// The default path must not fall through to a distributed backend.
+			sts := &appsv1.StatefulSet{}
+			consistentlyAbsent(kv.Name, sts)
+		})
+
+		ginkgo.It("produces the same resources when vineyard is requested explicitly", func() {
+			kv := makeKVCache(ns.Name, "explicit-vineyard", constants.KVCacheBackendVineyard)
+			gomega.Expect(k8sClient.Create(ctx, kv)).To(gomega.Succeed())
+
+			deploy := &appsv1.Deployment{}
+			eventuallyGet(kv.Name, deploy)
+
+			svc := &corev1.Service{}
+			eventuallyGet(fmt.Sprintf("%s-rpc", kv.Name), svc)
+		})
+
+		ginkgo.It("returns a reconcile error for an unsupported backend and creates nothing", func() {
+			kv := makeKVCache(ns.Name, "bad-backend", "not-a-real-backend")
+			gomega.Expect(k8sClient.Create(ctx, kv)).To(gomega.Succeed())
+
+			// Drive the reconciler directly: the manager retries this object with
+			// backoff, so the returned error is only observable from a direct call.
+			_, err := newKVCacheReconciler().Reconcile(ctx, ctrl.Request{
+				NamespacedName: types.NamespacedName{Namespace: ns.Name, Name: kv.Name},
+			})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.Equal("unsupported backend: not-a-real-backend"))
+
+			// An unsupported backend must be inert, not partially applied.
+			consistentlyAbsent(kv.Name, &appsv1.Deployment{})
+			consistentlyAbsent(kv.Name, &appsv1.StatefulSet{})
+			consistentlyAbsent(fmt.Sprintf("%s-rpc", kv.Name), &corev1.Service{})
+
+			// Stop the manager's retry loop so it cannot add noise to later specs.
+			gomega.Expect(k8sClient.Delete(ctx, kv)).To(gomega.Succeed())
+		})
+	})
+
+	ginkgo.Context("owned resource ownership", func() {
+		ginkgo.It("sets controller owner references on the vineyard Deployment and Service", func() {
+			kv := makeKVCache(ns.Name, "owner-vineyard", constants.KVCacheBackendVineyard)
+			gomega.Expect(k8sClient.Create(ctx, kv)).To(gomega.Succeed())
+
+			deploy := &appsv1.Deployment{}
+			eventuallyGet(kv.Name, deploy)
+			expectControllerOwnedBy(deploy, kv)
+
+			svc := &corev1.Service{}
+			eventuallyGet(fmt.Sprintf("%s-rpc", kv.Name), svc)
+			expectControllerOwnedBy(svc, kv)
+		})
+
+		ginkgo.It("sets controller owner references on the infinistore StatefulSet and Service", func() {
+			kv := makeKVCache(ns.Name, "owner-infinistore", constants.KVCacheBackendInfinistore)
+			gomega.Expect(k8sClient.Create(ctx, kv)).To(gomega.Succeed())
+
+			sts := &appsv1.StatefulSet{}
+			eventuallyGet(kv.Name, sts)
+			expectControllerOwnedBy(sts, kv)
+			gomega.Expect(sts.Labels).To(gomega.HaveKeyWithValue(constants.KVCacheLabelKeyIdentifier, kv.Name))
+			gomega.Expect(sts.Labels).To(gomega.HaveKeyWithValue(
+				constants.KVCacheLabelKeyRole, constants.KVCacheLabelValueRoleCache))
+			gomega.Expect(sts.Spec.Replicas).NotTo(gomega.BeNil())
+			gomega.Expect(*sts.Spec.Replicas).To(gomega.Equal(int32(1)))
+
+			svc := &corev1.Service{}
+			eventuallyGet(fmt.Sprintf("%s-headless-service", kv.Name), svc)
+			expectControllerOwnedBy(svc, kv)
+			// The distributed backends front their pods with a headless Service.
+			gomega.Expect(svc.Spec.ClusterIP).To(gomega.Equal(corev1.ClusterIPNone))
+			gomega.Expect(svc.Spec.Selector).To(gomega.HaveKeyWithValue(constants.KVCacheLabelKeyIdentifier, kv.Name))
+		})
+	})
+
+	// The controller watches Pods carrying the KVCache identifier label and maps
+	// them back to the named KVCache. StatefulSets are deliberately absent from
+	// the controller's Owns() list, so deleting one produces no self-healing
+	// event -- that makes its recreation an unambiguous signal that the Pod
+	// event, and nothing else, drove the reconcile.
+	ginkgo.Context("pod-triggered reconciliation", func() {
+		ginkgo.It("reconciles the KVCache named by the Pod's identifier label", func() {
+			kv := makeKVCache(ns.Name, "pod-trigger", constants.KVCacheBackendInfinistore)
+			gomega.Expect(k8sClient.Create(ctx, kv)).To(gomega.Succeed())
+
+			sts := &appsv1.StatefulSet{}
+			eventuallyGet(kv.Name, sts)
+
+			gomega.Expect(k8sClient.Delete(ctx, sts)).To(gomega.Succeed())
+			consistentlyAbsent(kv.Name, &appsv1.StatefulSet{})
+
+			gomega.Expect(k8sClient.Create(ctx, makePod(ns.Name, "labeled-pod", kv.Name))).To(gomega.Succeed())
+
+			eventuallyGet(kv.Name, &appsv1.StatefulSet{})
+		})
+
+		ginkgo.It("reconciles the matching KVCache when a labeled Pod is deleted", func() {
+			kv := makeKVCache(ns.Name, "pod-delete", constants.KVCacheBackendInfinistore)
+			gomega.Expect(k8sClient.Create(ctx, kv)).To(gomega.Succeed())
+
+			sts := &appsv1.StatefulSet{}
+			eventuallyGet(kv.Name, sts)
+
+			// Create the Pod first; its create event is not what we are testing.
+			// Note: removing a Pod emits both an update (deletionTimestamp set)
+			// and a delete event, and either is enough to enqueue the KVCache, so
+			// this spec proves removal reconciles but cannot single out DeleteFunc.
+			// Test_podWithLabelFilter pins each predicate branch individually.
+			pod := makePod(ns.Name, "doomed-pod", kv.Name)
+			gomega.Expect(k8sClient.Create(ctx, pod)).To(gomega.Succeed())
+			eventuallyGet(pod.Name, &corev1.Pod{})
+
+			// Remove the unwatched StatefulSet and confirm nothing restores it,
+			// so the only thing left that can is the Pod delete event.
+			gomega.Expect(k8sClient.Delete(ctx, sts)).To(gomega.Succeed())
+			consistentlyAbsent(kv.Name, &appsv1.StatefulSet{})
+
+			gomega.Expect(k8sClient.Delete(ctx, pod)).To(gomega.Succeed())
+
+			eventuallyGet(kv.Name, &appsv1.StatefulSet{})
+		})
+
+		ginkgo.It("ignores Pods without the identifier label", func() {
+			kv := makeKVCache(ns.Name, "pod-no-label", constants.KVCacheBackendInfinistore)
+			gomega.Expect(k8sClient.Create(ctx, kv)).To(gomega.Succeed())
+
+			sts := &appsv1.StatefulSet{}
+			eventuallyGet(kv.Name, sts)
+
+			gomega.Expect(k8sClient.Delete(ctx, sts)).To(gomega.Succeed())
+
+			gomega.Expect(k8sClient.Create(ctx, makePod(ns.Name, "unlabeled-pod", ""))).To(gomega.Succeed())
+
+			// The predicate drops this Pod, so no reconcile is enqueued.
+			consistentlyAbsent(kv.Name, &appsv1.StatefulSet{})
+		})
+
+		ginkgo.It("routes the Pod event only to the KVCache named by the label", func() {
+			target := makeKVCache(ns.Name, "route-target", constants.KVCacheBackendInfinistore)
+			other := makeKVCache(ns.Name, "route-other", constants.KVCacheBackendInfinistore)
+			gomega.Expect(k8sClient.Create(ctx, target)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, other)).To(gomega.Succeed())
+
+			targetSts := &appsv1.StatefulSet{}
+			otherSts := &appsv1.StatefulSet{}
+			eventuallyGet(target.Name, targetSts)
+			eventuallyGet(other.Name, otherSts)
+
+			gomega.Expect(k8sClient.Delete(ctx, targetSts)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Delete(ctx, otherSts)).To(gomega.Succeed())
+
+			gomega.Expect(k8sClient.Create(ctx, makePod(ns.Name, "target-pod", target.Name))).To(gomega.Succeed())
+
+			// Only the KVCache named by the label is reconciled.
+			eventuallyGet(target.Name, &appsv1.StatefulSet{})
+			consistentlyAbsent(other.Name, &appsv1.StatefulSet{})
+		})
+	})
+})


### PR DESCRIPTION
## Pull Request Description

Adds test coverage for the **KVCache controller integration tests** item on #2637. The controller previously had only the kubebuilder scaffold spec, which called `Reconcile` once and asserted nothing beyond a nil error.

### Integration tests (`test/integration/controller/kvcache_test.go`, 9 specs)

- **Default backend** — a KVCache with no backend annotation resolves to vineyard and produces the cache `Deployment` and `<name>-rpc` `Service`, and does not fall through to a distributed backend. Asserts identifier/role labels, replica count and selectors, not just existence. An explicit `vineyard` annotation is verified to produce the same result.
- **Unsupported backend** — reconciling a KVCache annotated with an unknown backend returns `unsupported backend: <name>` and leaves no partially applied Deployment/StatefulSet/Service behind.
- **Owner references** — the vineyard `Deployment`/`Service` and the infinistore `StatefulSet`/headless `Service` each carry exactly one controller owner reference back to their KVCache, with `Controller` and `BlockOwnerDeletion` set. Also checks the headless Service is `ClusterIP: None`.
- **Pod label events** — a labeled Pod reconciles the KVCache it names; removing a labeled Pod also reconciles it; a Pod without the identifier label is filtered out; and a labeled Pod reconciles **only** the KVCache it names, verified against a second KVCache in the same namespace.

The pod-event specs use the infinistore backend deliberately. `Service` and `Deployment` are both in the controller's `Owns()` list, so deleting one is self-healed by its own watch and could not attribute the reconcile to the Pod event. `StatefulSet` is not watched, so its recreation is an unambiguous signal that the Pod event alone drove the reconcile. I verified this by removing the `Watches(&corev1.Pod{}, ...)` clause and confirming the relevant specs fail.

One honest caveat, also noted in a code comment: removing a Pod emits both an update (`deletionTimestamp` set) and a delete event, and either alone is enough to enqueue the KVCache. The removal spec therefore proves removal reconciles, but cannot single out `DeleteFunc`; the unit test pins each predicate branch individually.

### Unit tests (`pkg/controller/kvcache/kvcache_controller_test.go`)

- `Test_kvCacheRequestsForPod` — the identifier label maps to the correctly namespaced request; unrelated/nil labels enqueue nothing.
- `Test_podWithLabelFilter` — all four predicate branches (create/update/delete/generic), including that a Pod gaining the label passes an update and one losing it is filtered.
- Extra `getKVCacheBackendFromAnnotations` cases: hpkv, nil annotations, empty map, and a blank annotation value.

### Production change

`kvcache_controller.go` extracts the inline Pod-to-KVCache map closure into a named `kvCacheRequestsForPod` so it can be unit tested directly. No behavior change.

### Test plan

- `make test` — 62 packages ok
- `bin/ginkgo ./test/integration/controller` — 54/54 specs pass
- `make lint` — clean
- Specs run 3x with `--randomize-all` and differing seeds, no flakes

## Related Issues

Refs: #2637

This does **not** close #2637 — it covers only the KVCache integration-tests item. Picking this up after #2641 was closed by its author so others could take this item.

---

<details>
<summary><strong>Submission Checklist</strong></summary>

- [x] PR title includes appropriate prefix(es)
- [x] Changes are clearly explained in the PR description
- [x] New and existing tests pass successfully
- [x] Code adheres to project style and best practices
- [x] Documentation updated to reflect changes (if applicable) — n/a, tests only
- [x] Thorough testing completed, no regressions introduced

</details>
