### PR TITLE
[Bug] Wire deployment detail and Playground to real data

### DIFF
--- a/apps/console/api/gen/console/v1/console.pb.go
+++ b/apps/console/api/gen/console/v1/console.pb.go
@@ -124,6 +124,7 @@ type Deployment struct {
 	ImplementationKind string                 `protobuf:"bytes,14,opt,name=implementation_kind,json=implementationKind,proto3" json:"implementation_kind,omitempty"` // "kubernetes", "stormservice"
 	ServingName        string                 `protobuf:"bytes,15,opt,name=serving_name,json=servingName,proto3" json:"serving_name,omitempty"`                      // model value used for inference requests
 	CreatedAt          string                 `protobuf:"bytes,16,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`                            // RFC3339 creation timestamp
+	InferenceUrl       string                 `protobuf:"bytes,17,opt,name=inference_url,json=inferenceUrl,proto3" json:"inference_url,omitempty"`                   // OpenAI-compatible chat completions URL for this deployment
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -266,6 +267,13 @@ func (x *Deployment) GetServingName() string {
 func (x *Deployment) GetCreatedAt() string {
 	if x != nil {
 		return x.CreatedAt
+	}
+	return ""
+}
+
+func (x *Deployment) GetInferenceUrl() string {
+	if x != nil {
+		return x.InferenceUrl
 	}
 	return ""
 }
@@ -5770,7 +5778,7 @@ var File_console_v1_console_proto protoreflect.FileDescriptor
 const file_console_v1_console_proto_rawDesc = "" +
 	"\n" +
 	"\x18console/v1/console.proto\x12\n" +
-	"console.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x87\x04\n" +
+	"console.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xac\x04\n" +
 	"\n" +
 	"Deployment\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
@@ -5793,7 +5801,8 @@ const file_console_v1_console_proto_rawDesc = "" +
 	"\x13implementation_kind\x18\x0e \x01(\tR\x12implementationKind\x12!\n" +
 	"\fserving_name\x18\x0f \x01(\tR\vservingName\x12\x1d\n" +
 	"\n" +
-	"created_at\x18\x10 \x01(\tR\tcreatedAt\"0\n" +
+	"created_at\x18\x10 \x01(\tR\tcreatedAt\x12#\n" +
+	"\rinference_url\x18\x11 \x01(\tR\finferenceUrl\"0\n" +
 	"\x16ListDeploymentsRequest\x12\x16\n" +
 	"\x06search\x18\x01 \x01(\tR\x06search\"S\n" +
 	"\x17ListDeploymentsResponse\x128\n" +

--- a/apps/console/api/handler/deployment.go
+++ b/apps/console/api/handler/deployment.go
@@ -35,8 +35,9 @@ const (
 
 type DeploymentHandler struct {
 	pb.UnimplementedDeploymentServiceServer
-	store     store.Store
-	providers *provider.Registry
+	store           store.Store
+	providers       *provider.Registry
+	gatewayEndpoint string
 }
 
 func NewDeploymentHandler(s store.Store, registries ...*provider.Registry) *DeploymentHandler {
@@ -47,12 +48,19 @@ func NewDeploymentHandler(s store.Store, registries ...*provider.Registry) *Depl
 	return &DeploymentHandler{store: s, providers: registry}
 }
 
+// SetGatewayEndpoint records the AIBrix gateway used to call deployments.
+// The chat completions URL is derived from this value and stamped onto
+// Deployment responses; it is not persisted.
+func (h *DeploymentHandler) SetGatewayEndpoint(endpoint string) {
+	h.gatewayEndpoint = strings.TrimRight(strings.TrimSpace(endpoint), "/")
+}
+
 func (h *DeploymentHandler) ListDeployments(ctx context.Context, req *pb.ListDeploymentsRequest) (*pb.ListDeploymentsResponse, error) {
 	deployments, err := h.store.ListDeployments(ctx, req.Search)
 	if err != nil {
 		return nil, err
 	}
-	return &pb.ListDeploymentsResponse{Deployments: deployments}, nil
+	return &pb.ListDeploymentsResponse{Deployments: h.withInferenceMetadata(deployments...)}, nil
 }
 
 func (h *DeploymentHandler) GetDeployment(ctx context.Context, req *pb.GetDeploymentRequest) (*pb.Deployment, error) {
@@ -60,7 +68,11 @@ func (h *DeploymentHandler) GetDeployment(ctx context.Context, req *pb.GetDeploy
 	if err != nil {
 		return nil, err
 	}
-	return h.refreshDeploymentStatus(ctx, deployment)
+	refreshed, err := h.refreshDeploymentStatus(ctx, deployment)
+	if err != nil {
+		return nil, err
+	}
+	return h.withInferenceMetadata(refreshed)[0], nil
 }
 
 func (h *DeploymentHandler) CreateDeployment(ctx context.Context, req *pb.CreateDeploymentRequest) (*pb.Deployment, error) {
@@ -114,12 +126,16 @@ func (h *DeploymentHandler) CreateDeployment(ctx context.Context, req *pb.Create
 			}
 			return nil, err
 		}
-		return saved, nil
+		return h.withInferenceMetadata(saved)[0], nil
 	}
 	if req.GetImplementation() != nil || req.GetOverrides() != nil {
 		return nil, status.Error(codes.InvalidArgument, "template is required when implementation or overrides are set")
 	}
-	return h.store.CreateDeployment(ctx, req)
+	created, err := h.store.CreateDeployment(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return h.withInferenceMetadata(created)[0], nil
 }
 
 func (h *DeploymentHandler) DeleteDeployment(ctx context.Context, req *pb.DeleteDeploymentRequest) (*emptypb.Empty, error) {
@@ -179,4 +195,26 @@ func (h *DeploymentHandler) refreshDeploymentStatus(ctx context.Context, deploym
 		return refreshed, nil
 	}
 	return h.store.UpdateDeploymentStatus(ctx, refreshed)
+}
+
+func inferenceChatCompletionsURL(endpoint string) string {
+	endpoint = strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if endpoint == "" {
+		return ""
+	}
+	return endpoint + "/v1/chat/completions"
+}
+
+func (h *DeploymentHandler) withInferenceMetadata(deployments ...*pb.Deployment) []*pb.Deployment {
+	url := ""
+	if h != nil {
+		url = inferenceChatCompletionsURL(h.gatewayEndpoint)
+	}
+	for _, deployment := range deployments {
+		if deployment == nil || url == "" || deployment.GetServingName() == "" {
+			continue
+		}
+		deployment.InferenceUrl = url
+	}
+	return deployments
 }

--- a/apps/console/api/handler/deployment_playground_flow_test.go
+++ b/apps/console/api/handler/deployment_playground_flow_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2025 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vllm-project/aibrix/apps/console/api/deployment/provider"
+	deploymentstatus "github.com/vllm-project/aibrix/apps/console/api/deployment/status"
+	pb "github.com/vllm-project/aibrix/apps/console/api/gen/console/v1"
+	"github.com/vllm-project/aibrix/apps/console/api/store"
+)
+
+func TestCreateDeploymentDetailThenPlaygroundChat(t *testing.T) {
+	var forwardedModel string
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("gateway path = %s", r.URL.Path)
+		}
+		var body chatCompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode gateway request: %v", err)
+			http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		forwardedModel = body.Model
+		if !body.Stream {
+			t.Error("playground proxy did not force streaming")
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"Hello from mock\"}}]}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(gateway.Close)
+
+	ctx := deploymentContext("owner@example.com")
+	s := store.NewMemoryStore(nil)
+	t.Cleanup(func() { _ = s.Close() })
+
+	model, err := s.CreateModel(ctx, &pb.Model{Id: "model-1", Name: "Mock Model", ServingName: "/models/mock"})
+	if err != nil {
+		t.Fatalf("CreateModel() error = %v", err)
+	}
+	template, err := s.CreateModelDeploymentTemplate(ctx, &pb.CreateModelDeploymentTemplateRequest{
+		Name:    "template-1",
+		Version: "v1.0.0",
+		Status:  "active",
+		ModelId: model.GetId(),
+		Spec: &pb.ModelDeploymentTemplateSpec{
+			Engine:      &pb.EngineSpec{Type: "vllm", Image: "example/vllm:latest"},
+			ModelSource: &pb.ModelSourceSpec{Uri: "org/model"},
+			Accelerator: &pb.AcceleratorSpec{Type: "CPU", Count: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateModelDeploymentTemplate() error = %v", err)
+	}
+
+	implementation := &fakeDeploymentProvider{}
+	deployments := NewDeploymentHandler(s, provider.NewRegistry(implementation))
+	deployments.SetGatewayEndpoint(gateway.URL)
+
+	created, err := deployments.CreateDeployment(ctx, &pb.CreateDeploymentRequest{
+		Name: "mock-deployment",
+		Template: &pb.DeploymentTemplateRef{
+			ModelId:    model.GetId(),
+			TemplateId: template.GetId(),
+		},
+		Implementation: &pb.DeploymentImplementationRef{Kind: implementation.Kind()},
+	})
+	if err != nil {
+		t.Fatalf("CreateDeployment() error = %v", err)
+	}
+	if created.GetStatus() != deploymentstatus.StatusDeploying {
+		t.Fatalf("created status = %q", created.GetStatus())
+	}
+
+	detail, err := deployments.GetDeployment(ctx, &pb.GetDeploymentRequest{Id: created.GetId()})
+	if err != nil {
+		t.Fatalf("GetDeployment() error = %v", err)
+	}
+	if detail.GetStatus() != deploymentstatus.StatusReady {
+		t.Fatalf("detail status = %q, want Ready", detail.GetStatus())
+	}
+	if detail.GetServingName() != model.GetServingName() {
+		t.Fatalf("serving_name = %q", detail.GetServingName())
+	}
+	if detail.GetDeploymentId() == "" {
+		t.Fatal("runtime resource name is empty")
+	}
+	if detail.GetInferenceUrl() != gateway.URL+"/v1/chat/completions" {
+		t.Fatalf("inference_url = %q", detail.GetInferenceUrl())
+	}
+	if _, err := time.Parse(time.RFC3339, detail.GetCreatedAt()); err != nil {
+		t.Fatalf("created_at = %q: %v", detail.GetCreatedAt(), err)
+	}
+
+	playground := NewPlaygroundHandler(gateway.URL)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/playground/chat/completions",
+		strings.NewReader(`{"model":"`+detail.GetServingName()+`","messages":[{"role":"user","content":"Hi"}]}`),
+	)
+	playground.HandleChatCompletion(recorder, request, nil)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("playground status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "Hello from mock") {
+		t.Fatalf("playground body = %q, want streamed completion", recorder.Body.String())
+	}
+	if forwardedModel != detail.GetServingName() {
+		t.Fatalf("forwarded model = %q, want %q", forwardedModel, detail.GetServingName())
+	}
+}

--- a/apps/console/api/handler/deployment_test.go
+++ b/apps/console/api/handler/deployment_test.go
@@ -84,7 +84,7 @@ func deploymentContext(email string) context.Context {
 
 func TestDeploymentProtoExposesDetailMetadata(t *testing.T) {
 	fields := (&pb.Deployment{}).ProtoReflect().Descriptor().Fields()
-	for _, name := range []string{"serving_name", "created_at"} {
+	for _, name := range []string{"serving_name", "created_at", "inference_url"} {
 		if fields.ByName(protoreflect.Name(name)) == nil {
 			t.Errorf("Deployment proto is missing %s", name)
 		}
@@ -117,6 +117,7 @@ func TestDeploymentHandlerTemplateLifecycle(t *testing.T) {
 
 	implementation := &fakeDeploymentProvider{}
 	handler := NewDeploymentHandler(s, provider.NewRegistry(implementation))
+	handler.SetGatewayEndpoint("http://gateway.example/")
 	created, err := handler.CreateDeployment(ctx, &pb.CreateDeploymentRequest{
 		Name: "test-deployment",
 		Template: &pb.DeploymentTemplateRef{
@@ -136,6 +137,12 @@ func TestDeploymentHandlerTemplateLifecycle(t *testing.T) {
 	}
 	if created.GetServingName() != model.GetServingName() {
 		t.Fatalf("serving_name = %q, want %q", created.GetServingName(), model.GetServingName())
+	}
+	if created.GetInferenceUrl() != "http://gateway.example/v1/chat/completions" {
+		t.Fatalf("inference_url = %q", created.GetInferenceUrl())
+	}
+	if created.GetDeploymentId() == "" {
+		t.Fatalf("deployment_id is empty")
 	}
 	if _, err := time.Parse(time.RFC3339, created.GetCreatedAt()); err != nil {
 		t.Fatalf("created_at = %q, want RFC3339 timestamp: %v", created.GetCreatedAt(), err)

--- a/apps/console/api/proto/console/v1/console.proto
+++ b/apps/console/api/proto/console/v1/console.proto
@@ -70,6 +70,7 @@ message Deployment {
   string implementation_kind = 14; // "kubernetes", "stormservice"
   string serving_name = 15; // model value used for inference requests
   string created_at = 16; // RFC3339 creation timestamp
+  string inference_url = 17; // OpenAI-compatible chat completions URL for this deployment
 }
 
 message ListDeploymentsRequest {

--- a/apps/console/api/server/server.go
+++ b/apps/console/api/server/server.go
@@ -169,7 +169,9 @@ func (s *Server) StartGRPC(addr string) error {
 	)
 
 	// Register all service handlers
-	pb.RegisterDeploymentServiceServer(s.grpcServer, handler.NewDeploymentHandler(s.store, deploymentProviders))
+	deploymentHandler := handler.NewDeploymentHandler(s.store, deploymentProviders)
+	deploymentHandler.SetGatewayEndpoint(s.cfg.GatewayEndpoint)
+	pb.RegisterDeploymentServiceServer(s.grpcServer, deploymentHandler)
 	pb.RegisterJobServiceServer(s.grpcServer, handler.NewJobHandler(s.store, s.planner, s.cfg.DefaultBatchModelDeploymentTemplate, s.cfg.DevMode, s.injector))
 	pb.RegisterModelServiceServer(s.grpcServer, handler.NewModelHandler(s.store))
 	pb.RegisterModelDeploymentTemplateServiceServer(s.grpcServer, handler.NewModelDeploymentTemplateHandler(s.store))

--- a/apps/console/web/src/App.tsx
+++ b/apps/console/web/src/App.tsx
@@ -31,6 +31,7 @@ import { ApiKeysPage } from './components/settings/ApiKeysPage';
 import { SecretsPage } from './components/settings/SecretsPage';
 import { Toast } from './components/settings/Toast';
 import { features } from './config/features';
+import { playgroundHref } from './utils/deploymentDetail';
 
 // ── Route adapters: each one reads useParams/useNavigate and forwards to the
 // existing component. Keeps the leaf components unchanged.
@@ -149,7 +150,7 @@ function DeploymentDetailRoute() {
     <DeploymentDetail
       deploymentId={deploymentId ?? null}
       onBack={() => navigate('/deployments')}
-      onOpenPlayground={(deployment) => navigate(`/playground?deployment=${encodeURIComponent(deployment.id)}`)}
+      onOpenPlayground={(deployment) => navigate(playgroundHref(deployment))}
     />
   );
 }

--- a/apps/console/web/src/components/DeploymentDetail.tsx
+++ b/apps/console/web/src/components/DeploymentDetail.tsx
@@ -6,6 +6,7 @@ import { copyToClipboard } from '../utils/clipboard';
 import {
   canOpenInPlayground,
   deploymentCodeExample,
+  deploymentExamplesAvailable,
   formatDeploymentCreatedAt,
   type DeploymentExampleLanguage,
 } from '../utils/deploymentDetail';
@@ -27,6 +28,7 @@ export function DeploymentDetail({
   const [error, setError] = useState<string | null>(null);
   const [selectedLanguage, setSelectedLanguage] = useState<DeploymentExampleLanguage>('python');
   const [copied, setCopied] = useState<string | null>(null);
+  const [showMore, setShowMore] = useState(false);
 
   useEffect(() => {
     if (!deploymentId) {
@@ -85,7 +87,8 @@ export function DeploymentDetail({
 
   const deploymentStatus = normalizeDeploymentStatus(deployment.status);
   const playgroundReady = canOpenInPlayground(deployment);
-  const code = deploymentCodeExample(deployment, selectedLanguage);
+  const examplesAvailable = deploymentExamplesAvailable(deployment);
+  const code = examplesAvailable ? deploymentCodeExample(deployment, selectedLanguage) : '';
 
   return (
     <div className="p-8">
@@ -141,38 +144,90 @@ export function DeploymentDetail({
               Send an OpenAI-compatible chat completion request to the shared AIBrix Gateway.
             </p>
 
-            <div className="flex items-center gap-2 mb-4">
-              {(['python', 'shell'] as const).map((language) => (
-                <button
-                  key={language}
-                  onClick={() => setSelectedLanguage(language)}
-                  className={`px-3 py-1.5 text-sm rounded-lg capitalize transition-colors ${
-                    selectedLanguage === language
-                      ? 'bg-slate-800 text-white'
-                      : 'text-gray-500 hover:bg-gray-100'
-                  }`}
-                >
-                  {language}
-                </button>
-              ))}
+            <div className="mb-4 rounded-xl border border-gray-100 bg-gray-50 p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-xs text-gray-500 mb-1">Inference URL</div>
+                  <code className="text-sm text-gray-900 break-all">
+                    {deployment.inferenceUrl || 'Not available'}
+                  </code>
+                </div>
+                {deployment.inferenceUrl && (
+                  <button
+                    onClick={() => copy(deployment.inferenceUrl || '', 'inference-url')}
+                    className="text-gray-400 hover:text-gray-700 flex-shrink-0"
+                    title="Copy inference URL"
+                    aria-label="Copy inference URL"
+                  >
+                    <Copy className="w-4 h-4" />
+                  </button>
+                )}
+              </div>
+              {copied === 'inference-url' && <div className="text-xs text-teal-600 mt-2">Copied</div>}
             </div>
 
-            <div className="relative bg-slate-900 rounded-xl p-4">
-              <button
-                onClick={() => copy(code, 'example')}
-                className="absolute top-4 right-4 text-gray-400 hover:text-white"
-                title="Copy example"
-                aria-label="Copy API example"
-              >
-                <Copy className="w-4 h-4" />
-              </button>
-              {copied === 'example' && (
-                <span className="absolute top-4 right-10 text-xs text-teal-300">Copied</span>
+            <div className="flex items-center justify-between gap-3 mb-4">
+              {examplesAvailable ? (
+                <div className="flex items-center gap-2">
+                  {(['python', 'shell'] as const).map((language) => (
+                    <button
+                      key={language}
+                      onClick={() => setSelectedLanguage(language)}
+                      className={`px-3 py-1.5 text-sm rounded-lg capitalize transition-colors ${
+                        selectedLanguage === language
+                          ? 'bg-slate-800 text-white'
+                          : 'text-gray-500 hover:bg-gray-100'
+                      }`}
+                    >
+                      {language}
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500">
+                  Code examples stay hidden until this deployment has a serving name and inference URL.
+                </p>
               )}
-              <pre className="text-sm text-gray-300 overflow-x-auto pr-10">
-                <code>{code}</code>
-              </pre>
+              <button
+                onClick={() => setShowMore((open) => !open)}
+                className="px-3 py-1.5 text-sm text-teal-700 hover:bg-teal-50 rounded-lg"
+                aria-expanded={showMore}
+              >
+                {showMore ? 'View Less' : 'View More'}
+              </button>
             </div>
+
+            {showMore && (
+              <dl className="mb-4 rounded-xl border border-gray-100 p-4 space-y-3 text-sm">
+                <Detail label="Serving name">
+                  <code className="break-all">{deployment.servingName || 'Not available'}</code>
+                </Detail>
+                <Detail label="Runtime resource">
+                  <code className="break-all">{deployment.deploymentId || 'Not available'}</code>
+                </Detail>
+                <Detail label="Base model">{deployment.baseModel || 'Not available'}</Detail>
+                <Detail label="Created at">{formatDeploymentCreatedAt(deployment.createdAt)}</Detail>
+              </dl>
+            )}
+
+            {examplesAvailable && (
+              <div className="relative bg-slate-900 rounded-xl p-4">
+                <button
+                  onClick={() => copy(code, 'example')}
+                  className="absolute top-4 right-4 text-gray-400 hover:text-white"
+                  title="Copy example"
+                  aria-label="Copy API example"
+                >
+                  <Copy className="w-4 h-4" />
+                </button>
+                {copied === 'example' && (
+                  <span className="absolute top-4 right-10 text-xs text-teal-300">Copied</span>
+                )}
+                <pre className="text-sm text-gray-300 overflow-x-auto pr-10">
+                  <code>{code}</code>
+                </pre>
+              </div>
+            )}
           </div>
 
           <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
@@ -199,6 +254,9 @@ export function DeploymentDetail({
               <Detail label="Base model">{deployment.baseModel || 'Not available'}</Detail>
               <Detail label="Serving name">
                 <code className="break-all">{deployment.servingName || 'Not available'}</code>
+              </Detail>
+              <Detail label="Inference URL">
+                <code className="break-all">{deployment.inferenceUrl || 'Not available'}</code>
               </Detail>
               <Detail label="Created by">{deployment.createdBy || 'Not available'}</Detail>
               <Detail label="Created at">{formatDeploymentCreatedAt(deployment.createdAt)}</Detail>

--- a/apps/console/web/src/data/mockData.ts
+++ b/apps/console/web/src/data/mockData.ts
@@ -209,6 +209,7 @@ export interface Deployment {
   implementationKind?: string;
   servingName: string;
   createdAt: string;
+  inferenceUrl?: string;
 }
 
 export type ModelCategory = 'LLM' | 'Audio' | 'Image' | 'Video' | 'Vision' | 'Embedding' | 'Reranks';

--- a/apps/console/web/src/utils/deploymentDetail.test.ts
+++ b/apps/console/web/src/utils/deploymentDetail.test.ts
@@ -3,7 +3,9 @@ import type { Deployment } from '../data/mockData';
 import {
   canOpenInPlayground,
   deploymentCodeExample,
+  deploymentExamplesAvailable,
   formatDeploymentCreatedAt,
+  playgroundHref,
 } from './deploymentDetail';
 
 const deployment: Deployment = {
@@ -14,6 +16,7 @@ const deployment: Deployment = {
   baseModelId: 'model-1',
   servingName: '/models/mock',
   createdAt: '2026-07-26T08:30:00Z',
+  inferenceUrl: 'http://gateway.example/v1/chat/completions',
   replicas: '1',
   gpusPerReplica: 0,
   gpuType: 'CPU',
@@ -29,11 +32,19 @@ describe('deployment detail helpers', () => {
     expect(canOpenInPlayground({ ...deployment, servingName: '' })).toBe(false);
   });
 
-  it('builds examples from the real serving name and shared gateway endpoint', () => {
+  it('builds examples from the real serving name and inference URL', () => {
     const shell = deploymentCodeExample(deployment, 'shell');
-    expect(shell).toContain('$AIBRIX_GATEWAY_URL/v1/chat/completions');
+    expect(shell).toContain('http://gateway.example/v1/chat/completions');
     expect(shell).toContain('"model": "/models/mock"');
     expect(shell).not.toContain('seedjeffwan');
+    expect(shell).not.toContain('api.aibrix.ai');
+    expect(deploymentExamplesAvailable(deployment)).toBe(true);
+    expect(deploymentExamplesAvailable({ ...deployment, inferenceUrl: '' })).toBe(false);
+  });
+
+  it('carries the selected deployment to the Playground route', () => {
+    expect(playgroundHref(deployment)).toBe('/playground?deployment=deployment-1');
+    expect(playgroundHref({ ...deployment, id: '', servingName: '/models/mock' })).toBe('/playground?deployment=%2Fmodels%2Fmock');
   });
 
   it('formats the API timestamp without inventing a date', () => {

--- a/apps/console/web/src/utils/deploymentDetail.ts
+++ b/apps/console/web/src/utils/deploymentDetail.ts
@@ -3,8 +3,21 @@ import { normalizeDeploymentStatus } from './deploymentStatus';
 
 export type DeploymentExampleLanguage = 'python' | 'shell';
 
+function trimmed(value?: string): string {
+  return value?.trim() ?? '';
+}
+
 export function canOpenInPlayground(deployment: Deployment): boolean {
-  return normalizeDeploymentStatus(deployment.status) === 'Ready' && deployment.servingName.trim() !== '';
+  return normalizeDeploymentStatus(deployment.status) === 'Ready' && trimmed(deployment.servingName) !== '';
+}
+
+export function deploymentExamplesAvailable(deployment: Deployment): boolean {
+  return trimmed(deployment.servingName) !== '' && trimmed(deployment.inferenceUrl) !== '';
+}
+
+export function playgroundHref(deployment: Pick<Deployment, 'id' | 'servingName'>): string {
+  const selected = trimmed(deployment.id) || trimmed(deployment.servingName);
+  return `/playground?deployment=${encodeURIComponent(selected)}`;
 }
 
 export function formatDeploymentCreatedAt(createdAt: string): string {
@@ -22,9 +35,12 @@ export function deploymentCodeExample(
   deployment: Deployment,
   language: DeploymentExampleLanguage,
 ): string {
-  const servingName = deployment.servingName || '<serving-name>';
+  const servingName = trimmed(deployment.servingName) || '<serving-name>';
+  const url = trimmed(deployment.inferenceUrl);
   if (language === 'shell') {
-    return `curl "$AIBRIX_GATEWAY_URL/v1/chat/completions" \\
+    const target = url || '"$AIBRIX_GATEWAY_URL/v1/chat/completions"';
+    const quotedTarget = url ? `"${url}"` : target;
+    return `curl ${quotedTarget} \\
   -H "Content-Type: application/json" \\
   -d '{
     "model": "${servingName}",
@@ -32,11 +48,15 @@ export function deploymentCodeExample(
   }'`;
   }
 
-  return `import os
-import requests
+  const pythonUrl = url
+    ? `"${url}"`
+    : `f"{os.environ['AIBRIX_GATEWAY_URL']}/v1/chat/completions"`;
+  const imports = url ? 'import requests' : `import os
+import requests`;
+  return `${imports}
 
 response = requests.post(
-    f"{os.environ['AIBRIX_GATEWAY_URL']}/v1/chat/completions",
+    ${pythonUrl},
     json={
         "model": "${servingName}",
         "messages": [{"role": "user", "content": "Hello!"}],

--- a/apps/console/web/src/utils/playground.test.ts
+++ b/apps/console/web/src/utils/playground.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Deployment } from '../data/mockData';
-import { callableDeployments, streamPlaygroundChat } from './playground';
+import { callableDeployments, preferredDeployment, streamPlaygroundChat } from './playground';
 
 function deployment(overrides: Partial<Deployment>): Deployment {
   return {
@@ -23,11 +23,15 @@ function deployment(overrides: Partial<Deployment>): Deployment {
 
 describe('Playground helpers', () => {
   it('lists only ready deployments with a serving name', () => {
-    expect(callableDeployments([
+    const items = [
       deployment({ id: 'ready' }),
       deployment({ id: 'starting', status: 'Deploying' }),
       deployment({ id: 'unnamed', servingName: '' }),
-    ]).map((item) => item.id)).toEqual(['ready']);
+    ];
+    const callable = callableDeployments(items);
+    expect(callable.map((item) => item.id)).toEqual(['ready']);
+    expect(preferredDeployment(callable, 'ready')?.id).toBe('ready');
+    expect(preferredDeployment(callable, '/models/mock')?.id).toBe('ready');
   });
 
   it('streams fragmented OpenAI chat completion events', async () => {

--- a/apps/console/web/src/utils/playground.ts
+++ b/apps/console/web/src/utils/playground.ts
@@ -20,10 +20,14 @@ export interface PlaygroundChatRequest {
 
 type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
+function servingNameOf(deployment: Deployment): string {
+  return deployment.servingName?.trim() ?? '';
+}
+
 export function callableDeployments(deployments: Deployment[]): Deployment[] {
   return deployments.filter(
     (deployment) => normalizeDeploymentStatus(deployment.status) === 'Ready'
-      && deployment.servingName.trim() !== '',
+      && servingNameOf(deployment) !== '',
   );
 }
 
@@ -34,7 +38,7 @@ export function preferredDeployment(
   if (!requestedDeployment) return deployments[0] ?? null;
   return deployments.find(
     (deployment) => deployment.id === requestedDeployment
-      || deployment.servingName === requestedDeployment,
+      || servingNameOf(deployment) === requestedDeployment,
   ) ?? deployments[0] ?? null;
 }
 


### PR DESCRIPTION
## Pull Request Description

Wire deployment detail to real data.

The deployment detail page now uses the Deployment record for the serving model name, creation time, runtime resource name, and gateway inference URL. Copy, View More, and Open in Playground act on that data. Playground lists callable deployments and sends chat completions through POST /api/v1/playground/chat/completions.

I reused the model labels already written by pull 2501 and did not reopen Gateway discovery work. Unsupported code examples stay hidden until a serving name and inference URL are present.

## Related Issues
Fixes #2495

## How to verify
- Run the console handler tests for deployment and playground.
- Run the console web unit tests.
- The flow test covers create deployment, then the detail record, then a streamed chat completion through the playground proxy.
- Manually create a deployment, open its detail page, copy the inference URL, use View More, then open Playground and send a message.

- [x] PR title includes appropriate prefix
- [x] Changes are clearly explained
- [x] New and existing tests pass
- [x] Code follows project style
