### PR TITLE
[Bug] Register PD prefill/decode selections atomically with the selection

### DIFF
--- a/pkg/plugins/gateway/algorithms/pd/selector/selector.go
+++ b/pkg/plugins/gateway/algorithms/pd/selector/selector.go
@@ -30,6 +30,10 @@ import (
 
 // PodSelector picks a prefill/decode pod pair from the full ready-pod list.
 // A nil prefill pod signals combined-role routing (decode pod handles both phases).
+//
+// A successful Select also registers the chosen pods with the request trackers
+// it consulted, atomically with the decision, so that concurrent selections
+// observe each other; the caller (Route) owns the matching removals.
 type PodSelector interface {
 	Select(routingCtx *types.RoutingContext, readyPods []*v1.Pod) (prefill *v1.Pod, decode *v1.Pod, err error)
 }

--- a/pkg/plugins/gateway/algorithms/pd/trackers.go
+++ b/pkg/plugins/gateway/algorithms/pd/trackers.go
@@ -43,9 +43,10 @@ func NewPrefillRequestTracker() *PrefillRequestTracker {
 }
 
 // AddPrefillRequest records that requestID has been assigned to podName and
-// increments that pod's active-request counter. Called in Route before
-// doPrefillRequest so concurrent routing sees in-flight assignments. Must be
-// paired with RemovePrefillRequest when prefill completes or the assignment is abandoned.
+// increments that pod's active-request counter. Called by the pod selector as
+// soon as the prefill pod is chosen, under the same lock as the selection, so
+// concurrent routing sees in-flight assignments. Must be paired with
+// RemovePrefillRequest when prefill completes or the assignment is abandoned.
 func (t *PrefillRequestTracker) AddPrefillRequest(requestID, podName string) {
 	countInterface, _ := t.podRequestCounts.LoadOrStore(podName, &atomic.Int32{})
 	count := countInterface.(*atomic.Int32)
@@ -148,8 +149,9 @@ func NewPendingDecodeTracker() *PendingDecodeTracker {
 }
 
 // AddPendingDecode records that requestID has been assigned to podName and
-// increments that pod's pending-decode counter. Called at the start of Route
-// after pod selection. RemovePendingDecode is deferred in Route.
+// increments that pod's pending-decode counter. Called by the pod selector as
+// soon as the decode pod is chosen, under the same lock as the selection.
+// RemovePendingDecode is deferred in Route.
 func (t *PendingDecodeTracker) AddPendingDecode(requestID, podName string) {
 	if t == nil {
 		return

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -206,6 +206,20 @@ type pdRouter struct {
 	selectionCounts       map[string]int64
 	podSelector           selector.PodSelector
 	prefillExecutor       prefill.PrefillExecutor
+
+	// selectMu makes "read every candidate's tracked load, pick the best,
+	// register the pick" one atomic step in filterPrefillDecodePods. Without
+	// it, concurrent requests in a burst all read the same pre-burst tracker
+	// snapshot and pile onto whichever pods looked idle at read time, because
+	// the registration that would have made them visible to each other only
+	// happened after selection returned.
+	//
+	// Only load-dependent work runs under it: the imbalance fast paths, the
+	// per-pod scoring, finalPDScore and the two tracker registrations.
+	// Tokenization and prefix matching (PrefillScorePolicy.Prepare) depend
+	// only on the request and run before the lock is taken. countersMu is
+	// taken inside selectMu (in finalPDScore) and never the other way round.
+	selectMu sync.Mutex
 }
 
 func newPrefixCachePrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHashTable) pd.PrefillScorePolicy {
@@ -288,6 +302,9 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		}
 	}
 
+	// Select registers the chosen pods with pendingDecodeTracker and
+	// prefillRequestTracker atomically with the decision (see selectMu);
+	// Route owns the matching removals.
 	prefillPod, decodePod, err := r.podSelector.Select(ctx, readyPods)
 	if err != nil {
 		metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
@@ -295,7 +312,6 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		return "", fmt.Errorf("failed to filter prefill/decode pods for request %s: %w", ctx.RequestID, err)
 	}
 
-	r.pendingDecodeTracker.AddPendingDecode(ctx.RequestID, decodePod.Name)
 	defer r.pendingDecodeTracker.RemovePendingDecode(ctx.RequestID)
 
 	if prefillPod != nil {
@@ -306,9 +322,8 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		}
 		ctx.RespHeaders[HeaderPrefillTargetPod] = prefillPod.Name
 		ctx.RespHeaders[HeaderPrefillTargetPodIP] = prefillPod.Status.PodIP
-		// Register before doPrefillRequest so concurrent scorers see in-flight work.
-		// Executor RemovePrefillRequest (sync/async) is the matching decrement.
-		r.prefillRequestTracker.AddPrefillRequest(ctx.RequestID, prefillPod.Name)
+		// The prefill registration was made by Select; the executor's
+		// RemovePrefillRequest (sync/async) is the matching decrement.
 		err = r.doPrefillRequest(ctx, prefillPod, ctx.Engine)
 
 		if err != nil {
@@ -363,8 +378,15 @@ type Scores struct {
 //     independent: both can fire on the same request if both prefill and decode are
 //     imbalanced, with each narrowing its own side of the pair.
 //
-//  6. Score remaining candidates — scorePrefillPods and scoreDecodePods evaluate
-//     every roleset; finalPDScore picks the roleset with the lowest combined score.
+//  6. Score remaining candidates — scorePreparedPrefillPods and scoreDecodePods
+//     evaluate every roleset; finalPDScore picks the roleset with the lowest
+//     combined score.
+//
+//  7. Register — the chosen decode pod is recorded in pendingDecodeTracker and the
+//     chosen prefill pod in prefillRequestTracker before returning, so the next
+//     selection sees this one. Steps 3b-7 read tracker state and run under
+//     selectMu; steps 1-3a and the policy Prepare step (tokenization, prefix
+//     matching) run before the lock is taken. Route owns the matching removals.
 func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, readyPods []*v1.Pod) (*v1.Pod, *v1.Pod, error) {
 	var promptLength int
 	if aibrixPromptLengthBucketing {
@@ -389,18 +411,36 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 				klog.InfoS("no bucket matches prompt length, routing to combined pod",
 					"requestId", routingCtx.RequestID, "promptLength", promptLength, "combinedPods", len(combinedPods),
 					"bucketPrefillPods", len(promptLengthBucketingPrefillPods), "bucketDecodePods", len(promptLengthBucketingDecodePods))
-				return nil, combinedPods[rand.Intn(len(combinedPods))], nil
+				combinedPod := combinedPods[rand.Intn(len(combinedPods))]
+				r.pendingDecodeTracker.AddPendingDecode(routingCtx.RequestID, combinedPod.Name)
+				return nil, combinedPod, nil
 			}
 			// Do not fall back to unfiltered PD pods: each pod group (storm) is sized for a
 			// specific prompt-length range and cross-bucket routing produces incorrect results.
 			return nil, nil, fmt.Errorf("no prompt-length bucket matches prompt length %d and no combined pods available", promptLength)
 		}
+	}
 
+	prefillPol, decodePol, err := r.effectiveScorePolicies(routingCtx)
+	if err != nil {
+		return nil, nil, err
+	}
+	prefillScorer, err := r.preparePrefillScorer(routingCtx, prefillPods, prefillPol)
+	if err != nil {
+		return nil, nil, fmt.Errorf("prefill scorer preparation failed: %w", err)
+	}
+
+	// Everything below reads tracker state that concurrent selections mutate.
+	r.selectMu.Lock()
+	defer r.selectMu.Unlock()
+
+	if aibrixPromptLengthBucketing {
 		// Bucket match exists; check if load imbalance favours a combined pod instead.
 		if r.shouldPickCombined(routingCtx, promptLengthBucketingPrefillPods, promptLengthBucketingDecodePods, combinedPods) {
 			combinedPod := r.scoreCombinedPods(routingCtx, combinedPods)
 			if combinedPod != nil {
 				klog.InfoS("load imbalance detected, selecting combined pod", "requestId", routingCtx.RequestID, "selectedCombinedPod", combinedPod.Name)
+				r.pendingDecodeTracker.AddPendingDecode(routingCtx.RequestID, combinedPod.Name)
 				return nil, combinedPod, nil
 			}
 		}
@@ -429,18 +469,16 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 		)
 	}
 
-	prefillPol, decodePol, err := r.effectiveScorePolicies(routingCtx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	prefillScores, maxPrefillScore, prefixHashes := r.scorePrefillPods(routingCtx, prefillPods, prefillPol)
+	prefillScores, maxPrefillScore, prefixHashes := r.scorePreparedPrefillPods(routingCtx, prefillPods, prefillScorer)
 	decodeRun := r.scoreDecodePods(routingCtx, decodePods, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage, decodePol)
 	selectedPrefill, selectedDecode, err := r.finalPDScore(routingCtx, prefixHashes, prefillScores, maxPrefillScore, decodeRun)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Register while still holding selectMu so the next selection counts this one.
+	r.pendingDecodeTracker.AddPendingDecode(routingCtx.RequestID, selectedDecode.Name)
+	r.prefillRequestTracker.AddPrefillRequest(routingCtx.RequestID, selectedPrefill.Name)
 	return selectedPrefill, selectedDecode, nil
 }
 
@@ -449,7 +487,8 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 //
 // podRequestCount holds per-pod active prefill counts from PrefillRequestTracker for
 // in-flight prefill HTTP calls from other concurrent requests. The current request is
-// not counted yet — it is registered by the caller after selection completes.
+// not counted yet — filterPrefillDecodePods registers it after selection completes,
+// under the same selectMu hold.
 // readyPods is shuffled before evaluation so ties among equally-loaded pods are broken
 // randomly rather than by map iteration order.
 //
@@ -650,7 +689,25 @@ func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filte
 // all pods were filtered by the stddev check).
 //
 // Policy resolution: the policy argument, then r.prefillPolicy, then prefix_cache.
+//
+// scorePrefillPods is preparePrefillScorer followed by scorePreparedPrefillPods;
+// filterPrefillDecodePods calls the two halves separately so that Prepare runs
+// before selectMu is taken and only the tracker-dependent half runs under it.
 func (r *pdRouter) scorePrefillPods(routingCtx *types.RoutingContext, prefillPods []*v1.Pod, prefillPolicy pd.PrefillScorePolicy) (map[string]*Scores, float64, []uint64) {
+	scorer, err := r.preparePrefillScorer(routingCtx, prefillPods, prefillPolicy)
+	if err != nil {
+		return nil, 0, nil
+	}
+	return r.scorePreparedPrefillPods(routingCtx, prefillPods, scorer)
+}
+
+// preparePrefillScorer resolves the prefill policy (the argument, then
+// r.prefillPolicy, then prefix_cache) and runs its Prepare step: tokenization
+// and prefix-cache matching over prefillPods. Prepare depends only on the
+// request and the prefix index, not on tracker state, so callers may run it
+// before taking selectMu. prefillPods may later be narrowed by the imbalance
+// fast paths; a scorer prepared over the wider set scores any subset of it.
+func (r *pdRouter) preparePrefillScorer(routingCtx *types.RoutingContext, prefillPods []*v1.Pod, prefillPolicy pd.PrefillScorePolicy) (pd.PrefillScorer, error) {
 	policy := prefillPolicy
 	if policy == nil {
 		policy = r.prefillPolicy
@@ -662,15 +719,28 @@ func (r *pdRouter) scorePrefillPods(routingCtx *types.RoutingContext, prefillPod
 		}
 		policy = newPrefixCachePrefillPolicy(tbl)
 	}
+	readyPodsMap := make(map[string]struct{}, len(prefillPods))
+	for _, pod := range prefillPods {
+		readyPodsMap[pod.Name] = struct{}{}
+	}
+	scorer, err := policy.Prepare(routingCtx, prefillPods, readyPodsMap)
+	if err != nil {
+		klog.ErrorS(err, "prefill scorer preparation failed",
+			"request_id", routingCtx.RequestID, "policy", policy.Name(), "model", routingCtx.Model)
+		return nil, err
+	}
+	return scorer, nil
+}
+
+// scorePreparedPrefillPods is the tracker-dependent half of scorePrefillPods:
+// it reads the current prefill request counts and scores prefillPods with an
+// already-prepared scorer. filterPrefillDecodePods calls it under selectMu.
+func (r *pdRouter) scorePreparedPrefillPods(routingCtx *types.RoutingContext, prefillPods []*v1.Pod, scorer pd.PrefillScorer) (map[string]*Scores, float64, []uint64) {
 	utils.CryptoShuffle(prefillPods)
 	podRequestCount := r.prefillRequestTracker.GetPrefillRequestCountsForPods(prefillPods)
 
 	var maxRequestCount float64 = 1
 	requestCounts := make([]float64, 0, len(podRequestCount))
-	readyPodsMap := make(map[string]struct{}, len(prefillPods))
-	for _, pod := range prefillPods {
-		readyPodsMap[pod.Name] = struct{}{}
-	}
 	for _, cnt := range podRequestCount {
 		cf := float64(cnt)
 		requestCounts = append(requestCounts, cf)
@@ -680,13 +750,6 @@ func (r *pdRouter) scorePrefillPods(routingCtx *types.RoutingContext, prefillPod
 	}
 	meanRequestCount := mean(requestCounts)
 	stdDevRequestCount := standardDeviation(requestCounts)
-
-	scorer, err := policy.Prepare(routingCtx, prefillPods, readyPodsMap)
-	if err != nil {
-		klog.ErrorS(err, "prefill scorer preparation failed",
-			"request_id", routingCtx.RequestID, "policy", policy.Name(), "model", routingCtx.Model)
-		return nil, 0, nil
-	}
 
 	prefillScores := map[string]*Scores{}
 	maxPrefillScore := float64(1)

--- a/pkg/plugins/gateway/algorithms/pd_select_register_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_select_register_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/prefill"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/selector"
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// gatedTransport answers every prefill POST with an empty JSON object (a valid
+// no-op vLLM prefill reply) but only after gate is closed. While the gate is
+// shut every in-flight prefill stays registered in PrefillRequestTracker, so
+// the tracker state observed by later selections is exactly the set of
+// decisions made so far.
+type gatedTransport struct {
+	gate <-chan struct{}
+}
+
+func (tr *gatedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		_ = req.Body.Close()
+	}
+	select {
+	case <-tr.gate:
+	case <-req.Context().Done():
+		return nil, req.Context().Err()
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		Request:    req,
+	}, nil
+}
+
+func burstPod(name, role string, ip string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{PDRoleSetIdentifier: "burst-rs", PDRoleIdentifier: role},
+		},
+		Status: v1.PodStatus{
+			PodIP:      ip,
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+		},
+	}
+}
+
+// TestPDRouter_ConcurrentBurstSeesPriorSelections drives a burst of concurrent
+// Route calls at idle prefill pods with the least_request policy and holds
+// every prefill HTTP call open until the whole burst has been routed.
+//
+// Selection and tracker registration must be one atomic step: the k-th
+// decision has to see the k-1 registrations made before it. When that holds,
+// least_request keeps the per-pod counts within one of each other and a burst
+// divisible by the pod count lands exactly evenly. When selection reads the
+// tracker and registration happens later, without a lock, concurrent decisions
+// read the same stale snapshot and the burst piles unevenly onto whichever
+// pods looked idle at read time.
+func TestPDRouter_ConcurrentBurstSeesPriorSelections(t *testing.T) {
+	const (
+		prefillCount = 4
+		requests     = 256 // divisible by prefillCount
+	)
+
+	prefillPods := make([]*v1.Pod, 0, prefillCount)
+	for i := 0; i < prefillCount; i++ {
+		prefillPods = append(prefillPods, burstPod(fmt.Sprintf("prefill-%d", i), "prefill", fmt.Sprintf("127.0.0.%d", i+1)))
+	}
+	decodePod := burstPod("decode-0", "decode", "127.0.0.100")
+	readyPods := append(append([]*v1.Pod{}, prefillPods...), decodePod)
+
+	gate := make(chan struct{})
+	tracker := pd.NewPrefillRequestTracker()
+	pending := pd.NewPendingDecodeTracker()
+	client := &http.Client{Transport: &gatedTransport{gate: gate}}
+	r := &pdRouter{
+		cache:                 cache.NewForTest(),
+		prefillPolicy:         pd.NewLeastRequestPrefillPolicy(),
+		prefillRequestTracker: tracker,
+		pendingDecodeTracker:  pending,
+		httpClient:            client,
+		prefixUpdateCh:        make(chan prefixUpdateJob, 1024),
+		selectionCounts:       map[string]int64{},
+	}
+	r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
+	r.prefillExecutor = prefill.NewDefaultExecutor(client, tracker, prefillRequestTimeout)
+
+	ctxs := make([]*types.RoutingContext, requests)
+	errs := make([]error, requests)
+	for i := range ctxs {
+		ctx := types.NewRoutingContext(context.Background(), "pd", "burst-model", "hello", fmt.Sprintf("burst-%d", i), "user")
+		ctx.Engine = "vllm"
+		ctx.ReqPath = testChatCompletionsPath
+		ctx.ReqBody = []byte(`{"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+		ctxs[i] = ctx
+	}
+
+	podList := &utils.PodArray{Pods: readyPods}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range ctxs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, errs[i] = r.Route(ctxs[i], podList)
+		}(i)
+	}
+	close(start)
+
+	// Wait until every request has been routed and parked on the gate, i.e.
+	// every prefill registration is in the tracker at once.
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		total := int32(0)
+		for _, cnt := range tracker.GetPrefillRequestCountsForPods(prefillPods) {
+			total += cnt
+		}
+		if total == requests {
+			break
+		}
+		require.True(t, time.Now().Before(deadline), "only %d of %d prefill requests registered before deadline", total, requests)
+		time.Sleep(5 * time.Millisecond)
+	}
+	heldCounts := tracker.GetPrefillRequestCountsForPods(prefillPods)
+	heldPending := pending.GetPendingDecodeCount(decodePod.Name)
+
+	close(gate)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "Route for request %d failed", i)
+	}
+
+	// Decisions as reported to the client must agree with the tracker ledger
+	// observed while the burst was held, and both must be exactly even.
+	selected := map[string]int{}
+	for _, ctx := range ctxs {
+		selected[ctx.RespHeaders[HeaderPrefillTargetPod]]++
+	}
+	want := requests / prefillCount
+	for _, pod := range prefillPods {
+		assert.Equalf(t, want, selected[pod.Name], "%s selections (all: %v)", pod.Name, selected)
+		assert.Equalf(t, int32(want), heldCounts[pod.Name], "%s tracked prefill count while held (all: %v)", pod.Name, heldCounts)
+	}
+	assert.Equal(t, float64(requests), heldPending, "pending decode count while held")
+
+	// Every registration is released once its prefill call returns.
+	for _, cnt := range tracker.GetPrefillRequestCountsForPods(prefillPods) {
+		assert.Equal(t, int32(0), cnt)
+	}
+	assert.Equal(t, float64(0), pending.GetPendingDecodeCount(decodePod.Name))
+}


### PR DESCRIPTION
## Pull Request Description

`filterPrefillDecodePods` reads `PrefillRequestTracker` and `PendingDecodeTracker` to score candidates, but the winning pods were only registered back in `Route` after `Select` returned. Concurrent requests therefore all scored the same pre-burst snapshot: none of them saw the others' picks, and a burst at idle pods piled onto whichever pods looked emptiest at read time. With four idle prefill pods and 256 concurrent requests under `least_request`, one run on `main` landed `59/62/76/59` instead of `64` each.

#2389 / #2394 moved registration to right after the pair is selected, which narrows the window but does not close it. This PR makes "read tracked load → pick → register" one atomic step:

- **`pdRouter.selectMu`.** The load-dependent part of `filterPrefillDecodePods` (combined-pod imbalance check, prefill/decode imbalance fast paths, per-pod scoring, `finalPDScore`) runs under it, and the chosen decode and prefill pods are registered with the trackers before the lock is released. `Route` no longer registers; it still owns the matching removals (`RemovePendingDecode` deferred, `RemovePrefillRequest` on prefill failure / in the executor).
- **`scorePrefillPods` split into `preparePrefillScorer` + `scorePreparedPrefillPods`.** `PrefillScorePolicy.Prepare` (tokenization and prefix matching) depends only on the request, so it runs before the lock is taken; only the tracker-dependent half is serialized. `scorePrefillPods` keeps its signature as the composition of the two, so existing tests and callers are unchanged.
- Combined-pod early returns register the pending decode too, matching what `Route` did for them before.
- `PodSelector.Select` doc now states that a successful `Select` registers its picks; `DefaultSelector` delegates to `filterPrefillDecodePods`, which does so.

Lock scope: `selectMu` is router-scoped, `countersMu` is taken inside it (in `finalPDScore`) and never the other way round, and nothing inside performs I/O (the prefix-index update is a non-blocking channel send; metric reads are in-memory cache lookups).

### Test

`TestPDRouter_ConcurrentBurstSeesPriorSelections` (new, `pd_select_register_test.go`): 256 concurrent `Route` calls at four idle prefill pods with every prefill HTTP call parked on a gate until the whole burst is routed. It asserts that the tracker ledger observed while the burst is held and the `prefill-target-pod` response headers both show exactly 64 per pod, that the pending-decode count is 256, and that every registration is released afterwards.

- On `main` the test fails (`59/62/76/59` in the run above).
- With this PR: `go test -race -count=3 -run TestPDRouter_ConcurrentBurstSeesPriorSelections ./pkg/plugins/gateway/algorithms/` passes.
- `go test -race ./pkg/plugins/gateway/algorithms/... ./pkg/types/...` and `go test ./pkg/plugins/gateway/` pass.

## Related Issues
Resolves: #2677

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>
