### PR TITLE
Add pending replica guard for pod autoscaler

### DIFF
--- a/pkg/controller/podautoscaler/autoscaler.go
+++ b/pkg/controller/podautoscaler/autoscaler.go
@@ -18,7 +18,9 @@ package podautoscaler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -50,16 +52,26 @@ type ReplicaComputeRequest struct {
 	PodAutoscaler   autoscalingv1alpha1.PodAutoscaler
 	ScalingContext  scalingctx.ScalingContext // Single source of truth for PA-level configuration
 	CurrentReplicas int32
+	ReplicaState    ReplicaState
 	Pods            []corev1.Pod
 	Timestamp       time.Time
 }
 
+// ReplicaState captures scale target readiness state for pipeline-level guards.
+type ReplicaState struct {
+	ReadyReplicas   int32
+	PendingReplicas int32
+}
+
 // ReplicaComputeResult represents the result of replica calculation
 type ReplicaComputeResult struct {
-	DesiredReplicas int32
-	Algorithm       string
-	Reason          string
-	Valid           bool
+	DesiredReplicas           int32
+	Algorithm                 string
+	MetricName                string
+	MetricValue               float64
+	Reason                    string
+	Valid                     bool
+	PendingReplicaGuardActive bool
 }
 
 // DefaultAutoScaler implements the complete scaling pipeline
@@ -196,12 +208,110 @@ func (a *DefaultAutoScaler) ComputeDesiredReplicas(ctx context.Context, request 
 		"currentReplicas", request.CurrentReplicas,
 	)
 
+	bestResult = applyPendingReplicaGuard(request, bestResult)
+
 	return &ReplicaComputeResult{
-		DesiredReplicas: bestResult.DesiredReplicas,
-		Algorithm:       bestResult.Algorithm,
-		Reason:          bestResult.Reason,
-		Valid:           true,
+		DesiredReplicas:           bestResult.DesiredReplicas,
+		Algorithm:                 bestResult.Algorithm,
+		MetricName:                bestResult.MetricName,
+		MetricValue:               bestResult.MetricValue,
+		Reason:                    bestResult.Reason,
+		Valid:                     true,
+		PendingReplicaGuardActive: bestResult.PendingReplicaGuardActive,
 	}, nil
+}
+
+func applyPendingReplicaGuard(request ReplicaComputeRequest, result *ReplicaComputeResult) *ReplicaComputeResult {
+	if result == nil || !result.Valid {
+		return result
+	}
+	if request.PodAutoscaler.Spec.ScalingStrategy != autoscalingv1alpha1.KPA &&
+		request.PodAutoscaler.Spec.ScalingStrategy != autoscalingv1alpha1.APA {
+		return result
+	}
+	if request.ReplicaState.PendingReplicas <= 0 || result.DesiredReplicas == request.CurrentReplicas {
+		return result
+	}
+	if request.CurrentReplicas <= 0 {
+		return result
+	}
+
+	targetValue, ok := request.ScalingContext.GetTargetValueForMetric(result.MetricName)
+	if !ok || targetValue <= 0 {
+		return result
+	}
+
+	readyReplicas := request.ReplicaState.ReadyReplicas
+	if readyReplicas < 0 {
+		readyReplicas = 0
+	}
+	if readyReplicas > request.CurrentReplicas {
+		readyReplicas = request.CurrentReplicas
+	}
+
+	pendingReplicas := request.CurrentReplicas - readyReplicas
+	if pendingReplicas <= 0 {
+		return result
+	}
+
+	currentReplicas := float64(request.CurrentReplicas)
+	readyCount := float64(readyReplicas)
+	pendingCount := float64(pendingReplicas)
+
+	var desiredReplicas int32
+	var reason string
+
+	if result.DesiredReplicas > request.CurrentReplicas {
+		adjustedMetricValue := result.MetricValue * readyCount / currentReplicas
+		desiredReplicas = computePendingAdjustedReplicas(request, result, adjustedMetricValue, targetValue)
+		if desiredReplicas < request.CurrentReplicas {
+			desiredReplicas = request.CurrentReplicas
+		}
+		if desiredReplicas > result.DesiredReplicas {
+			desiredReplicas = result.DesiredReplicas
+		}
+		reason = "scale-up adjusted: pending replicas treated as missing metrics"
+	} else {
+		adjustedMetricValue := (result.MetricValue*readyCount + targetValue*pendingCount) / currentReplicas
+		desiredReplicas = computePendingAdjustedReplicas(request, result, adjustedMetricValue, targetValue)
+		if desiredReplicas > request.CurrentReplicas {
+			desiredReplicas = request.CurrentReplicas
+		}
+		if desiredReplicas < result.DesiredReplicas {
+			desiredReplicas = result.DesiredReplicas
+		}
+		reason = "scale-down adjusted: pending replicas treated at target utilization"
+	}
+
+	if desiredReplicas == result.DesiredReplicas {
+		return result
+	}
+
+	return &ReplicaComputeResult{
+		DesiredReplicas:           desiredReplicas,
+		Algorithm:                 result.Algorithm,
+		MetricName:                result.MetricName,
+		MetricValue:               result.MetricValue,
+		Reason:                    reason,
+		Valid:                     true,
+		PendingReplicaGuardActive: true,
+	}
+}
+
+func computePendingAdjustedReplicas(
+	request ReplicaComputeRequest,
+	result *ReplicaComputeResult,
+	adjustedMetricValue float64,
+	targetValue float64,
+) int32 {
+	switch request.PodAutoscaler.Spec.ScalingStrategy {
+	case autoscalingv1alpha1.APA:
+		return int32(math.Ceil(float64(request.CurrentReplicas) * adjustedMetricValue / targetValue))
+	case autoscalingv1alpha1.KPA:
+		return int32(math.Ceil(adjustedMetricValue / targetValue))
+	default:
+		return result.DesiredReplicas
+	}
 }
 
 // computeReplicasForSingleMetric computes desired replicas for a single MetricSource.
@@ -229,9 +339,37 @@ func (a *DefaultAutoScaler) computeReplicasForSingleMetric(
 	return &ReplicaComputeResult{
 		DesiredReplicas: recommendation.DesiredReplicas,
 		Algorithm:       recommendation.Algorithm,
+		MetricName:      metricSource.TargetMetric,
+		MetricValue:     recommendationMetricValue(recommendation),
 		Reason:          recommendation.Reason,
 		Valid:           true,
 	}, nil
+}
+
+func recommendationMetricValue(recommendation *algorithm.ScalingRecommendation) float64 {
+	if recommendation == nil || recommendation.Metadata == nil {
+		return 0
+	}
+	switch value := recommendation.Metadata["current_value"].(type) {
+	case float64:
+		return value
+	case float32:
+		return float64(value)
+	case int:
+		return float64(value)
+	case int32:
+		return float64(value)
+	case int64:
+		return float64(value)
+	case json.Number:
+		floatValue, err := value.Float64()
+		if err == nil {
+			return floatValue
+		}
+		return 0
+	default:
+		return 0
+	}
 }
 
 // executeScalingPipeline contains the common scaling logic for replica computation

--- a/pkg/controller/podautoscaler/autoscaler.go
+++ b/pkg/controller/podautoscaler/autoscaler.go
@@ -68,6 +68,7 @@ type ReplicaComputeResult struct {
 	DesiredReplicas           int32
 	Algorithm                 string
 	MetricName                string
+	MetricSourceType          autoscalingv1alpha1.MetricSourceType
 	MetricValue               float64
 	Reason                    string
 	Valid                     bool
@@ -214,6 +215,7 @@ func (a *DefaultAutoScaler) ComputeDesiredReplicas(ctx context.Context, request 
 		DesiredReplicas:           bestResult.DesiredReplicas,
 		Algorithm:                 bestResult.Algorithm,
 		MetricName:                bestResult.MetricName,
+		MetricSourceType:          bestResult.MetricSourceType,
 		MetricValue:               bestResult.MetricValue,
 		Reason:                    bestResult.Reason,
 		Valid:                     true,
@@ -227,6 +229,10 @@ func applyPendingReplicaGuard(request ReplicaComputeRequest, result *ReplicaComp
 	}
 	if request.PodAutoscaler.Spec.ScalingStrategy != autoscalingv1alpha1.KPA &&
 		request.PodAutoscaler.Spec.ScalingStrategy != autoscalingv1alpha1.APA {
+		return result
+	}
+	if result.MetricSourceType != autoscalingv1alpha1.POD &&
+		result.MetricSourceType != autoscalingv1alpha1.RESOURCE {
 		return result
 	}
 	if request.ReplicaState.PendingReplicas <= 0 || result.DesiredReplicas == request.CurrentReplicas {
@@ -263,7 +269,7 @@ func applyPendingReplicaGuard(request ReplicaComputeRequest, result *ReplicaComp
 
 	if result.DesiredReplicas > request.CurrentReplicas {
 		adjustedMetricValue := result.MetricValue * readyCount / currentReplicas
-		desiredReplicas = computePendingAdjustedReplicas(request, result, adjustedMetricValue, targetValue)
+		desiredReplicas = computePendingAdjustedReplicas(request, result, adjustedMetricValue, targetValue, readyReplicas, pendingReplicas)
 		if desiredReplicas < request.CurrentReplicas {
 			desiredReplicas = request.CurrentReplicas
 		}
@@ -273,7 +279,7 @@ func applyPendingReplicaGuard(request ReplicaComputeRequest, result *ReplicaComp
 		reason = "scale-up adjusted: pending replicas treated as missing metrics"
 	} else {
 		adjustedMetricValue := (result.MetricValue*readyCount + targetValue*pendingCount) / currentReplicas
-		desiredReplicas = computePendingAdjustedReplicas(request, result, adjustedMetricValue, targetValue)
+		desiredReplicas = computePendingAdjustedReplicas(request, result, adjustedMetricValue, targetValue, readyReplicas, pendingReplicas)
 		if desiredReplicas > request.CurrentReplicas {
 			desiredReplicas = request.CurrentReplicas
 		}
@@ -291,6 +297,7 @@ func applyPendingReplicaGuard(request ReplicaComputeRequest, result *ReplicaComp
 		DesiredReplicas:           desiredReplicas,
 		Algorithm:                 result.Algorithm,
 		MetricName:                result.MetricName,
+		MetricSourceType:          result.MetricSourceType,
 		MetricValue:               result.MetricValue,
 		Reason:                    reason,
 		Valid:                     true,
@@ -303,11 +310,16 @@ func computePendingAdjustedReplicas(
 	result *ReplicaComputeResult,
 	adjustedMetricValue float64,
 	targetValue float64,
+	readyReplicas int32,
+	pendingReplicas int32,
 ) int32 {
 	switch request.PodAutoscaler.Spec.ScalingStrategy {
 	case autoscalingv1alpha1.APA:
 		return int32(math.Ceil(float64(request.CurrentReplicas) * adjustedMetricValue / targetValue))
 	case autoscalingv1alpha1.KPA:
+		if result.DesiredReplicas < request.CurrentReplicas {
+			return int32(math.Ceil((result.MetricValue*float64(readyReplicas) + targetValue*float64(pendingReplicas)) / targetValue))
+		}
 		return int32(math.Ceil(adjustedMetricValue / targetValue))
 	default:
 		return result.DesiredReplicas
@@ -337,12 +349,13 @@ func (a *DefaultAutoScaler) computeReplicasForSingleMetric(
 	}
 
 	return &ReplicaComputeResult{
-		DesiredReplicas: recommendation.DesiredReplicas,
-		Algorithm:       recommendation.Algorithm,
-		MetricName:      metricSource.TargetMetric,
-		MetricValue:     recommendationMetricValue(recommendation),
-		Reason:          recommendation.Reason,
-		Valid:           true,
+		DesiredReplicas:  recommendation.DesiredReplicas,
+		Algorithm:        recommendation.Algorithm,
+		MetricName:       metricSource.TargetMetric,
+		MetricSourceType: metricSource.MetricSourceType,
+		MetricValue:      recommendationMetricValue(recommendation),
+		Reason:           recommendation.Reason,
+		Valid:            true,
 	}, nil
 }
 

--- a/pkg/controller/podautoscaler/autoscaler_test.go
+++ b/pkg/controller/podautoscaler/autoscaler_test.go
@@ -18,6 +18,7 @@ package podautoscaler
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	autoscalingv1alpha1 "github.com/vllm-project/aibrix/api/autoscaling/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/controller/podautoscaler/algorithm"
 	scalingctx "github.com/vllm-project/aibrix/pkg/controller/podautoscaler/context"
 	"github.com/vllm-project/aibrix/pkg/controller/podautoscaler/metrics"
 	"github.com/vllm-project/aibrix/pkg/controller/podautoscaler/types"
@@ -210,6 +212,166 @@ func TestComputeDesiredReplicasConfiguresMetricWindowsFromPodAutoscalerSpec(t *t
 	assert.Equal(t, 70.0, panicValue)
 }
 
+func TestComputeDesiredReplicasAdjustsKPAAPAConservativelyWhenReplicasPending(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		strategy     autoscalingv1alpha1.ScalingStrategyType
+		metricValue  float64
+		readyPods    int32
+		pendingPods  int32
+		wantReason   string
+		wantReplicas int32
+	}{
+		{
+			name:         "kpa scale-up adjusted",
+			strategy:     autoscalingv1alpha1.KPA,
+			metricValue:  250,
+			readyPods:    2,
+			pendingPods:  2,
+			wantReason:   "scale-up adjusted: pending replicas treated as missing metrics",
+			wantReplicas: 4,
+		},
+		{
+			name:         "kpa scale-up dampened",
+			strategy:     autoscalingv1alpha1.KPA,
+			metricValue:  350,
+			readyPods:    3,
+			pendingPods:  1,
+			wantReason:   "scale-up adjusted: pending replicas treated as missing metrics",
+			wantReplicas: 6,
+		},
+		{
+			name:         "apa scale-up adjusted",
+			strategy:     autoscalingv1alpha1.APA,
+			metricValue:  90,
+			readyPods:    2,
+			pendingPods:  2,
+			wantReason:   "scale-up adjusted: pending replicas treated as missing metrics",
+			wantReplicas: 4,
+		},
+		{
+			name:         "apa scale-down adjusted",
+			strategy:     autoscalingv1alpha1.APA,
+			metricValue:  10,
+			readyPods:    2,
+			pendingPods:  2,
+			wantReason:   "scale-down adjusted: pending replicas treated at target utilization",
+			wantReplicas: 3,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pa := testPodAutoscaler(tt.strategy)
+			autoScaler := NewDefaultAutoScaler(&mockMetricFetcherFactory{
+				mockMetricFetcher: mockMetricFetcher{metricsValue: tt.metricValue},
+			}, fake.NewClientBuilder().Build())
+			scalingContext := testScalingContext(t, &pa)
+
+			result, err := autoScaler.ComputeDesiredReplicas(context.TODO(), ReplicaComputeRequest{
+				PodAutoscaler:   pa,
+				ScalingContext:  scalingContext,
+				CurrentReplicas: 4,
+				ReplicaState: ReplicaState{
+					ReadyReplicas:   tt.readyPods,
+					PendingReplicas: tt.pendingPods,
+				},
+				Pods: []corev1.Pod{
+					{ObjectMeta: metav1.ObjectMeta{Name: "ready-1"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "ready-2"}},
+				},
+				Timestamp: time.Now(),
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantReplicas, result.DesiredReplicas)
+			assert.Equal(t, tt.wantReason, result.Reason)
+			assert.True(t, result.PendingReplicaGuardActive)
+		})
+	}
+}
+
+func TestComputeDesiredReplicasDoesNotHoldWhenNoReplicasPending(t *testing.T) {
+	pa := testPodAutoscaler(autoscalingv1alpha1.APA)
+	autoScaler := NewDefaultAutoScaler(&mockMetricFetcherFactory{
+		mockMetricFetcher: mockMetricFetcher{metricsValue: 90},
+	}, fake.NewClientBuilder().Build())
+	scalingContext := testScalingContext(t, &pa)
+
+	result, err := autoScaler.ComputeDesiredReplicas(context.TODO(), ReplicaComputeRequest{
+		PodAutoscaler:   pa,
+		ScalingContext:  scalingContext,
+		CurrentReplicas: 4,
+		ReplicaState: ReplicaState{
+			ReadyReplicas:   4,
+			PendingReplicas: 0,
+		},
+		Pods: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "ready-1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "ready-2"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "ready-3"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "ready-4"}},
+		},
+		Timestamp: time.Now(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int32(8), result.DesiredReplicas)
+	assert.Equal(t, "apa scaling based on current metrics", result.Reason)
+}
+
+func TestComputeDesiredReplicasDoesNotHoldHPAWhenReplicasPending(t *testing.T) {
+	pa := testPodAutoscaler(autoscalingv1alpha1.HPA)
+	autoScaler := NewDefaultAutoScaler(&mockMetricFetcherFactory{
+		mockMetricFetcher: mockMetricFetcher{metricsValue: 90},
+	}, fake.NewClientBuilder().Build())
+	scalingContext := testScalingContext(t, &pa)
+
+	result, err := autoScaler.ComputeDesiredReplicas(context.TODO(), ReplicaComputeRequest{
+		PodAutoscaler:   pa,
+		ScalingContext:  scalingContext,
+		CurrentReplicas: 4,
+		ReplicaState: ReplicaState{
+			ReadyReplicas:   2,
+			PendingReplicas: 2,
+		},
+		Pods: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "ready-1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "ready-2"}},
+		},
+		Timestamp: time.Now(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int32(4), result.DesiredReplicas)
+	assert.Equal(t, "HPA managed by Kubernetes", result.Reason)
+}
+
+func TestRecommendationMetricValueConvertsNumericMetadata(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		raw  interface{}
+		want float64
+	}{
+		{name: "float64", raw: 12.5, want: 12.5},
+		{name: "float32", raw: float32(12.5), want: 12.5},
+		{name: "int", raw: 12, want: 12},
+		{name: "int64", raw: int64(12), want: 12},
+		{name: "json number", raw: json.Number("12.5"), want: 12.5},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			recommendation := &algorithm.ScalingRecommendation{
+				Metadata: map[string]interface{}{
+					"current_value": tt.raw,
+				},
+			}
+
+			assert.Equal(t, tt.want, recommendationMetricValue(recommendation))
+		})
+	}
+}
+
 type mockMetricFetcherFactory struct {
 	mockMetricFetcher
 }
@@ -224,4 +386,38 @@ type mockMetricFetcher struct {
 
 func (f *mockMetricFetcher) FetchPodMetrics(ctx context.Context, pod corev1.Pod, source autoscalingv1alpha1.MetricSource) (float64, error) {
 	return f.metricsValue, nil
+}
+
+func testPodAutoscaler(strategy autoscalingv1alpha1.ScalingStrategyType) autoscalingv1alpha1.PodAutoscaler {
+	return autoscalingv1alpha1.PodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-pending-guard",
+		},
+		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+			ScaleTargetRef: corev1.ObjectReference{
+				Kind: "Deployment",
+				Name: "test-llm",
+			},
+			MaxReplicas:     20,
+			ScalingStrategy: strategy,
+			MetricsSources: []autoscalingv1alpha1.MetricSource{
+				{
+					MetricSourceType: autoscalingv1alpha1.POD,
+					TargetMetric:     "gpu_cache_usage_perc",
+					TargetValue:      "50",
+				},
+			},
+		},
+	}
+}
+
+func testScalingContext(t *testing.T, pa *autoscalingv1alpha1.PodAutoscaler) scalingctx.ScalingContext {
+	t.Helper()
+
+	scalingContext := scalingctx.NewBaseScalingContext()
+	scalingContext.MaxReplicas = 20
+	scalingContext.MaxScaleUpRate = 4
+	require.NoError(t, scalingContext.UpdateByPaTypes(pa))
+	return scalingContext
 }

--- a/pkg/controller/podautoscaler/autoscaler_test.go
+++ b/pkg/controller/podautoscaler/autoscaler_test.go
@@ -216,51 +216,91 @@ func TestComputeDesiredReplicasAdjustsKPAAPAConservativelyWhenReplicasPending(t 
 	for _, tt := range []struct {
 		name         string
 		strategy     autoscalingv1alpha1.ScalingStrategyType
+		sourceType   autoscalingv1alpha1.MetricSourceType
 		metricValue  float64
+		currentPods  int32
 		readyPods    int32
 		pendingPods  int32
 		wantReason   string
 		wantReplicas int32
+		wantGuard    bool
 	}{
 		{
 			name:         "kpa scale-up adjusted",
 			strategy:     autoscalingv1alpha1.KPA,
+			sourceType:   autoscalingv1alpha1.POD,
 			metricValue:  250,
+			currentPods:  4,
 			readyPods:    2,
 			pendingPods:  2,
 			wantReason:   "scale-up adjusted: pending replicas treated as missing metrics",
 			wantReplicas: 4,
+			wantGuard:    true,
 		},
 		{
 			name:         "kpa scale-up dampened",
 			strategy:     autoscalingv1alpha1.KPA,
+			sourceType:   autoscalingv1alpha1.POD,
 			metricValue:  350,
+			currentPods:  4,
 			readyPods:    3,
 			pendingPods:  1,
 			wantReason:   "scale-up adjusted: pending replicas treated as missing metrics",
 			wantReplicas: 6,
+			wantGuard:    true,
+		},
+		{
+			name:         "kpa scale-down adjusted",
+			strategy:     autoscalingv1alpha1.KPA,
+			sourceType:   autoscalingv1alpha1.POD,
+			metricValue:  10,
+			currentPods:  10,
+			readyPods:    5,
+			pendingPods:  5,
+			wantReason:   "scale-down adjusted: pending replicas treated at target utilization",
+			wantReplicas: 6,
+			wantGuard:    true,
+		},
+		{
+			name:         "kpa external metric not adjusted",
+			strategy:     autoscalingv1alpha1.KPA,
+			sourceType:   autoscalingv1alpha1.EXTERNAL,
+			metricValue:  350,
+			currentPods:  4,
+			readyPods:    2,
+			pendingPods:  2,
+			wantReason:   "stable mode scaling",
+			wantReplicas: 7,
+			wantGuard:    false,
 		},
 		{
 			name:         "apa scale-up adjusted",
 			strategy:     autoscalingv1alpha1.APA,
+			sourceType:   autoscalingv1alpha1.POD,
 			metricValue:  90,
+			currentPods:  4,
 			readyPods:    2,
 			pendingPods:  2,
 			wantReason:   "scale-up adjusted: pending replicas treated as missing metrics",
 			wantReplicas: 4,
+			wantGuard:    true,
 		},
 		{
 			name:         "apa scale-down adjusted",
 			strategy:     autoscalingv1alpha1.APA,
+			sourceType:   autoscalingv1alpha1.POD,
 			metricValue:  10,
+			currentPods:  4,
 			readyPods:    2,
 			pendingPods:  2,
 			wantReason:   "scale-down adjusted: pending replicas treated at target utilization",
 			wantReplicas: 3,
+			wantGuard:    true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			pa := testPodAutoscaler(tt.strategy)
+			pa.Spec.MetricsSources[0].MetricSourceType = tt.sourceType
 			autoScaler := NewDefaultAutoScaler(&mockMetricFetcherFactory{
 				mockMetricFetcher: mockMetricFetcher{metricsValue: tt.metricValue},
 			}, fake.NewClientBuilder().Build())
@@ -269,7 +309,7 @@ func TestComputeDesiredReplicasAdjustsKPAAPAConservativelyWhenReplicasPending(t 
 			result, err := autoScaler.ComputeDesiredReplicas(context.TODO(), ReplicaComputeRequest{
 				PodAutoscaler:   pa,
 				ScalingContext:  scalingContext,
-				CurrentReplicas: 4,
+				CurrentReplicas: tt.currentPods,
 				ReplicaState: ReplicaState{
 					ReadyReplicas:   tt.readyPods,
 					PendingReplicas: tt.pendingPods,
@@ -285,7 +325,7 @@ func TestComputeDesiredReplicasAdjustsKPAAPAConservativelyWhenReplicasPending(t 
 			require.NotNil(t, result)
 			assert.Equal(t, tt.wantReplicas, result.DesiredReplicas)
 			assert.Equal(t, tt.wantReason, result.Reason)
-			assert.True(t, result.PendingReplicaGuardActive)
+			assert.Equal(t, tt.wantGuard, result.PendingReplicaGuardActive)
 		})
 	}
 }

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -94,6 +94,7 @@ const (
 	ReasonMetricsConfigError        = "MetricsConfigError"
 	ReasonInvalidSpec               = "InvalidSpec"
 	ReasonConfigured                = "Configured"
+	ReasonPendingReplicas           = "PendingReplicas"
 	maxScalingHistorySize           = 5
 	minScalingHistoryRecordInterval = 5 * time.Second
 	maxMetricWindowSeconds          = int64(3600)
@@ -883,7 +884,7 @@ func (r *PodAutoscalerReconciler) reconcileCustomPA(ctx context.Context, pa auto
 	// Pass ScaleTargetRef to handle special cases like RayClusterFleet
 	scaleDecision, err := r.computeScaleDecision(ctx, pa, scaleObj, currentReplicas)
 	if err != nil {
-		setStatus(&pa, currentReplicas, currentReplicas, false, "FailedComputeScale", false, err)
+		setStatus(&pa, currentReplicas, currentReplicas, false, "FailedComputeScale", false, false, err)
 		if updateErr := r.updateStatusIfNeeded(ctx, paStatusOriginal, &pa); updateErr != nil {
 			return ctrl.Result{}, updateErr
 		}
@@ -922,7 +923,7 @@ func (r *PodAutoscalerReconciler) reconcileCustomPA(ctx context.Context, pa auto
 
 	// Step 5: Update status
 	setStatus(&pa, currentReplicas, scaleDecision.DesiredReplicas,
-		scaleDecision.ShouldScale, scaleDecision.Reason, scaleError == nil, scaleError)
+		scaleDecision.ShouldScale, scaleDecision.Reason, scaleDecision.PendingReplicaGuardActive, scaleError == nil, scaleError)
 
 	if err := r.updateStatusIfNeeded(ctx, paStatusOriginal, &pa); err != nil {
 		return ctrl.Result{}, err
@@ -999,7 +1000,7 @@ func setCondition(pa *autoscalingv1alpha1.PodAutoscaler, conditionType string, s
 
 // setStatus recreates the status of the given PA, updating the current and
 // desired replicas, as well as the metric statuses and optionally records a scaling decision
-func setStatus(pa *autoscalingv1alpha1.PodAutoscaler, currentReplicas, desiredReplicas int32, rescale bool, reason string, success bool, err error) {
+func setStatus(pa *autoscalingv1alpha1.PodAutoscaler, currentReplicas, desiredReplicas int32, rescale bool, reason string, pendingGuardActive bool, success bool, err error) {
 	pa.Status = autoscalingv1alpha1.PodAutoscalerStatus{
 		ActualScale:     currentReplicas,
 		DesiredScale:    desiredReplicas,
@@ -1008,6 +1009,19 @@ func setStatus(pa *autoscalingv1alpha1.PodAutoscaler, currentReplicas, desiredRe
 		ScalingHistory:  pa.Status.ScalingHistory, // preserve existing history
 		ScheduledBounds: scheduledBoundsStatus(pa, time.Now()),
 	}
+
+	scalingActive := desiredReplicas != currentReplicas
+	scalingMessage := fmt.Sprintf("desired=%d, actual=%d", desiredReplicas, currentReplicas)
+	if reason != "" {
+		scalingMessage = fmt.Sprintf("%s; reason=%s", scalingMessage, reason)
+	}
+	scalingReason := ReasonStable
+	if scalingActive {
+		scalingReason = ReasonReconcilingScaleDiff
+	} else if pendingGuardActive {
+		scalingReason = ReasonPendingReplicas
+	}
+	setCondition(pa, ConditionScalingActive, boolToCond(scalingActive), scalingReason, scalingMessage)
 
 	if rescale || !success {
 		now := metav1.NewTime(time.Now())
@@ -1091,10 +1105,11 @@ func (r *PodAutoscalerReconciler) updateStatus(ctx context.Context, pa *autoscal
 
 // ScaleDecision represents a scaling decision made by the autoscaler
 type ScaleDecision struct {
-	DesiredReplicas int32
-	ShouldScale     bool
-	Reason          string
-	Algorithm       string
+	DesiredReplicas           int32
+	ShouldScale               bool
+	Reason                    string
+	Algorithm                 string
+	PendingReplicaGuardActive bool
 }
 
 // getScaleResource retrieves the scale resource for the PodAutoscaler target
@@ -1147,17 +1162,7 @@ func (r *PodAutoscalerReconciler) computeScaleDecision(
 		}, nil
 	}
 
-	// Check boundary conditions first
-	if currentReplicas > maxReplicas {
-		return &ScaleDecision{
-			DesiredReplicas: maxReplicas,
-			ShouldScale:     true,
-			Reason:          "current replicas exceed maximum",
-			Algorithm:       "boundary-check",
-		}, nil
-	}
-
-	if currentReplicas < minReplicas {
+	if currentReplicas == 0 && minReplicas > 0 {
 		return &ScaleDecision{
 			DesiredReplicas: minReplicas,
 			ShouldScale:     true,
@@ -1189,7 +1194,9 @@ func (r *PodAutoscalerReconciler) computeScaleDecision(
 
 	reason := ""
 
-	// Apply constraints
+	pendingGuardActive := replicaResult.PendingReplicaGuardActive
+
+	// Hard replica bounds always take precedence over metric and pending-replica recommendations.
 	if desiredReplicas > maxReplicas {
 		klog.InfoS("Scaling adjustment: Algorithm recommended scaling above maximum limit",
 			"recommendedReplicas", desiredReplicas, "adjustedTo", maxReplicas)
@@ -1207,15 +1214,18 @@ func (r *PodAutoscalerReconciler) computeScaleDecision(
 		} else {
 			reason = "All metrics below target"
 		}
+	} else if pendingGuardActive {
+		reason = replicaResult.Reason
 	} else {
 		reason = "stable"
 	}
 
 	return &ScaleDecision{
-		DesiredReplicas: desiredReplicas,
-		ShouldScale:     shouldScale,
-		Reason:          reason,
-		Algorithm:       metricName,
+		DesiredReplicas:           desiredReplicas,
+		ShouldScale:               shouldScale,
+		Reason:                    reason,
+		Algorithm:                 metricName,
+		PendingReplicaGuardActive: pendingGuardActive,
 	}, nil
 }
 
@@ -1257,12 +1267,14 @@ func (r *PodAutoscalerReconciler) computeMetricBasedReplicas(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod list: %w", err)
 	}
+	replicaState := replicaStateFromPods(podList.Items, currentReplicas)
 
 	// Create request for autoscaler with ScalingContext
 	replicaRequest := ReplicaComputeRequest{
 		PodAutoscaler:   pa,
 		ScalingContext:  scalingContext,
 		CurrentReplicas: currentReplicas,
+		ReplicaState:    replicaState,
 		Pods:            podList.Items,
 		Timestamp:       r.nowTime(),
 	}

--- a/pkg/controller/podautoscaler/podautoscaler_controller.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller.go
@@ -1177,6 +1177,22 @@ func (r *PodAutoscalerReconciler) computeScaleDecision(
 	// Use autoscaler for metric-based scaling with provided selector
 	replicaResult, err := r.computeMetricBasedReplicas(ctx, pa, scalingContext, scaleObj, currentReplicas)
 	if err != nil {
+		if currentReplicas > maxReplicas {
+			return &ScaleDecision{
+				DesiredReplicas: maxReplicas,
+				ShouldScale:     true,
+				Reason:          "current replicas above maximum",
+				Algorithm:       "boundary-check",
+			}, nil
+		}
+		if currentReplicas < minReplicas {
+			return &ScaleDecision{
+				DesiredReplicas: minReplicas,
+				ShouldScale:     true,
+				Reason:          "current replicas below minimum",
+				Algorithm:       "boundary-check",
+			}, nil
+		}
 		return nil, fmt.Errorf("failed to compute metric-based replicas: %w", err)
 	}
 

--- a/pkg/controller/podautoscaler/podautoscaler_controller_test.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller_test.go
@@ -89,6 +89,24 @@ func (f *fakeAutoScaler) ComputeDesiredReplicas(ctx context.Context, req Replica
 	return f.result, f.err
 }
 
+func readyPod(ns, name string, lbls map[string]string) *corev1.Pod {
+	pod := buildPod(ns, name, lbls)
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionTrue,
+	}}
+	return pod
+}
+
+func notReadyPod(ns, name string, lbls map[string]string) *corev1.Pod {
+	pod := buildPod(ns, name, lbls)
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionFalse,
+	}}
+	return pod
+}
+
 func TestValidateMetricsSourcesAllowsK8sExternalMetrics(t *testing.T) {
 	for _, metricSourceType := range []autoscalingv1alpha1.MetricSourceType{
 		autoscalingv1alpha1.EXTERNAL,
@@ -724,6 +742,84 @@ func TestComputeScaleDecisionAllowsScheduledMinReplicasFromZero(t *testing.T) {
 				t.Fatalf("ShouldScale=%t, want %t", decision.ShouldScale, tt.wantShouldRun)
 			}
 		})
+	}
+}
+
+func TestComputeScaleDecisionPendingGuardDoesNotOverrideHardBounds(t *testing.T) {
+	sch := runtime.NewScheme()
+	_ = scheme.AddToScheme(sch)
+	_ = corev1.AddToScheme(sch)
+	_ = autoscalingv1alpha1.AddToScheme(sch)
+
+	r := &PodAutoscalerReconciler{
+		Client:              fake.NewClientBuilder().WithScheme(sch).Build(),
+		workloadScaleClient: &fakeWorkloadScaleClient{},
+		autoScaler: &fakeAutoScaler{
+			result: &ReplicaComputeResult{
+				DesiredReplicas:           12,
+				Algorithm:                 "apa",
+				Reason:                    "scale-up suppressed: pending replicas have no metrics yet",
+				Valid:                     true,
+				PendingReplicaGuardActive: true,
+			},
+		},
+	}
+	pa := *validPodAutoscalerForSpec()
+	pa.Namespace = ns
+	pa.Spec.ScalingStrategy = autoscalingv1alpha1.APA
+	pa.Spec.MinReplicas = ptr.To[int32](6)
+	pa.Spec.MaxReplicas = 10
+
+	scaleObj := buildScaleObject("apps/v1", "Deployment", ns, "test-deployment")
+
+	decision, err := r.computeScaleDecision(context.Background(), pa, scaleObj, 12)
+
+	if err != nil {
+		t.Fatalf("computeScaleDecision returned error: %v", err)
+	}
+	if decision.DesiredReplicas != 10 {
+		t.Fatalf("DesiredReplicas=%d, want 10", decision.DesiredReplicas)
+	}
+	if !decision.ShouldScale {
+		t.Fatal("expected maxReplicas boundary to override pending guard")
+	}
+	if decision.Reason != "All metrics below target" {
+		t.Fatalf("Reason=%q", decision.Reason)
+	}
+}
+
+func TestReplicaStateFromPodsUsesCurrentReplicasMinusReadyPodsAsPending(t *testing.T) {
+	labels := map[string]string{"app": "foo"}
+	state := replicaStateFromPods([]corev1.Pod{
+		*readyPod(ns, "old-ready-1", labels),
+		*readyPod(ns, "old-ready-2", labels),
+		*readyPod(ns, "old-ready-3", labels),
+		*readyPod(ns, "old-ready-4", labels),
+		*readyPod(ns, "old-ready-5", labels),
+		*notReadyPod(ns, "new-pending-1", labels),
+		*notReadyPod(ns, "new-pending-2", labels),
+	}, 4)
+
+	if state.ReadyReplicas != 4 {
+		t.Fatalf("ReadyReplicas=%d, want 4", state.ReadyReplicas)
+	}
+	if state.PendingReplicas != 0 {
+		t.Fatalf("PendingReplicas=%d, want 0", state.PendingReplicas)
+	}
+}
+
+func TestReplicaStateFromPodsTreatsMissingPodsAsPending(t *testing.T) {
+	labels := map[string]string{"app": "foo"}
+	state := replicaStateFromPods([]corev1.Pod{
+		*readyPod(ns, "ready-1", labels),
+		*readyPod(ns, "ready-2", labels),
+	}, 4)
+
+	if state.ReadyReplicas != 2 {
+		t.Fatalf("ReadyReplicas=%d, want 2", state.ReadyReplicas)
+	}
+	if state.PendingReplicas != 2 {
+		t.Fatalf("PendingReplicas=%d, want 2", state.PendingReplicas)
 	}
 }
 

--- a/pkg/controller/podautoscaler/podautoscaler_controller_test.go
+++ b/pkg/controller/podautoscaler/podautoscaler_controller_test.go
@@ -18,6 +18,7 @@ package podautoscaler
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"sort"
 	"strings"
@@ -785,6 +786,71 @@ func TestComputeScaleDecisionPendingGuardDoesNotOverrideHardBounds(t *testing.T)
 	}
 	if decision.Reason != "All metrics below target" {
 		t.Fatalf("Reason=%q", decision.Reason)
+	}
+}
+
+func TestComputeScaleDecisionAppliesHardBoundsWhenMetricsFail(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		currentReplicas int32
+		minReplicas     int32
+		maxReplicas     int32
+		wantReplicas    int32
+		wantReason      string
+	}{
+		{
+			name:            "above max",
+			currentReplicas: 12,
+			minReplicas:     1,
+			maxReplicas:     10,
+			wantReplicas:    10,
+			wantReason:      "current replicas above maximum",
+		},
+		{
+			name:            "below min",
+			currentReplicas: 2,
+			minReplicas:     4,
+			maxReplicas:     10,
+			wantReplicas:    4,
+			wantReason:      "current replicas below minimum",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			sch := runtime.NewScheme()
+			_ = scheme.AddToScheme(sch)
+			_ = corev1.AddToScheme(sch)
+			_ = autoscalingv1alpha1.AddToScheme(sch)
+
+			r := &PodAutoscalerReconciler{
+				Client:              fake.NewClientBuilder().WithScheme(sch).Build(),
+				workloadScaleClient: &fakeWorkloadScaleClient{},
+				autoScaler: &fakeAutoScaler{
+					err: errors.New("metrics unavailable"),
+				},
+			}
+			pa := *validPodAutoscalerForSpec()
+			pa.Namespace = ns
+			pa.Spec.ScalingStrategy = autoscalingv1alpha1.APA
+			pa.Spec.MinReplicas = ptr.To(tt.minReplicas)
+			pa.Spec.MaxReplicas = tt.maxReplicas
+
+			scaleObj := buildScaleObject("apps/v1", "Deployment", ns, "test-deployment")
+
+			decision, err := r.computeScaleDecision(context.Background(), pa, scaleObj, tt.currentReplicas)
+
+			if err != nil {
+				t.Fatalf("computeScaleDecision returned error: %v", err)
+			}
+			if decision.DesiredReplicas != tt.wantReplicas {
+				t.Fatalf("DesiredReplicas=%d, want %d", decision.DesiredReplicas, tt.wantReplicas)
+			}
+			if !decision.ShouldScale {
+				t.Fatal("expected hard boundary to apply when metrics fail")
+			}
+			if decision.Reason != tt.wantReason {
+				t.Fatalf("Reason=%q", decision.Reason)
+			}
+		})
 	}
 }
 

--- a/pkg/controller/podautoscaler/utils.go
+++ b/pkg/controller/podautoscaler/utils.go
@@ -54,6 +54,28 @@ func isPodReady(pod corev1.Pod) bool {
 	return false
 }
 
+func replicaStateFromPods(pods []corev1.Pod, currentReplicas int32) ReplicaState {
+	var readyReplicas int32
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		if isPodReady(pod) {
+			readyReplicas++
+		}
+	}
+
+	pendingReplicas := currentReplicas - readyReplicas
+	if pendingReplicas < 0 {
+		pendingReplicas = 0
+	}
+
+	return ReplicaState{
+		ReadyReplicas:   currentReplicas - pendingReplicas,
+		PendingReplicas: pendingReplicas,
+	}
+}
+
 func minFloat64(a, b float64) float64 {
 	if a < b {
 		return a

--- a/test/integration/controller/podautoscaler_test.go
+++ b/test/integration/controller/podautoscaler_test.go
@@ -18,12 +18,17 @@ package controller
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -114,6 +119,41 @@ var _ = ginkgo.Describe("PodAutoscaler controller test", func() {
 		}
 		gomega.Expect(k8sClient.Create(ctx, deployment)).To(gomega.Succeed())
 		return deployment
+	}
+
+	createPodWithReadiness := func(name, namespace string, podLabels map[string]string, ready bool, podIP string) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    podLabels,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "target",
+						Image: "nginx:latest",
+					},
+				},
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, pod)).To(gomega.Succeed())
+
+		conditionStatus := corev1.ConditionFalse
+		phase := corev1.PodPending
+		if ready {
+			conditionStatus = corev1.ConditionTrue
+			phase = corev1.PodRunning
+			pod.Status.PodIP = podIP
+		}
+		pod.Status.Phase = phase
+		pod.Status.Conditions = []corev1.PodCondition{
+			{
+				Type:   corev1.PodReady,
+				Status: conditionStatus,
+			},
+		}
+		gomega.Expect(k8sClient.Status().Update(ctx, pod)).To(gomega.Succeed())
 	}
 
 	// Helper: creates a StormService with two roles (prefill and decode)
@@ -224,6 +264,77 @@ var _ = ginkgo.Describe("PodAutoscaler controller test", func() {
 							expectedCondition, expectedStatus,
 							expectedReason,
 						)
+					},
+				},
+			},
+		}
+	}
+
+	makePendingReplicaGuardTestCase := func() *testValidatingCase {
+		var metricsServer *httptest.Server
+
+		return &testValidatingCase{
+			makePodAutoscaler: func() *autoscalingv1alpha1.PodAutoscaler {
+				return wrapper.MakePodAutoscaler("pa-pending-replica-guard").
+					Namespace(ns.Name).
+					ScalingStrategy(autoscalingv1alpha1.APA).
+					MinReplicas(1).
+					MaxReplicas(20).
+					ScaleTargetRefWithKind("Deployment", "apps/v1", "pending-guard-deployment").
+					MetricSource(autoscalingv1alpha1.MetricSource{
+						MetricSourceType: autoscalingv1alpha1.EXTERNAL,
+						ProtocolType:     autoscalingv1alpha1.HTTP,
+						Endpoint:         "pending-guard.invalid",
+						Path:             "/metrics",
+						TargetMetric:     "aibrix_test_queue_depth",
+						TargetValue:      "50",
+					}).
+					Obj()
+			},
+			updates: []*update{
+				{
+					updateFunc: func(pa *autoscalingv1alpha1.PodAutoscaler) {
+						metricsServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							_, _ = w.Write([]byte("# TYPE aibrix_test_queue_depth gauge\n"))
+							_, _ = w.Write([]byte("aibrix_test_queue_depth 90\n"))
+						}))
+						ginkgo.DeferCleanup(metricsServer.Close)
+						pa.Spec.MetricsSources[0].Endpoint = strings.TrimPrefix(metricsServer.URL, "http://")
+
+						createDeployment("pending-guard-deployment", ns.Name, 4)
+						podLabels := map[string]string{"app": "pending-guard-deployment"}
+						createPodWithReadiness("pending-guard-pod-1", ns.Name, podLabels, true, "10.0.0.1")
+						createPodWithReadiness("pending-guard-pod-2", ns.Name, podLabels, true, "10.0.0.2")
+						createPodWithReadiness("pending-guard-pod-3", ns.Name, podLabels, false, "")
+						createPodWithReadiness("pending-guard-pod-4", ns.Name, podLabels, false, "")
+
+						gomega.Expect(k8sClient.Create(ctx, pa)).To(gomega.Succeed())
+						ginkgo.DeferCleanup(func() {
+							err := k8sClient.Delete(ctx, pa)
+							gomega.Expect(err == nil || apierrors.IsNotFound(err)).To(gomega.BeTrue())
+							gomega.Eventually(func() bool {
+								err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pa), &autoscalingv1alpha1.PodAutoscaler{})
+								return apierrors.IsNotFound(err)
+							}, time.Second*10, time.Millisecond*250).Should(gomega.BeTrue())
+						})
+					},
+					checkFunc: func(ctx context.Context, k8sClient client.Client, pa *autoscalingv1alpha1.PodAutoscaler) {
+						gomega.Eventually(func(g gomega.Gomega) {
+							deployment := &appsv1.Deployment{}
+							key := client.ObjectKey{Namespace: ns.Name, Name: "pending-guard-deployment"}
+							g.Expect(k8sClient.Get(ctx, key, deployment)).To(gomega.Succeed())
+							g.Expect(deployment.Spec.Replicas).NotTo(gomega.BeNil())
+							g.Expect(*deployment.Spec.Replicas).To(gomega.Equal(int32(4)))
+
+							fetched := validation.GetPodAutoscaler(ctx, k8sClient, pa)
+							g.Expect(fetched.Status.ActualScale).To(gomega.Equal(int32(4)))
+							g.Expect(fetched.Status.DesiredScale).To(gomega.Equal(int32(4)))
+
+							condition := apimeta.FindStatusCondition(fetched.Status.Conditions, ConditionScalingActive)
+							g.Expect(condition).NotTo(gomega.BeNil())
+							g.Expect(condition.Reason).To(gomega.Equal("PendingReplicas"))
+							g.Expect(condition.Message).To(gomega.ContainSubstring("pending replicas"))
+						}, time.Second*15, time.Millisecond*250).Should(gomega.Succeed())
 					},
 				},
 			},
@@ -769,6 +880,10 @@ var _ = ginkgo.Describe("PodAutoscaler controller test", func() {
 					},
 				},
 			},
+		),
+
+		ginkgo.Entry("Scale Target - APA pending replica guard holds current replicas",
+			makePendingReplicaGuardTestCase(),
 		),
 
 		// =========================================================================

--- a/test/integration/controller/podautoscaler_test.go
+++ b/test/integration/controller/podautoscaler_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"net/url"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -35,6 +35,7 @@ import (
 
 	autoscalingv1alpha1 "github.com/vllm-project/aibrix/api/autoscaling/v1alpha1"
 	orchestrationapi "github.com/vllm-project/aibrix/api/orchestration/v1alpha1"
+	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/test/utils/validation"
 	"github.com/vllm-project/aibrix/test/utils/wrapper"
 )
@@ -272,6 +273,8 @@ var _ = ginkgo.Describe("PodAutoscaler controller test", func() {
 
 	makePendingReplicaGuardTestCase := func() *testValidatingCase {
 		var metricsServer *httptest.Server
+		var metricsHost string
+		var metricsPort string
 
 		return &testValidatingCase{
 			makePodAutoscaler: func() *autoscalingv1alpha1.PodAutoscaler {
@@ -282,11 +285,11 @@ var _ = ginkgo.Describe("PodAutoscaler controller test", func() {
 					MaxReplicas(20).
 					ScaleTargetRefWithKind("Deployment", "apps/v1", "pending-guard-deployment").
 					MetricSource(autoscalingv1alpha1.MetricSource{
-						MetricSourceType: autoscalingv1alpha1.EXTERNAL,
+						MetricSourceType: autoscalingv1alpha1.POD,
 						ProtocolType:     autoscalingv1alpha1.HTTP,
-						Endpoint:         "pending-guard.invalid",
+						Port:             "0",
 						Path:             "/metrics",
-						TargetMetric:     "aibrix_test_queue_depth",
+						TargetMetric:     "gpu_cache_usage_perc",
 						TargetValue:      "50",
 					}).
 					Obj()
@@ -295,16 +298,25 @@ var _ = ginkgo.Describe("PodAutoscaler controller test", func() {
 				{
 					updateFunc: func(pa *autoscalingv1alpha1.PodAutoscaler) {
 						metricsServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							_, _ = w.Write([]byte("# TYPE aibrix_test_queue_depth gauge\n"))
-							_, _ = w.Write([]byte("aibrix_test_queue_depth 90\n"))
+							_, _ = w.Write([]byte("# TYPE vllm:gpu_cache_usage_perc gauge\n"))
+							_, _ = w.Write([]byte("vllm:gpu_cache_usage_perc 90\n"))
 						}))
 						ginkgo.DeferCleanup(metricsServer.Close)
-						pa.Spec.MetricsSources[0].Endpoint = strings.TrimPrefix(metricsServer.URL, "http://")
+						metricsURL, err := url.Parse(metricsServer.URL)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						metricsHost = metricsURL.Hostname()
+						metricsPort = metricsURL.Port()
+						gomega.Expect(metricsHost).NotTo(gomega.BeEmpty())
+						gomega.Expect(metricsPort).NotTo(gomega.BeEmpty())
+						pa.Spec.MetricsSources[0].Port = metricsPort
 
 						createDeployment("pending-guard-deployment", ns.Name, 4)
-						podLabels := map[string]string{"app": "pending-guard-deployment"}
-						createPodWithReadiness("pending-guard-pod-1", ns.Name, podLabels, true, "10.0.0.1")
-						createPodWithReadiness("pending-guard-pod-2", ns.Name, podLabels, true, "10.0.0.2")
+						podLabels := map[string]string{
+							"app":                      "pending-guard-deployment",
+							constants.ModelLabelEngine: "vllm",
+						}
+						createPodWithReadiness("pending-guard-pod-1", ns.Name, podLabels, true, metricsHost)
+						createPodWithReadiness("pending-guard-pod-2", ns.Name, podLabels, true, metricsHost)
 						createPodWithReadiness("pending-guard-pod-3", ns.Name, podLabels, false, "")
 						createPodWithReadiness("pending-guard-pod-4", ns.Name, podLabels, false, "")
 


### PR DESCRIPTION
## Summary
- Add a pending-replica guard for KPA/APA that conservatively dampens POD/RESOURCE metric recommendations while selected pods are not ready.
- Preserve global EXTERNAL/DOMAIN metric recommendations without pending-replica dilution.
- Apply min/max bounds even when metric collection fails, so invalid current scale still converges back into configured limits.
- Add unit coverage for KPA/APA/HPA behavior plus controller boundary/readiness cases, and an integration focus test for APA pending guard behavior.

Fixes #2670

## Test Plan
- [x] git diff --check
- [x] go test ./pkg/controller/podautoscaler -count=1
- [x] go test ./test/integration/controller -run TestAPIs -ginkgo.focus "APA pending replica guard" -count=1
- [x] make lint-all
- [ ] go test ./test/integration/controller -run TestAPIs -count=1 (previously failed in existing integration cases: 68 passed / 8 failed; new pending guard focus passes)