### PR TITLE
[API] Reject StormService /scale above 1 in Pooled mode

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -210,3 +210,22 @@ webhooks:
     resources:
     - stormservices
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-orchestration-aibrix-ai-v1alpha1-stormservice-scale
+  failurePolicy: Ignore
+  name: vstormservicescale.kb.io
+  rules:
+  - apiGroups:
+    - orchestration.aibrix.ai
+    apiVersions:
+    - v1alpha1
+    operations:
+    - UPDATE
+    resources:
+    - stormservices/scale
+  sideEffects: None

--- a/dist/chart/templates/webhook/webhooks.yaml
+++ b/dist/chart/templates/webhook/webhooks.yaml
@@ -208,6 +208,25 @@ webhooks:
     service:
       name: aibrix-webhook-service
       namespace: {{ .Release.Namespace }}
+      path: /validate-orchestration-aibrix-ai-v1alpha1-stormservice-scale
+  failurePolicy: Ignore
+  name: vstormservicescale.kb.io
+  rules:
+    - apiGroups:
+        - orchestration.aibrix.ai
+      apiVersions:
+        - v1alpha1
+      operations:
+        - UPDATE
+      resources:
+        - stormservices/scale
+  sideEffects: None
+- admissionReviewVersions:
+    - v1
+  clientConfig:
+    service:
+      name: aibrix-webhook-service
+      namespace: {{ .Release.Namespace }}
       path: /validate-apps-v1-deployment
   failurePolicy: Ignore
   name: vedeployment.aibrix.ai

--- a/docs/source/designs/aibrix-stormservice.rst
+++ b/docs/source/designs/aibrix-stormservice.rst
@@ -39,7 +39,7 @@ Stormservice supports two deployment modes: **Replica Mode** and **Pooled Mode**
 .. note::
     1. These two modes are mutually exclusive. The mode is declared through the `stormservice.spec.mode` field, which accepts `Replica` or `Pooled`.
     2. `spec.mode` is optional and is not defaulted. When it is omitted the mode is inferred for backward compatibility from `stormservice.spec.replicas`: replica mode when `replicas > 1`, otherwise pooled mode.
-    3. When `spec.mode` is set to `Pooled`, `spec.replicas` must stay at `1`; roles are scaled through `spec.template.spec.roles[].replicas`.
+    3. When `spec.mode` is set to `Pooled`, `spec.replicas` must stay at `1`; roles are scaled through `spec.template.spec.roles[].replicas`. The validating webhook enforces this on create/update and on the `/scale` subresource (`kubectl scale`, HPA, and other external autoscalers).
     4. A declared `spec.mode` drives the update path: `Replica` uses the rolling update path and `Pooled` uses the in-place update path, even when `spec.updateStrategy.type` holds the (possibly CRD-defaulted) `RollingUpdate` value. Declaring `mode: Replica` together with `updateStrategy.type: InPlaceUpdate` is rejected by the webhook. When `spec.mode` is omitted, `spec.updateStrategy.type` keeps selecting the update path as before.
     5. A declared `spec.mode` is also the source of truth for PodAutoscaler role-level scaling. The `autoscaling.aibrix.ai/storm-service-mode` annotation is deprecated and only honored when the target StormService does not declare `spec.mode`.
 
@@ -940,7 +940,7 @@ Autoscaling
 -----------
 
 - **Replica Mode**: StormService enables the `/scale` subresource on its CRD. The scale unit is `RoleSet`. It involves extending the StormService status with a dynamic label selector and implementing the controller logic to ensure this selector is correctly populated, thereby allowing external autoscalers to manage StormService replicas effectively.
-- **Pooled Mode**: In pooled mode, each role in the RoleSet is supposed to be independently scalable.
+- **Pooled Mode**: In pooled mode, each role in the RoleSet is supposed to be independently scalable. The `/scale` subresource still exists, but scaling `spec.replicas` above 1 is rejected when `spec.mode` is `Pooled`.
 
 .. warning::
    Pooled mode autoscaling (independent scaling of each role) is not yet supported. See Issue `#1260 <https://github.com/vllm-project/aibrix/issues/1260>`_ for more details.

--- a/pkg/webhook/stormservice_webhook.go
+++ b/pkg/webhook/stormservice_webhook.go
@@ -18,18 +18,23 @@ package webhook
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -38,12 +43,63 @@ import (
 	"github.com/vllm-project/aibrix/pkg/utils"
 )
 
+const stormServiceScaleWebhookPath = "/validate-orchestration-aibrix-ai-v1alpha1-stormservice-scale"
+
 // SetupStormServiceWebhookWithManager registers the webhook for StormService in the manager.
 func SetupStormServiceWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).For(&orchestrationv1alpha1.StormService{}).
+	if err := ctrl.NewWebhookManagedBy(mgr).For(&orchestrationv1alpha1.StormService{}).
 		WithValidator(&StormServiceCustomDefaulter{}).
 		WithDefaulter(&StormServiceCustomDefaulter{}).
-		Complete()
+		Complete(); err != nil {
+		return err
+	}
+	// kubectl scale, HPA, and other external autoscalers write spec.replicas through
+	// the /scale subresource, which does not invoke the main StormService validator.
+	mgr.GetWebhookServer().Register(stormServiceScaleWebhookPath, &admission.Webhook{
+		Handler: &StormServiceScaleValidator{Reader: mgr.GetAPIReader()},
+	})
+	return nil
+}
+
+//+kubebuilder:webhook:path=/validate-orchestration-aibrix-ai-v1alpha1-stormservice-scale,mutating=false,failurePolicy=ignore,sideEffects=None,groups=orchestration.aibrix.ai,resources=stormservices/scale,verbs=update,versions=v1alpha1,name=vstormservicescale.kb.io,admissionReviewVersions=v1
+
+// StormServiceScaleValidator rejects /scale updates that would set spec.replicas > 1
+// on a StormService with a declared mode of Pooled. Omitted mode is left alone so
+// inferred pooled objects can still scale spec.replicas, matching validateStormServiceMode.
+type StormServiceScaleValidator struct {
+	Reader client.Reader
+}
+
+var _ admission.Handler = &StormServiceScaleValidator{}
+
+// Handle implements admission.Handler for the StormService /scale subresource.
+func (v *StormServiceScaleValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	scale := &autoscalingv1.Scale{}
+	if err := json.Unmarshal(req.Object.Raw, scale); err != nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to decode Scale: %w", err))
+	}
+
+	stormService := &orchestrationv1alpha1.StormService{}
+	if err := v.Reader.Get(ctx, types.NamespacedName{Name: req.Name, Namespace: req.Namespace}, stormService); err != nil {
+		if apierrors.IsNotFound(err) {
+			return admission.Errored(http.StatusNotFound, err)
+		}
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to get StormService %s/%s: %w", req.Namespace, req.Name, err))
+	}
+
+	if err := validateStormServiceScale(stormService, scale.Spec.Replicas); err != nil {
+		return admission.Denied(err.Error())
+	}
+	return admission.Allowed("")
+}
+
+// validateStormServiceScale applies the proposed replica count onto a copy of the
+// parent StormService and reuses validateStormServiceMode. That keeps /scale on
+// the same declared-mode rule as create/update and does not pin inferred mode.
+func validateStormServiceScale(stormService *orchestrationv1alpha1.StormService, replicas int32) error {
+	proposed := stormService.DeepCopy()
+	proposed.Spec.Replicas = &replicas
+	return validateStormServiceMode(proposed)
 }
 
 type StormServiceCustomDefaulter struct {
@@ -275,7 +331,8 @@ func schedulingConfigChanged(oldSpec, newSpec *orchestrationv1alpha1.RoleSetSpec
 // declared mode instead (see EffectiveUpdateStrategyType in the stormservice controller).
 //
 // Only an explicitly declared spec.mode is checked, so objects that rely on the inferred
-// mode keep scaling spec.replicas and choosing updateStrategy.type freely.
+// mode keep scaling spec.replicas and choosing updateStrategy.type freely. The /scale
+// subresource validator reuses this helper so kubectl scale and HPA follow the same rule.
 func validateStormServiceMode(stormService *orchestrationv1alpha1.StormService) error {
 	switch stormService.Spec.Mode {
 	case orchestrationv1alpha1.StormServicePooledMode:

--- a/pkg/webhook/stormservice_webhook_test.go
+++ b/pkg/webhook/stormservice_webhook_test.go
@@ -18,13 +18,21 @@ package webhook
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	orchestrationv1alpha1 "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
 )
@@ -139,6 +147,97 @@ func TestStormServiceValidateUpdate_ModeUpdateStrategy(t *testing.T) {
 
 	_, err := validator.ValidateUpdate(context.Background(), oldSS, newSS)
 	require.Error(t, err)
+}
+
+func scaleAdmissionRequest(t *testing.T, name, namespace string, replicas int32, raw []byte) admission.Request {
+	t.Helper()
+	if raw == nil {
+		scale := &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec:       autoscalingv1.ScaleSpec{Replicas: replicas},
+		}
+		var err error
+		raw, err = json.Marshal(scale)
+		require.NoError(t, err)
+	}
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Name:      name,
+			Namespace: namespace,
+			Object:    runtime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+func TestStormServiceScaleValidator_Handle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, orchestrationv1alpha1.AddToScheme(scheme))
+
+	pooled := &orchestrationv1alpha1.StormService{
+		ObjectMeta: metav1.ObjectMeta{Name: "pooled", Namespace: "default"},
+		Spec: orchestrationv1alpha1.StormServiceSpec{
+			Mode:     orchestrationv1alpha1.StormServicePooledMode,
+			Replicas: ptr.To[int32](1),
+		},
+	}
+	replica := &orchestrationv1alpha1.StormService{
+		ObjectMeta: metav1.ObjectMeta{Name: "replica", Namespace: "default"},
+		Spec: orchestrationv1alpha1.StormServiceSpec{
+			Mode:     orchestrationv1alpha1.StormServiceReplicaMode,
+			Replicas: ptr.To[int32](1),
+		},
+	}
+	inferred := &orchestrationv1alpha1.StormService{
+		ObjectMeta: metav1.ObjectMeta{Name: "inferred", Namespace: "default"},
+		Spec: orchestrationv1alpha1.StormServiceSpec{
+			Replicas: ptr.To[int32](1),
+		},
+	}
+	reader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pooled, replica, inferred).Build()
+	validator := &StormServiceScaleValidator{Reader: reader}
+
+	tests := map[string]struct {
+		name        string
+		replicas    int32
+		raw         []byte
+		wantAllowed bool
+		wantDenied  string
+		wantCode    int32
+	}{
+		"declared pooled mode rejects scale above 1": {
+			name: "pooled", replicas: 3, wantAllowed: false, wantDenied: "Pooled",
+		},
+		"declared pooled mode allows scale to 1": {
+			name: "pooled", replicas: 1, wantAllowed: true,
+		},
+		"declared replica mode allows scale above 1": {
+			name: "replica", replicas: 5, wantAllowed: true,
+		},
+		"omitted mode allows scale above 1": {
+			name: "inferred", replicas: 3, wantAllowed: true,
+		},
+		"malformed scale object is rejected": {
+			name: "pooled", raw: []byte("not-json"), wantAllowed: false, wantCode: http.StatusBadRequest,
+		},
+		"missing stormservice returns 404": {
+			name: "missing", replicas: 2, wantAllowed: false, wantCode: http.StatusNotFound,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			resp := validator.Handle(context.Background(), scaleAdmissionRequest(t, tc.name, "default", tc.replicas, tc.raw))
+			assert.Equal(t, tc.wantAllowed, resp.Allowed)
+			if tc.wantDenied != "" {
+				require.NotNil(t, resp.Result)
+				assert.Contains(t, resp.Result.Message, tc.wantDenied)
+			}
+			if tc.wantCode != 0 {
+				require.NotNil(t, resp.Result)
+				assert.Equal(t, tc.wantCode, resp.Result.Code)
+			}
+		})
+	}
 }
 
 func TestStormServiceValidateUpdate_ModeReplicas(t *testing.T) {

--- a/test/integration/webhook/stormservice_webhook_test.go
+++ b/test/integration/webhook/stormservice_webhook_test.go
@@ -23,10 +23,12 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	orchestrationapi "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
 	"github.com/vllm-project/aibrix/pkg/webhook"
@@ -441,6 +443,46 @@ var _ = ginkgo.Describe("stormservice default webhook", func() {
 		gomega.Expect(k8sClient.Update(ctx, stormService)).ShouldNot(gomega.Succeed())
 	})
 
+	ginkgo.It("rejects /scale above one replica for explicit Pooled mode", func() {
+		stormService := wrapper.MakeStormService("pooled-scale-subresource").
+			Namespace(ns.Name).
+			WithDefaultConfiguration().
+			Mode(orchestrationapi.StormServicePooledMode).
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, stormService)).To(gomega.Succeed())
+
+		err := updateStormServiceScale(stormService, 3)
+		gomega.Expect(err).Should(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("Pooled"))
+	})
+
+	ginkgo.It("allows /scale above one replica for explicit Replica mode", func() {
+		stormService := wrapper.MakeStormService("replica-scale-subresource").
+			Namespace(ns.Name).
+			WithDefaultConfiguration().
+			Mode(orchestrationapi.StormServiceReplicaMode).
+			Replicas(ptr.To(int32(1))).
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, stormService)).To(gomega.Succeed())
+
+		gomega.Expect(updateStormServiceScale(stormService, 3)).To(gomega.Succeed())
+		gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(stormService), stormService)).To(gomega.Succeed())
+		gomega.Expect(stormService.Spec.Replicas).To(gomega.Equal(ptr.To(int32(3))))
+	})
+
+	ginkgo.It("allows /scale above one replica when mode is omitted", func() {
+		stormService := wrapper.MakeStormService("inferred-scale-subresource").
+			Namespace(ns.Name).
+			WithDefaultConfiguration().
+			Replicas(ptr.To(int32(1))).
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, stormService)).To(gomega.Succeed())
+
+		gomega.Expect(updateStormServiceScale(stormService, 3)).To(gomega.Succeed())
+		gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(stormService), stormService)).To(gomega.Succeed())
+		gomega.Expect(stormService.Spec.Replicas).To(gomega.Equal(ptr.To(int32(3))))
+	})
+
 	ginkgo.It("rejects an update that makes the Volcano gang invalid", func() {
 		stormService := gangStormService("gang-update-invalid", ns.Name,
 			volcanoStrategy(3, map[string]int32{"master": 1, "worker": 2}), nil)
@@ -461,6 +503,17 @@ var _ = ginkgo.Describe("stormservice default webhook", func() {
 		gomega.Expect(k8sClient.Update(ctx, stormService)).To(gomega.Succeed())
 	})
 })
+
+// updateStormServiceScale writes spec.replicas through the /scale subresource,
+// the same path used by kubectl scale and HPA.
+func updateStormServiceScale(stormService *orchestrationapi.StormService, replicas int32) error {
+	scale := &autoscalingv1.Scale{}
+	if err := k8sClient.SubResource("scale").Get(ctx, stormService, scale); err != nil {
+		return err
+	}
+	scale.Spec.Replicas = replicas
+	return k8sClient.SubResource("scale").Update(ctx, stormService, client.WithSubResourceBody(scale))
+}
 
 // volcanoStrategy returns a scheduling strategy that gang schedules through Volcano.
 func volcanoStrategy(minMember int32, minTaskMember map[string]int32) *orchestrationapi.SchedulingStrategy {

--- a/test/integration/webhook/suit_test.go
+++ b/test/integration/webhook/suit_test.go
@@ -33,6 +33,7 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	"k8s.io/client-go/rest"
@@ -106,6 +107,8 @@ var _ = BeforeSuite(func() {
 	err = corev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = appsv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = autoscalingv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION
## Pull Request Description

#2450 and #2617 added optional `StormServiceSpec.Mode` and consume it in the controller and PodAutoscaler. Create/update admission already rejects a declared `mode: Pooled` with `spec.replicas > 1`.

That check does not run for the `/scale` subresource. `kubectl scale`, HPA, and other external autoscalers write `spec.replicas` through `/scale`, so a pooled StormService could still be scaled above one RoleSet.

This change registers a validating webhook for `stormservices/scale`. The handler loads the parent StormService, applies the proposed replica count, and reuses `validateStormServiceMode`:

- Declared `mode: Pooled` cannot set replicas > 1 via `/scale`. The admission error tells operators to scale roles through `spec.template.spec.roles[].replicas` instead.
- Declared `mode: Replica` can still scale `spec.replicas`.
- Omitted `spec.mode` is not pinned to inferred Pooled, so existing replica scaling continues to work.

Helm and kubebuilder webhook manifests include the new `vstormservicescale.kb.io` rule.

### Tests

- Unit: reject/allow table for `/scale` (Pooled > 1, Pooled == 1, Replica > 1, omitted mode > 1), plus malformed Scale and missing StormService.
- Integration: envtest `/scale` subresource reject for declared Pooled, allow for declared Replica, allow when mode is omitted.

Verified locally:

```
go test -count=1 ./pkg/webhook/
ok  	github.com/vllm-project/aibrix/pkg/webhook	0.089s

make test-integration-webhook
Ran 84 of 84 Specs in 7.265 seconds
SUCCESS! -- 84 Passed | 0 Failed
```

## Related Issues
Part of #2449. This is the leftover `/scale` subresource enforcement from the follow-up list after #2450 and #2617. It does not close #2449; the original issue still has remaining items such as reporting the resolved mode in status.