### PR TITLE
[Bug] Fix TestSonicSerializationWithRawMessage failing outside sonic's supported range

### DIFF
--- a/pkg/utils/tokenizer/serialization_test.go
+++ b/pkg/utils/tokenizer/serialization_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tokenizer
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -65,9 +66,16 @@ func TestSonicSerializationWithRawMessage(t *testing.T) {
 				t.Errorf("Role mismatch: got %v, want %v", result.Role, tt.message.Role)
 			}
 
-			// Content should be preserved as-is
-			if string(result.Content) != string(tt.message.Content) {
-				t.Errorf("Content mismatch:\ngot:  %s\nwant: %s", string(result.Content), string(tt.message.Content))
+			// Content must survive the round trip. Compare compacted forms:
+			// whitespace between JSON tokens is insignificant and the
+			// marshaller may drop it (encoding/json compacts a
+			// json.RawMessage, sonic copies it verbatim), so a byte-for-byte
+			// comparison would assert which implementation is active rather
+			// than whether the content is intact.
+			got := mustCompact(t, result.Content)
+			want := mustCompact(t, tt.message.Content)
+			if got != want {
+				t.Errorf("Content mismatch:\ngot:  %s\nwant: %s", got, want)
 			}
 		})
 	}
@@ -132,4 +140,16 @@ func TestVLLMRequestSerialization(t *testing.T) {
 	if len(content) != 2 {
 		t.Fatalf("Expected 2 content parts, got %d", len(content))
 	}
+}
+
+// mustCompact strips insignificant whitespace so comparisons do not depend
+// on which JSON implementation produced the bytes.
+func mustCompact(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		t.Fatalf("json.Compact failed on %s: %v", raw, err)
+	}
+	return buf.String()
 }


### PR DESCRIPTION
## Pull Request Description

`TestSonicSerializationWithRawMessage/multimodal_array_content` fails on any machine where `sonic` is not usable. No production code is changed.

**Cause.** The test compares `json.RawMessage` content byte for byte:

```go
if string(result.Content) != string(tt.message.Content) {
```

`sonic` copies a `json.RawMessage` verbatim, but it falls back to `encoding/json` outside its supported range (go1.17–1.26 on amd64, go1.20–1.26 on arm64), and `encoding/json` compacts a `json.RawMessage` while marshalling. The `multimodal_array_content` case supplies indented JSON, so on a fallback the round trip returns semantically identical but compacted bytes and the comparison fails:

```
WARNING: sonic/ast only supports (go1.17~1.26 and amd64 CPU) or (go1.20~1.26 and arm64 CPU),
         but your environment is not suitable and will fallback to encoding/json
--- FAIL: TestSonicSerializationWithRawMessage/multimodal_array_content
    serialization_test.go:70: Content mismatch
```

So the assertion asserts which JSON implementation is active, not whether the content survived the round trip — which is what the surrounding comment says it intends to check.

**Impact.** CI runs Go 1.26, so this is green today. It fails for anyone building on Go 1.27+ or on an architecture `sonic` does not support (`make test` fails on a fresh clone), and it will break CI the next time the Go version is raised.

**Fix.** Compare compacted forms via `json.Compact`. Whitespace between JSON tokens is insignificant; key order, values and types are still compared strictly.

Verified on Go 1.27 (sonic falling back):

- both subtests pass after the change;
- corrupting `result.Content` before the comparison still fails the test, so the assertion has not been weakened into an unconditional pass;
- re-indenting `result.Content` without changing its meaning passes, which is the behaviour the fix is for.

`gofmt`, `go vet`, `golangci-lint` and the full package test suite pass locally.

## Related Issues

N/A — no tracking issue; found while running `make test` on a fresh clone.
