### PR TITLE
[Misc] Add ModelAdapter controller integration tests

### DIFF
--- a/pkg/controller/modeladapter/modeladapter_controller.go
+++ b/pkg/controller/modeladapter/modeladapter_controller.go
@@ -41,6 +41,7 @@ import (
 	discoverylisters "k8s.io/client-go/listers/discovery/v1"
 	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -873,8 +874,11 @@ func (r *ModelAdapterReconciler) reconcileLoading(ctx context.Context, instance 
 				// Clear scheduled pods annotation once we have successful loadings
 				if loadedCount == 1 {
 					r.clearScheduledPods(instance)
-					if err := r.persistAnnotations(ctx, instance); err != nil {
-						return err
+					if perr := r.persistAnnotations(ctx, instance); perr != nil {
+						// Load already succeeded; do not treat a metadata patch failure as a
+						// loading error or skip Status.Instances updates.
+						klog.ErrorS(perr, "Failed to persist cleared scheduled-pods annotation after successful load",
+							"ModelAdapter", klog.KObj(instance))
 					}
 
 					// If this is a recovery from pod removal, update Scheduled condition back to True
@@ -1141,6 +1145,9 @@ func (r *ModelAdapterReconciler) tryLoadModelAdapterOnPod(ctx context.Context, i
 		r.updateRetryInfo(instance, pod.Name, retryCount+1)
 		if perr := r.persistAnnotations(ctx, instance); perr != nil {
 			klog.ErrorS(perr, "Failed to persist retry annotations", "pod", pod.Name, "ModelAdapter", klog.KObj(instance))
+			// Return the persist error so reconcile requeues and retry state can stick;
+			// Status().Update does not persist annotations on its own.
+			return false, true, fmt.Errorf("load failed: %w; also failed to persist retry annotations: %v", err, perr)
 		}
 		if r.isRetriableError(err) {
 			klog.V(4).InfoS("Retriable error loading adapter", "pod", pod.Name, "error", err)
@@ -1154,7 +1161,10 @@ func (r *ModelAdapterReconciler) tryLoadModelAdapterOnPod(ctx context.Context, i
 	if retryCount > 0 || !lastRetryTime.IsZero() {
 		r.clearRetryInfo(instance, pod.Name)
 		if perr := r.persistAnnotations(ctx, instance); perr != nil {
-			return false, true, perr
+			// Adapter is already loaded on the pod; a metadata patch failure must not
+			// be reported as a load failure (which would skip Status.Instances).
+			klog.ErrorS(perr, "Failed to persist cleared retry annotations after successful load",
+				"pod", pod.Name, "ModelAdapter", klog.KObj(instance))
 		}
 	}
 
@@ -1194,45 +1204,57 @@ func (r *ModelAdapterReconciler) isRetriableError(err error) bool {
 	return false
 }
 
+// managedAnnotationPrefix is derived from RetryCountAnnotationKey so the scoped
+// merge patch stays aligned with controller-managed annotation naming.
+func managedAnnotationPrefix() string {
+	idx := strings.LastIndex(RetryCountAnnotationKey, "/")
+	if idx < 0 {
+		return RetryCountAnnotationKey
+	}
+	return RetryCountAnnotationKey[:idx+1]
+}
+
 // persistAnnotations writes managed annotations from instance to the API object
 // so retry and scheduling state survives across reconcile cycles. Only keys under
-// the adapter.model.aibrix.ai/ prefix are copied or deleted; unrelated annotations
-// added concurrently on the API object are left alone. A merge patch keeps
-// resourceVersion coherent on the in-memory object after status updates.
+// the managed adapter.model.aibrix.ai/ prefix are copied or deleted; unrelated
+// annotations added concurrently on the API object are left alone. A merge patch
+// keeps resourceVersion coherent on the in-memory object after status updates.
 func (r *ModelAdapterReconciler) persistAnnotations(ctx context.Context, instance *modelv1alpha1.ModelAdapter) error {
-	latest := &modelv1alpha1.ModelAdapter{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, latest); err != nil {
-		return err
-	}
-	before := latest.DeepCopy()
-
-	if latest.Annotations == nil {
-		latest.Annotations = make(map[string]string)
-	}
-
-	const managedAnnotationPrefix = "adapter.model.aibrix.ai/"
-
-	// Copy or update annotations managed by this controller.
-	for k, v := range instance.Annotations {
-		if strings.HasPrefix(k, managedAnnotationPrefix) {
-			latest.Annotations[k] = v
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &modelv1alpha1.ModelAdapter{}
+		if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, latest); err != nil {
+			return err
 		}
-	}
+		before := latest.DeepCopy()
 
-	// Remove any managed annotations that were cleared on the in-memory instance.
-	for k := range latest.Annotations {
-		if strings.HasPrefix(k, managedAnnotationPrefix) {
-			if _, exists := instance.Annotations[k]; !exists {
-				delete(latest.Annotations, k)
+		if latest.Annotations == nil {
+			latest.Annotations = make(map[string]string)
+		}
+
+		prefix := managedAnnotationPrefix()
+
+		// Copy or update annotations managed by this controller.
+		for k, v := range instance.Annotations {
+			if strings.HasPrefix(k, prefix) {
+				latest.Annotations[k] = v
 			}
 		}
-	}
 
-	if err := r.Patch(ctx, latest, client.MergeFrom(before)); err != nil {
-		return err
-	}
-	instance.SetResourceVersion(latest.GetResourceVersion())
-	return nil
+		// Remove any managed annotations that were cleared on the in-memory instance.
+		for k := range latest.Annotations {
+			if strings.HasPrefix(k, prefix) {
+				if _, exists := instance.Annotations[k]; !exists {
+					delete(latest.Annotations, k)
+				}
+			}
+		}
+
+		if err := r.Patch(ctx, latest, client.MergeFrom(before)); err != nil {
+			return err
+		}
+		instance.SetResourceVersion(latest.GetResourceVersion())
+		return nil
+	})
 }
 
 // getRetryInfo gets retry count and last retry time from annotations

--- a/pkg/controller/modeladapter/modeladapter_controller.go
+++ b/pkg/controller/modeladapter/modeladapter_controller.go
@@ -1194,17 +1194,40 @@ func (r *ModelAdapterReconciler) isRetriableError(err error) bool {
 	return false
 }
 
-// persistAnnotations writes instance.Annotations to the API object so retry and
-// scheduling state survives across reconcile cycles. A merge patch is used so we
-// do not clobber unrelated metadata and so status subresource updates keep a
-// coherent resourceVersion on the in-memory object.
+// persistAnnotations writes managed annotations from instance to the API object
+// so retry and scheduling state survives across reconcile cycles. Only keys under
+// the adapter.model.aibrix.ai/ prefix are copied or deleted; unrelated annotations
+// added concurrently on the API object are left alone. A merge patch keeps
+// resourceVersion coherent on the in-memory object after status updates.
 func (r *ModelAdapterReconciler) persistAnnotations(ctx context.Context, instance *modelv1alpha1.ModelAdapter) error {
 	latest := &modelv1alpha1.ModelAdapter{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, latest); err != nil {
 		return err
 	}
 	before := latest.DeepCopy()
-	latest.Annotations = instance.Annotations
+
+	if latest.Annotations == nil {
+		latest.Annotations = make(map[string]string)
+	}
+
+	const managedAnnotationPrefix = "adapter.model.aibrix.ai/"
+
+	// Copy or update annotations managed by this controller.
+	for k, v := range instance.Annotations {
+		if strings.HasPrefix(k, managedAnnotationPrefix) {
+			latest.Annotations[k] = v
+		}
+	}
+
+	// Remove any managed annotations that were cleared on the in-memory instance.
+	for k := range latest.Annotations {
+		if strings.HasPrefix(k, managedAnnotationPrefix) {
+			if _, exists := instance.Annotations[k]; !exists {
+				delete(latest.Annotations, k)
+			}
+		}
+	}
+
 	if err := r.Patch(ctx, latest, client.MergeFrom(before)); err != nil {
 		return err
 	}

--- a/pkg/controller/modeladapter/modeladapter_controller.go
+++ b/pkg/controller/modeladapter/modeladapter_controller.go
@@ -689,6 +689,9 @@ func (r *ModelAdapterReconciler) reconcileLoadOnSinglePod(ctx context.Context, i
 
 			// Persist the scheduling decision in annotations
 			r.setScheduledPods(instance, getPodNames(selectedPods))
+			if err := r.persistAnnotations(ctx, instance); err != nil {
+				return ctrl.Result{}, err
+			}
 			klog.InfoS("Selected pods for adapter scheduling", "ModelAdapter", klog.KObj(instance), "selectedPods", getPodNames(selectedPods))
 
 			instance.Status.Phase = modelv1alpha1.ModelAdapterScheduled
@@ -870,6 +873,9 @@ func (r *ModelAdapterReconciler) reconcileLoading(ctx context.Context, instance 
 				// Clear scheduled pods annotation once we have successful loadings
 				if loadedCount == 1 {
 					r.clearScheduledPods(instance)
+					if err := r.persistAnnotations(ctx, instance); err != nil {
+						return err
+					}
 
 					// If this is a recovery from pod removal, update Scheduled condition back to True
 					if podRemoved {
@@ -1127,12 +1133,15 @@ func (r *ModelAdapterReconciler) tryLoadModelAdapterOnPod(ctx context.Context, i
 		return false, false, fmt.Errorf("max retries (%d) exceeded", MaxLoadingRetries)
 	}
 
-	// Update retry info
-	r.updateRetryInfo(instance, pod.Name, retryCount+1)
-
 	_, exists, err := r.loraClient.LoadAdapter(ctx, instance, pod)
 
 	if err != nil {
+		// Record the failed attempt only after LoadAdapter returns an error so a
+		// successful (re)verification does not churn retry annotations.
+		r.updateRetryInfo(instance, pod.Name, retryCount+1)
+		if perr := r.persistAnnotations(ctx, instance); perr != nil {
+			klog.ErrorS(perr, "Failed to persist retry annotations", "pod", pod.Name, "ModelAdapter", klog.KObj(instance))
+		}
 		if r.isRetriableError(err) {
 			klog.V(4).InfoS("Retriable error loading adapter", "pod", pod.Name, "error", err)
 			return false, true, err
@@ -1142,14 +1151,17 @@ func (r *ModelAdapterReconciler) tryLoadModelAdapterOnPod(ctx context.Context, i
 		return false, false, err
 	}
 
+	if retryCount > 0 || !lastRetryTime.IsZero() {
+		r.clearRetryInfo(instance, pod.Name)
+		if perr := r.persistAnnotations(ctx, instance); perr != nil {
+			return false, true, perr
+		}
+	}
+
 	if exists {
 		klog.V(4).InfoS("LoRA adapter already exists on pod", "pod", pod.Name)
-		// Reset retry count on success
-		r.clearRetryInfo(instance, pod.Name)
 		return true, false, nil
 	}
-	// Success - reset retry count
-	r.clearRetryInfo(instance, pod.Name)
 	klog.InfoS("Successfully loaded adapter on pod", "pod", pod.Name, "ModelAdapter", klog.KObj(instance))
 	return true, false, nil
 }
@@ -1180,6 +1192,24 @@ func (r *ModelAdapterReconciler) isRetriableError(err error) bool {
 	}
 
 	return false
+}
+
+// persistAnnotations writes instance.Annotations to the API object so retry and
+// scheduling state survives across reconcile cycles. A merge patch is used so we
+// do not clobber unrelated metadata and so status subresource updates keep a
+// coherent resourceVersion on the in-memory object.
+func (r *ModelAdapterReconciler) persistAnnotations(ctx context.Context, instance *modelv1alpha1.ModelAdapter) error {
+	latest := &modelv1alpha1.ModelAdapter{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, latest); err != nil {
+		return err
+	}
+	before := latest.DeepCopy()
+	latest.Annotations = instance.Annotations
+	if err := r.Patch(ctx, latest, client.MergeFrom(before)); err != nil {
+		return err
+	}
+	instance.SetResourceVersion(latest.GetResourceVersion())
+	return nil
 }
 
 // getRetryInfo gets retry count and last retry time from annotations

--- a/pkg/controller/modeladapter/modeladapter_controller_reconcile_test.go
+++ b/pkg/controller/modeladapter/modeladapter_controller_reconcile_test.go
@@ -263,3 +263,65 @@ func TestDoReconcile_HealsStaleBoundScheduledConditions(t *testing.T) {
 		}
 	}
 }
+
+// TestPersistAnnotations_ScopesToManagedPrefix ensures persistAnnotations only
+// syncs adapter.model.aibrix.ai/* keys. Concurrently-added unrelated annotations
+// on the API object must survive the merge patch, and managed keys cleared on the
+// in-memory instance must still be deleted.
+func TestPersistAnnotations_ScopesToManagedPrefix(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := modelv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register scheme: %v", err)
+	}
+
+	seed := &modelv1alpha1.ModelAdapter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adapter1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"user.custom/annotation":                "server-side-value",
+				ScheduledPodsAnnotationKey:              "old-pod",
+				RetryCountAnnotationKey + ".old-pod":    "3",
+				LastRetryTimeAnnotationKey + ".old-pod": "2026-01-01T00:00:00Z",
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(seed).Build()
+	r := &ModelAdapterReconciler{Client: cl, Scheme: scheme}
+
+	// Stale in-memory view: missing the user annotation that landed on the API
+	// object after the original fetch, with updated managed scheduling state and
+	// cleared retry annotations for the departed pod.
+	instance := &modelv1alpha1.ModelAdapter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adapter1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				ScheduledPodsAnnotationKey: "new-pod",
+			},
+		},
+	}
+
+	if err := r.persistAnnotations(context.Background(), instance); err != nil {
+		t.Fatalf("persistAnnotations returned error: %v", err)
+	}
+
+	latest := &modelv1alpha1.ModelAdapter{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "adapter1"}, latest); err != nil {
+		t.Fatalf("failed to fetch patched ModelAdapter: %v", err)
+	}
+
+	if got := latest.Annotations["user.custom/annotation"]; got != "server-side-value" {
+		t.Errorf("unrelated annotation was clobbered: got %q, want %q", got, "server-side-value")
+	}
+	if got := latest.Annotations[ScheduledPodsAnnotationKey]; got != "new-pod" {
+		t.Errorf("managed annotation not updated: got %q, want %q", got, "new-pod")
+	}
+	if _, exists := latest.Annotations[RetryCountAnnotationKey+".old-pod"]; exists {
+		t.Errorf("cleared managed retry-count annotation should have been deleted")
+	}
+	if _, exists := latest.Annotations[LastRetryTimeAnnotationKey+".old-pod"]; exists {
+		t.Errorf("cleared managed last-retry-time annotation should have been deleted")
+	}
+}

--- a/test/integration/controller/modeladapter_test.go
+++ b/test/integration/controller/modeladapter_test.go
@@ -1,0 +1,500 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	modelapi "github.com/vllm-project/aibrix/api/model/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/controller/modeladapter"
+	"github.com/vllm-project/aibrix/test/utils/wrapper"
+)
+
+const (
+	modelAdapterTimeout    = time.Second * 20
+	modelAdapterInterval   = time.Millisecond * 250
+	modelAdapterEnginePort = 8000
+)
+
+// modelAdapterEngineIP is a non-loopback local IPv4. EndpointSlice rejects
+// loopback addresses, so the mock inference engine must listen on a real
+// local address that we also stamp onto Pod.Status.PodIP.
+var modelAdapterEngineIP = localNonLoopbackIPv4()
+
+var _ = ginkgo.Describe("ModelAdapter controller test", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-modeladapter-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+		gomega.Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKeyFromObject(ns), ns)
+		}, time.Second*3).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		// Delete adapters first so finalizers/owned objects are cleaned before the namespace goes terminating.
+		adapters := &modelapi.ModelAdapterList{}
+		gomega.Expect(k8sClient.List(ctx, adapters, client.InNamespace(ns.Name))).To(gomega.Succeed())
+		for i := range adapters.Items {
+			_ = k8sClient.Delete(ctx, &adapters.Items[i])
+		}
+		gomega.Eventually(func() int {
+			latest := &modelapi.ModelAdapterList{}
+			if err := k8sClient.List(ctx, latest, client.InNamespace(ns.Name)); err != nil {
+				return -1
+			}
+			return len(latest.Items)
+		}, modelAdapterTimeout, modelAdapterInterval).Should(gomega.Equal(0))
+
+		err := k8sClient.Delete(ctx, ns)
+		gomega.Expect(client.IgnoreNotFound(err)).To(gomega.Succeed())
+	})
+
+	ginkgo.Context("Service and EndpointSlice lifecycle", func() {
+		var srv *modelAdapterMockEngine
+
+		ginkgo.BeforeEach(func() {
+			// Placeholder handler; each It replaces it with an adapter-specific response.
+			srv = startModelAdapterMockEngine(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(modelListJSON("placeholder")))
+			})
+		})
+
+		ginkgo.AfterEach(func() {
+			if srv != nil {
+				srv.Close()
+			}
+		})
+
+		ginkgo.It("creates an owned headless Service and EndpointSlice after the adapter loads", func() {
+			adapterName := "adapter-svc"
+			pod := createModelAdapterEnginePod(ns.Name, "engine-0", "base-model", true, time.Now().Add(-30*time.Second))
+			srv.setHandler(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(modelListJSON(adapterName)))
+			})
+
+			adapter := createIntegrationModelAdapter(ns.Name, adapterName, "base-model", nil)
+
+			svc := &corev1.Service{}
+			gomega.Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: adapterName}, svc)
+			}, modelAdapterTimeout, modelAdapterInterval).Should(gomega.Succeed())
+			gomega.Expect(svc.Spec.ClusterIP).To(gomega.Equal(corev1.ClusterIPNone))
+			gomega.Expect(svc.Spec.Ports).ToNot(gomega.BeEmpty())
+			gomega.Expect(svc.Spec.Ports[0].Port).To(gomega.Equal(int32(8000)))
+			expectModelAdapterOwnedBy(svc, adapter)
+
+			eps := &discoveryv1.EndpointSlice{}
+			gomega.Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: adapterName}, eps)
+			}, modelAdapterTimeout, modelAdapterInterval).Should(gomega.Succeed())
+			gomega.Expect(eps.AddressType).To(gomega.Equal(discoveryv1.AddressTypeIPv4))
+			gomega.Expect(eps.Labels).To(gomega.HaveKeyWithValue("kubernetes.io/service-name", adapterName))
+			gomega.Expect(eps.Endpoints).To(gomega.HaveLen(1))
+			gomega.Expect(eps.Endpoints[0].Addresses).To(gomega.ConsistOf(modelAdapterEngineIP))
+			expectModelAdapterOwnedBy(eps, adapter)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				latest := &modelapi.ModelAdapter{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(adapter), latest)).To(gomega.Succeed())
+				g.Expect(latest.Status.Instances).To(gomega.ConsistOf(pod.Name))
+				g.Expect(latest.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+				g.Expect(latest.Status.Phase).To(gomega.Equal(modelapi.ModelAdapterRunning))
+				ready := apimeta.FindStatusCondition(latest.Status.Conditions, string(modelapi.ModelAdapterConditionReady))
+				g.Expect(ready).NotTo(gomega.BeNil())
+				g.Expect(ready.Status).To(gomega.Equal(metav1.ConditionTrue))
+			}, modelAdapterTimeout, modelAdapterInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("updates EndpointSlice addresses when another engine pod becomes ready", func() {
+			adapterName := "adapter-eps-update"
+			_ = createModelAdapterEnginePod(ns.Name, "engine-a", "base-model", true, time.Now().Add(-30*time.Second))
+			srv.setHandler(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(modelListJSON(adapterName)))
+			})
+			adapter := createIntegrationModelAdapter(ns.Name, adapterName, "base-model", nil)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				eps := &discoveryv1.EndpointSlice{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: adapterName}, eps)).To(gomega.Succeed())
+				g.Expect(eps.Endpoints).To(gomega.HaveLen(1))
+			}, modelAdapterTimeout, modelAdapterInterval).Should(gomega.Succeed())
+
+			_ = createModelAdapterEnginePod(ns.Name, "engine-b", "base-model", true, time.Now().Add(-30*time.Second))
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				latest := &modelapi.ModelAdapter{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(adapter), latest)).To(gomega.Succeed())
+				g.Expect(latest.Status.Instances).To(gomega.ContainElements("engine-a", "engine-b"))
+				g.Expect(latest.Status.ReadyReplicas).To(gomega.Equal(int32(2)))
+
+				eps := &discoveryv1.EndpointSlice{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: adapterName}, eps)).To(gomega.Succeed())
+				g.Expect(eps.Endpoints).To(gomega.HaveLen(2))
+				var addrs []string
+				for _, ep := range eps.Endpoints {
+					addrs = append(addrs, ep.Addresses...)
+				}
+				g.Expect(addrs).To(gomega.ConsistOf(modelAdapterEngineIP, modelAdapterEngineIP))
+			}, time.Second*40, modelAdapterInterval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.Context("pod readiness and scheduling backoff", func() {
+		ginkgo.It("reports NoReadyPods while matching pods are not ready", func() {
+			_ = createModelAdapterEnginePod(ns.Name, "not-ready", "base-model", false, time.Time{})
+			adapter := createIntegrationModelAdapter(ns.Name, "adapter-no-ready", "base-model", ptr.To(int32(1)))
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				latest := &modelapi.ModelAdapter{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(adapter), latest)).To(gomega.Succeed())
+				g.Expect(latest.Status.Candidates).To(gomega.Equal(int32(0)))
+				g.Expect(latest.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
+
+				scheduled := apimeta.FindStatusCondition(latest.Status.Conditions, string(modelapi.ModelAdapterConditionTypeScheduled))
+				g.Expect(scheduled).NotTo(gomega.BeNil())
+				g.Expect(scheduled.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(scheduled.Reason).To(gomega.Equal(modeladapter.NoReadyPodsReason))
+
+				ready := apimeta.FindStatusCondition(latest.Status.Conditions, string(modelapi.ModelAdapterConditionReady))
+				g.Expect(ready).NotTo(gomega.BeNil())
+				g.Expect(ready.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(ready.Reason).To(gomega.Equal(modeladapter.NoReadyPodsReason))
+			}, modelAdapterTimeout, modelAdapterInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("waits out the readiness backoff before scheduling a recently ready pod", func() {
+			_ = createModelAdapterEnginePod(ns.Name, "fresh-ready", "base-model", true, time.Now().Add(-1*time.Second))
+			adapter := createIntegrationModelAdapter(ns.Name, "adapter-backoff", "base-model", ptr.To(int32(1)))
+
+			// While the pod is still inside the RetryBackoffSeconds window, the
+			// single-replica path must not schedule it (Candidates may be 1 from
+			// getActivePodsForModelAdapter, but ReadyReplicas stays 0).
+			gomega.Eventually(func(g gomega.Gomega) {
+				latest := &modelapi.ModelAdapter{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(adapter), latest)).To(gomega.Succeed())
+				g.Expect(latest.Status.Candidates).To(gomega.Equal(int32(1)))
+				g.Expect(latest.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
+				g.Expect(latest.Status.Instances).To(gomega.BeEmpty())
+
+				scheduled := apimeta.FindStatusCondition(latest.Status.Conditions, string(modelapi.ModelAdapterConditionTypeScheduled))
+				g.Expect(scheduled).NotTo(gomega.BeNil())
+				g.Expect(scheduled.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(scheduled.Reason).To(gomega.Equal(modeladapter.NoReadyPodsReason))
+			}, modelAdapterTimeout, modelAdapterInterval).Should(gomega.Succeed())
+
+			gomega.Consistently(func(g gomega.Gomega) {
+				latest := &modelapi.ModelAdapter{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(adapter), latest)).To(gomega.Succeed())
+				g.Expect(latest.Status.Instances).To(gomega.BeEmpty())
+				g.Expect(latest.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
+			}, time.Second*2, modelAdapterInterval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.Context("retry annotations", func() {
+		ginkgo.It("sets retry annotations on load failure and clears them after a successful load", func() {
+			adapterName := "adapter-retry"
+			var failLoad sync.Mutex
+			shouldFail := true
+
+			srv := startModelAdapterMockEngine(func(w http.ResponseWriter, r *http.Request) {
+				failLoad.Lock()
+				fail := shouldFail
+				failLoad.Unlock()
+				if fail {
+					// Retriable engine error so the controller records retry annotations.
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write([]byte("service unavailable"))
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(modelListJSON(adapterName)))
+			})
+			defer srv.Close()
+
+			pod := createModelAdapterEnginePod(ns.Name, "retry-engine", "base-model", true, time.Now().Add(-30*time.Second))
+			adapter := createIntegrationModelAdapter(ns.Name, adapterName, "base-model", nil)
+
+			retryCountKey := fmt.Sprintf("%s.%s", modeladapter.RetryCountAnnotationKey, pod.Name)
+			lastRetryKey := fmt.Sprintf("%s.%s", modeladapter.LastRetryTimeAnnotationKey, pod.Name)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				latest := &modelapi.ModelAdapter{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(adapter), latest)).To(gomega.Succeed())
+				g.Expect(latest.Annotations).To(gomega.HaveKey(retryCountKey))
+				g.Expect(latest.Annotations).To(gomega.HaveKey(lastRetryKey))
+				count, err := strconv.Atoi(latest.Annotations[retryCountKey])
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(count).To(gomega.BeNumerically(">=", 1))
+			}, modelAdapterTimeout, modelAdapterInterval).Should(gomega.Succeed())
+
+			failLoad.Lock()
+			shouldFail = false
+			failLoad.Unlock()
+
+			// Allow the exponential backoff window (5s * 2^retryCount) to elapse after the
+			// recorded failure before asserting that annotations were cleared on success.
+			gomega.Eventually(func(g gomega.Gomega) {
+				latest := &modelapi.ModelAdapter{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(adapter), latest)).To(gomega.Succeed())
+				g.Expect(latest.Annotations).NotTo(gomega.HaveKey(retryCountKey))
+				g.Expect(latest.Annotations).NotTo(gomega.HaveKey(lastRetryKey))
+				g.Expect(latest.Status.Instances).To(gomega.ConsistOf(pod.Name))
+				g.Expect(latest.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: adapterName}, svc)).To(gomega.Succeed())
+				eps := &discoveryv1.EndpointSlice{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: adapterName}, eps)).To(gomega.Succeed())
+			}, time.Second*45, modelAdapterInterval).Should(gomega.Succeed())
+		})
+	})
+})
+
+func expectModelAdapterOwnedBy(obj metav1.Object, owner *modelapi.ModelAdapter) {
+	ginkgo.GinkgoHelper()
+	refs := obj.GetOwnerReferences()
+	gomega.Expect(refs).To(gomega.HaveLen(1))
+	ref := refs[0]
+	gomega.Expect(ref.Kind).To(gomega.Equal("ModelAdapter"))
+	gomega.Expect(ref.APIVersion).To(gomega.Equal(modelapi.GroupVersion.String()))
+	gomega.Expect(ref.Name).To(gomega.Equal(owner.Name))
+	gomega.Expect(ref.UID).To(gomega.Equal(owner.UID))
+	gomega.Expect(ref.Controller).NotTo(gomega.BeNil())
+	gomega.Expect(*ref.Controller).To(gomega.BeTrue())
+}
+
+func createIntegrationModelAdapter(namespace, name, baseModel string, replicas *int32) *modelapi.ModelAdapter {
+	ginkgo.GinkgoHelper()
+	adapter := wrapper.MakeModelAdapter(name).
+		Namespace(namespace).
+		ArtifactURL("huggingface://example/test-adapter").
+		PodSelector(&metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app":                    "modeladapter-engine",
+				constants.ModelLabelName: baseModel,
+			},
+		}).
+		Replicas(replicas).
+		Obj()
+	adapter.Labels = map[string]string{
+		constants.ModelLabelName: name,
+	}
+	gomega.Expect(k8sClient.Create(ctx, adapter)).To(gomega.Succeed())
+	gomega.Eventually(func() error {
+		return k8sClient.Get(ctx, client.ObjectKeyFromObject(adapter), adapter)
+	}, time.Second*3, modelAdapterInterval).Should(gomega.Succeed())
+	return adapter
+}
+
+func createModelAdapterEnginePod(namespace, name, baseModel string, ready bool, readySince time.Time) *corev1.Pod {
+	ginkgo.GinkgoHelper()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":                    "modeladapter-engine",
+				constants.ModelLabelName: baseModel,
+				modeladapter.ModelAdapterPodTemplateLabelKey: modeladapter.ModelAdapterPodTemplateLabelValue,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "vllm", Image: "vllm/vllm-openai:test"},
+			},
+		},
+	}
+	gomega.Expect(k8sClient.Create(ctx, pod)).To(gomega.Succeed())
+
+	gomega.Eventually(func(g gomega.Gomega) {
+		latest := &corev1.Pod{}
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), latest)).To(gomega.Succeed())
+		latest.Status.Phase = corev1.PodRunning
+		latest.Status.PodIP = modelAdapterEngineIP
+		latest.Status.PodIPs = []corev1.PodIP{{IP: modelAdapterEngineIP}}
+		if ready {
+			cond := corev1.PodCondition{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+				Reason: "TestReady",
+			}
+			if !readySince.IsZero() {
+				cond.LastTransitionTime = metav1.NewTime(readySince)
+			} else {
+				cond.LastTransitionTime = metav1.NewTime(time.Now().Add(-30 * time.Second))
+			}
+			latest.Status.Conditions = []corev1.PodCondition{cond}
+		} else {
+			latest.Status.Conditions = []corev1.PodCondition{{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionFalse,
+				Reason:             "TestNotReady",
+				LastTransitionTime: metav1.Now(),
+			}}
+		}
+		g.Expect(k8sClient.Status().Update(ctx, latest)).To(gomega.Succeed())
+		*pod = *latest
+	}, time.Second*5, modelAdapterInterval).Should(gomega.Succeed())
+
+	return pod
+}
+
+func modelListJSON(adapterName string) string {
+	return fmt.Sprintf(`{
+  "object": "list",
+  "data": [
+    {
+      "id": "%s",
+      "object": "model",
+      "created": 1765479369,
+      "owned_by": "vllm",
+      "root": "dummy/path",
+      "parent": null
+    }
+  ]
+}`, adapterName)
+}
+
+func localNonLoopbackIPv4() string {
+	// Prefer an address already assigned to the host that EndpointSlice will accept
+	// and that we can bind the mock engine to.
+	candidates := []string{}
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() || ip.To4() == nil {
+				continue
+			}
+			candidates = append(candidates, ip.String())
+		}
+	}
+	for _, candidate := range candidates {
+		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", candidate, modelAdapterEnginePort))
+		if err != nil {
+			continue
+		}
+		_ = ln.Close()
+		return candidate
+	}
+	if len(candidates) > 0 {
+		return candidates[0]
+	}
+	return ""
+}
+
+type modelAdapterMockEngine struct {
+	server  *httptest.Server
+	mu      sync.Mutex
+	handler http.HandlerFunc
+}
+
+func (m *modelAdapterMockEngine) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	h := m.handler
+	m.mu.Unlock()
+	if h != nil {
+		h(w, r)
+		return
+	}
+	w.WriteHeader(http.StatusServiceUnavailable)
+}
+
+func (m *modelAdapterMockEngine) setHandler(handler http.HandlerFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.handler = handler
+}
+
+func (m *modelAdapterMockEngine) Close() {
+	if m != nil && m.server != nil {
+		m.server.Close()
+	}
+}
+
+var modelAdapterListenMu sync.Mutex
+
+func startModelAdapterMockEngine(handler http.HandlerFunc) *modelAdapterMockEngine {
+	ginkgo.GinkgoHelper()
+	modelAdapterListenMu.Lock()
+	defer modelAdapterListenMu.Unlock()
+
+	gomega.Expect(modelAdapterEngineIP).NotTo(gomega.BeEmpty(), "need a non-loopback local IPv4 for EndpointSlice-compatible mock engine")
+
+	mock := &modelAdapterMockEngine{handler: handler}
+	addr := fmt.Sprintf("%s:%d", modelAdapterEngineIP, modelAdapterEnginePort)
+	ts := httptest.NewUnstartedServer(mock)
+	_ = ts.Listener.Close()
+
+	var l net.Listener
+	var err error
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		l, err = net.Listen("tcp", addr)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "listen on mock engine address")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	ts.Listener = l
+	ts.Start()
+	mock.server = ts
+	return mock
+}

--- a/test/integration/controller/modeladapter_test.go
+++ b/test/integration/controller/modeladapter_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -106,10 +107,7 @@ var _ = ginkgo.Describe("ModelAdapter controller test", func() {
 		ginkgo.It("creates an owned headless Service and EndpointSlice after the adapter loads", func() {
 			adapterName := "adapter-svc"
 			pod := createModelAdapterEnginePod(ns.Name, "engine-0", "base-model", true, time.Now().Add(-30*time.Second))
-			srv.setHandler(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(modelListJSON(adapterName)))
-			})
+			srv.setHandler(newModelAdapterLoadHandler(adapterName, 0))
 
 			adapter := createIntegrationModelAdapter(ns.Name, adapterName, "base-model", nil)
 
@@ -119,7 +117,7 @@ var _ = ginkgo.Describe("ModelAdapter controller test", func() {
 			}, modelAdapterTimeout, modelAdapterInterval).Should(gomega.Succeed())
 			gomega.Expect(svc.Spec.ClusterIP).To(gomega.Equal(corev1.ClusterIPNone))
 			gomega.Expect(svc.Spec.Ports).ToNot(gomega.BeEmpty())
-			gomega.Expect(svc.Spec.Ports[0].Port).To(gomega.Equal(int32(8000)))
+			gomega.Expect(svc.Spec.Ports[0].Port).To(gomega.Equal(int32(modelAdapterEnginePort)))
 			expectModelAdapterOwnedBy(svc, adapter)
 
 			eps := &discoveryv1.EndpointSlice{}
@@ -147,10 +145,7 @@ var _ = ginkgo.Describe("ModelAdapter controller test", func() {
 		ginkgo.It("updates EndpointSlice addresses when another engine pod becomes ready", func() {
 			adapterName := "adapter-eps-update"
 			_ = createModelAdapterEnginePod(ns.Name, "engine-a", "base-model", true, time.Now().Add(-30*time.Second))
-			srv.setHandler(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(modelListJSON(adapterName)))
-			})
+			srv.setHandler(newModelAdapterLoadHandler(adapterName, 0))
 			adapter := createIntegrationModelAdapter(ns.Name, adapterName, "base-model", nil)
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -206,8 +201,13 @@ var _ = ginkgo.Describe("ModelAdapter controller test", func() {
 		})
 
 		ginkgo.It("waits out the readiness backoff before scheduling a recently ready pod", func() {
-			_ = createModelAdapterEnginePod(ns.Name, "fresh-ready", "base-model", true, time.Now().Add(-1*time.Second))
-			adapter := createIntegrationModelAdapter(ns.Name, "adapter-backoff", "base-model", ptr.To(int32(1)))
+			adapterName := "adapter-backoff"
+			podName := "fresh-ready"
+			srv := startModelAdapterMockEngine(newModelAdapterLoadHandler(adapterName, 0))
+			defer srv.Close()
+
+			_ = createModelAdapterEnginePod(ns.Name, podName, "base-model", true, time.Now().Add(-1*time.Second))
+			adapter := createIntegrationModelAdapter(ns.Name, adapterName, "base-model", ptr.To(int32(1)))
 
 			// While the pod is still inside the RetryBackoffSeconds window, the
 			// single-replica path must not schedule it (Candidates may be 1 from
@@ -234,28 +234,23 @@ var _ = ginkgo.Describe("ModelAdapter controller test", func() {
 				g.Expect(latest.Status.Instances).To(gomega.BeEmpty())
 				g.Expect(latest.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
 			}, time.Second*2, modelAdapterInterval).Should(gomega.Succeed())
+
+			// After the remaining RetryBackoffSeconds window elapses, the pod should
+			// be scheduled and the mock engine should accept the load path.
+			gomega.Eventually(func(g gomega.Gomega) {
+				latest := &modelapi.ModelAdapter{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(adapter), latest)).To(gomega.Succeed())
+				g.Expect(latest.Status.Instances).To(gomega.ConsistOf(podName))
+				g.Expect(latest.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+			}, modelAdapterTimeout, modelAdapterInterval).Should(gomega.Succeed())
 		})
 	})
 
 	ginkgo.Context("retry annotations", func() {
 		ginkgo.It("sets retry annotations on load failure and clears them after a successful load", func() {
 			adapterName := "adapter-retry"
-			var failLoad sync.Mutex
-			shouldFail := true
-
-			srv := startModelAdapterMockEngine(func(w http.ResponseWriter, r *http.Request) {
-				failLoad.Lock()
-				fail := shouldFail
-				failLoad.Unlock()
-				if fail {
-					// Retriable engine error so the controller records retry annotations.
-					w.WriteHeader(http.StatusServiceUnavailable)
-					_, _ = w.Write([]byte("service unavailable"))
-					return
-				}
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(modelListJSON(adapterName)))
-			})
+			// Fail only the first POST /v1/load_lora_adapter so retryCount stays exactly 1.
+			srv := startModelAdapterMockEngine(newModelAdapterLoadHandler(adapterName, 1))
 			defer srv.Close()
 
 			pod := createModelAdapterEnginePod(ns.Name, "retry-engine", "base-model", true, time.Now().Add(-30*time.Second))
@@ -264,6 +259,7 @@ var _ = ginkgo.Describe("ModelAdapter controller test", func() {
 			retryCountKey := fmt.Sprintf("%s.%s", modeladapter.RetryCountAnnotationKey, pod.Name)
 			lastRetryKey := fmt.Sprintf("%s.%s", modeladapter.LastRetryTimeAnnotationKey, pod.Name)
 
+			var observedCount int
 			gomega.Eventually(func(g gomega.Gomega) {
 				latest := &modelapi.ModelAdapter{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(adapter), latest)).To(gomega.Succeed())
@@ -271,15 +267,13 @@ var _ = ginkgo.Describe("ModelAdapter controller test", func() {
 				g.Expect(latest.Annotations).To(gomega.HaveKey(lastRetryKey))
 				count, err := strconv.Atoi(latest.Annotations[retryCountKey])
 				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(count).To(gomega.BeNumerically(">=", 1))
+				g.Expect(count).To(gomega.Equal(1))
+				observedCount = count
 			}, modelAdapterTimeout, modelAdapterInterval).Should(gomega.Succeed())
 
-			failLoad.Lock()
-			shouldFail = false
-			failLoad.Unlock()
-
-			// Allow the exponential backoff window (5s * 2^retryCount) to elapse after the
-			// recorded failure before asserting that annotations were cleared on success.
+			// Backoff after retryCount=1 is RetryBackoffSeconds * 2^1; wait that out plus
+			// the usual reconcile timeout for the successful load to clear annotations.
+			backoff := time.Duration(modeladapter.RetryBackoffSeconds*(1<<observedCount)) * time.Second
 			gomega.Eventually(func(g gomega.Gomega) {
 				latest := &modelapi.ModelAdapter{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(adapter), latest)).To(gomega.Succeed())
@@ -292,7 +286,7 @@ var _ = ginkgo.Describe("ModelAdapter controller test", func() {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: adapterName}, svc)).To(gomega.Succeed())
 				eps := &discoveryv1.EndpointSlice{}
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: adapterName}, eps)).To(gomega.Succeed())
-			}, time.Second*45, modelAdapterInterval).Should(gomega.Succeed())
+			}, backoff+modelAdapterTimeout, modelAdapterInterval).Should(gomega.Succeed())
 		})
 	})
 })
@@ -402,6 +396,50 @@ func modelListJSON(adapterName string) string {
 }`, adapterName)
 }
 
+func emptyModelListJSON() string {
+	return `{
+  "object": "list",
+  "data": []
+}`
+}
+
+// newModelAdapterLoadHandler returns a mock engine handler that exercises the real
+// load path: GET /v1/models is empty until a successful POST /v1/load_lora_adapter,
+// after which the adapter appears in the model list. failLoadPosts controls how
+// many load POSTs return 503 before succeeding (0 = succeed immediately).
+func newModelAdapterLoadHandler(adapterName string, failLoadPosts int) http.HandlerFunc {
+	var mu sync.Mutex
+	loaded := false
+	remainingFails := failLoadPosts
+	return func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/v1/models"):
+			w.WriteHeader(http.StatusOK)
+			if loaded {
+				_, _ = w.Write([]byte(modelListJSON(adapterName)))
+			} else {
+				_, _ = w.Write([]byte(emptyModelListJSON()))
+			}
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "load_lora_adapter"):
+			if remainingFails > 0 {
+				remainingFails--
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte("service unavailable"))
+				return
+			}
+			loaded = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}
+}
+
 func localNonLoopbackIPv4() string {
 	// Prefer an address already assigned to the host that EndpointSlice will accept
 	// and that we can bind the mock engine to.
@@ -436,9 +474,6 @@ func localNonLoopbackIPv4() string {
 		}
 		_ = ln.Close()
 		return candidate
-	}
-	if len(candidates) > 0 {
-		return candidates[0]
 	}
 	return ""
 }

--- a/test/integration/controller/modeladapter_test.go
+++ b/test/integration/controller/modeladapter_test.go
@@ -190,7 +190,10 @@ var _ = ginkgo.Describe("ModelAdapter controller test", func() {
 				g.Expect(latest.Status.Candidates).To(gomega.Equal(int32(0)))
 				g.Expect(latest.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
 
-				scheduled := apimeta.FindStatusCondition(latest.Status.Conditions, string(modelapi.ModelAdapterConditionTypeScheduled))
+				scheduled := apimeta.FindStatusCondition(
+					latest.Status.Conditions,
+					string(modelapi.ModelAdapterConditionTypeScheduled),
+				)
 				g.Expect(scheduled).NotTo(gomega.BeNil())
 				g.Expect(scheduled.Status).To(gomega.Equal(metav1.ConditionFalse))
 				g.Expect(scheduled.Reason).To(gomega.Equal(modeladapter.NoReadyPodsReason))
@@ -216,7 +219,10 @@ var _ = ginkgo.Describe("ModelAdapter controller test", func() {
 				g.Expect(latest.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
 				g.Expect(latest.Status.Instances).To(gomega.BeEmpty())
 
-				scheduled := apimeta.FindStatusCondition(latest.Status.Conditions, string(modelapi.ModelAdapterConditionTypeScheduled))
+				scheduled := apimeta.FindStatusCondition(
+					latest.Status.Conditions,
+					string(modelapi.ModelAdapterConditionTypeScheduled),
+				)
 				g.Expect(scheduled).NotTo(gomega.BeNil())
 				g.Expect(scheduled.Status).To(gomega.Equal(metav1.ConditionFalse))
 				g.Expect(scheduled.Reason).To(gomega.Equal(modeladapter.NoReadyPodsReason))
@@ -473,7 +479,10 @@ func startModelAdapterMockEngine(handler http.HandlerFunc) *modelAdapterMockEngi
 	modelAdapterListenMu.Lock()
 	defer modelAdapterListenMu.Unlock()
 
-	gomega.Expect(modelAdapterEngineIP).NotTo(gomega.BeEmpty(), "need a non-loopback local IPv4 for EndpointSlice-compatible mock engine")
+	gomega.Expect(modelAdapterEngineIP).NotTo(
+		gomega.BeEmpty(),
+		"need a non-loopback local IPv4 for EndpointSlice-compatible mock engine",
+	)
 
 	mock := &modelAdapterMockEngine{handler: handler}
 	addr := fmt.Sprintf("%s:%d", modelAdapterEngineIP, modelAdapterEnginePort)


### PR DESCRIPTION
## Pull Request Description

I added ModelAdapter controller integration coverage for the item called out on #2637.

The tests complement the currently disabled controller-level Ginkgo suite and cover:

- Service/EndpointSlice lifecycle after a successful adapter load, including owner references and EndpointSlice updates when another matching engine pod becomes ready
- Pod readiness/backoff status for the single-replica scheduling path (`NoReadyPods`, and waiting out the readiness backoff window)
- Retry annotations being set on retriable load failures and cleared after a successful load

I also made a small controller fix so retry/scheduling annotations are persisted across reconcile cycles (and retry counts are recorded only after a failed load). Without that, the retry-annotation assertions are not observable via the API.

This addresses the ModelAdapter controller integration tests item on #2637 only. It does not close the tracking issue; the other checkboxes are still open.

## Related Issues

Refs #2637 (ModelAdapter controller integration-tests item only)

## Tests

- `go test ./pkg/controller/modeladapter -count=1`
- `go test ./test/integration/controller -count=1 --ginkgo.focus="ModelAdapter"`