### PR TITLE
[Misc] Batch: Improve batch output persistence resilience during execution and finalization

### DIFF
--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -1082,16 +1082,16 @@ class BaseJobDriver:
     async def _sync_completed_request_tasks(
         self,
         job: BatchJob,
-        completed_request_results: Iterable[tuple[int, bool]],
+        completed_request_results: Iterable[tuple[int, Optional[bool]]],
     ) -> tuple[BatchJob, int]:
         """Compatibility seam for tests and drivers that sync completions after
         a pass or request batch."""
         completed_results = list(completed_request_results)
         completed_request_ids = [
-            request_id for request_id, failed in completed_results if not failed
+            request_id for request_id, failed in completed_results if failed is False
         ]
         failed_request_ids = [
-            request_id for request_id, failed in completed_results if failed
+            request_id for request_id, failed in completed_results if failed is True
         ]
         self._accumulate_done_requests(
             job.job_id,
@@ -1104,13 +1104,13 @@ class BaseJobDriver:
             failed=len(failed_request_ids),
         )
         job = await self._persist_worker_status(job)
-        return job, len(completed_results)
+        return job, len(completed_request_ids) + len(failed_request_ids)
 
     async def _execute_request(
         self,
         job: BatchJob,
         request_input: dict[str, Any],
-    ) -> tuple[int, bool]:
+    ) -> tuple[int, Optional[bool]]:
         """Execute one request and persist its output record."""
         request_id = request_input.pop("_request_index")
         input_line_no = request_id
@@ -1158,7 +1158,7 @@ class BaseJobDriver:
                     custom_id=custom_id,
                     error=exc,
                 ):
-                    return request_id, False
+                    return request_id, None
                 raise
             self._record_output_persistence_success()
             return request_id, last_error is not None
@@ -1442,7 +1442,7 @@ class BaseJobDriver:
         job_id = job.job_id
         assert job_id is not None
 
-        completed_request_ids: asyncio.Queue[Optional[tuple[int, bool]]] = (
+        completed_request_ids: asyncio.Queue[Optional[tuple[int, Optional[bool]]]] = (
             asyncio.Queue()
         )
         if start_index is None:
@@ -1553,7 +1553,9 @@ class BaseJobDriver:
         async def sync_completed_requests() -> None:
             nonlocal job, pending_in_round
 
-            async def sync_batch(request_results: list[tuple[int, bool]]) -> None:
+            async def sync_batch(
+                request_results: list[tuple[int, Optional[bool]]],
+            ) -> None:
                 nonlocal job, pending_in_round
                 if not request_results:
                     return

--- a/python/aibrix/aibrix/batch/job_driver/base.py
+++ b/python/aibrix/aibrix/batch/job_driver/base.py
@@ -35,6 +35,7 @@ worker only after the output files it writes to exist.
 import asyncio
 import contextlib
 import os
+import time
 import uuid
 from datetime import datetime, timezone
 from math import isfinite
@@ -94,6 +95,12 @@ _INFERENCE_MAX_RETRIES_ENV = "AIBRIX_BATCH_INFERENCE_MAX_RETRIES"
 _NO_ENDPOINT_MAX_RETRIES_ENV = "AIBRIX_BATCH_NO_ENDPOINT_MAX_RETRIES"
 _RETRY_BASE_DELAY_ENV = "AIBRIX_BATCH_RETRY_BASE_DELAY_SECONDS"
 _RETRY_MAX_DELAY_ENV = "AIBRIX_BATCH_RETRY_MAX_DELAY_SECONDS"
+_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD_ENV = (
+    "AIBRIX_BATCH_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD"
+)
+_OUTPUT_PERSISTENCE_FAILURE_BUCKET_SECONDS_ENV = (
+    "AIBRIX_BATCH_OUTPUT_PERSISTENCE_FAILURE_BUCKET_SECONDS"
+)
 _DEFAULT_ADAPTIVE_MAX_FACTOR = 8.0
 _DEFAULT_TELEMETRY_INTERVAL_SECONDS = 5.0
 _DEFAULT_INFERENCE_MAX_RETRIES = 5
@@ -103,6 +110,8 @@ _DEFAULT_INFERENCE_MAX_RETRIES = 5
 _DEFAULT_NO_ENDPOINT_MAX_RETRIES = 120
 _DEFAULT_RETRY_BASE_DELAY_SECONDS = 0.5
 _DEFAULT_RETRY_MAX_DELAY_SECONDS = 5.0
+_DEFAULT_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD = 3
+_DEFAULT_OUTPUT_PERSISTENCE_FAILURE_BUCKET_SECONDS = 15
 _DONE_RECONCILE_CHUNK_SIZE = 256
 
 
@@ -171,6 +180,26 @@ def _retry_max_delay_seconds() -> float:
     return max(
         _float_env(_RETRY_MAX_DELAY_ENV, _DEFAULT_RETRY_MAX_DELAY_SECONDS),
         0.0,
+    )
+
+
+def _output_persistence_failure_threshold() -> int:
+    return max(
+        _int_env(
+            _OUTPUT_PERSISTENCE_FAILURE_THRESHOLD_ENV,
+            _DEFAULT_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD,
+        ),
+        1,
+    )
+
+
+def _output_persistence_failure_bucket_seconds() -> int:
+    return max(
+        _int_env(
+            _OUTPUT_PERSISTENCE_FAILURE_BUCKET_SECONDS_ENV,
+            _DEFAULT_OUTPUT_PERSISTENCE_FAILURE_BUCKET_SECONDS,
+        ),
+        1,
     )
 
 
@@ -279,6 +308,9 @@ class BaseJobDriver:
         self._usage_counted_ids: Set[str] = set()
         self._request_counts: Optional[RequestCountStats] = None
         self._launched_request_ids: Set[int] = set()
+        self._output_persistence_consecutive_failed_buckets = 0
+        self._output_persistence_last_failed_bucket: Optional[int] = None
+        self._output_persistence_last_success_bucket: Optional[int] = None
         self._set_error_injector(job)
         self._usage_lock = asyncio.Lock()
 
@@ -769,6 +801,9 @@ class BaseJobDriver:
         self._usage = None
         self._usage_counted_ids.clear()
         self._launched_request_ids = set()
+        self._output_persistence_consecutive_failed_buckets = 0
+        self._output_persistence_last_failed_bucket = None
+        self._output_persistence_last_success_bucket = None
 
     # ── usage accounting ─────────────────────────────────────────────────
 
@@ -868,6 +903,63 @@ class BaseJobDriver:
             emitted_usage.output_tokens_details.reasoning_tokens = reasoning_tokens
         return emitted_usage
 
+    def _record_output_persistence_success(self) -> None:
+        self._output_persistence_last_success_bucket = (
+            self._current_output_persistence_failure_bucket()
+        )
+
+    def _current_output_persistence_failure_bucket(self) -> int:
+        return int(time.monotonic() // _output_persistence_failure_bucket_seconds())
+
+    def _should_defer_output_persistence_failure(
+        self,
+        *,
+        job_id: str,
+        request_id: int,
+        custom_id: str,
+        error: Exception,
+    ) -> bool:
+        threshold = _output_persistence_failure_threshold()
+        bucket = self._current_output_persistence_failure_bucket()
+        last_failed_bucket = self._output_persistence_last_failed_bucket
+        last_success_bucket = self._output_persistence_last_success_bucket
+
+        # Collapse bursts inside the same time bucket into one streak increment so
+        # a transient concurrency spike does not look like multiple independent
+        # storage outages.
+        if last_failed_bucket == bucket:
+            return self._output_persistence_consecutive_failed_buckets < threshold
+
+        # Idle time between slow requests should not break the streak. Only a
+        # successful persistence attempt clears the active-bucket failure run.
+        success_cleared_streak = (
+            last_success_bucket is not None
+            and last_failed_bucket is not None
+            and last_success_bucket >= last_failed_bucket
+        )
+        if last_failed_bucket is None or success_cleared_streak:
+            self._output_persistence_consecutive_failed_buckets = 1
+        else:
+            self._output_persistence_consecutive_failed_buckets += 1
+        self._output_persistence_last_failed_bucket = bucket
+
+        consecutive_failed_buckets = self._output_persistence_consecutive_failed_buckets
+        if consecutive_failed_buckets >= threshold:
+            return False
+        logger.warning(
+            "Deferring batch request completion after output persistence error",
+            job_id=job_id,
+            request_id=request_id,
+            custom_id=custom_id,
+            bucket=bucket,
+            bucket_seconds=_output_persistence_failure_bucket_seconds(),
+            consecutive_failed_buckets=consecutive_failed_buckets,
+            abort_after_failed_buckets=threshold,
+            error=str(error),
+            error_type=type(error).__name__,
+        )  # type: ignore[call-arg]
+        return True
+
     def _get_accumulated_usage(self, job_id: str) -> Optional[BatchUsage]:
         """Return the running token usage for a job, or None if no successful
         inference has been recorded yet."""
@@ -943,6 +1035,13 @@ class BaseJobDriver:
                 kwargs["max_concurrency"] = max_concurrency
         return kwargs
 
+    def _pending_request_retry_poll_seconds(self, job: BatchJob) -> float:
+        client = job.spec.aibrix.client if job.spec.aibrix else None
+        request_timeout_seconds = getattr(client, "request_timeout_seconds", None)
+        if request_timeout_seconds is None:
+            return 0.1
+        return min(max(float(request_timeout_seconds) / 10.0, 0.1), 1.0)
+
     def _drop_usage_state(self, job_id: str) -> None:
         """Release per-job usage state after terminal persistence.
         Subclasses override this when they aggregate usage differently or need
@@ -955,6 +1054,9 @@ class BaseJobDriver:
         self._usage_counted_ids.clear()
         self._request_counts = None
         self._launched_request_ids.clear()
+        self._output_persistence_consecutive_failed_buckets = 0
+        self._output_persistence_last_failed_bucket = None
+        self._output_persistence_last_success_bucket = None
 
     async def _persist_worker_status(self, job: BatchJob) -> BatchJob:
         """Persist per-worker status after progress or failure updates.
@@ -1046,7 +1148,19 @@ class BaseJobDriver:
                 last_error,
                 request_payload=request_input.get("body"),
             )
-            await storage.write_job_output_data(job, request_id, response)
+
+            try:
+                await storage.write_job_output_data(job, request_id, response)
+            except Exception as exc:
+                if self._should_defer_output_persistence_failure(
+                    job_id=job.job_id,
+                    request_id=request_id,
+                    custom_id=custom_id,
+                    error=exc,
+                ):
+                    return request_id, False
+                raise
+            self._record_output_persistence_success()
             return request_id, last_error is not None
         except Exception as exc:
             raise self._ensure_batch_job_error(
@@ -1367,6 +1481,7 @@ class BaseJobDriver:
             nonlocal job, start_index, pending_in_round
             # The loop is necessary in cases of job driver lock a request but unable to process it (complete or fail), e.g., server crash.
             while start_index >= 0:
+                dispatched_in_pass = False
                 async for request_input in storage.read_job_next_request(
                     job, start_index
                 ):
@@ -1385,6 +1500,7 @@ class BaseJobDriver:
                     self._accumulate_dispatched_request(job_id, request_id)
                     pending_in_round += 1
                     round_drained.clear()
+                    dispatched_in_pass = True
 
                     if "body" not in request_input:
                         raise BatchJobError(
@@ -1418,6 +1534,12 @@ class BaseJobDriver:
                 if self._should_stop_before_proceed(job):
                     return
                 start_index = await self._get_next_pass_start(job)
+                if start_index >= 0 and not dispatched_in_pass:
+                    # Nothing was dispatchable in this pass, which usually means
+                    # the next remaining request is still lock-held by an earlier
+                    # timed-out/deferred attempt. Sleep briefly so we poll for
+                    # lock expiry / external completion instead of hot-spinning.
+                    await asyncio.sleep(self._pending_request_retry_poll_seconds(job))
                 local_request_counts = self._get_local_request_counts(job_id)
                 if start_index < 0 and local_request_counts.total > 0:
                     job = self._mark_job_completed_when_reconciled(job)
@@ -1466,7 +1588,7 @@ class BaseJobDriver:
             response: Optional[dict[str, Any]],
             error: Optional[InferenceError],
         ) -> None:
-            nonlocal job, processed_requests
+            nonlocal job, processed_requests, pending_in_round
             request_id, custom_id, input_line_data = request.ref
             input_line_no = request_id
             try:
@@ -1483,7 +1605,21 @@ class BaseJobDriver:
                     error,
                     request_payload=request.payload,
                 )
-                await storage.write_job_output_data(job, request_id, record)
+                try:
+                    await storage.write_job_output_data(job, request_id, record)
+                except Exception as exc:
+                    if self._should_defer_output_persistence_failure(
+                        job_id=job_id,
+                        request_id=request_id,
+                        custom_id=custom_id,
+                        error=exc,
+                    ):
+                        pending_in_round = max(0, pending_in_round - 1)
+                        if pending_in_round == 0:
+                            round_drained.set()
+                        return
+                    raise
+                self._record_output_persistence_success()
                 await completed_request_ids.put((request_id, error is not None))
                 processed_requests += 1
                 await self._apply_error_injector_breakpoint(

--- a/python/aibrix/aibrix/batch/storage/adapter.py
+++ b/python/aibrix/aibrix/batch/storage/adapter.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import asyncio
+import hashlib
 import json
+import math
 import uuid
 from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, cast
 
 from aibrix import envs
-from aibrix.batch.job_entity import BatchJob, BatchJobError
+from aibrix.batch.job_entity import BatchJob, BatchJobError, BatchJobErrorCode
 from aibrix.batch.job_entity.batch_job import BatchUsage
 from aibrix.batch.storage.batch_metastore import (
     METASTORE_LIST_PAGE_SIZE,
@@ -32,9 +34,20 @@ from aibrix.batch.storage.batch_metastore import (
     unlock_request,
 )
 from aibrix.logger import init_logger
-from aibrix.storage.base import BaseStorage
+from aibrix.storage.base import (
+    LOCAL_PART_PROVIDER_MARKER,
+    LOCAL_PART_PROVIDER_MARKER_VALUE,
+    BaseStorage,
+)
 
 logger = init_logger(__name__)
+
+UNREADABLE_COMPLETED_OUTPUT_PART_MESSAGE = (
+    "Failed to read completed request output part during batch finalization"
+)
+UNREADABLE_FAILED_ERROR_PART_MESSAGE = (
+    "Failed to read failed request error part during batch finalization"
+)
 
 
 class BatchStorageAdapter:
@@ -47,6 +60,14 @@ class BatchStorageAdapter:
 
     def __init__(self, storage: BaseStorage):
         self.storage = storage
+
+    def _request_lock_timeout_seconds(self, job: BatchJob) -> int:
+        timeout_seconds = int(envs.INFERENCE_TASK_TIMEOUT)
+        client = job.spec.aibrix.client if job.spec.aibrix else None
+        request_timeout_seconds = getattr(client, "request_timeout_seconds", None)
+        if request_timeout_seconds is None:
+            return timeout_seconds
+        return max(1, math.ceil(float(request_timeout_seconds)))
 
     async def write_job_input_data(
         self, file_id: str, input_data_file_name: str
@@ -123,7 +144,8 @@ class BatchStorageAdapter:
                 try:
                     # Try to acquire lock with configurable expiration
                     locked = await lock_request(
-                        lock_key, expiration_seconds=envs.INFERENCE_TASK_TIMEOUT
+                        lock_key,
+                        expiration_seconds=self._request_lock_timeout_seconds(job),
                     )
                 except Exception as e:
                     logger.warning(
@@ -297,7 +319,7 @@ class BatchStorageAdapter:
 
         # Unlock the request by setting completion status.
         unlock_key = self._get_request_meta_output_key(job, request_index)
-        completion_status = self._get_request_meta_output_val(is_error, etag)
+        completion_status = self._get_request_meta_output_val(is_error, etag, custom_id)
         try:
             metastore_type = get_metastore_type().value
         except Exception:
@@ -404,13 +426,17 @@ class BatchStorageAdapter:
                         missing_keys += 1
                         continue
 
-                    etag, is_error = self._parse_request_meta_output_val(meta_val)
+                    etag, is_error, custom_id = self._parse_request_meta_output_val(
+                        meta_val
+                    )
                     if etag == "":
                         pending_keys += 1
                         continue
 
                     valid_keys.append(key)
                     val: Dict[str, str | int] = {"etag": etag, "part_number": idx}
+                    if custom_id is not None:
+                        val["custom_id"] = custom_id
 
                     if is_error:
                         error.append(val)
@@ -449,6 +475,40 @@ class BatchStorageAdapter:
                 failed=failed,
             )  # type: ignore[call-arg]
 
+        # Aggregate results sequentially: parallel completes hammer
+        # MinIO bucket-level locks under small_parts mode (each complete
+        # does N list/delete/put_object calls under .multipart/).
+        failed_output_parts = await self.storage.complete_multipart_upload(
+            job.status.output_file_id,
+            job.status.temp_output_file_id,
+            output,
+            tolerate_part_get_error=True,
+        )
+        rerouted_output_parts: List[Dict[str, str | int]] = []
+        if failed_output_parts:
+            rerouted_output_parts, skipped_rerouted_parts = (
+                self._filter_rerouted_output_parts(error, failed_output_parts)
+            )
+            synthesized_error_parts = self._synthesize_unreadable_error_parts(
+                rerouted_output_parts,
+                message=UNREADABLE_COMPLETED_OUTPUT_PART_MESSAGE,
+            )
+            error, inserted_rerouted_parts, duplicate_rerouted_parts = (
+                self._merge_error_parts_by_part_number(error, synthesized_error_parts)
+            )
+            completed -= inserted_rerouted_parts
+            failed += inserted_rerouted_parts
+            logger.warning(
+                "Synthesizing error records for unreadable output parts",
+                job_id=job.job_id,
+                failed_output_part_count=len(rerouted_output_parts),
+                skipped_rerouted_part_count=skipped_rerouted_parts,
+                inserted_rerouted_part_count=inserted_rerouted_parts,
+                duplicate_rerouted_part_count=duplicate_rerouted_parts,
+                completed=completed,
+                failed=failed,
+            )  # type: ignore[call-arg]
+
         # 4. Update job object with calculated request counts if they differ.
         # Preserve the validated input total when it is larger, but allow
         # metastore truth to grow a stale lower total after restart recovery.
@@ -477,22 +537,50 @@ class BatchStorageAdapter:
             job.status.request_counts.completed = completed
             job.status.request_counts.failed = failed
 
-        # Aggregate results sequentially: parallel completes hammer
-        # MinIO bucket-level locks under small_parts mode (each complete
-        # does N list/delete/put_object calls under .multipart/).
-        await self.storage.complete_multipart_upload(
-            job.status.output_file_id,
-            job.status.temp_output_file_id,
-            output,
-        )
-        await self.storage.complete_multipart_upload(
+        async def provide_local_error_part(
+            part: Dict[str, str | int],
+        ) -> bytes | None:
+            if part.get(LOCAL_PART_PROVIDER_MARKER) == LOCAL_PART_PROVIDER_MARKER_VALUE:
+                return self._build_unreadable_error_part_body(
+                    part,
+                    message=UNREADABLE_COMPLETED_OUTPUT_PART_MESSAGE,
+                )
+            return self._build_unreadable_error_part_body(
+                part,
+                message=UNREADABLE_FAILED_ERROR_PART_MESSAGE,
+            )
+
+        # The local provider is consulted only for parts carrying
+        # LOCAL_PART_PROVIDER_MARKER=LOCAL_PART_PROVIDER_MARKER_VALUE for the
+        # local-only rerouted output records. During tolerant reads, BaseStorage2
+        # also asks the provider for an unmarked error part if its staged object
+        # cannot be loaded, so unreadable original error records are synthesized
+        # in the same pass instead of requiring a second completion attempt.
+        unexpected_failed_error_parts = await self.storage.complete_multipart_upload(
             job.status.error_file_id,
             job.status.temp_error_file_id,
             error,
+            tolerate_part_get_error=True,
+            local_part_provider=provide_local_error_part,
         )
+        if unexpected_failed_error_parts:
+            raise RuntimeError(
+                "Error-file completion unexpectedly returned unreadable parts "
+                "after local fallback was enabled"
+            )
+        if rerouted_output_parts:
+            await self.storage.abort_multipart_upload(
+                job.status.output_file_id,
+                job.status.temp_output_file_id,
+            )
 
         # Sum usage from the assembled output file.
         job.status.usage = await self._sum_usage_from_output(job.status.output_file_id)
+        if rerouted_output_parts:
+            self._merge_usage(
+                job.status.usage,
+                await self._sum_usage_from_output(job.status.error_file_id),
+            )
 
         # Delete metadata for valid keys only
         if valid_keys:
@@ -589,18 +677,166 @@ class BatchStorageAdapter:
             return prefix
         return f"{prefix}{idx}"
 
-    def _get_request_meta_output_val(self, is_error: bool, etag: str) -> str:
-        return f"{'error' if is_error else 'output'}:{etag}"
+    def _get_request_meta_output_val(
+        self,
+        is_error: bool,
+        etag: str,
+        custom_id: Optional[str] = None,
+    ) -> str:
+        payload: Dict[str, str] = {
+            "result": "error" if is_error else "output",
+            "etag": etag,
+        }
+        if custom_id:
+            payload["custom_id"] = custom_id
+        return json.dumps(payload, separators=(",", ":"))
 
-    def _parse_request_meta_output_val(self, meta_val: str) -> Tuple[str, bool]:
+    def _parse_request_meta_output_val(
+        self, meta_val: str
+    ) -> Tuple[str, bool, Optional[str]]:
         """valid output can be:
-        1. output:[etag]
-        2. error:[etag]
-        3. processing
+        1. {"result":"output","etag":"...","custom_id":"..."}
+        2. output:[etag]
+        3. error:[etag]
+        4. processing
         """
+        try:
+            parsed = json.loads(meta_val)
+        except Exception:
+            parsed = None
+
+        if isinstance(parsed, dict):
+            result = parsed.get("result")
+            etag = parsed.get("etag")
+            custom_id = parsed.get("custom_id")
+            if isinstance(result, str) and isinstance(etag, str):
+                return (
+                    etag,
+                    result == "error",
+                    (custom_id if isinstance(custom_id, str) else None),
+                )
+
         status = meta_val.split(":", 1)
         if len(status) == 2:
             is_error, etag = status
-            return etag, is_error == "error"
+            return etag, is_error == "error", None
         else:
-            return "", False
+            return "", False, None
+
+    def _merge_usage(self, target: BatchUsage, source: BatchUsage) -> None:
+        target.input_tokens += source.input_tokens
+        target.output_tokens += source.output_tokens
+        target.total_tokens += source.total_tokens
+        target.input_tokens_details.cached_tokens += (
+            source.input_tokens_details.cached_tokens
+        )
+        target.output_tokens_details.reasoning_tokens += (
+            source.output_tokens_details.reasoning_tokens
+        )
+
+    def _merge_error_parts_by_part_number(
+        self,
+        existing_error_parts: List[Dict[str, str | int]],
+        rerouted_error_parts: List[Dict[str, str | int]],
+    ) -> Tuple[List[Dict[str, str | int]], int, int]:
+        merged_by_part_number: Dict[int, Dict[str, str | int]] = {
+            int(part["part_number"]): dict(part) for part in existing_error_parts
+        }
+        inserted = 0
+        duplicates = 0
+
+        for part in rerouted_error_parts:
+            part_number = int(part["part_number"])
+            if part_number in merged_by_part_number:
+                duplicates += 1
+                continue
+            merged_by_part_number[part_number] = dict(part)
+            inserted += 1
+
+        merged_parts = [
+            merged_by_part_number[part_number]
+            for part_number in sorted(merged_by_part_number)
+        ]
+        return merged_parts, inserted, duplicates
+
+    def _filter_rerouted_output_parts(
+        self,
+        existing_error_parts: List[Dict[str, str | int]],
+        candidate_rerouted_parts: List[Dict[str, str | int]],
+    ) -> Tuple[List[Dict[str, str | int]], int]:
+        existing_part_numbers = {
+            int(part["part_number"]) for part in existing_error_parts
+        }
+        filtered_parts: List[Dict[str, str | int]] = []
+        seen_part_numbers: set[int] = set()
+        skipped_parts = 0
+
+        for part in sorted(
+            candidate_rerouted_parts, key=lambda item: int(item["part_number"])
+        ):
+            part_number = int(part["part_number"])
+            if part_number in existing_part_numbers or part_number in seen_part_numbers:
+                skipped_parts += 1
+                continue
+            filtered_parts.append(dict(part))
+            seen_part_numbers.add(part_number)
+
+        return filtered_parts, skipped_parts
+
+    def _build_unreadable_error_part_body(
+        self,
+        part: Dict[str, str | int],
+        *,
+        message: str,
+    ) -> bytes:
+        part_number = int(part["part_number"])
+        custom_id = part.get("custom_id")
+        if not isinstance(custom_id, str) or not custom_id:
+            custom_id = f"request-{part_number}"
+
+        error_record = {
+            "id": f"unreadable-{part_number}",
+            "error": BatchJobError(
+                code=BatchJobErrorCode.INTERNAL_ERROR,
+                message=message,
+                line=part_number,
+            ),
+            "response": None,
+            "custom_id": custom_id,
+        }
+        return (
+            json.dumps(error_record, default=BatchJobError.json_serializer) + "\n"
+        ).encode("utf-8")
+
+    def _synthesize_unreadable_error_parts(
+        self,
+        unreadable_parts: List[Dict[str, str | int]],
+        *,
+        message: str,
+    ) -> List[Dict[str, str | int]]:
+        synthesized_error_parts: List[Dict[str, str | int]] = []
+
+        for part in unreadable_parts:
+            part_number = int(part["part_number"])
+            custom_id = part.get("custom_id")
+            if not isinstance(custom_id, str) or not custom_id:
+                custom_id = f"request-{part_number}"
+
+            error_body = self._build_unreadable_error_part_body(
+                part,
+                message=message,
+            )
+            etag = hashlib.md5(error_body).hexdigest()
+            synthesized_error_parts.append(
+                {
+                    "etag": etag,
+                    "part_number": part_number,
+                    "custom_id": custom_id,
+                    # Mark this synthesized part as local-only so error-file
+                    # completion consumes the in-memory body instead of trying
+                    # to fetch a staged part object that was never uploaded.
+                    LOCAL_PART_PROVIDER_MARKER: LOCAL_PART_PROVIDER_MARKER_VALUE,
+                }
+            )
+
+        return synthesized_error_parts

--- a/python/aibrix/aibrix/storage/base.py
+++ b/python/aibrix/aibrix/storage/base.py
@@ -17,11 +17,16 @@ import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from io import BytesIO, StringIO
-from typing import AsyncIterator, BinaryIO, Optional, TextIO, Union
+from typing import AsyncIterator, Awaitable, BinaryIO, Callable, Optional, TextIO, Union
 
 from aibrix.storage.reader import Reader
 from aibrix.storage.types import StorageListOrdering, StorageType
 from aibrix.storage.utils import ObjectMetadata
+
+# Internal multipart part flag: only parts carrying this marker may source their
+# bytes from a caller-provided local callback instead of remote staged storage.
+LOCAL_PART_PROVIDER_MARKER = "__aibrix_local_part__"
+LOCAL_PART_PROVIDER_MARKER_VALUE = 1
 
 
 @dataclass
@@ -582,60 +587,18 @@ class BaseStorage(ABC):
         key: str,
         upload_id: str,
         parts: list[dict[str, Union[str, int]]],
-    ) -> None:
-        """Default implementation for completing multipart upload.
-
-        Downloads all part objects, aggregates them locally, and uploads the final object.
-        Suitable for S3/TOS backends that don't have native multipart support for small files.
-
-        Args:
-            key: Object key/path
-            upload_id: Upload ID from create_multipart_upload
-            parts: List of parts with 'part_number' and 'etag' keys
-        """
-        try:
-            # Get upload metadata
-            metadata_data = await self.get_object(self._multipart_upload_key(upload_id))
-            upload_metadata = eval(
-                metadata_data.decode("utf-8")
-            )  # Simple parsing for dict
-        except Exception:
-            # Use _native_complete_multipart_upload if metadata object doesn't exist
-            if self.is_native_multipart_supported():
-                return await self._native_complete_multipart_upload(
-                    key, upload_id, parts
-                )
-            raise ValueError(f"Upload ID {upload_id} not found or corrupted")
-
-        content_type = upload_metadata.get("content_type")
-        metadata = upload_metadata.get("metadata", {})
-
-        # Sort parts by part number
-        sorted_parts = sorted(parts, key=lambda p: p["part_number"])
-
-        # Download and aggregate all parts locally
-        aggregated_data = BytesIO()
-
-        for part in sorted_parts:
-            part_number = part["part_number"]
-            try:
-                part_data = await self.get_object(
-                    self._multipart_upload_part_key(upload_id, int(part_number))
-                )
-                aggregated_data.write(part_data)
-            except Exception:
-                # Clean up and raise error
-                await self.abort_multipart_upload(key, upload_id)
-                raise ValueError(
-                    f"Failed to retrieve part {part_number} for upload {upload_id}"
-                )
-
-        # Upload the final aggregated object
-        aggregated_data.seek(0)
-        await self.put_object(key, aggregated_data, content_type, metadata)
-
-        # Clean up multipart upload objects
-        await self.abort_multipart_upload(key, upload_id)
+        *,
+        tolerate_part_get_error: bool = False,
+        local_part_provider: Callable[
+            [dict[str, Union[str, int]]], Awaitable[bytes | str | None]
+        ]
+        | None = None,
+    ) -> list[dict[str, Union[str, int]]]:
+        _ = (key, upload_id, parts, tolerate_part_get_error, local_part_provider)
+        raise NotImplementedError(
+            "BaseStorage.complete_multipart_upload() must not be called; "
+            "use BaseStorage2-backed storage implementations instead."
+        )
 
     async def abort_multipart_upload(
         self,

--- a/python/aibrix/aibrix/storage/base2.py
+++ b/python/aibrix/aibrix/storage/base2.py
@@ -81,7 +81,7 @@ class BaseStorage2(BaseStorage):
             if tolerate_part_get_error:
                 chunk_results = await asyncio.gather(*tasks, return_exceptions=True)
                 for part, result in zip(chunk_parts, chunk_results):
-                    if isinstance(result, Exception):
+                    if isinstance(result, BaseException):
                         if failed_parts is not None:
                             failed_parts.append(dict(part))
                         continue
@@ -101,7 +101,7 @@ class BaseStorage2(BaseStorage):
                 await asyncio.gather(*tasks, return_exceptions=True)
                 raise
 
-            for part, part_data in chunk_results:
+            for part, part_data in await asyncio.gather(*tasks):
                 yield part, part_data
 
     async def complete_multipart_upload(
@@ -129,15 +129,17 @@ class BaseStorage2(BaseStorage):
         content_type = upload_metadata.get("content_type")
         metadata = upload_metadata.get("metadata", {})
         sorted_parts = sorted(parts, key=lambda p: p["part_number"])
-        staged_part_keys = [
-            self._multipart_upload_part_key(
-                part.get("source_upload_id", upload_id)
-                if isinstance(part.get("source_upload_id", upload_id), str)
-                else upload_id,
-                int(part["part_number"]),
+        staged_part_keys: list[str] = []
+        for part in sorted_parts:
+            source_upload_id = part.get("source_upload_id")
+            part_upload_id = (
+                source_upload_id if isinstance(source_upload_id, str) else upload_id
             )
-            for part in sorted_parts
-        ]
+            staged_part_keys.append(
+                self._multipart_upload_part_key(
+                    part_upload_id, int(part["part_number"])
+                )
+            )
         failed_parts: list[dict[str, Union[str, int]]] = []
 
         if not sorted_parts:

--- a/python/aibrix/aibrix/storage/base2.py
+++ b/python/aibrix/aibrix/storage/base2.py
@@ -1,9 +1,13 @@
 import ast
 import asyncio
 from io import BytesIO
-from typing import AsyncIterator, Union
+from typing import AsyncIterator, Awaitable, Callable, Union
 
-from aibrix.storage.base import BaseStorage
+from aibrix.storage.base import (
+    LOCAL_PART_PROVIDER_MARKER,
+    LOCAL_PART_PROVIDER_MARKER_VALUE,
+    BaseStorage,
+)
 
 
 class BaseStorage2(BaseStorage):
@@ -18,7 +22,14 @@ class BaseStorage2(BaseStorage):
         upload_id: str,
         parts: list[dict[str, Union[str, int]]],
         staged_part_keys: list[str],
-    ) -> AsyncIterator[tuple[int, bytes]]:
+        *,
+        tolerate_part_get_error: bool = False,
+        failed_parts: list[dict[str, Union[str, int]]] | None = None,
+        local_part_provider: Callable[
+            [dict[str, Union[str, int]]], Awaitable[bytes | str | None]
+        ]
+        | None = None,
+    ) -> AsyncIterator[tuple[dict[str, Union[str, int]], bytes]]:
         prefetch_concurrency = max(
             1,
             min(
@@ -28,11 +39,32 @@ class BaseStorage2(BaseStorage):
         )
 
         async def _load_part(
-            part_number: int, staged_part_key: str
-        ) -> tuple[int, bytes]:
+            part: dict[str, Union[str, int]], staged_part_key: str
+        ) -> tuple[dict[str, Union[str, int]], bytes]:
+            part_number = int(part["part_number"])
+            # Only explicitly tagged internal parts may bypass remote reads via
+            # the local provider. Unmarked parts still use the staged-object
+            # contract first, but tolerant callers may ask the provider for a
+            # local fallback body if the staged read fails.
+            if (
+                local_part_provider is not None
+                and part.get(LOCAL_PART_PROVIDER_MARKER)
+                == LOCAL_PART_PROVIDER_MARKER_VALUE
+            ):
+                provided_part = await local_part_provider(part)
+                if isinstance(provided_part, str):
+                    return part, provided_part.encode("utf-8")
+                if isinstance(provided_part, bytes):
+                    return part, provided_part
             try:
-                return part_number, await self.get_object(staged_part_key)
+                return part, await self.get_object(staged_part_key)
             except Exception as exc:
+                if local_part_provider is not None and tolerate_part_get_error:
+                    provided_part = await local_part_provider(part)
+                    if isinstance(provided_part, str):
+                        return part, provided_part.encode("utf-8")
+                    if isinstance(provided_part, bytes):
+                        return part, provided_part
                 raise ValueError(
                     f"Failed to retrieve part {part_number} for upload {upload_id}"
                 ) from exc
@@ -43,11 +75,18 @@ class BaseStorage2(BaseStorage):
                 chunk_start : chunk_start + prefetch_concurrency
             ]
             tasks = [
-                asyncio.create_task(
-                    _load_part(int(part["part_number"]), staged_part_key)
-                )
+                asyncio.create_task(_load_part(part, staged_part_key))
                 for part, staged_part_key in zip(chunk_parts, chunk_keys)
             ]
+            if tolerate_part_get_error:
+                chunk_results = await asyncio.gather(*tasks, return_exceptions=True)
+                for part, result in zip(chunk_parts, chunk_results):
+                    if isinstance(result, Exception):
+                        if failed_parts is not None:
+                            failed_parts.append(dict(part))
+                        continue
+                    yield result
+                continue
             try:
                 chunk_results = await asyncio.gather(*tasks)
             except Exception:
@@ -62,38 +101,49 @@ class BaseStorage2(BaseStorage):
                 await asyncio.gather(*tasks, return_exceptions=True)
                 raise
 
-            for part_number, part_data in chunk_results:
-                yield part_number, part_data
+            for part, part_data in chunk_results:
+                yield part, part_data
 
     async def complete_multipart_upload(
         self,
         key: str,
         upload_id: str,
         parts: list[dict[str, Union[str, int]]],
-    ) -> None:
+        *,
+        tolerate_part_get_error: bool = False,
+        local_part_provider: Callable[
+            [dict[str, Union[str, int]]], Awaitable[bytes | str | None]
+        ]
+        | None = None,
+    ) -> list[dict[str, Union[str, int]]]:
         """Complete small-parts uploads using bounded native multipart reassembly."""
         try:
             metadata_data = await self.get_object(self._multipart_upload_key(upload_id))
             upload_metadata = ast.literal_eval(metadata_data.decode("utf-8"))
         except Exception:
             if self.is_native_multipart_supported():
-                return await self._native_complete_multipart_upload(
-                    key, upload_id, parts
-                )
+                await self._native_complete_multipart_upload(key, upload_id, parts)
+                return []
             raise ValueError(f"Upload ID {upload_id} not found or corrupted")
 
         content_type = upload_metadata.get("content_type")
         metadata = upload_metadata.get("metadata", {})
         sorted_parts = sorted(parts, key=lambda p: p["part_number"])
         staged_part_keys = [
-            self._multipart_upload_part_key(upload_id, int(part["part_number"]))
+            self._multipart_upload_part_key(
+                part.get("source_upload_id", upload_id)
+                if isinstance(part.get("source_upload_id", upload_id), str)
+                else upload_id,
+                int(part["part_number"]),
+            )
             for part in sorted_parts
         ]
+        failed_parts: list[dict[str, Union[str, int]]] = []
 
         if not sorted_parts:
             await self.put_object(key, b"", content_type, metadata)
             await self.abort_multipart_upload(key, upload_id)
-            return
+            return []
 
         if self.is_native_multipart_supported():
             strict_min_part_size = self._is_strict_multipart_min_part_size_enabled()
@@ -105,7 +155,12 @@ class BaseStorage2(BaseStorage):
 
             try:
                 async for _, part_data in self._iter_prefetched_staged_parts(
-                    upload_id, sorted_parts, staged_part_keys
+                    upload_id,
+                    sorted_parts,
+                    staged_part_keys,
+                    tolerate_part_get_error=tolerate_part_get_error,
+                    failed_parts=failed_parts,
+                    local_part_provider=local_part_provider,
                 ):
                     buffer.extend(part_data)
                     flush_threshold = (
@@ -134,8 +189,9 @@ class BaseStorage2(BaseStorage):
                             "final part"
                         )
                     await self.put_object(key, bytes(buffer), content_type, metadata)
-                    await self.abort_multipart_upload(key, upload_id)
-                    return
+                    if not failed_parts:
+                        await self.abort_multipart_upload(key, upload_id)
+                    return failed_parts
 
                 if buffer or not aggregated_parts:
                     if native_upload_id is None:
@@ -160,18 +216,26 @@ class BaseStorage2(BaseStorage):
                     await self._native_abort_multipart_upload(key, native_upload_id)
                 raise
 
-            await self.abort_multipart_upload(key, upload_id)
-            return
+            if not failed_parts:
+                await self.abort_multipart_upload(key, upload_id)
+            return failed_parts
 
         aggregated_data = BytesIO()
         async for _, part_data in self._iter_prefetched_staged_parts(
-            upload_id, sorted_parts, staged_part_keys
+            upload_id,
+            sorted_parts,
+            staged_part_keys,
+            tolerate_part_get_error=tolerate_part_get_error,
+            failed_parts=failed_parts,
+            local_part_provider=local_part_provider,
         ):
             aggregated_data.write(part_data)
 
         aggregated_data.seek(0)
         await self.put_object(key, aggregated_data, content_type, metadata)
-        await self.abort_multipart_upload(key, upload_id)
+        if not failed_parts:
+            await self.abort_multipart_upload(key, upload_id)
+        return failed_parts
 
     async def abort_multipart_upload(
         self,

--- a/python/aibrix/tests/batch/job_driver/test_base_job_driver_concurrent.py
+++ b/python/aibrix/tests/batch/job_driver/test_base_job_driver_concurrent.py
@@ -322,7 +322,7 @@ async def test_execute_request_raises_after_consecutive_failed_active_buckets(
         {"_request_index": 0, "custom_id": "req-0", "body": {"i": 0}},
     )
 
-    assert first_result == (0, False)
+    assert first_result == (0, None)
 
     with pytest.raises(BatchJobError, match="RuntimeError: retry later"):
         await driver._execute_request(
@@ -374,8 +374,8 @@ async def test_execute_request_counts_only_once_per_failed_bucket(
         {"_request_index": 0, "custom_id": "req-0", "body": {"i": 0}},
     )
 
-    assert first_result == (0, False)
-    assert second_result == (0, False)
+    assert first_result == (0, None)
+    assert second_result == (0, None)
 
     with pytest.raises(BatchJobError, match="RuntimeError: retry later"):
         await driver._execute_request(
@@ -433,9 +433,32 @@ async def test_execute_request_success_resets_failed_active_bucket_streak(
         {"_request_index": 2, "custom_id": "req-2", "body": {"i": 2}},
     )
 
-    assert first_result == (0, False)
+    assert first_result == (0, None)
     assert second_result == (1, False)
-    assert third_result == (2, False)
+    assert third_result == (2, None)
+
+
+@pytest.mark.asyncio
+async def test_sync_completed_request_tasks_ignores_deferred_results():
+    job = _make_job(total=3)
+    driver = BaseJobDriver(
+        InfrastructureContext(),
+        SingleJobRunner(job),
+        ExternalRuntime(None),
+    )
+
+    updated_job, synced = await driver._sync_completed_request_tasks(
+        job,
+        [
+            (0, None),
+            (1, False),
+            (2, True),
+        ],
+    )
+
+    assert synced == 2
+    assert updated_job.status.request_counts.completed == 1
+    assert updated_job.status.request_counts.failed == 1
 
 
 def _patch_storage(monkeypatch, requests, done: Optional[set[int]] = None):

--- a/python/aibrix/tests/batch/job_driver/test_base_job_driver_concurrent.py
+++ b/python/aibrix/tests/batch/job_driver/test_base_job_driver_concurrent.py
@@ -28,6 +28,7 @@ from aibrix.batch.job_driver import BaseJobDriver, ExternalRuntime
 from aibrix.batch.job_entity import (
     AibrixMetadata,
     BatchJob,
+    BatchJobError,
     BatchJobSpec,
     BatchJobState,
     BatchJobStatus,
@@ -281,6 +282,162 @@ def test_build_response_shapes_output_payload_model():
     assert response["response"]["body"]["model"] == "requested-model"
 
 
+@pytest.mark.asyncio
+async def test_execute_request_raises_after_consecutive_failed_active_buckets(
+    monkeypatch,
+):
+    # Unit-level coverage for the per-request path: use failed buckets 0 then 3
+    # to model slow requests / idle wall-clock gaps between attempts. Active-
+    # bucket semantics should not reset on empty buckets 1 and 2, so the second
+    # failed attempt still reaches the threshold and raises.
+    from aibrix.batch.job_driver import base as base_module
+
+    monkeypatch.setenv("AIBRIX_BATCH_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD", "2")
+    job = _make_job(total=1)
+    driver = BaseJobDriver(
+        InfrastructureContext(),
+        SingleJobRunner(job),
+        ExternalRuntime(None),
+    )
+
+    async def fake_send_one(_endpoint, _body, _request_id):
+        return {"usage": {"prompt_tokens": 1, "completion_tokens": 2}}, None
+
+    async def write_job_output_data(_job, _request_index, _output_data):
+        raise RuntimeError("retry later")
+
+    monkeypatch.setattr(driver, "_send_one", fake_send_one)
+    failed_buckets = iter([0, 3])
+    monkeypatch.setattr(
+        driver,
+        "_current_output_persistence_failure_bucket",
+        lambda: next(failed_buckets),
+    )
+    monkeypatch.setattr(
+        base_module.storage, "write_job_output_data", write_job_output_data
+    )
+
+    first_result = await driver._execute_request(
+        job,
+        {"_request_index": 0, "custom_id": "req-0", "body": {"i": 0}},
+    )
+
+    assert first_result == (0, False)
+
+    with pytest.raises(BatchJobError, match="RuntimeError: retry later"):
+        await driver._execute_request(
+            job,
+            {"_request_index": 0, "custom_id": "req-0", "body": {"i": 0}},
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_request_counts_only_once_per_failed_bucket(
+    monkeypatch,
+):
+    # Per-request coverage for the burst-collapse rule: two failures in bucket 0
+    # count as one failed active bucket, so only the later failure in bucket 1
+    # reaches the threshold.
+    from aibrix.batch.job_driver import base as base_module
+
+    monkeypatch.setenv("AIBRIX_BATCH_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD", "2")
+    job = _make_job(total=1)
+    driver = BaseJobDriver(
+        InfrastructureContext(),
+        SingleJobRunner(job),
+        ExternalRuntime(None),
+    )
+
+    async def fake_send_one(_endpoint, _body, _request_id):
+        return {"usage": {"prompt_tokens": 1, "completion_tokens": 2}}, None
+
+    async def write_job_output_data(_job, _request_index, _output_data):
+        raise RuntimeError("retry later")
+
+    monkeypatch.setattr(driver, "_send_one", fake_send_one)
+    failed_buckets = iter([0, 0, 1])
+    monkeypatch.setattr(
+        driver,
+        "_current_output_persistence_failure_bucket",
+        lambda: next(failed_buckets),
+    )
+    monkeypatch.setattr(
+        base_module.storage, "write_job_output_data", write_job_output_data
+    )
+
+    first_result = await driver._execute_request(
+        job,
+        {"_request_index": 0, "custom_id": "req-0", "body": {"i": 0}},
+    )
+    second_result = await driver._execute_request(
+        job,
+        {"_request_index": 0, "custom_id": "req-0", "body": {"i": 0}},
+    )
+
+    assert first_result == (0, False)
+    assert second_result == (0, False)
+
+    with pytest.raises(BatchJobError, match="RuntimeError: retry later"):
+        await driver._execute_request(
+            job,
+            {"_request_index": 0, "custom_id": "req-0", "body": {"i": 0}},
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_request_success_resets_failed_active_bucket_streak(
+    monkeypatch,
+):
+    # Per-request coverage for the success-reset rule: a successful persistence
+    # between failures clears the failed active-bucket streak, so a later failure
+    # starts a new streak instead of inheriting the previous bucket.
+    from aibrix.batch.job_driver import base as base_module
+
+    monkeypatch.setenv("AIBRIX_BATCH_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD", "2")
+    job = _make_job(total=3)
+    driver = BaseJobDriver(
+        InfrastructureContext(),
+        SingleJobRunner(job),
+        ExternalRuntime(None),
+    )
+    failures = iter([True, False, True])
+
+    async def fake_send_one(_endpoint, _body, _request_id):
+        return {"usage": {"prompt_tokens": 1, "completion_tokens": 2}}, None
+
+    async def write_job_output_data(_job, _request_index, _output_data):
+        if next(failures):
+            raise RuntimeError("retry later")
+
+    monkeypatch.setattr(driver, "_send_one", fake_send_one)
+    buckets = iter([0, 1, 3])
+    monkeypatch.setattr(
+        driver,
+        "_current_output_persistence_failure_bucket",
+        lambda: next(buckets),
+    )
+    monkeypatch.setattr(
+        base_module.storage, "write_job_output_data", write_job_output_data
+    )
+
+    first_result = await driver._execute_request(
+        job,
+        {"_request_index": 0, "custom_id": "req-0", "body": {"i": 0}},
+    )
+    second_result = await driver._execute_request(
+        job,
+        {"_request_index": 1, "custom_id": "req-1", "body": {"i": 1}},
+    )
+    third_result = await driver._execute_request(
+        job,
+        {"_request_index": 2, "custom_id": "req-2", "body": {"i": 2}},
+    )
+
+    assert first_result == (0, False)
+    assert second_result == (1, False)
+    assert third_result == (2, False)
+
+
 def _patch_storage(monkeypatch, requests, done: Optional[set[int]] = None):
     done = done or set()
     outputs = {}
@@ -426,7 +583,115 @@ async def test_execute_worker_reconciles_storage_done_requests(monkeypatch):
 
     assert read_starts == [1]
     assert result.status.request_counts.completed == 1
-    assert set(outputs) == {1}
+
+
+@pytest.mark.asyncio
+async def test_execute_worker_defers_generic_output_persistence_failure(monkeypatch):
+    # Worker-level coverage for the deferred path: the request is launched and a
+    # response is built, but the worker must not count it completed/failed until
+    # persistence succeeds and the completion queue is updated.
+    monkeypatch.setenv("AIBRIX_BATCH_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD", "2")
+    job = _make_job(total=1)
+    driver = BaseJobDriver(
+        InfrastructureContext(),
+        SingleJobRunner(job),
+        ExternalRuntime(None),
+    )
+    requests = [{"_request_index": 0, "custom_id": "req-0", "body": {"i": 0}}]
+    done: set[int] = set()
+    outputs = {}
+
+    class _OneShotEngine:
+        async def run(self, request_iter, on_result, **_kwargs):
+            request = await anext(request_iter.__aiter__())
+            await on_result(request, {"usage": {"prompt_tokens": 1}}, None)
+
+        async def capacity(self) -> CapacitySignal:
+            return CapacitySignal(count=1)
+
+    driver._engine = _OneShotEngine()
+
+    async def read_job_next_request(_job, _start_index=0):
+        for request in requests:
+            yield dict(request)
+
+    async def write_job_output_data(_job, request_index, output_data):
+        outputs[request_index] = output_data
+        raise RuntimeError("retry later")
+
+    async def is_request_done(_job, request_index):
+        return request_index in done
+
+    from aibrix.batch.job_driver import base as base_module
+
+    monkeypatch.setattr(
+        base_module.storage, "read_job_next_request", read_job_next_request
+    )
+    monkeypatch.setattr(
+        base_module.storage, "write_job_output_data", write_job_output_data
+    )
+    monkeypatch.setattr(base_module.storage, "is_request_done", is_request_done)
+
+    result = await driver.execute_worker(job.job_id)
+    local_counts = driver._get_local_request_counts(job.job_id)
+
+    assert result.status.state == BatchJobState.IN_PROGRESS
+    assert result.status.request_counts.completed == 0
+    assert result.status.request_counts.failed == 0
+    assert local_counts.launched == 1
+    assert done == set()
+    assert outputs[0]["custom_id"] == "req-0"
+    assert set(outputs) == {0}
+
+
+@pytest.mark.asyncio
+async def test_execute_worker_raises_after_output_persistence_failure_threshold(
+    monkeypatch,
+):
+    # Worker-level coverage for the concurrent dispatch path: repeated
+    # persistence failures across active buckets propagate out of execute_worker.
+    # Buckets 0 then 4 model slow requests / idle gaps that must not reset the
+    # active-bucket streak before the threshold is reached.
+    monkeypatch.setenv("AIBRIX_BATCH_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD", "2")
+    job = _make_job(total=2)
+    driver, _ = _driver(job, capacity=1)
+    requests = [
+        {"_request_index": i, "custom_id": f"req-{i}", "body": {"i": i}}
+        for i in range(2)
+    ]
+    outputs = {}
+
+    async def read_job_next_request(_job, _start_index=0):
+        for request in requests:
+            yield dict(request)
+
+    async def write_job_output_data(_job, request_index, output_data):
+        outputs[request_index] = output_data
+        raise RuntimeError("retry later")
+
+    async def is_request_done(_job, _request_index):
+        return False
+
+    from aibrix.batch.job_driver import base as base_module
+
+    failed_buckets = iter([0, 4])
+    monkeypatch.setattr(
+        driver,
+        "_current_output_persistence_failure_bucket",
+        lambda: next(failed_buckets),
+    )
+    monkeypatch.setattr(
+        base_module.storage, "read_job_next_request", read_job_next_request
+    )
+    monkeypatch.setattr(
+        base_module.storage, "write_job_output_data", write_job_output_data
+    )
+    monkeypatch.setattr(base_module.storage, "is_request_done", is_request_done)
+
+    with pytest.raises(BatchJobError, match="RuntimeError: retry later"):
+        await driver.execute_worker(job.job_id)
+
+    assert set(outputs) == {0, 1}
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/batch/test_batch_storage_adapter.py
+++ b/python/aibrix/tests/batch/test_batch_storage_adapter.py
@@ -23,18 +23,26 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from aibrix.batch.job_entity import (
+    AibrixMetadata,
     BatchJob,
     BatchJobEndpoint,
     BatchJobSpec,
     BatchJobState,
     BatchJobStatus,
+    BatchUsage,
+    ClientConfig,
     CompletionWindow,
     ObjectMeta,
     RequestCountStats,
     TypeMeta,
 )
 from aibrix.batch.storage.adapter import BatchStorageAdapter
-from aibrix.storage.base import BaseStorage, StorageType
+from aibrix.storage.base import (
+    LOCAL_PART_PROVIDER_MARKER,
+    LOCAL_PART_PROVIDER_MARKER_VALUE,
+    BaseStorage,
+    StorageType,
+)
 
 
 def create_test_batch_job(
@@ -182,6 +190,7 @@ async def test_write_job_output_data_logs_persistence_failure(
 async def test_read_job_next_input_data_keeps_locking_behavior(mock_storage):
     adapter = BatchStorageAdapter(mock_storage)
     job = create_test_batch_job(total=2)
+    job.spec.aibrix = AibrixMetadata(client=ClientConfig(request_timeout_seconds=45))
     mock_storage.readline_iter.side_effect = _readline_iter_from_lines(
         [
             '{"custom_id":"a","body":{"i":0}}',
@@ -210,6 +219,8 @@ async def test_read_job_next_input_data_keeps_locking_behavior(mock_storage):
 
     assert [request["_request_index"] for request in requests] == [0, 1]
     assert mock_lock.await_count == 2
+    assert mock_lock.await_args_list[0].kwargs["expiration_seconds"] == 45
+    assert mock_lock.await_args_list[1].kwargs["expiration_seconds"] == 45
 
 
 @pytest.mark.asyncio
@@ -704,6 +715,233 @@ async def test_finalize_job_output_data_preserves_part_numbers(mock_storage):
 
                 # Total should be max index + 1
                 assert batch_job.status.request_counts.total == 16  # 15 + 1
+
+
+@pytest.mark.asyncio
+async def test_finalize_job_output_data_reroutes_unreadable_output_parts(
+    mock_storage,
+):
+    adapter = BatchStorageAdapter(mock_storage)
+    batch_job = create_test_batch_job(job_id="job-reroute")
+    batch_job.status.usage = BatchUsage()
+
+    expected_keys = [
+        f"batch:{batch_job.job_id}:done/0",
+        f"batch:{batch_job.job_id}:done/1",
+    ]
+
+    output_usage = BatchUsage(input_tokens=3, output_tokens=4, total_tokens=7)
+    error_usage = BatchUsage(input_tokens=1, output_tokens=2, total_tokens=3)
+
+    with patch(
+        "aibrix.batch.storage.adapter.list_metastore_keys", new_callable=AsyncMock
+    ) as mock_list_keys:
+        with patch(
+            "aibrix.batch.storage.adapter.get_metadata", new_callable=AsyncMock
+        ) as mock_get_metadata:
+            with patch(
+                "aibrix.batch.storage.adapter.delete_metadata", new_callable=AsyncMock
+            ) as mock_delete_metadata:
+                with patch.object(
+                    adapter,
+                    "_sum_usage_from_output",
+                    new=AsyncMock(side_effect=[output_usage, error_usage]),
+                ):
+                    mock_list_keys.return_value = (expected_keys, None)
+                    mock_get_metadata.side_effect = [
+                        (
+                            '{"result":"output","etag":"etag0","custom_id":"request-0"}',
+                            True,
+                        ),
+                        (
+                            '{"result":"output","etag":"etag1","custom_id":"request-1"}',
+                            True,
+                        ),
+                    ]
+                    mock_storage.complete_multipart_upload.side_effect = [
+                        [{"etag": "etag1", "part_number": 1}],
+                        [],
+                    ]
+                    mock_storage.abort_multipart_upload.return_value = None
+
+                    await adapter.finalize_job_output_data(batch_job)
+
+    assert batch_job.status.request_counts.total == 2
+    assert batch_job.status.request_counts.launched == 2
+    assert batch_job.status.request_counts.completed == 1
+    assert batch_job.status.request_counts.failed == 1
+    assert batch_job.status.usage.input_tokens == 4
+    assert batch_job.status.usage.output_tokens == 6
+    assert batch_job.status.usage.total_tokens == 10
+
+    output_call = mock_storage.complete_multipart_upload.call_args_list[0]
+    assert output_call.kwargs["tolerate_part_get_error"] is True
+
+    error_call = mock_storage.complete_multipart_upload.call_args_list[1]
+    local_part_provider = error_call.kwargs["local_part_provider"]
+    synthesized_parts = error_call.args[2]
+    assert [part["part_number"] for part in synthesized_parts] == [1]
+    assert synthesized_parts[0]["custom_id"] == "request-1"
+    assert (
+        synthesized_parts[0][LOCAL_PART_PROVIDER_MARKER]
+        == LOCAL_PART_PROVIDER_MARKER_VALUE
+    )
+    synth_payload = json.loads(
+        (await local_part_provider(synthesized_parts[0])).decode("utf-8")
+    )
+    assert synth_payload["custom_id"] == "request-1"
+    assert synth_payload["response"] is None
+    assert synth_payload["error"]["code"] == "internal_error"
+    mock_storage.abort_multipart_upload.assert_awaited_once_with(
+        batch_job.status.output_file_id,
+        batch_job.status.temp_output_file_id,
+    )
+    assert mock_delete_metadata.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_finalize_job_output_data_merges_rerouted_parts_by_part_number(
+    mock_storage,
+):
+    adapter = BatchStorageAdapter(mock_storage)
+    batch_job = create_test_batch_job(job_id="job-reroute-merge")
+    batch_job.status.usage = BatchUsage()
+
+    expected_keys = [
+        f"batch:{batch_job.job_id}:done/0",
+        f"batch:{batch_job.job_id}:done/1",
+        f"batch:{batch_job.job_id}:done/2",
+    ]
+
+    with patch(
+        "aibrix.batch.storage.adapter.list_metastore_keys", new_callable=AsyncMock
+    ) as mock_list_keys:
+        with patch(
+            "aibrix.batch.storage.adapter.get_metadata", new_callable=AsyncMock
+        ) as mock_get_metadata:
+            with patch(
+                "aibrix.batch.storage.adapter.delete_metadata", new_callable=AsyncMock
+            ):
+                with patch.object(
+                    adapter,
+                    "_sum_usage_from_output",
+                    new=AsyncMock(side_effect=[BatchUsage(), BatchUsage()]),
+                ):
+                    mock_list_keys.return_value = (expected_keys, None)
+                    mock_get_metadata.side_effect = [
+                        (
+                            '{"result":"output","etag":"etag0","custom_id":"request-0"}',
+                            True,
+                        ),
+                        (
+                            '{"result":"error","etag":"etag1","custom_id":"request-1"}',
+                            True,
+                        ),
+                        (
+                            '{"result":"output","etag":"etag2","custom_id":"request-2"}',
+                            True,
+                        ),
+                    ]
+                    mock_storage.complete_multipart_upload.side_effect = [
+                        [
+                            {"etag": "etag2", "part_number": 2},
+                            {"etag": "etag1-duplicate", "part_number": 1},
+                        ],
+                        [],
+                    ]
+                    mock_storage.abort_multipart_upload.return_value = None
+
+                    await adapter.finalize_job_output_data(batch_job)
+
+    assert batch_job.status.request_counts.total == 3
+    assert batch_job.status.request_counts.launched == 3
+    assert batch_job.status.request_counts.completed == 1
+    assert batch_job.status.request_counts.failed == 2
+
+    error_call = mock_storage.complete_multipart_upload.call_args_list[1]
+    assert error_call.args[2][0] == {
+        "etag": "etag1",
+        "part_number": 1,
+        "custom_id": "request-1",
+    }
+    synthesized_part = error_call.args[2][1]
+    assert synthesized_part["part_number"] == 2
+    assert synthesized_part["custom_id"] == "request-2"
+    assert (
+        synthesized_part[LOCAL_PART_PROVIDER_MARKER] == LOCAL_PART_PROVIDER_MARKER_VALUE
+    )
+    synth_payload = json.loads(
+        (await error_call.kwargs["local_part_provider"](synthesized_part)).decode(
+            "utf-8"
+        )
+    )
+    assert synth_payload["custom_id"] == "request-2"
+    assert synth_payload["error"]["code"] == "internal_error"
+
+
+@pytest.mark.asyncio
+async def test_finalize_job_output_data_synthesizes_unreadable_error_parts(
+    mock_storage,
+):
+    adapter = BatchStorageAdapter(mock_storage)
+    batch_job = create_test_batch_job(job_id="job-unreadable-error-part")
+    batch_job.status.usage = BatchUsage()
+
+    expected_keys = [f"batch:{batch_job.job_id}:done/0"]
+
+    with patch(
+        "aibrix.batch.storage.adapter.list_metastore_keys", new_callable=AsyncMock
+    ) as mock_list_keys:
+        with patch(
+            "aibrix.batch.storage.adapter.get_metadata", new_callable=AsyncMock
+        ) as mock_get_metadata:
+            with patch(
+                "aibrix.batch.storage.adapter.delete_metadata", new_callable=AsyncMock
+            ):
+                with patch.object(
+                    adapter,
+                    "_sum_usage_from_output",
+                    new=AsyncMock(side_effect=[BatchUsage(), BatchUsage()]),
+                ):
+                    mock_list_keys.return_value = (expected_keys, None)
+                    mock_get_metadata.side_effect = [
+                        (
+                            '{"result":"error","etag":"etag0","custom_id":"request-0"}',
+                            True,
+                        ),
+                    ]
+                    mock_storage.complete_multipart_upload.side_effect = [
+                        [],
+                        [],
+                    ]
+
+                    await adapter.finalize_job_output_data(batch_job)
+
+    assert batch_job.status.request_counts.total == 1
+    assert batch_job.status.request_counts.launched == 1
+    assert batch_job.status.request_counts.completed == 0
+    assert batch_job.status.request_counts.failed == 1
+
+    first_error_call = mock_storage.complete_multipart_upload.call_args_list[1]
+    assert first_error_call.kwargs["tolerate_part_get_error"] is True
+    assert len(mock_storage.complete_multipart_upload.call_args_list) == 2
+    original_error_part = first_error_call.args[2][0]
+    assert original_error_part == {
+        "etag": "etag0",
+        "part_number": 0,
+        "custom_id": "request-0",
+    }
+    synth_payload = json.loads(
+        (
+            await first_error_call.kwargs["local_part_provider"](original_error_part)
+        ).decode("utf-8")
+    )
+    assert synth_payload["custom_id"] == "request-0"
+    assert synth_payload["response"] is None
+    assert (
+        synth_payload["error"]["message"]
+        == "Failed to read failed request error part during batch finalization"
+    )
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
+++ b/python/aibrix/tests/batch/test_e2e_abnormal_job_behavior.py
@@ -23,6 +23,7 @@ These tests cover various failure modes and edge cases in the batch job lifecycl
 """
 
 import asyncio
+import json
 import pydoc
 import threading
 import time
@@ -36,6 +37,8 @@ from fastapi.testclient import TestClient
 import aibrix.batch.constant as constant
 from aibrix import envs
 from aibrix.batch.batch_manager import BatchManager
+from aibrix.batch.client.engine import DispatchEngine
+from aibrix.batch.client.errors import InferenceError, InferenceErrorCode
 from aibrix.batch.job_driver import BaseJobDriver, JobDriver, TerminateResult
 from aibrix.batch.job_entity import (
     AibrixMetadata,
@@ -48,6 +51,12 @@ from aibrix.batch.job_entity import (
     ResourceAllocation,
 )
 from aibrix.batch.job_entity.batch_job import parse_completion_window
+from aibrix.batch.storage import batch_storage
+from aibrix.batch.storage.adapter import (
+    UNREADABLE_COMPLETED_OUTPUT_PART_MESSAGE,
+    UNREADABLE_FAILED_ERROR_PART_MESSAGE,
+    BatchStorageAdapter,
+)
 from aibrix.context import InfrastructureContext
 from tests.batch.conftest import (
     backend_has_feature,
@@ -412,6 +421,7 @@ def install_request_lock_retry_harness(
     monkeypatch,
     *,
     lock_timeout_seconds: float,
+    respect_expiration_seconds: bool = False,
 ):
     import aibrix.batch.storage.adapter as storage_adapter_module
 
@@ -434,11 +444,15 @@ def install_request_lock_retry_harness(
             purge_expired(key)
 
     async def fake_lock_request(key: str, expiration_seconds: int = 3600) -> bool:
-        del expiration_seconds
         purge_expired(key)
         if key in lock_state:
             return False
-        lock_state[key] = ("processing", time.monotonic() + lock_timeout_seconds)
+        effective_timeout = (
+            float(expiration_seconds)
+            if respect_expiration_seconds
+            else lock_timeout_seconds
+        )
+        lock_state[key] = ("processing", time.monotonic() + effective_timeout)
         return True
 
     async def fake_unlock_request(key: str, status: str) -> bool:
@@ -567,6 +581,11 @@ async def wait_for_completed_at_least(
             return result
         await asyncio.sleep(poll_interval)
     return result
+
+
+def decode_jsonl_content(content: bytes) -> List[Dict[str, Any]]:
+    lines = content.decode("utf-8").splitlines()
+    return [json.loads(line) for line in lines if line.strip()]
 
 
 def validate_batch_response(
@@ -1862,6 +1881,231 @@ async def test_job_finalizing_failure(e2e_test_app, test_backend):
                     finalizing_patcher.stop()
                 except RuntimeError:
                     pass
+
+
+@pytest.mark.asyncio
+async def test_job_deferred_persistence_error_and_finalization_reroute(
+    e2e_test_app, test_backend, monkeypatch
+):
+    """Exercise a mixed abnormal batch where finalization must handle both:
+    - a completed output part that became unreadable and must be rerouted into
+      the synthesized error file, and
+    - an original failed-request error part that became unreadable and must be
+      rebuilt by the local error-part callback during error-file completion.
+
+    The same run also keeps the deferred-after-durable persistence path alive so
+    the larger request set covers the current end-to-end recovery contract."""
+    print("Test 3b: Deferred persistence error with finalization reroute scenario")
+
+    monkeypatch.setenv("AIBRIX_BATCH_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD", "2")
+    retry_timeout_seconds = 1.0
+    inject_job_creation_client_config(
+        monkeypatch,
+        e2e_test_app,
+        {
+            "max_concurrency": 1,
+            "adaptive_concurrency": False,
+            "request_timeout_seconds": retry_timeout_seconds,
+        },
+    )
+    install_request_lock_retry_harness(
+        monkeypatch,
+        lock_timeout_seconds=retry_timeout_seconds,
+        respect_expiration_seconds=True,
+    )
+
+    with create_test_client(e2e_test_app) as client:
+        input_file_id = upload_batch_input_file(client, 4)
+        debug_state = capture_runtime_debug_state(e2e_test_app, test_backend)
+        batch_id = None
+
+        adapter = batch_storage.p_storage
+        assert isinstance(adapter, BatchStorageAdapter)
+        storage_backend = adapter.storage
+        import aibrix.batch.storage.adapter as storage_adapter_module
+
+        original_write_job_output_data = adapter.write_job_output_data
+        original_get_object = storage_backend.get_object
+        original_send_with_failover = DispatchEngine._send_with_failover
+        original_unlock_request = storage_adapter_module.unlock_request
+        write_attempts: Dict[int, int] = {}
+        write_attempt_times: Dict[int, List[float]] = {}
+        deferred_failure_count = 0
+        rerouted_output_part_key: Optional[str] = None
+        unreadable_error_part_key: Optional[str] = None
+        deferred_unlock_key: Optional[str] = None
+
+        async def patched_send_with_failover(self, request):
+            request_id = request.ref[0]
+            # Force request-3 down the real error-record path so finalization
+            # has an original staged error part to read back.
+            if request_id == 2:
+                raise InferenceError(
+                    InferenceErrorCode.HTTP_ERROR,
+                    "simulated per-request inference failure",
+                    status_code=500,
+                    response_body={"error": "simulated failure"},
+                )
+            return await original_send_with_failover(self, request)
+
+        async def flaky_write_job_output_data(job, request_index, output_data):
+            nonlocal rerouted_output_part_key
+            nonlocal unreadable_error_part_key
+            nonlocal deferred_unlock_key
+            write_attempts[request_index] = write_attempts.get(request_index, 0) + 1
+            write_attempt_times.setdefault(request_index, []).append(time.monotonic())
+            # Capture the staged multipart keys that finalization will read
+            # later so the test can selectively make one completed-output part
+            # and one error part unreadable.
+            if request_index == 1 and job.status.temp_output_file_id is not None:
+                rerouted_output_part_key = storage_backend._multipart_upload_part_key(
+                    job.status.temp_output_file_id,
+                    1,
+                )
+            if request_index == 2 and job.status.temp_error_file_id is not None:
+                unreadable_error_part_key = storage_backend._multipart_upload_part_key(
+                    job.status.temp_error_file_id,
+                    2,
+                )
+            if request_index == 0:
+                # Request 0 is the deferred-persistence case. We do not fail the
+                # upload itself; instead we remember the metastore key and fail
+                # the first unlock below so the request stays "processing" until
+                # the lock timeout expires and the next pass retries it.
+                deferred_unlock_key = adapter._get_request_meta_output_key(
+                    job, request_index
+                )
+            return await original_write_job_output_data(job, request_index, output_data)
+
+        async def flaky_get_object(key: str):
+            if rerouted_output_part_key is not None and key == rerouted_output_part_key:
+                raise FileNotFoundError("simulated unreadable completed output part")
+            if (
+                unreadable_error_part_key is not None
+                and key == unreadable_error_part_key
+            ):
+                raise FileNotFoundError("simulated unreadable failed error part")
+            return await original_get_object(key)
+
+        async def flaky_unlock_request(key: str, status: str) -> bool:
+            nonlocal deferred_failure_count
+            if key == deferred_unlock_key and deferred_failure_count == 0:
+                deferred_failure_count += 1
+                # Simulate "part upload succeeded but completion marker write
+                # failed". The request remains locked, so the concurrent worker
+                # has to wait for lock expiry and retry the request in a later
+                # pass.
+                raise RuntimeError(
+                    "simulated completion metastore write failure after durable write"
+                )
+            return await original_unlock_request(key, status)
+
+        monkeypatch.setattr(
+            DispatchEngine, "_send_with_failover", patched_send_with_failover
+        )
+        monkeypatch.setattr(
+            adapter, "write_job_output_data", flaky_write_job_output_data
+        )
+        monkeypatch.setattr(storage_backend, "get_object", flaky_get_object)
+        monkeypatch.setattr(
+            storage_adapter_module, "unlock_request", flaky_unlock_request
+        )
+
+        try:
+            batch_id = create_batch_job(
+                client, input_file_id, test_backend=test_backend
+            )
+
+            await wait_for_status(
+                client,
+                batch_id,
+                "in_progress",
+                **backend_status_wait_kwargs(
+                    test_backend, expected_status="in_progress"
+                ),
+            )
+            final_status = await wait_for_status(
+                client,
+                batch_id,
+                "completed",
+                max_polls=120,
+                poll_interval=0.5,
+                **backend_status_wait_kwargs(test_backend, expected_status="completed"),
+            )
+
+            validate_batch_response_with_runtime_teardown(
+                final_status,
+                e2e_test_app=e2e_test_app,
+                test_backend=test_backend,
+                batch_id=batch_id,
+                debug_state=debug_state,
+                expect_runtime_teardown=backend_expect_runtime_teardown(test_backend),
+                expected_status="completed",
+                expected_endpoint="/v1/chat/completions",
+                expected_input_file_id=input_file_id,
+                expected_in_progress_at=True,
+                expected_finalizing_at=True,
+                expected_completed_at=True,
+                expected_failed_at=False,
+                expected_expired_at=False,
+                expected_cancelling_at=False,
+                expected_cancelled_at=False,
+                expected_errors=False,
+                expected_output_file_id=True,
+                expected_error_file_id=True,
+                expected_request_counts={"total": 4, "completed": 2, "failed": 2},
+            )
+
+            # Request 0 simulates the real deferred-after-durable flow:
+            # the first write lands, the worker observes a transient failure,
+            # the processing lock times out after request_timeout_seconds, and
+            # the next worker pass retries the same request and persists it
+            # again. Assert both the retry and the lock-timeout gap.
+            assert deferred_failure_count == 1
+            assert write_attempts.get(0, 0) == 2
+            assert len(write_attempt_times.get(0, [])) == 2
+            retry_delay = write_attempt_times[0][1] - write_attempt_times[0][0]
+            assert retry_delay >= retry_timeout_seconds
+            assert write_attempts.get(1, 0) >= 1
+            assert write_attempts.get(2, 0) >= 1
+            assert write_attempts.get(3, 0) >= 1
+
+            output_response = client.get(
+                f"/v1/files/{final_status['output_file_id']}/content"
+            )
+            assert output_response.status_code == 200, output_response.text
+            output_rows = decode_jsonl_content(output_response.content)
+            assert len(output_rows) == 2
+            output_rows_by_custom_id = {row["custom_id"]: row for row in output_rows}
+            assert set(output_rows_by_custom_id) == {"request-1", "request-4"}
+            assert output_rows_by_custom_id["request-1"]["error"] is None
+            assert output_rows_by_custom_id["request-4"]["error"] is None
+
+            error_response = client.get(
+                f"/v1/files/{final_status['error_file_id']}/content"
+            )
+            assert error_response.status_code == 200, error_response.text
+            error_rows = decode_jsonl_content(error_response.content)
+            assert len(error_rows) == 2
+            error_rows_by_custom_id = {row["custom_id"]: row for row in error_rows}
+            assert set(error_rows_by_custom_id) == {"request-2", "request-3"}
+            assert error_rows_by_custom_id["request-2"]["response"] is None
+            assert (
+                error_rows_by_custom_id["request-2"]["error"]["message"]
+                == UNREADABLE_COMPLETED_OUTPUT_PART_MESSAGE
+            )
+            assert error_rows_by_custom_id["request-3"]["response"] is None
+            assert (
+                error_rows_by_custom_id["request-3"]["error"]["message"]
+                == UNREADABLE_FAILED_ERROR_PART_MESSAGE
+            )
+
+            print(
+                "✅ Deferred persistence error and finalization reroute test completed successfully"
+            )
+        finally:
+            if batch_id is not None:
+                await e2e_test_app.state.batch_driver.clear_job(batch_id)
 
 
 @pytest.mark.asyncio

--- a/python/aibrix/tests/storage/test_base2.py
+++ b/python/aibrix/tests/storage/test_base2.py
@@ -21,7 +21,12 @@ from typing import Any, Union
 import pytest
 import tos
 
-from aibrix.storage.base import StorageConfig
+from aibrix.storage.base import (
+    LOCAL_PART_PROVIDER_MARKER,
+    LOCAL_PART_PROVIDER_MARKER_VALUE,
+    BaseStorage,
+    StorageConfig,
+)
 from aibrix.storage.base2 import BaseStorage2
 from aibrix.storage.reader import Reader
 from aibrix.storage.s3 import S3Storage
@@ -434,6 +439,203 @@ class TestBaseStorage2:
         assert storage.native_upload_part_calls == []
         assert storage.native_complete_calls == []
         assert storage.native_abort_calls == []
+
+    @pytest.mark.asyncio
+    async def test_complete_multipart_upload_tolerates_missing_staged_parts(self):
+        storage = NativeMultipartTestStorage(multipart_threshold=8)
+        key = "test/native_small_parts_tolerant.txt"
+
+        upload_id = await storage.create_multipart_upload(
+            key,
+            content_type="text/plain",
+            metadata={"source": "batch"},
+            small_parts=True,
+        )
+
+        parts: list[dict[str, Union[str, int]]] = []
+        for part_number, payload in enumerate((b"abc", b"def", b"ghi"), start=1):
+            etag = await storage.upload_part(key, upload_id, part_number, payload)
+            parts.append({"part_number": part_number, "etag": etag})
+
+        await storage.delete_object(storage._multipart_upload_part_key(upload_id, 2))
+
+        failed_parts = await storage.complete_multipart_upload(
+            key,
+            upload_id,
+            parts,
+            tolerate_part_get_error=True,
+        )
+
+        assert failed_parts == [{"part_number": 2, "etag": parts[1]["etag"]}]
+        assert await storage.get_object(key) == b"abcghi"
+        assert await storage.object_exists(storage._multipart_upload_key(upload_id))
+        assert await storage.object_exists(
+            storage._multipart_upload_part_key(upload_id, 1)
+        )
+
+    @pytest.mark.asyncio
+    async def test_complete_multipart_upload_uses_local_part_provider(self):
+        storage = NativeMultipartTestStorage(multipart_threshold=8)
+        key = "test/native_small_parts_local_provider.txt"
+
+        upload_id = await storage.create_multipart_upload(
+            key,
+            content_type="text/plain",
+            metadata={"source": "batch"},
+            small_parts=True,
+        )
+
+        etag = await storage.upload_part(key, upload_id, 1, b"provider-part")
+        parts: list[dict[str, Union[str, int]]] = [
+            {
+                "part_number": 1,
+                "etag": etag,
+                LOCAL_PART_PROVIDER_MARKER: LOCAL_PART_PROVIDER_MARKER_VALUE,
+            }
+        ]
+        await storage.delete_object(storage._multipart_upload_part_key(upload_id, 1))
+
+        async def local_part_provider(
+            part: dict[str, Union[str, int]],
+        ) -> bytes | None:
+            if int(part["part_number"]) == 1:
+                return b"provider-part"
+            return None
+
+        failed_parts = await storage.complete_multipart_upload(
+            key,
+            upload_id,
+            parts,
+            local_part_provider=local_part_provider,
+        )
+
+        assert failed_parts == []
+        assert await storage.get_object(key) == b"provider-part"
+
+    @pytest.mark.asyncio
+    async def test_complete_multipart_upload_ignores_provider_without_marker(self):
+        storage = NativeMultipartTestStorage(multipart_threshold=8)
+        key = "test/native_small_parts_unmarked_provider.txt"
+
+        upload_id = await storage.create_multipart_upload(
+            key,
+            content_type="text/plain",
+            metadata={"source": "batch"},
+            small_parts=True,
+        )
+
+        etag = await storage.upload_part(key, upload_id, 1, b"stored-part")
+        parts: list[dict[str, Union[str, int]]] = [{"part_number": 1, "etag": etag}]
+
+        async def local_part_provider(
+            part: dict[str, Union[str, int]],
+        ) -> bytes | None:
+            _ = part
+            return b"provider-part"
+
+        failed_parts = await storage.complete_multipart_upload(
+            key,
+            upload_id,
+            parts,
+            local_part_provider=local_part_provider,
+        )
+
+        assert failed_parts == []
+        assert await storage.get_object(key) == b"stored-part"
+
+    @pytest.mark.asyncio
+    async def test_complete_multipart_upload_uses_provider_as_fallback_on_read_error(
+        self,
+    ):
+        storage = NativeMultipartTestStorage(multipart_threshold=8)
+        key = "test/native_small_parts_provider_fallback.txt"
+
+        upload_id = await storage.create_multipart_upload(
+            key,
+            content_type="text/plain",
+            metadata={"source": "batch"},
+            small_parts=True,
+        )
+
+        etag = await storage.upload_part(key, upload_id, 1, b"stored-part")
+        parts: list[dict[str, Union[str, int]]] = [
+            {"part_number": 1, "etag": etag, "custom_id": "request-1"}
+        ]
+        await storage.delete_object(storage._multipart_upload_part_key(upload_id, 1))
+
+        async def local_part_provider(
+            part: dict[str, Union[str, int]],
+        ) -> bytes | None:
+            if int(part["part_number"]) == 1:
+                return b"provider-fallback"
+            return None
+
+        failed_parts = await storage.complete_multipart_upload(
+            key,
+            upload_id,
+            parts,
+            tolerate_part_get_error=True,
+            local_part_provider=local_part_provider,
+        )
+
+        assert failed_parts == []
+        assert await storage.get_object(key) == b"provider-fallback"
+
+    @pytest.mark.asyncio
+    async def test_complete_multipart_upload_reads_from_source_upload_id(self):
+        storage = NativeMultipartTestStorage(multipart_threshold=8)
+        output_key = "test/output.jsonl"
+        error_key = "test/error.jsonl"
+
+        output_upload_id = await storage.create_multipart_upload(
+            output_key,
+            content_type="application/jsonl",
+            metadata={"source": "output"},
+            small_parts=True,
+        )
+        error_upload_id = await storage.create_multipart_upload(
+            error_key,
+            content_type="application/jsonl",
+            metadata={"source": "error"},
+            small_parts=True,
+        )
+
+        output_etag = await storage.upload_part(
+            output_key,
+            output_upload_id,
+            1,
+            b'{"id":"rerouted"}\n',
+        )
+
+        failed_parts = await storage.complete_multipart_upload(
+            error_key,
+            error_upload_id,
+            [
+                {
+                    "part_number": 1,
+                    "etag": output_etag,
+                    "source_upload_id": output_upload_id,
+                }
+            ],
+        )
+
+        assert failed_parts == []
+        assert await storage.get_object(error_key) == b'{"id":"rerouted"}\n'
+
+    @pytest.mark.asyncio
+    async def test_base_storage_complete_multipart_upload_fails_fast(self):
+        storage = NativeMultipartTestStorage(multipart_threshold=8)
+
+        with pytest.raises(
+            NotImplementedError,
+            match="BaseStorage.complete_multipart_upload\\(\\) must not be called",
+        ):
+            await BaseStorage.complete_multipart_upload(
+                storage,
+                "test/fail-fast.txt",
+                "upload-id",
+                [],
+            )
 
 
 class TestTOSStorageConfig:


### PR DESCRIPTION
## Pull Request Description

- tolerate output persistence failures for a bounded number of time buckets via `AIBRIX_BATCH_OUTPUT_PERSISTENCE_FAILURE_THRESHOLD`
- keep batch jobs progressing while transient storage persistence failures are still below the configured threshold
- reroute unreadable finalized output parts into synthesized error records so finalization still produces a consistent error file
- strengthen multipart aggregation and finalize-path coverage with targeted tests

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>