### PR TITLE
ci: improve workflow check display

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -50,6 +50,7 @@ jobs:
           retention-days: 1
 
   test:
+    name: Helm Chart Install Test
     needs: [build-images]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -102,6 +102,7 @@ jobs:
           retention-days: 1
 
   installation-test:
+    name: Installation E2E Tests
     needs: [build-images]
     runs-on: ubuntu-latest
     steps:
@@ -206,7 +207,7 @@ jobs:
           kind create cluster --name installation-test --config=./hack/ci/kind-config.yaml
           kubectl cluster-info --context kind-installation-test
 
-      - name: Load image into Kind
+      - name: Load images into kind
         run: |
           set -euo pipefail
           sha="${{ github.sha }}"
@@ -245,7 +246,7 @@ jobs:
             aibrix/inplace-e2e:v2 \
             --name installation-test
 
-      - name: Deploy controller with the built image
+      - name: Deploy AIBrix control plane
         run: |
           kubectl apply -k config/dependency --server-side
           kubectl apply -k config/crd --server-side
@@ -256,14 +257,14 @@ jobs:
           cd ${{ github.workspace }}
           kubectl apply -k config/test
 
-      - name: Deploy Workload
+      - name: Deploy mock workload
         run: |
           cd development/app/config/mock
           kustomize edit set image aibrix/vllm-mock=aibrix/vllm-mock:${{ github.sha }}
           kustomize edit set image aibrix/runtime=aibrix/runtime:${{ github.sha }}
           kubectl apply -k .
 
-      - name: Check pod status
+      - name: Wait for pods and open port forwards
         run: |
           sleep 60s
           
@@ -280,7 +281,7 @@ jobs:
           kubectl -n envoy-gateway-system port-forward service/envoy-aibrix-system-aibrix-eg-903790dc  8888:80 &
           kubectl -n aibrix-system port-forward service/aibrix-redis-master 6379:6379 &
 
-      - name: Run e2e tests
+      - name: Run installation e2e tests
         run: |
           kind get kubeconfig --name installation-test > /tmp/admin.conf
           export KUBECONFIG=/tmp/admin.conf
@@ -294,12 +295,17 @@ jobs:
           make test-e2e-external-metrics
 
       - name: Clean up
-        run: kind delete cluster --name installation-test
+        if: always()
+        continue-on-error: true
+        run: kind delete cluster --name installation-test || true
 
   delete-artifacts:
-    needs: [installation-test]
+    name: Delete image artifacts
+    needs: [build-images, installation-test]
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest  
     steps:   
       - uses: geekyeggo/delete-artifact@v5
         with:
-          name: vllm-mock-image
+          name: '*-image'
+          failOnError: false

--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -31,6 +31,7 @@ on:
 
 jobs:
   lint:
+    name: Go Lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -43,6 +44,7 @@ jobs:
         run: make lint-all
 
   verify:
+    name: Verify Generated Code
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -58,7 +60,8 @@ jobs:
       - name: Verify CRD Synchronization
         run: bash ${GITHUB_WORKSPACE}/hack/verify-crd-sync.sh
 
-  test:
+  unit-test:
+    name: Go Unit Tests
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -97,17 +100,42 @@ jobs:
           path: cover.out
           if-no-files-found: error
           retention-days: 1
-      
+
+  race-test:
+    name: Go Race Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.22'
+      - name: Install ZMQ dependencies
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev libzmq3-dev
       - name: Run Race Condition Tests
         run: make test-race-condition
 
+  integration-test:
+    name: Go Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.22'
+      - name: Install ZMQ dependencies
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev libzmq3-dev
       - name: Run Integration Tests
         run: make test-integration
 
 
   check-coverage:
+    name: Go Coverage
     runs-on: ubuntu-latest
-    needs: test
+    needs: unit-test
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/python-aibrix-kvcache-tests.yml
+++ b/.github/workflows/python-aibrix-kvcache-tests.yml
@@ -5,17 +5,19 @@ on:
     branches: [ "main", "release-*" ]
     paths:
       - 'python/aibrix_kvcache/**'
+      - '.github/workflows/python-aibrix-kvcache-tests.yml'
   pull_request:
     branches: [ "main" ]
     paths:
       - 'python/aibrix_kvcache/**'
+      - '.github/workflows/python-aibrix-kvcache-tests.yml'
 jobs:
   lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
-    name: Lint
+    name: Python AIBrix KVCache Tests (${{ matrix.python-version }})
     steps:
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/.github/workflows/python-aibrix-tests.yml
+++ b/.github/workflows/python-aibrix-tests.yml
@@ -5,17 +5,19 @@ on:
     branches: [ "main", "release-*" ]
     paths:
       - 'python/aibrix/**'
+      - '.github/workflows/python-aibrix-tests.yml'
   pull_request:
     branches: [ "main" ]
     paths:
       - 'python/aibrix/**'
+      - '.github/workflows/python-aibrix-tests.yml'
 jobs:
   lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-    name: Lint
+    name: Python AIBrix Tests (${{ matrix.python-version }})
     steps:
       - name: Check out source repository
         uses: actions/checkout@v6

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12"]
-    name: publish
+    name: Publish AIBrix Python Wheel
     steps:
       - name: Check out source repository
         uses: actions/checkout@v6
@@ -147,7 +147,7 @@ jobs:
       url: https://pypi.org/p/aibrix_kvcache
     permissions:
       id-token: write
-    name: publish
+    name: Publish AIBrix KVCache Python Wheel
     steps:
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@v1.3.1


### PR DESCRIPTION
## Summary
- split Go unit, race, and integration checks into separate CI jobs
- clarify workflow job names for Python and release publishing checks
- make installation test cleanup and artifact deletion run on failure paths

## Test Plan
- git diff --check
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/*.yml .github/workflows/*.yaml
- make -n test ENVTEST=true
- make -n test-race-condition ENVTEST=true
- make -n test-integration ENVTEST=true