### PR TITLE
[Bug] Fix /v1/embeddings input limits the gateway cannot measure

### DIFF
--- a/pkg/plugins/gateway/types.go
+++ b/pkg/plugins/gateway/types.go
@@ -95,9 +95,11 @@ const (
 
 	// Embedding Constraints
 	// https://github.com/openai/openai-go/blob/main/embedding.go#L126
-	MaxInputTokensPerModel = 8192
-	MaxTotalTokens         = 300000
-	MaxArrayDimensions     = 2048
+	//
+	// The token-count limits from that reference (8192 per input, 300000 per
+	// batch) are not enforced here: they are denominated in the target model's
+	// tokens, which the gateway cannot measure. See validateStringInputs.
+	MaxArrayDimensions = 2048
 
 	// Request Paths
 	PathChatCompletions     = "/v1/chat/completions"

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -296,17 +296,15 @@ type embeddingContentPart struct {
 	Video    string          `json:"video"`
 }
 
-// validateEmbeddingContentParts validates a multimodal embeddings `input` array. Only
-// "text" parts are tokenized and counted against MaxInputTokensPerModel / MaxTotalTokens;
-// image/video parts are excluded because the gateway's text tokenizer cannot estimate
-// their cost, and the backend's own multimodal processor is responsible for that
-// accounting.
+// validateEmbeddingContentParts validates the shape of a multimodal embeddings
+// `input` array. Text length is not checked, for the reasons given on
+// validateStringInputs. Image and video parts were never counted anyway, since
+// the gateway's text tokenizer cannot estimate their cost.
 func validateEmbeddingContentParts(parts []embeddingContentPart) error {
 	if len(parts) == 0 {
 		return errors.New("input array cannot be empty")
 	}
 
-	totalEstimatedTokens := 0
 	for i, part := range parts {
 		typ := part.Type
 		if typ == "" {
@@ -328,16 +326,6 @@ func validateEmbeddingContentParts(parts []embeddingContentPart) error {
 			if part.Text == "" {
 				return fmt.Errorf("input at index %d cannot be an empty string", i)
 			}
-			tokens, err := utils.TokenizeInputText(part.Text)
-			if err != nil {
-				return fmt.Errorf("failed to tokenize input for validation: %w", err)
-			}
-			estimatedTokens := len(tokens)
-			if estimatedTokens > MaxInputTokensPerModel {
-				return fmt.Errorf("input at index %d exceeds max tokens per model (%d), estimated tokens: %d",
-					i, MaxInputTokensPerModel, estimatedTokens)
-			}
-			totalEstimatedTokens += estimatedTokens
 		case "image_url":
 			if len(part.ImageURL) == 0 {
 				return fmt.Errorf("input at index %d is missing image_url", i)
@@ -357,11 +345,6 @@ func validateEmbeddingContentParts(parts []embeddingContentPart) error {
 		default:
 			return fmt.Errorf("input at index %d has unsupported content type %q", i, typ)
 		}
-	}
-
-	if totalEstimatedTokens > MaxTotalTokens {
-		return fmt.Errorf("total tokens across all inputs exceeds maximum (%d), estimated total: %d",
-			MaxTotalTokens, totalEstimatedTokens)
 	}
 
 	return nil
@@ -960,13 +943,35 @@ func embeddingNewParamsInputUnionAsAny(u *openai.EmbeddingNewParamsInputUnion) a
 	return nil
 }
 
-// validateStringInputs validates string inputs (both single string and array of strings)
+// validateStringInputs validates the shape of string inputs (both single string
+// and array of strings).
+//
+// Input length is deliberately not checked here. The gateway estimates tokens
+// with tiktoken (cl100k_base), but the limit that matters is denominated in the
+// target model's own tokens -- a different unit. For sentencepiece models such
+// as bge-m3 or multilingual-e5, cl100k over-counts non-English text by roughly
+// 2x, so valid requests are rejected with a misleading message. The gateway
+// also cannot know which model's limit to apply: validateRequestBody runs
+// before the pod list and engine are resolved, so the addressed model's
+// tokenizer and context length are both out of reach.
+//
+// The backend already enforces the real limit with the model's own tokenizer
+// and reports it accurately. It also honours truncate_prompt_tokens, which a
+// gateway-side rejection pre-empts entirely -- clients that ask the backend to
+// truncate oversized input currently get a 400 from the gateway instead.
+//
+// The batch size is still bounded: MaxArrayDimensions is OpenAI's documented
+// maxItems for the input array, a property of the request rather than of the
+// model, so the gateway can and does check it.
 func validateStringInputs(inputs []string) error {
 	if len(inputs) == 0 {
 		return errors.New("input array cannot be empty")
 	}
 
-	totalEstimatedTokens := 0
+	if len(inputs) > MaxArrayDimensions {
+		return fmt.Errorf("input array exceeds max dimensions (%d), actual dimensions: %d",
+			MaxArrayDimensions, len(inputs))
+	}
 
 	for i, input := range inputs {
 		if input == "" {
@@ -975,39 +980,32 @@ func validateStringInputs(inputs []string) error {
 			}
 			return fmt.Errorf("input at index %d cannot be an empty string", i)
 		}
-
-		tokens, err := utils.TokenizeInputText(input)
-		if err != nil {
-			return fmt.Errorf("failed to tokenize input for validation: %w", err)
-		}
-		estimatedTokens := len(tokens)
-		if estimatedTokens > MaxInputTokensPerModel {
-			if len(inputs) == 1 {
-				return fmt.Errorf("input exceeds max tokens per model (%d), estimated tokens: %d",
-					MaxInputTokensPerModel, estimatedTokens)
-			}
-			return fmt.Errorf("input at index %d exceeds max tokens per model (%d), estimated tokens: %d",
-				i, MaxInputTokensPerModel, estimatedTokens)
-		}
-
-		totalEstimatedTokens += estimatedTokens
-	}
-
-	if totalEstimatedTokens > MaxTotalTokens {
-		return fmt.Errorf("total tokens across all inputs exceeds maximum (%d), estimated total: %d",
-			MaxTotalTokens, totalEstimatedTokens)
 	}
 
 	return nil
 }
 
-// validateTokenInputs validates token inputs (both single token array and multiple token arrays)
+// validateTokenInputs validates pre-tokenized inputs (both single token array
+// and multiple token arrays).
+//
+// As in validateStringInputs, the token count is not checked against a context
+// length: a single global constant cannot match every served model, and only
+// the backend knows the real limit.
+//
+// MaxArrayDimensions bounds the batch size, matching OpenAI's maxItems for the
+// input array. It is deliberately not compared against len(tokens): the number
+// of tokens in one input is a context-length question, and capping it at 2048
+// would reject a pre-tokenized input that the same model accepts happily when
+// sent as a string.
 func validateTokenInputs(tokenArrays [][]int64) error {
 	if len(tokenArrays) == 0 {
 		return errors.New("token arrays cannot be empty")
 	}
 
-	totalTokens := 0
+	if len(tokenArrays) > MaxArrayDimensions {
+		return fmt.Errorf("input array exceeds max dimensions (%d), actual dimensions: %d",
+			MaxArrayDimensions, len(tokenArrays))
+	}
 
 	for i, tokens := range tokenArrays {
 		if len(tokens) == 0 {
@@ -1016,31 +1014,6 @@ func validateTokenInputs(tokenArrays [][]int64) error {
 			}
 			return fmt.Errorf("token array at index %d cannot be empty", i)
 		}
-
-		if len(tokens) > MaxInputTokensPerModel {
-			if len(tokenArrays) == 1 {
-				return fmt.Errorf("token array exceeds max tokens per model (%d), actual tokens: %d",
-					MaxInputTokensPerModel, len(tokens))
-			}
-			return fmt.Errorf("token array at index %d exceeds max tokens per model (%d), actual tokens: %d",
-				i, MaxInputTokensPerModel, len(tokens))
-		}
-
-		if len(tokens) > MaxArrayDimensions {
-			if len(tokenArrays) == 1 {
-				return fmt.Errorf("token array exceeds max dimensions (%d), actual dimensions: %d",
-					MaxArrayDimensions, len(tokens))
-			}
-			return fmt.Errorf("token array at index %d exceeds max dimensions (%d), actual dimensions: %d",
-				i, MaxArrayDimensions, len(tokens))
-		}
-
-		totalTokens += len(tokens)
-	}
-
-	if totalTokens > MaxTotalTokens {
-		return fmt.Errorf("total tokens across all inputs exceeds maximum (%d), actual total: %d",
-			MaxTotalTokens, totalTokens)
 	}
 
 	return nil

--- a/pkg/plugins/gateway/util_test.go
+++ b/pkg/plugins/gateway/util_test.go
@@ -297,11 +297,36 @@ func Test_ValidateRequestBody_Embeddings(t *testing.T) {
 			requestBody: []byte(`{"model": "text-embedding-ada-002", "input": [[]]}`),
 			statusCode:  envoyTypePb.StatusCode_BadRequest,
 		},
+		// Long inputs are not rejected here: the gateway cannot measure them in
+		// the target model's tokens, so the backend decides. This holds whether
+		// or not the client asked the backend to truncate, and the three cases
+		// below must not collapse into an identical gateway-side 400.
 		{
-			message:     "/v1/embeddings string exceeding max tokens",
+			message:     "/v1/embeddings long string is forwarded, no truncate_prompt_tokens",
 			requestPath: "/v1/embeddings",
-			requestBody: []byte(`{"model": "text-embedding-ada-002", "input": "` + strings.Repeat("word ", MaxInputTokensPerModel+1) + `"}`),
-			statusCode:  envoyTypePb.StatusCode_BadRequest,
+			requestBody: []byte(`{"model": "text-embedding-ada-002", "input": "` + strings.Repeat("word ", 9000) + `"}`),
+			model:       "text-embedding-ada-002",
+			messages:    "",
+			stream:      false,
+			statusCode:  envoyTypePb.StatusCode_OK,
+		},
+		{
+			message:     "/v1/embeddings long string is forwarded with truncate_prompt_tokens -1",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "text-embedding-ada-002", "truncate_prompt_tokens": -1, "input": "` + strings.Repeat("word ", 9000) + `"}`),
+			model:       "text-embedding-ada-002",
+			messages:    "",
+			stream:      false,
+			statusCode:  envoyTypePb.StatusCode_OK,
+		},
+		{
+			message:     "/v1/embeddings long string is forwarded with explicit truncate_prompt_tokens",
+			requestPath: "/v1/embeddings",
+			requestBody: []byte(`{"model": "text-embedding-ada-002", "truncate_prompt_tokens": 400, "input": "` + strings.Repeat("word ", 9000) + `"}`),
+			model:       "text-embedding-ada-002",
+			messages:    "",
+			stream:      false,
+			statusCode:  envoyTypePb.StatusCode_OK,
 		},
 
 		// Stream validation errors
@@ -539,14 +564,15 @@ func TestValidateEmbeddingInput(t *testing.T) {
 			errorMsg:    "input cannot be an empty string",
 		},
 		{
-			name: "string input exceeding max tokens per model",
+			// The gateway does not enforce a context length; the backend does,
+			// with the addressed model's own tokenizer.
+			name: "long string input is accepted",
 			input: openai.EmbeddingNewParams{
 				Input: openai.EmbeddingNewParamsInputUnion{
-					OfString: openai.Opt(strings.Repeat("word ", MaxInputTokensPerModel+1)),
+					OfString: openai.Opt(strings.Repeat("word ", 9000)),
 				},
 			},
-			expectError: true,
-			errorMsg:    "input exceeds max tokens per model",
+			expectError: false,
 		},
 
 		// Array of strings tests
@@ -580,28 +606,25 @@ func TestValidateEmbeddingInput(t *testing.T) {
 			errorMsg:    "input at index 1 cannot be an empty string",
 		},
 		{
-			name: "array of strings with one exceeding max tokens",
+			name: "array of strings with one long entry is accepted",
 			input: openai.EmbeddingNewParams{
 				Input: openai.EmbeddingNewParamsInputUnion{
-					OfArrayOfStrings: []string{"Hello", strings.Repeat("word ", MaxInputTokensPerModel+1)},
+					OfArrayOfStrings: []string{"Hello", strings.Repeat("word ", 9000)},
 				},
 			},
-			expectError: true,
-			errorMsg:    "input at index 1 exceeds max tokens per model",
+			expectError: false,
 		},
 		{
-			name: "array of strings exceeding total tokens",
+			name: "array of strings with a large total length is accepted",
 			input: openai.EmbeddingNewParams{
 				Input: openai.EmbeddingNewParamsInputUnion{
 					OfArrayOfStrings: func() []string {
-						// Create an array that would exceed MaxTotalTokens
-						largeString := strings.Repeat("word ", MaxTotalTokens/2)
+						largeString := strings.Repeat("word ", 9000)
 						return []string{largeString, largeString, largeString}
 					}(),
 				},
 			},
-			expectError: true,
-			errorMsg:    "input at index 0 exceeds max tokens per model (8192)",
+			expectError: false,
 		},
 
 		// Single token array tests
@@ -625,24 +648,16 @@ func TestValidateEmbeddingInput(t *testing.T) {
 			errorMsg:    "token array cannot be empty",
 		},
 		{
-			name: "single token array exceeding max tokens per model",
-			input: openai.EmbeddingNewParams{
-				Input: openai.EmbeddingNewParamsInputUnion{
-					OfArrayOfTokens: make([]int64, MaxInputTokensPerModel+1),
-				},
-			},
-			expectError: true,
-			errorMsg:    "token array exceeds max tokens per model",
-		},
-		{
-			name: "single token array exceeding max dimensions",
+			// A long pre-tokenized input is accepted, exactly as the same
+			// content sent as a string would be. MaxArrayDimensions bounds the
+			// batch, not the token count of one input.
+			name: "long single token array is accepted",
 			input: openai.EmbeddingNewParams{
 				Input: openai.EmbeddingNewParamsInputUnion{
 					OfArrayOfTokens: make([]int64, MaxArrayDimensions+1),
 				},
 			},
-			expectError: true,
-			errorMsg:    "token array exceeds max dimensions",
+			expectError: false,
 		},
 
 		// Multiple token arrays tests
@@ -694,20 +709,7 @@ func TestValidateEmbeddingInput(t *testing.T) {
 			errorMsg:    "token array at index 1 cannot be empty",
 		},
 		{
-			name: "multiple token arrays with one exceeding max tokens per model",
-			input: openai.EmbeddingNewParams{
-				Input: openai.EmbeddingNewParamsInputUnion{
-					OfArrayOfTokenArrays: [][]int64{
-						{1, 2, 3},
-						make([]int64, MaxInputTokensPerModel+1),
-					},
-				},
-			},
-			expectError: true,
-			errorMsg:    "token array at index 1 exceeds max tokens per model",
-		},
-		{
-			name: "multiple token arrays with one exceeding max dimensions",
+			name: "batch with one long token array is accepted",
 			input: openai.EmbeddingNewParams{
 				Input: openai.EmbeddingNewParamsInputUnion{
 					OfArrayOfTokenArrays: [][]int64{
@@ -716,22 +718,56 @@ func TestValidateEmbeddingInput(t *testing.T) {
 					},
 				},
 			},
-			expectError: true,
-			errorMsg:    "token array at index 1 exceeds max dimensions",
+			expectError: false,
 		},
 		{
-			name: "multiple token arrays exceeding total tokens",
+			name: "multiple token arrays with a large total length is accepted",
 			input: openai.EmbeddingNewParams{
 				Input: openai.EmbeddingNewParamsInputUnion{
 					OfArrayOfTokenArrays: func() [][]int64 {
-						// Create arrays that would exceed MaxTotalTokens
-						largeArray := make([]int64, MaxTotalTokens/2)
+						// Each array is within MaxArrayDimensions; only the sum
+						// is large, which is no longer capped.
+						largeArray := make([]int64, MaxArrayDimensions)
 						return [][]int64{largeArray, largeArray, largeArray}
 					}(),
 				},
 			},
+			expectError: false,
+		},
+
+		// Batch size is still bounded: MaxArrayDimensions is OpenAI's maxItems
+		// for the input array, which the gateway can measure exactly.
+		{
+			name: "array of strings exceeding max batch size",
+			input: openai.EmbeddingNewParams{
+				Input: openai.EmbeddingNewParamsInputUnion{
+					OfArrayOfStrings: func() []string {
+						inputs := make([]string, MaxArrayDimensions+1)
+						for i := range inputs {
+							inputs[i] = "hello"
+						}
+						return inputs
+					}(),
+				},
+			},
 			expectError: true,
-			errorMsg:    "token array at index 0 exceeds max tokens per model (8192)",
+			errorMsg:    "input array exceeds max dimensions (2048)",
+		},
+		{
+			name: "multiple token arrays exceeding max batch size",
+			input: openai.EmbeddingNewParams{
+				Input: openai.EmbeddingNewParamsInputUnion{
+					OfArrayOfTokenArrays: func() [][]int64 {
+						arrays := make([][]int64, MaxArrayDimensions+1)
+						for i := range arrays {
+							arrays[i] = []int64{1, 2, 3}
+						}
+						return arrays
+					}(),
+				},
+			},
+			expectError: true,
+			errorMsg:    "input array exceeds max dimensions (2048)",
 		},
 
 		// Nil input test
@@ -776,6 +812,30 @@ func TestValidateStringInputs(t *testing.T) {
 			name:        "valid multiple strings",
 			inputs:      []string{"Hello", "world", "test"},
 			expectError: false,
+		},
+		{
+			// Length is the backend's call, not the gateway's: the gateway has
+			// no access to the target model's tokenizer or context length.
+			name:        "very long single string",
+			inputs:      []string{strings.Repeat("word ", 100000)},
+			expectError: false,
+		},
+		{
+			name:        "non-ASCII input that cl100k over-counts",
+			inputs:      []string{strings.Repeat("Příliš žluťoučký kůň úpěl ďábelské ódy. ", 2000)},
+			expectError: false,
+		},
+		{
+			name: "array exceeding max batch size",
+			inputs: func() []string {
+				inputs := make([]string, MaxArrayDimensions+1)
+				for i := range inputs {
+					inputs[i] = "hello"
+				}
+				return inputs
+			}(),
+			expectError: true,
+			errorMsg:    "input array exceeds max dimensions (2048)",
 		},
 		{
 			name:        "empty array",
@@ -849,28 +909,24 @@ func TestValidateTokenInputs(t *testing.T) {
 			errorMsg:    "token array at index 1 cannot be empty",
 		},
 		{
-			name:        "single token array exceeding max tokens per model",
-			tokenArrays: [][]int64{make([]int64, MaxInputTokensPerModel+1)},
-			expectError: true,
-			errorMsg:    "token array exceeds max tokens per model (8192)",
+			// Token count per input is not capped: that is a context-length
+			// question, and the same content sent as a string is accepted.
+			name:        "long token arrays are accepted",
+			tokenArrays: [][]int64{make([]int64, MaxArrayDimensions+1), make([]int64, MaxArrayDimensions+1)},
+			expectError: false,
 		},
 		{
-			name:        "multiple token arrays with one exceeding max tokens per model",
-			tokenArrays: [][]int64{{1, 2, 3}, make([]int64, MaxInputTokensPerModel+1)},
+			// Batch size is capped, per OpenAI's maxItems for the input array.
+			name: "batch exceeding max dimensions",
+			tokenArrays: func() [][]int64 {
+				arrays := make([][]int64, MaxArrayDimensions+1)
+				for i := range arrays {
+					arrays[i] = []int64{1, 2, 3}
+				}
+				return arrays
+			}(),
 			expectError: true,
-			errorMsg:    "token array at index 1 exceeds max tokens per model",
-		},
-		{
-			name:        "single token array exceeding max dimensions",
-			tokenArrays: [][]int64{make([]int64, MaxArrayDimensions+1)},
-			expectError: true,
-			errorMsg:    "token array exceeds max dimensions (2048)",
-		},
-		{
-			name:        "multiple token arrays with one exceeding max dimensions",
-			tokenArrays: [][]int64{{1, 2, 3}, make([]int64, MaxArrayDimensions+1)},
-			expectError: true,
-			errorMsg:    "token array at index 1 exceeds max dimensions",
+			errorMsg:    "input array exceeds max dimensions (2048)",
 		},
 	}
 


### PR DESCRIPTION
## Pull Request Description

`/v1/embeddings` requests are rejected at the gateway whenever a tiktoken (`cl100k_base`) estimate of the input exceeds `MaxInputTokensPerModel` (8192), before the request ever reaches the inference engine.

There are two independent problems with that check.

**`truncate_prompt_tokens` is invisible to it.** `embeddingReqMinimal` never parses the field, so a client that explicitly asks the backend to truncate oversized input receives a 400 that is byte-for-byte identical to one that did not ask. vLLM implements the parameter (including `-1` for "the model's maximum"), but the request never gets there.

**The units do not match.** The estimate is in cl100k tokens, while the limit that matters is denominated in the target model's own tokens. For sentencepiece models such as `bge-m3` or `multilingual-e5`, cl100k over-counts non-English text by roughly 2x, so valid requests are rejected with a misleading message. Measured on Czech prose, cl100k yields ~2.18 chars/token where XLM-R style tokenizers typically run 3.5–4.5.

The constant is also global despite its name, so it cannot match every served model simultaneously:

| model | real limit | gateway enforces | effect |
| --- | --- | --- | --- |
| `multilingual-e5-large-instruct` | 512 | 8192 | 16x too loose — guard protects nothing |
| `bge-m3` | 8192 | 8192 | same number, wrong unit |
| `qwen3-embedding-4b` | 32768 | 8192 | 4x too tight — rejects valid input |

There is no correct value to raise it to, because the gateway cannot know which model's limit applies. `validateRequestBody` runs before the pod list and engine label are resolved (`gateway_req_body.go`), so neither the addressed model's tokenizer nor its context length is reachable at that point.

### Change

**1. Drop the token-count checks.** Removed from all three call sites — `validateStringInputs`, `validateTokenInputs`, and `validateEmbeddingContentParts` (multimodal text parts). The backend already enforces the real context length using the model's own tokenizer and reports it accurately, and it is the only component that has both pieces of information. `MaxInputTokensPerModel` and `MaxTotalTokens` are dropped as unused.

**2. Correct `MaxArrayDimensions` to bound what it describes** (per @varungup90's review). OpenAI documents 2048 as `maxItems` for the input array — the batch size — but it was being compared against `len(tokens)`, the number of tokens in one pre-tokenized input. Because 2048 < 8192 that comparison always fired first, so pre-tokenized input was effectively capped at 2048 tokens: content a model accepts as a string was rejected at 2049 tokens when sent as an array. The check now applies to `len(inputs)` and `len(tokenArrays)` in both input paths, which is a property of the request the gateway can measure exactly.

Note this makes the string path slightly *stricter*: `validateStringInputs` previously had no dimensions check at all, so a >2048-string batch used to pass. It is now rejected, matching `maxItems`.

No request-parsing change is needed: `routingCtx.ReqBody` is forwarded verbatim in the `BodyMutation`, so `truncate_prompt_tokens` already reaches the backend once the gateway stops rejecting the request first. Removing the token-count check also takes a full tiktoken pass over every embeddings input off the request path.

### Reproduction (before this change)

`POST /v1/embeddings` with ~86 000 chars of Czech prose to a 512-token embedding model:

| `truncate_prompt_tokens` | result |
| --- | --- |
| `400` | 400 `input exceeds max tokens per model (8192), estimated tokens: 39480` |
| `-1` | 400, byte-for-byte identical |
| omitted | 400, byte-for-byte identical |

The identical response in all three cases is the symptom. With input small enough to clear the guard, vLLM honours both `-1` and an explicit value and returns 200 — the feature works, it is simply unreachable.

### Testing

`make test` passes: 63 packages ok, 0 failures. `go vet ./pkg/...` and `gofmt -l` clean.

- Oversized input is asserted to be forwarded rather than rejected, with `truncate_prompt_tokens` absent, set to `-1`, and set to an explicit value — the three cases must no longer collapse into an identical gateway-side 400.
- A non-ASCII case covers the over-count described above.
- Cases that previously locked in the per-input 2048 token cap now assert acceptance (`long_single_token_array_is_accepted`, `long_token_arrays_are_accepted`).
- New cases assert a batch beyond `maxItems` is rejected for both string and pre-tokenized inputs (`array_of_strings_exceeding_max_batch_size`, `batch_exceeding_max_dimensions`).

### Open question for reviewers

`validateEmbeddingContentParts` did **not** get the batch bound, because whether its array is one multimodal input's content parts or a batch of separate inputs is ambiguous in that code path: the OpenAI-style `{"type": ..., "text": ...}` shape reads like content parts of a single input, while sglang's flat `{"text": ...}` / `{"image": ...}` shape reads like a batch. Applying `maxItems` under the wrong reading would reject valid requests. Happy to add it if you can confirm which it is.

## Related Issues

Resolves: #2663

---

### Submission Checklist

- [x] PR title includes appropriate prefix(es)
- [x] Changes are clearly explained in the PR description
- [x] New and existing tests pass successfully
- [x] Code adheres to project style and best practices
- [x] Documentation updated to reflect changes (n/a — no user-facing docs cover this guard)
- [x] Thorough testing completed, no regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
