### PR TITLE
[Bug] Fix spurious malformed JSON errors on split SSE chunks

### DIFF
--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -255,6 +255,7 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 			s.finishRequestCount(st)
 		}
 		requestBuffers.Delete(st.requestID)
+		streamBuffers.Delete(st.requestID)
 		// end spans created by this server
 		for _, span := range []trace.Span{st.toLastRespSpan, st.firstRespSpan, st.inferenceSpan} {
 			if span != nil {

--- a/pkg/plugins/gateway/gateway_rsp_body.go
+++ b/pkg/plugins/gateway/gateway_rsp_body.go
@@ -78,6 +78,12 @@ type TokenUsage struct {
 	TotalTokens      int64
 }
 
+// streamBufferOverflow is stored in streamBuffers (in place of the actual trailing bytes)
+// to mark that a request's current SSE line grew past maxStreamBufferSize. It is a
+// zero-length, non-nil slice, which is otherwise never stored (the normal path only stores
+// a tail once len(tail) > 0), so it is unambiguous as a sentinel.
+var streamBufferOverflow = []byte{}
+
 func processStreamingResponse(requestID string, bodyBytes []byte, endOfStream bool) (TokenUsage, *extProcPb.ProcessingResponse) {
 	var usage TokenUsage
 
@@ -88,7 +94,24 @@ func processStreamingResponse(requestID string, bodyBytes []byte, endOfStream bo
 	// not only after "usage" has already appeared. Reassemble any trailing partial
 	// line carried over from the previous chunk before scanning.
 	if v, ok := streamBuffers.LoadAndDelete(requestID); ok {
-		if buf, ok := v.([]byte); ok {
+		buf, ok := v.([]byte)
+		if !ok {
+			klog.Warningf("streamBuffers held unexpected type %T for requestID %s; discarding", v, requestID)
+		} else if len(buf) == 0 {
+			// A previous call gave up on this line after it exceeded maxStreamBufferSize
+			// (see below). Discard bytes up to and including the next newline -- the rest
+			// of that same oversized line -- without attempting to validate/parse it, since
+			// its beginning was already dropped, then resume normal processing on whatever
+			// follows.
+			if idx := bytes.IndexByte(bodyBytes, '\n'); idx >= 0 {
+				bodyBytes = bodyBytes[idx+1:]
+			} else {
+				if !endOfStream {
+					streamBuffers.Store(requestID, streamBufferOverflow)
+				}
+				return usage, nil
+			}
+		} else {
 			bodyBytes = append(buf, bodyBytes...)
 		}
 	}
@@ -98,32 +121,31 @@ func processStreamingResponse(requestID string, bodyBytes []byte, endOfStream bo
 	// it currently contains "usage" -- the "usage" key itself may not have arrived
 	// yet. This keeps the scanning below operating only on complete lines, so a
 	// chunk boundary landing mid-JSON never gets misreported as malformed JSON.
-	// The carried-over tail is capped so a malformed upstream that never emits a
-	// newline cannot grow this buffer without bound.
+	//
+	// The carried-over tail is capped so a malformed upstream that never emits a newline
+	// cannot grow this buffer without bound. A single SSE event legitimately exceeding the
+	// cap (e.g. a large tool-call/reasoning/multimodal delta arriving as one long line) must
+	// not abort the client's stream with a 500 -- that reproduces the original bug this
+	// buffering was added to fix. So instead of erroring, drop the oversized tail, skip usage
+	// extraction for that one line, and let the stream continue; the loss is logged.
 	if !endOfStream {
 		if idx := bytes.LastIndexByte(bodyBytes, '\n'); idx >= 0 {
 			if tail := bodyBytes[idx+1:]; len(tail) > 0 {
 				if len(tail) > maxStreamBufferSize {
-					return usage, generateErrorResponse(
-						envoyTypePb.StatusCode_InternalServerError,
-						[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
-							Key: HeaderErrorStreaming, RawValue: []byte("true"),
-						}}},
-						"buffered SSE line exceeded size limit", "", "")
+					klog.Warningf("requestID %s: buffered SSE line exceeded %d bytes; dropping remainder, usage extraction for that line may be lost", requestID, maxStreamBufferSize)
+					streamBuffers.Store(requestID, streamBufferOverflow)
+				} else {
+					streamBuffers.Store(requestID, bytes.Clone(tail))
 				}
-				streamBuffers.Store(requestID, bytes.Clone(tail))
 				bodyBytes = bodyBytes[:idx+1]
 			}
 		} else if len(bodyBytes) > 0 {
 			if len(bodyBytes) > maxStreamBufferSize {
-				return usage, generateErrorResponse(
-					envoyTypePb.StatusCode_InternalServerError,
-					[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
-						Key: HeaderErrorStreaming, RawValue: []byte("true"),
-					}}},
-					"buffered SSE line exceeded size limit", "", "")
+				klog.Warningf("requestID %s: buffered SSE line exceeded %d bytes; dropping remainder, usage extraction for that line may be lost", requestID, maxStreamBufferSize)
+				streamBuffers.Store(requestID, streamBufferOverflow)
+			} else {
+				streamBuffers.Store(requestID, bytes.Clone(bodyBytes))
 			}
-			streamBuffers.Store(requestID, bytes.Clone(bodyBytes))
 			bodyBytes = nil
 		}
 	}

--- a/pkg/plugins/gateway/gateway_rsp_body.go
+++ b/pkg/plugins/gateway/gateway_rsp_body.go
@@ -74,8 +74,35 @@ type TokenUsage struct {
 	TotalTokens      int64
 }
 
-func processStreamingResponse(requestID string, bodyBytes []byte) (TokenUsage, *extProcPb.ProcessingResponse) {
+func processStreamingResponse(requestID string, bodyBytes []byte, endOfStream bool) (TokenUsage, *extProcPb.ProcessingResponse) {
 	var usage TokenUsage
+
+	// HandleResponseBody runs once per ext_proc callback, and Envoy delivers response
+	// body chunks as TCP data arrives rather than aligned to SSE line boundaries. A
+	// "data: {...}" line (and the "usage" field inside it) can therefore be split
+	// across two consecutive calls, and the split can land anywhere in the line --
+	// not only after "usage" has already appeared. Reassemble any trailing partial
+	// line carried over from the previous chunk before scanning.
+	if v, ok := streamBuffers.LoadAndDelete(requestID); ok {
+		bodyBytes = append(v.([]byte), bodyBytes...)
+	}
+
+	// Unless this is the final chunk, carve off any trailing line that isn't yet
+	// newline-terminated and carry it over to the next call, regardless of whether
+	// it currently contains "usage" -- the "usage" key itself may not have arrived
+	// yet. This keeps the scanning below operating only on complete lines, so a
+	// chunk boundary landing mid-JSON never gets misreported as malformed JSON.
+	if !endOfStream {
+		if idx := bytes.LastIndexByte(bodyBytes, '\n'); idx >= 0 {
+			if tail := bodyBytes[idx+1:]; len(tail) > 0 {
+				streamBuffers.Store(requestID, append([]byte(nil), tail...))
+				bodyBytes = bodyBytes[:idx+1]
+			}
+		} else if len(bodyBytes) > 0 {
+			streamBuffers.Store(requestID, append([]byte(nil), bodyBytes...))
+			bodyBytes = nil
+		}
+	}
 
 	// The previous implementation unmarshalled every single SSE chunk into a struct (openai.ChatCompletionChunk).
 	// This caused significant CPU overhead and high GC pressure under heavy concurrency.
@@ -86,7 +113,10 @@ func processStreamingResponse(requestID string, bodyBytes []byte) (TokenUsage, *
 
 		for len(remaining) > 0 {
 			var line []byte
-			// Manually find the newline to avoid the allocations of bytes.Split
+			// Manually find the newline to avoid the allocations of bytes.Split.
+			// Every line here is guaranteed complete: bodyBytes was trimmed to a
+			// newline boundary above unless this is the final chunk, in which case
+			// a trailing line with no newline is legitimately the last line.
 			if idx := bytes.IndexByte(remaining, '\n'); idx >= 0 {
 				line = remaining[:idx]
 				remaining = remaining[idx+1:]
@@ -192,7 +222,7 @@ func (s *Server) HandleResponseBody(ctx context.Context, routerCtx *types.Routin
 
 	if stream {
 		var streamRes *extProcPb.ProcessingResponse
-		usage, streamRes = processStreamingResponse(requestID, b.ResponseBody.GetBody())
+		usage, streamRes = processStreamingResponse(requestID, b.ResponseBody.GetBody(), b.ResponseBody.EndOfStream)
 		if streamRes != nil {
 			complete = true
 			return streamRes, complete, usage

--- a/pkg/plugins/gateway/gateway_rsp_body.go
+++ b/pkg/plugins/gateway/gateway_rsp_body.go
@@ -40,6 +40,10 @@ import (
 
 const (
 	defaultTTFTThreshold = 1
+	// maxStreamBufferSize bounds the trailing partial SSE line carried over between
+	// HandleResponseBody calls, so a malformed or malicious upstream that never emits
+	// a newline cannot grow streamBuffers without bound.
+	maxStreamBufferSize = 1024 * 1024 // 1MB
 )
 
 var (
@@ -84,7 +88,9 @@ func processStreamingResponse(requestID string, bodyBytes []byte, endOfStream bo
 	// not only after "usage" has already appeared. Reassemble any trailing partial
 	// line carried over from the previous chunk before scanning.
 	if v, ok := streamBuffers.LoadAndDelete(requestID); ok {
-		bodyBytes = append(v.([]byte), bodyBytes...)
+		if buf, ok := v.([]byte); ok {
+			bodyBytes = append(buf, bodyBytes...)
+		}
 	}
 
 	// Unless this is the final chunk, carve off any trailing line that isn't yet
@@ -92,14 +98,32 @@ func processStreamingResponse(requestID string, bodyBytes []byte, endOfStream bo
 	// it currently contains "usage" -- the "usage" key itself may not have arrived
 	// yet. This keeps the scanning below operating only on complete lines, so a
 	// chunk boundary landing mid-JSON never gets misreported as malformed JSON.
+	// The carried-over tail is capped so a malformed upstream that never emits a
+	// newline cannot grow this buffer without bound.
 	if !endOfStream {
 		if idx := bytes.LastIndexByte(bodyBytes, '\n'); idx >= 0 {
 			if tail := bodyBytes[idx+1:]; len(tail) > 0 {
-				streamBuffers.Store(requestID, append([]byte(nil), tail...))
+				if len(tail) > maxStreamBufferSize {
+					return usage, generateErrorResponse(
+						envoyTypePb.StatusCode_InternalServerError,
+						[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
+							Key: HeaderErrorStreaming, RawValue: []byte("true"),
+						}}},
+						"buffered SSE line exceeded size limit", "", "")
+				}
+				streamBuffers.Store(requestID, bytes.Clone(tail))
 				bodyBytes = bodyBytes[:idx+1]
 			}
 		} else if len(bodyBytes) > 0 {
-			streamBuffers.Store(requestID, append([]byte(nil), bodyBytes...))
+			if len(bodyBytes) > maxStreamBufferSize {
+				return usage, generateErrorResponse(
+					envoyTypePb.StatusCode_InternalServerError,
+					[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
+						Key: HeaderErrorStreaming, RawValue: []byte("true"),
+					}}},
+					"buffered SSE line exceeded size limit", "", "")
+			}
+			streamBuffers.Store(requestID, bytes.Clone(bodyBytes))
 			bodyBytes = nil
 		}
 	}

--- a/pkg/plugins/gateway/gateway_rsp_body_test.go
+++ b/pkg/plugins/gateway/gateway_rsp_body_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gateway
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -1102,9 +1103,12 @@ func TestHandleResponseBody_SSEChunkSplitAcrossCallbacks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			requestID := "test-req-id-" + tt.name + "-" + time.Now().Format("150405.000000")
+			t.Cleanup(func() { streamBuffers.Delete(requestID) })
+
 			server := &Server{}
 
-			routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", "test-req-id", "")
+			routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", requestID, "")
 			routerCtx.ReqPath = PathChatCompletions
 			routerCtx.RequestTime = time.Now()
 
@@ -1118,7 +1122,7 @@ func TestHandleResponseBody_SSEChunkSplitAcrossCallbacks(t *testing.T) {
 					},
 				},
 			}
-			resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", firstReq, utils.User{}, 0, "test-model", true, false)
+			resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, requestID, firstReq, utils.User{}, 0, "test-model", true, false)
 			assert.False(t, complete, "stream is not complete after the first partial chunk")
 			assert.Equal(t, TokenUsage{}, usage)
 			assert.Nil(t, resp.GetImmediateResponse(), "a mid-stream chunk boundary must not be reported as malformed JSON")
@@ -1131,12 +1135,193 @@ func TestHandleResponseBody_SSEChunkSplitAcrossCallbacks(t *testing.T) {
 					},
 				},
 			}
-			resp, complete, usage = server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", secondReq, utils.User{}, 0, "test-model", true, false)
+			resp, complete, usage = server.HandleResponseBody(context.Background(), routerCtx, requestID, secondReq, utils.User{}, 0, "test-model", true, false)
 			assert.True(t, complete)
 			assert.Nil(t, resp.GetImmediateResponse())
 			assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, usage)
 		})
 	}
+}
+
+// TestHandleResponseBody_SSEEmptyEOSChunkAfterBufferedTail covers a standard Envoy
+// ext_proc pattern that TestHandleResponseBody_SSEChunkSplitAcrossCallbacks does not: the
+// final chunk carrying EndOfStream can itself have an empty body, with the actual last
+// bytes of the line having arrived in the previous (non-final) chunk. The buffered tail
+// must still be reassembled and scanned on EOS even though the EOS chunk contributes no
+// new bytes.
+func TestHandleResponseBody_SSEEmptyEOSChunkAfterBufferedTail(t *testing.T) {
+	// No trailing "\n\n": the whole line arrives with no newline terminator at all, so it
+	// is entirely carried over into streamBuffers rather than scanned on this call.
+	noTerminator := []byte("data: {\"id\": \"1\", \"usage\": {\"prompt_tokens\": 10, \"completion_tokens\": 20, \"total_tokens\": 30}}")
+
+	requestID := "test-req-id-empty-eos-" + time.Now().Format("150405.000000")
+	t.Cleanup(func() { streamBuffers.Delete(requestID) })
+
+	server := &Server{}
+	routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", requestID, "")
+	routerCtx.ReqPath = PathChatCompletions
+	routerCtx.RequestTime = time.Now()
+
+	firstReq := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body:        noTerminator,
+				EndOfStream: false,
+			},
+		},
+	}
+	resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, requestID, firstReq, utils.User{}, 0, "test-model", true, false)
+	assert.False(t, complete)
+	assert.Equal(t, TokenUsage{}, usage)
+	assert.Nil(t, resp.GetImmediateResponse())
+
+	eosReq := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body:        []byte{},
+				EndOfStream: true,
+			},
+		},
+	}
+	resp, complete, usage = server.HandleResponseBody(context.Background(), routerCtx, requestID, eosReq, utils.User{}, 0, "test-model", true, false)
+	assert.True(t, complete)
+	assert.Nil(t, resp.GetImmediateResponse())
+	assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, usage)
+}
+
+// TestHandleResponseBody_SSEChunkSplitThreeWays covers a line split across three (not just
+// two) consecutive HandleResponseBody calls, chaining the trailing-buffer carry-over twice.
+func TestHandleResponseBody_SSEChunkSplitThreeWays(t *testing.T) {
+	full := []byte("data: {\"id\": \"1\", \"usage\": {\"prompt_tokens\": 10, \"completion_tokens\": 20, \"total_tokens\": 30}}\n\n")
+
+	requestID := "test-req-id-three-way-" + time.Now().Format("150405.000000")
+	t.Cleanup(func() { streamBuffers.Delete(requestID) })
+
+	server := &Server{}
+	routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", requestID, "")
+	routerCtx.ReqPath = PathChatCompletions
+	routerCtx.RequestTime = time.Now()
+
+	part1, part2, part3 := full[:10], full[10:40], full[40:]
+
+	for i, part := range [][]byte{part1, part2} {
+		req := &extProcPb.ProcessingRequest{
+			Request: &extProcPb.ProcessingRequest_ResponseBody{
+				ResponseBody: &extProcPb.HttpBody{
+					Body:        part,
+					EndOfStream: false,
+				},
+			},
+		}
+		resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, requestID, req, utils.User{}, 0, "test-model", true, false)
+		assert.False(t, complete, "part %d should not complete the stream", i)
+		assert.Equal(t, TokenUsage{}, usage)
+		assert.Nil(t, resp.GetImmediateResponse(), "part %d must not be reported as malformed JSON", i)
+	}
+
+	finalReq := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body:        part3,
+				EndOfStream: true,
+			},
+		},
+	}
+	resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, requestID, finalReq, utils.User{}, 0, "test-model", true, false)
+	assert.True(t, complete)
+	assert.Nil(t, resp.GetImmediateResponse())
+	assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, usage)
+}
+
+// TestHandleResponseBody_SSECarriageReturnSplitAcrossCallbacks covers the line terminator
+// itself being split across callbacks: one chunk ends with '\r' and the next begins with
+// '\n'. bytes.TrimSpace strips a trailing '\r' from the line content either way, but the
+// buffering must not treat the dangling '\r' as part of an unterminated next line.
+func TestHandleResponseBody_SSECarriageReturnSplitAcrossCallbacks(t *testing.T) {
+	full := []byte("data: {\"id\": \"1\", \"usage\": {\"prompt_tokens\": 10, \"completion_tokens\": 20, \"total_tokens\": 30}}\r\n\r\n")
+	splitAt := bytes.IndexByte(full, '\r') + 1 // split right after the '\r', before the '\n'
+
+	requestID := "test-req-id-crlf-split-" + time.Now().Format("150405.000000")
+	t.Cleanup(func() { streamBuffers.Delete(requestID) })
+
+	server := &Server{}
+	routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", requestID, "")
+	routerCtx.ReqPath = PathChatCompletions
+	routerCtx.RequestTime = time.Now()
+
+	firstReq := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body:        full[:splitAt],
+				EndOfStream: false,
+			},
+		},
+	}
+	resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, requestID, firstReq, utils.User{}, 0, "test-model", true, false)
+	assert.False(t, complete)
+	assert.Equal(t, TokenUsage{}, usage)
+	assert.Nil(t, resp.GetImmediateResponse())
+
+	secondReq := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body:        full[splitAt:],
+				EndOfStream: true,
+			},
+		},
+	}
+	resp, complete, usage = server.HandleResponseBody(context.Background(), routerCtx, requestID, secondReq, utils.User{}, 0, "test-model", true, false)
+	assert.True(t, complete)
+	assert.Nil(t, resp.GetImmediateResponse())
+	assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, usage)
+}
+
+// TestHandleResponseBody_SSELineExceedsBufferLimit reproduces a single SSE event (e.g. a
+// large tool-call/reasoning/multimodal delta) that exceeds maxStreamBufferSize before a
+// newline arrives. Per https://github.com/vllm-project/aibrix/pull/2653#issuecomment
+// feedback, this must not abort the client's stream with a 500 -- that reproduces the
+// original bug (issue #2638) for a different reason. The gateway should drop the oversized
+// line and let the stream continue; only usage extraction for that one line is lost.
+func TestHandleResponseBody_SSELineExceedsBufferLimit(t *testing.T) {
+	requestID := "test-req-id-oversized-line-" + time.Now().Format("150405.000000")
+	t.Cleanup(func() { streamBuffers.Delete(requestID) })
+
+	server := &Server{}
+	routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", requestID, "")
+	routerCtx.ReqPath = PathChatCompletions
+	routerCtx.RequestTime = time.Now()
+
+	// A single line, no newline yet, larger than maxStreamBufferSize.
+	oversizedChunk := append([]byte("data: "), bytes.Repeat([]byte("a"), maxStreamBufferSize+1)...)
+
+	firstReq := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body:        oversizedChunk,
+				EndOfStream: false,
+			},
+		},
+	}
+	resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, requestID, firstReq, utils.User{}, 0, "test-model", true, false)
+	assert.False(t, complete)
+	assert.Equal(t, TokenUsage{}, usage)
+	assert.Nil(t, resp.GetImmediateResponse(), "an oversized single-line SSE event must not abort the client stream with a 500")
+
+	// The line finally terminates, along with a well-formed subsequent usage line. The
+	// terminator here only closes out (and discards) the oversized line; usage extraction
+	// for that dropped line is lost, but the stream must still complete cleanly.
+	finalReq := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body:        []byte("\n\ndata: {\"id\": \"2\", \"usage\": {\"prompt_tokens\": 1, \"completion_tokens\": 1, \"total_tokens\": 2}}\n\n"),
+				EndOfStream: true,
+			},
+		},
+	}
+	resp, complete, usage = server.HandleResponseBody(context.Background(), routerCtx, requestID, finalReq, utils.User{}, 0, "test-model", true, false)
+	assert.True(t, complete)
+	assert.Nil(t, resp.GetImmediateResponse())
+	assert.Equal(t, TokenUsage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2}, usage)
 }
 
 func TestRequestEndHelper_EmitsTokenUsageMetrics(t *testing.T) {

--- a/pkg/plugins/gateway/gateway_rsp_body_test.go
+++ b/pkg/plugins/gateway/gateway_rsp_body_test.go
@@ -1081,6 +1081,64 @@ func TestHandleResponseBody_SSEParsing(t *testing.T) {
 	}
 }
 
+// TestHandleResponseBody_SSEChunkSplitAcrossCallbacks reproduces
+// https://github.com/vllm-project/aibrix/issues/2638: Envoy ext_proc delivers
+// response body chunks as TCP data arrives, so a single SSE "data: {...}" line
+// carrying the final usage payload can be split across two HandleResponseBody
+// invocations, and the split can land anywhere in the line -- including before
+// the "usage" key itself has arrived. The first (non-final) call must not treat
+// its truncated tail as malformed JSON; the second call should complete the
+// line and extract usage.
+func TestHandleResponseBody_SSEChunkSplitAcrossCallbacks(t *testing.T) {
+	full := []byte("data: {\"id\": \"1\", \"usage\": {\"prompt_tokens\": 10, \"completion_tokens\": 20, \"total_tokens\": 30}}\n\n")
+
+	tests := []struct {
+		name    string
+		splitAt int
+	}{
+		{name: "split after the usage key has appeared", splitAt: 40},
+		{name: "split before the usage key appears", splitAt: 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &Server{}
+
+			routerCtx := types.NewRoutingContext(context.Background(), "random", "test-model", "", "test-req-id", "")
+			routerCtx.ReqPath = PathChatCompletions
+			routerCtx.RequestTime = time.Now()
+
+			firstHalf, secondHalf := full[:tt.splitAt], full[tt.splitAt:]
+
+			firstReq := &extProcPb.ProcessingRequest{
+				Request: &extProcPb.ProcessingRequest_ResponseBody{
+					ResponseBody: &extProcPb.HttpBody{
+						Body:        firstHalf,
+						EndOfStream: false,
+					},
+				},
+			}
+			resp, complete, usage := server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", firstReq, utils.User{}, 0, "test-model", true, false)
+			assert.False(t, complete, "stream is not complete after the first partial chunk")
+			assert.Equal(t, TokenUsage{}, usage)
+			assert.Nil(t, resp.GetImmediateResponse(), "a mid-stream chunk boundary must not be reported as malformed JSON")
+
+			secondReq := &extProcPb.ProcessingRequest{
+				Request: &extProcPb.ProcessingRequest_ResponseBody{
+					ResponseBody: &extProcPb.HttpBody{
+						Body:        secondHalf,
+						EndOfStream: true,
+					},
+				},
+			}
+			resp, complete, usage = server.HandleResponseBody(context.Background(), routerCtx, "test-req-id", secondReq, utils.User{}, 0, "test-model", true, false)
+			assert.True(t, complete)
+			assert.Nil(t, resp.GetImmediateResponse())
+			assert.Equal(t, TokenUsage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, usage)
+		})
+	}
+}
+
 func TestRequestEndHelper_EmitsTokenUsageMetrics(t *testing.T) {
 	var counterCalls []struct {
 		name  string

--- a/pkg/plugins/gateway/types.go
+++ b/pkg/plugins/gateway/types.go
@@ -123,4 +123,5 @@ const (
 var (
 	ErrorUnknownResponse = errors.New("unknown response")
 	requestBuffers       sync.Map // Thread-safe map to track buffers per request
+	streamBuffers        sync.Map // Thread-safe map to track the trailing partial SSE line per streaming request
 )


### PR DESCRIPTION
## Pull Request Description

Fixes spurious "malformed JSON in SSE stream" 500 errors on streaming (SSE) chat completion responses.

`HandleResponseBody` in `pkg/plugins/gateway/gateway_rsp_body.go` runs once per Envoy ext_proc response-body callback, and Envoy delivers those callbacks aligned to TCP arrival rather than to SSE line boundaries. A single `data: {...}` SSE line — in particular the final line carrying the `"usage"` object — can therefore be split across two or more consecutive `HandleResponseBody` calls. The previous code scanned each chunk's bytes line-by-line and treated any line without a trailing newline as a complete line, so a chunk boundary landing mid-JSON was validated with `gjson.ValidBytes`, failed, and was misreported as malformed JSON, aborting the request with an internal server error.

This change buffers any trailing, not-yet-newline-terminated line across `HandleResponseBody` calls (keyed by request ID, mirroring the existing `requestBuffers` pattern used for non-streaming bodies) and only validates/scans complete lines. The buffering is unconditional whenever more chunks are expected (`!EndOfStream`) — it does not depend on whether the `"usage"` key has already appeared in the chunk, since the split can land anywhere in the line, including before `"usage"` arrives. A safety-net cleanup (`streamBuffers.Delete`) was added alongside the existing `requestBuffers.Delete` in `Process()`'s deferred cleanup to avoid leaking a buffered tail if a stream is aborted mid-way.

### Approach
- `processStreamingResponse` now takes an `endOfStream bool` parameter (the chunk's `ResponseBody.EndOfStream`).
- Before scanning, any leftover partial line bytes for this request ID are loaded from a new `streamBuffers sync.Map` and prepended to the chunk.
- Unless this is the final chunk, any trailing line without a `\n` terminator is carved off (via `bytes.LastIndexByte`) and stored back into `streamBuffers` instead of being validated as JSON.
- On the final chunk (`EndOfStream == true`), the trailing segment is treated as complete, same as before.

### Validation
- `go build ./pkg/plugins/gateway/...` — passes.
- `go vet ./pkg/plugins/gateway/...` — passes, no findings.
- `gofmt -l` on the four touched files — clean, no output.
- `go test ./pkg/plugins/gateway/...` (and the full `./pkg/plugins/gateway/...` tree) — all pass, including:
  - the pre-existing `TestHandleResponseBody_SSEParsing` table, which still confirms a genuinely malformed final-chunk JSON payload is still correctly reported as an error (no regression in the real-malformed-JSON case);
  - a new `TestHandleResponseBody_SSEChunkSplitAcrossCallbacks` table test that sends the same SSE line carrying `usage` split across two `HandleResponseBody` calls at two different split points — once after the `"usage"` key has already appeared in the first chunk, and once before it appears at all (split lands inside the `id` field). Both subtests assert the first (non-final) chunk produces no error, and the second (final) chunk successfully extracts the correct usage counts. Both subtests fail against the pre-fix code (one with a spurious malformed-JSON error, the other with silently-zeroed usage) and pass against the fix — this is the direct reproduction of the reported bug.
- `golangci-lint` could not be run in this environment: the repository-pinned `v1.57.2` fails to compile against the installed Go toolchain here, a newer `v1.61.0` attempt failed due to local disk space exhaustion, and the ambient system `golangci-lint v2.12.2` rejects the repository's v1-style `.golangci.yml` config. All are pre-existing local environment issues unrelated to this diff; `go vet` and `gofmt` were run in its place.

No user-visible behavior changes for well-formed, non-split streams; the fix only changes how a chunk-boundary-split line is handled internally (buffered and reassembled instead of misreported as malformed).

## Related Issues
Resolves: #2638

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>

Fixes #2638