### PR TITLE
[Misc] Add unit tests for KPA panic mode and HPA algorithm

### DIFF
--- a/pkg/controller/podautoscaler/algorithm/hpa_test.go
+++ b/pkg/controller/podautoscaler/algorithm/hpa_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package algorithm
+
+import (
+	"context"
+	"testing"
+)
+
+func TestHPAAlgorithm_ComputeRecommendation(t *testing.T) {
+	// HPA scaling is delegated to the Kubernetes HPA controller, so the
+	// recommendation must echo the current replica count unchanged.
+	tests := []struct {
+		name            string
+		currentReplicas int32
+	}{
+		{"zero replicas", 0},
+		{"single replica", 1},
+		{"multiple replicas", 7},
+	}
+
+	a := &HPAAlgorithm{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := a.ComputeRecommendation(context.Background(), ScalingRequest{
+				CurrentReplicas: tt.currentReplicas,
+			})
+			if err != nil {
+				t.Fatalf("ComputeRecommendation() returned error: %v", err)
+			}
+
+			if got.DesiredReplicas != tt.currentReplicas {
+				t.Errorf("DesiredReplicas = %d, want %d", got.DesiredReplicas, tt.currentReplicas)
+			}
+			if got.Algorithm != "hpa" {
+				t.Errorf("Algorithm = %q, want %q", got.Algorithm, "hpa")
+			}
+			if !got.ScaleValid {
+				t.Error("ScaleValid = false, want true")
+			}
+			if got.Confidence != 1.0 {
+				t.Errorf("Confidence = %v, want 1.0", got.Confidence)
+			}
+		})
+	}
+}
+
+func TestHPAAlgorithm_GetAlgorithmType(t *testing.T) {
+	a := &HPAAlgorithm{}
+	if got := a.GetAlgorithmType(); got != "hpa" {
+		t.Errorf("GetAlgorithmType() = %q, want %q", got, "hpa")
+	}
+}

--- a/pkg/controller/podautoscaler/algorithm/hpa_test.go
+++ b/pkg/controller/podautoscaler/algorithm/hpa_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 )
 
+// hpaAlgorithmType is the algorithm identifier reported by HPAAlgorithm.
+const hpaAlgorithmType = "hpa"
+
 func TestHPAAlgorithm_ComputeRecommendation(t *testing.T) {
 	// HPA scaling is delegated to the Kubernetes HPA controller, so the
 	// recommendation must echo the current replica count unchanged.
@@ -47,8 +50,8 @@ func TestHPAAlgorithm_ComputeRecommendation(t *testing.T) {
 			if got.DesiredReplicas != tt.currentReplicas {
 				t.Errorf("DesiredReplicas = %d, want %d", got.DesiredReplicas, tt.currentReplicas)
 			}
-			if got.Algorithm != "hpa" {
-				t.Errorf("Algorithm = %q, want %q", got.Algorithm, "hpa")
+			if got.Algorithm != hpaAlgorithmType {
+				t.Errorf("Algorithm = %q, want %q", got.Algorithm, hpaAlgorithmType)
 			}
 			if !got.ScaleValid {
 				t.Error("ScaleValid = false, want true")
@@ -62,7 +65,7 @@ func TestHPAAlgorithm_ComputeRecommendation(t *testing.T) {
 
 func TestHPAAlgorithm_GetAlgorithmType(t *testing.T) {
 	a := &HPAAlgorithm{}
-	if got := a.GetAlgorithmType(); got != "hpa" {
-		t.Errorf("GetAlgorithmType() = %q, want %q", got, "hpa")
+	if got := a.GetAlgorithmType(); got != hpaAlgorithmType {
+		t.Errorf("GetAlgorithmType() = %q, want %q", got, hpaAlgorithmType)
 	}
 }

--- a/pkg/controller/podautoscaler/algorithm/kpa_test.go
+++ b/pkg/controller/podautoscaler/algorithm/kpa_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	scalingctx "github.com/vllm-project/aibrix/pkg/controller/podautoscaler/context"
+	"github.com/vllm-project/aibrix/pkg/controller/podautoscaler/types"
 )
 
 func TestKPAAlgorithm_ComputeTargetReplicas(t *testing.T) {
@@ -201,6 +202,39 @@ func TestKPAAlgorithm_ComputeTargetReplicas(t *testing.T) {
 			result := algorithm.computeTargetReplicas(tt.currentPodCount, tt.context, metricsName)
 			if result != tt.expected {
 				t.Errorf("computeTargetReplicas() = %d, expected %d. %s", result, tt.expected, tt.description)
+			}
+		})
+	}
+}
+
+func TestKPAAlgorithm_shouldEnterPanicMode(t *testing.T) {
+	tests := []struct {
+		name           string
+		stableValue    float64
+		panicValue     float64
+		panicThreshold float64
+		want           bool
+	}{
+		// no usable stable history, guard against division by zero
+		{"zero stable value enters panic", 0, 5, 2.0, true},
+		{"negative stable value enters panic", -1, 5, 2.0, true},
+		// ratio compared against the threshold
+		{"ratio above threshold enters panic", 10, 30, 2.0, true},
+		{"ratio below threshold stays stable", 10, 15, 2.0, false},
+		{"ratio exactly at threshold stays stable", 10, 20, 2.0, false},
+	}
+
+	a := &KPAAlgorithm{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := &types.AggregatedMetrics{
+				StableValue: tt.stableValue,
+				PanicValue:  tt.panicValue,
+			}
+			if got := a.shouldEnterPanicMode(metrics, tt.panicThreshold); got != tt.want {
+				t.Errorf("shouldEnterPanicMode(stable=%v, panic=%v, threshold=%v) = %v, want %v",
+					tt.stableValue, tt.panicValue, tt.panicThreshold, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Pull Request Description

Adds unit tests for three previously untested functions in `pkg/controller/podautoscaler/algorithm`. No production code is changed.

`hpa.go` had no test file at all, and `KPAAlgorithm.shouldEnterPanicMode` was at 0% statement coverage.

**`shouldEnterPanicMode`** — covers the `StableValue <= 0` guard, including a negative value so the `<=` comparison is actually exercised. That guard matters: without it the ratio below would divide by zero and produce `NaN`, and since any `NaN` comparison is false, panic mode would be skipped exactly when there is no stable history to fall back on. Also covers the ratio above and below the panic threshold, plus the exact-threshold boundary that pins down `>` versus `>=`.

**`HPAAlgorithm.ComputeRecommendation`** — exercised with several replica counts (0, 1, 7) so the test distinguishes "echoes `CurrentReplicas`" from "returns a constant", and asserts the fixed `Confidence`, `Algorithm` and `ScaleValid` fields along with a nil error.

**`HPAAlgorithm.GetAlgorithmType`** — covered.

Package statement coverage goes from 59.4% to 61.8%; all three functions reach 100%.

Verified locally with `gofmt`, `go vet`, `golangci-lint` and `go test`.

## Related Issues

N/A — no tracking issue. Continues chipping away at the coverage gap, in line with the 90% total-coverage goal noted in `.github/workflows/lint-and-tests.yml`. Follows the same approach as #2666.
