### PR TITLE
[Gateway] Add token_load prefill score policy to the PD router

### DIFF
--- a/development/app/config/mock/vllm-pd-config.yaml
+++ b/development/app/config/mock/vllm-pd-config.yaml
@@ -6,6 +6,11 @@
 # and routes the prefill probe to the prefill pod before sending the full request
 # to the decode pod.
 #
+# Pods only inherit the role template metadata, so the model.aibrix.ai/config
+# profiles used by config-profile e2e tests are declared on each role:
+#   - "pd" (default): PD routing with the gateway's default prefill score policy
+#   - "token-load":   PD routing with prefillScorePolicy token_load
+#
 # Apply alongside components.yaml (provides mocked-app-sa and RBAC).
 apiVersion: orchestration.aibrix.ai/v1alpha1
 kind: StormService
@@ -49,6 +54,22 @@ spec:
                 model.aibrix.ai/port: "8000"
                 model.aibrix.ai/engine: vllm
                 adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd"
+                      },
+                      "token-load": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "prefillScorePolicy": "token_load"
+                        }
+                      }
+                    }
+                  }
             spec:
               serviceAccountName: mocked-app-sa
               containers:
@@ -83,6 +104,22 @@ spec:
                 model.aibrix.ai/port: "8000"
                 model.aibrix.ai/engine: vllm
                 adapter.model.aibrix.ai/enabled: "true"
+              annotations:
+                model.aibrix.ai/config: |
+                  {
+                    "defaultProfile": "pd",
+                    "profiles": {
+                      "pd": {
+                        "routingStrategy": "pd"
+                      },
+                      "token-load": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "prefillScorePolicy": "token_load"
+                        }
+                      }
+                    }
+                  }
             spec:
               serviceAccountName: mocked-app-sa
               containers:

--- a/docs/source/features/pd-disaggregation.rst
+++ b/docs/source/features/pd-disaggregation.rst
@@ -288,7 +288,7 @@ Configure the range in the pod's ``routingConfig``:
    * - ``combined``
      - ``true`` = this pod is a standard inference pod (runs both prefill and decode). Default: ``false``.
    * - ``prefillScorePolicy``
-     - How to score prefill pods. ``prefix_cache`` (default), ``least_request``, or ``conductor``.
+     - How to score prefill pods. ``prefix_cache`` (default), ``least_request``, ``conductor``, or ``token_load``.
    * - ``decodeScorePolicy``
      - How to score decode pods. ``load_balancing`` (default), ``least_request``, or ``conductor``.
 
@@ -344,6 +344,85 @@ Or set gateway-wide via ``AIBRIX_PREFILL_SCORE_POLICY`` and ``AIBRIX_DECODE_SCOR
 - You want routing based on predicted latency rather than just request count
 - Your workload has variable prompt lengths and mixed cache-hit patterns
 - You need to account for GPU memory pressure in decode routing
+
+
+.. _pd-token-load-policy:
+
+Token Load Scoring Policy
+-------------------------
+
+The ``token_load`` prefill scoring policy spreads prefill work by prompt size instead of by request count. ``least_request`` treats a 100-token prompt and a 30,000-token prompt as the same unit of load, so a pod that drew a few long prompts keeps receiving new requests until its count catches up with its neighbours. Under a mix of short and long prompts this shows up as a long TTFT tail on the pods that hold the long prompts. ``token_load`` charges each request by its estimated prompt tokens, so one long prompt counts as much as many short ones.
+
+**Scoring**
+
+The router keeps two per-pod counters and scores each prefill pod as (lower is better):
+
+.. code-block:: text
+
+    score = active_tokens + kv_weight × kv_tokens
+
+- ``active_tokens`` — prompt tokens of the prefill requests the pod is computing right now.
+- ``kv_tokens`` — prompt tokens whose KV cache is still resident on the pod because the decode pod has not finished with the request yet. Weighted by ``kv_weight`` (``AIBRIX_TOKEN_LOAD_KV_WEIGHT``, default ``0.3``) since resident KV costs the pod less than active compute.
+
+Each request is charged ``request_cost + prompt_tokens``, where ``request_cost`` (``AIBRIX_TOKEN_LOAD_REQUEST_COST``, default ``3500``) models the fixed scheduling and KV-transfer work that does not scale with prompt length, and ``prompt_tokens`` is estimated as one token per four bytes of request body. The prefix cache is not consulted.
+
+**Charge lifecycle**
+
+1. The request is charged to the selected prefill pod in the same critical section as the selection itself, so concurrent selections see each other's charges.
+2. When the prefill HTTP call returns, the ``active_tokens`` part is released; ``kv_tokens`` stays.
+3. When the request completes (or the prefill call fails), the ``kv_tokens`` part is released too.
+
+A charge whose release never arrives is force-released after ``AIBRIX_TOKEN_LOAD_TTL_SECONDS`` (default ``3600``) with a warning log, so a leaked entry cannot pin load on a pod indefinitely. Releases are idempotent and the counters never go below zero.
+
+**Metrics**
+
+The gateway exports the two counters per prefill pod as gauges labelled by ``pod_name``:
+
+- ``pd_token_load_active_tokens``
+- ``pd_token_load_kv_tokens``
+
+**Configuration**
+
+Enable ``token_load`` via the routing config:
+
+.. code-block:: yaml
+
+    annotations:
+      model.aibrix.ai/config: |
+        {
+          "profiles": {
+            "default": {
+              "routingStrategy": "pd",
+              "routingConfig": {
+                "prefillScorePolicy": "token_load"
+              }
+            }
+          }
+        }
+
+Or set gateway-wide via ``AIBRIX_PREFILL_SCORE_POLICY=token_load``. The tunables are gateway-wide environment variables:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 36 12 52
+
+   * - Variable
+     - Default
+     - Description
+   * - ``AIBRIX_TOKEN_LOAD_KV_WEIGHT``
+     - ``0.3``
+     - Weight of resident KV tokens in the score.
+   * - ``AIBRIX_TOKEN_LOAD_REQUEST_COST``
+     - ``3500``
+     - Fixed per-request cost added to every charge, in tokens.
+   * - ``AIBRIX_TOKEN_LOAD_TTL_SECONDS``
+     - ``3600``
+     - Maximum age of an outstanding charge before it is force-released.
+
+**When to use token_load:**
+
+- Your prompt lengths vary widely (for example agentic or RAG traffic mixed with short chat) and you see a TTFT tail on some prefill pods under ``least_request``
+- Prefix-cache locality matters less than balancing prefill compute, or your prefix cache hit rate is low
 
 
 Complete Example
@@ -463,6 +542,7 @@ Each prefill pod is scored by the selected policy. Pods with a request count mor
 
 - ``prefix_cache`` (default): ``score = (100 − prefix_match_percent) × 0.1 + req_count / max_req_count`` — lower score means more cache hits and less load.
 - ``least_request``: ``score = req_count``.
+- ``token_load``: ``score = active_tokens + kv_weight × kv_tokens`` — the token-weighted load the router has charged to the pod; see :ref:`Token Load Scoring Policy <pd-token-load-policy>`.
 
 **Step 4 — Decode scoring**
 
@@ -502,7 +582,16 @@ These are set on the **gateway plugin** deployment.
      - Seconds before a prefill request to a prefill pod times out.
    * - ``AIBRIX_PREFILL_SCORE_POLICY``
      - ``prefix_cache``
-     - Default scoring policy for selecting prefill pods. ``prefix_cache``, ``least_request``, or ``conductor``.
+     - Default scoring policy for selecting prefill pods. ``prefix_cache``, ``least_request``, ``conductor``, or ``token_load``.
+   * - ``AIBRIX_TOKEN_LOAD_KV_WEIGHT``
+     - ``0.3``
+     - ``token_load`` only. Weight of resident KV tokens in the prefill score. Must be positive.
+   * - ``AIBRIX_TOKEN_LOAD_REQUEST_COST``
+     - ``3500``
+     - ``token_load`` only. Fixed per-request cost, in tokens, added to every prefill charge. Must be positive.
+   * - ``AIBRIX_TOKEN_LOAD_TTL_SECONDS``
+     - ``3600``
+     - ``token_load`` only. Charges older than this are force-released and logged; must exceed the longest legitimate request. Must be positive.
    * - ``AIBRIX_DECODE_SCORE_POLICY``
      - ``load_balancing``
      - Default scoring policy for selecting decode pods. ``load_balancing``, ``least_request``, or ``conductor``.

--- a/docs/source/features/pd-disaggregation.rst
+++ b/docs/source/features/pd-disaggregation.rst
@@ -372,7 +372,7 @@ Each request is charged ``request_cost + prompt_tokens``, where ``request_cost``
 2. When the prefill HTTP call returns, the ``active_tokens`` part is released; ``kv_tokens`` stays.
 3. When the request completes (or the prefill call fails), the ``kv_tokens`` part is released too.
 
-A charge whose release never arrives is force-released after ``AIBRIX_TOKEN_LOAD_TTL_SECONDS`` (default ``3600``) with a warning log, so a leaked entry cannot pin load on a pod indefinitely. Releases are idempotent and the counters never go below zero.
+A charge whose release never arrives is force-released after ``AIBRIX_TOKEN_LOAD_TTL_SECONDS`` (default ``3600``) with a warning log, so a leaked entry cannot pin load on a pod indefinitely. Releases are idempotent and the counters never go below zero. The same janitor, which runs once a minute, drops the counters and metric series of any pod that has been at zero load and untouched for a whole minute, so prefill pods that come and go under autoscaling or rollouts do not accumulate on the gateway; the next charge re-creates the pod from zero.
 
 **Metrics**
 

--- a/pkg/metrics/custom_metrics.go
+++ b/pkg/metrics/custom_metrics.go
@@ -101,6 +101,27 @@ func DecGaugeMetric(name string, help string, labelNames []string, labelValues .
 	DecGaugeMetricFnForTest(name, help, labelNames, labelValues...)
 }
 
+// DeleteGaugeMetric removes one label combination of a custom gauge so the
+// series is no longer exported. No-op when the gauge or the series does not
+// exist, or when labelNames and labelValues differ in length.
+func DeleteGaugeMetric(name string, labelNames []string, labelValues ...string) {
+	if len(labelNames) != len(labelValues) {
+		return
+	}
+	customGaugesMu.RLock()
+	gauge, ok := customGauges[name]
+	canonicalNames := customGaugeLabelNames[name]
+	customGaugesMu.RUnlock()
+	if !ok || gauge == nil {
+		return
+	}
+	if len(canonicalNames) == 0 {
+		_ = gauge.DeleteLabelValues(labelValues...)
+		return
+	}
+	_ = gauge.DeleteLabelValues(orderedGaugeLabelValues(canonicalNames, labelNames, labelValues)...)
+}
+
 func DeleteGaugeMetricForPod(metricName string, routingCtx *types.RoutingContext, pod *v1.Pod, extras map[string]string) {
 	customGaugesMu.RLock()
 	gauge, ok := customGauges[metricName]

--- a/pkg/metrics/custom_metrics_test.go
+++ b/pkg/metrics/custom_metrics_test.go
@@ -80,6 +80,34 @@ func TestSetupMetricsForTest(t *testing.T) {
 	assert.Equal(t, testValue, value, "Metric value should not change after cleanup")
 }
 
+func TestDeleteGaugeMetric(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	const name = "test_delete_gauge_metric"
+
+	// Deleting before the gauge exists is a no-op.
+	DeleteGaugeMetric(name, []string{testLabelName, testLabelName2}, testLabelValue, testLabelValue2)
+
+	defaultSetGaugeMetric(name, testMetricHelp, 1, []string{testLabelName, testLabelName2}, "a", "b")
+	defaultSetGaugeMetric(name, testMetricHelp, 2, []string{testLabelName, testLabelName2}, "c", "d")
+	customGaugesMu.RLock()
+	gauge := customGauges[name]
+	customGaugesMu.RUnlock()
+	assert.Equal(t, 2, testutil.CollectAndCount(gauge))
+
+	// Label order need not match the registration order.
+	DeleteGaugeMetric(name, []string{testLabelName2, testLabelName}, "b", "a")
+	assert.Equal(t, 1, testutil.CollectAndCount(gauge))
+	assert.Equal(t, 2.0, testutil.ToFloat64(gauge.WithLabelValues("c", "d")))
+
+	// Mismatched or unknown labels do nothing.
+	DeleteGaugeMetric(name, []string{testLabelName}, "c", "d")
+	DeleteGaugeMetric(name, []string{testLabelName, testLabelName2}, "x", "y")
+	assert.Equal(t, 1, testutil.CollectAndCount(gauge))
+
+	DeleteGaugeMetric(name, []string{testLabelName, testLabelName2}, "c", "d")
+	assert.Equal(t, 0, testutil.CollectAndCount(gauge))
+}
+
 func TestMetricRegistrationOnlyOnce(t *testing.T) {
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	customGauges = make(map[string]*prometheus.GaugeVec)

--- a/pkg/metrics/gateway_metrics.go
+++ b/pkg/metrics/gateway_metrics.go
@@ -48,6 +48,11 @@ const (
 	PDSelectedPrefillPodTotal = "pd_selected_prefill_pod_total"
 	PDSelectedDecodePodTotal  = "pd_selected_decode_pod_total"
 
+	// gauges to track the token-weighted prefill load the pd router has
+	// charged to each prefill pod (token_load prefill score policy)
+	PDTokenLoadActiveTokens = "pd_token_load_active_tokens"
+	PDTokenLoadKVTokens     = "pd_token_load_kv_tokens"
+
 	// Duration bucket counters for timing breakdowns
 	GatewayRoutingTimeBucketTotal    = "gateway_routing_time_bucket_total"
 	GatewayPrefillTimeBucketTotal    = "gateway_prefill_time_bucket_total"
@@ -110,6 +115,22 @@ var (
 				Raw: Gauge,
 			},
 			Description: "Total number of outstanding prefill requests received by the gateway",
+		},
+		PDTokenLoadActiveTokens: {
+			MetricScope:  PodMetricScope,
+			MetricSource: PodRawMetrics,
+			MetricType: MetricType{
+				Raw: Gauge,
+			},
+			Description: "Estimated prompt tokens of the prefill requests currently in flight on a prefill pod, as charged by the pd router",
+		},
+		PDTokenLoadKVTokens: {
+			MetricScope:  PodMetricScope,
+			MetricSource: PodRawMetrics,
+			MetricType: MetricType{
+				Raw: Gauge,
+			},
+			Description: "Estimated prompt tokens whose KV cache is still resident on a prefill pod, as charged by the pd router",
 		},
 		GatewayInFlight: {
 			MetricScope:  PodMetricScope,

--- a/pkg/plugins/gateway/algorithms/pd/prefill/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default.go
@@ -65,16 +65,42 @@ func decPrefillOutstanding() {
 type DefaultExecutor struct {
 	httpClient     *http.Client
 	tracker        *pd.PrefillRequestTracker
-	requestTimeout int // seconds
+	tokenLoad      *pd.TokenLoadTracker // optional; nil when no policy charges it
+	requestTimeout int                  // seconds
+}
+
+// ExecutorOption customizes a DefaultExecutor.
+type ExecutorOption func(*DefaultExecutor)
+
+// WithTokenLoadTracker makes the executor release a request's active
+// token-load charge (TokenLoadTracker.ReleaseTokens) at the same point where
+// it removes the request from the PrefillRequestTracker: when the prefill
+// HTTP call returns, on both the sync and the async path.
+func WithTokenLoadTracker(tokenLoad *pd.TokenLoadTracker) ExecutorOption {
+	return func(e *DefaultExecutor) { e.tokenLoad = tokenLoad }
 }
 
 // NewDefaultExecutor constructs a DefaultExecutor.
 // httpClient and tracker are shared with the router; requestTimeout is in seconds.
-func NewDefaultExecutor(httpClient *http.Client, tracker *pd.PrefillRequestTracker, requestTimeout int) PrefillExecutor {
-	return &DefaultExecutor{
+func NewDefaultExecutor(httpClient *http.Client, tracker *pd.PrefillRequestTracker, requestTimeout int, opts ...ExecutorOption) PrefillExecutor {
+	e := &DefaultExecutor{
 		httpClient:     httpClient,
 		tracker:        tracker,
 		requestTimeout: requestTimeout,
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// prefillDone is the single point where a finished prefill call is taken off
+// the router's ledgers: the request-count tracker always, the token-load
+// tracker when one is attached.
+func (e *DefaultExecutor) prefillDone(requestID string) {
+	e.tracker.RemovePrefillRequest(requestID)
+	if e.tokenLoad != nil {
+		e.tokenLoad.ReleaseTokens(requestID)
 	}
 }
 
@@ -133,7 +159,7 @@ func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *
 		go func() {
 			incPrefillOutstanding()
 			defer decPrefillOutstanding()
-			defer e.tracker.RemovePrefillRequest(requestID)
+			defer e.prefillDone(requestID)
 
 			if _, err := e.executeHTTP(apiURL, asyncCtx, payload); err != nil {
 				klog.ErrorS(err, "prefill_request_failed",
@@ -174,7 +200,7 @@ func (e *DefaultExecutor) handleSync(
 ) error {
 	incPrefillOutstanding()
 	defer decPrefillOutstanding()
-	defer e.tracker.RemovePrefillRequest(routingCtx.RequestID)
+	defer e.prefillDone(routingCtx.RequestID)
 
 	responseData, err := e.executeHTTP(apiURL, routingCtx, payload)
 	if err != nil {

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
@@ -19,12 +19,15 @@ limitations under the License.
 // files:
 //
 //   - prefill_scorer.go  — PrefillScorePolicy / PrefillScorer interfaces and
-//     their built-in implementations (prefix_cache, least_request).
+//     their built-in implementations (prefix_cache, least_request, conductor,
+//     token_load).
 //   - decode_scorer.go   — DecodeScorePolicy / DecodeScorer interfaces and
 //     their built-in implementations (load_balancing, least_request), plus the
 //     policy registry used by AIBRIX_DECODE_SCORE_POLICY.
 //   - trackers.go        — PrefillRequestTracker and PendingDecodeTracker,
 //     which bridge the gap between pod selection and actual request start.
+//   - token_load_tracker.go — TokenLoadTracker, the token-weighted prefill
+//     load ledger behind the token_load policy.
 package pd
 
 import (
@@ -54,6 +57,11 @@ const (
 	// PrefillScorePolicyConductor selects the conductor scoring policy, which
 	// estimates the TTFT (contains queue, prefix, and prefill) for each pod
 	PrefillScorePolicyConductor = "conductor"
+
+	// PrefillScorePolicyTokenLoad selects the token-load scoring policy, which
+	// routes prefill requests to the pod with the lowest token-weighted load
+	// as tracked by TokenLoadTracker, without consulting the prefix cache.
+	PrefillScorePolicyTokenLoad = "token_load"
 
 	// Default TTFT estimation coefficients for conductor policy.
 	// Units: time in milliseconds, tokens are unitless.
@@ -361,5 +369,64 @@ func (s *conductorScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
 		"queue_estimate", queueEst,
 		"prefix_estimate", prefixEst,
 		"prefill_estimate", prefillEst)
+	return score
+}
+
+// tokenLoadPrefillPolicy scores prefill pods by the token-weighted load the
+// router has charged to them in a shared TokenLoadTracker:
+//
+//	score = active_tokens + kv_weight * kv_tokens
+//
+// Lower is better. Unlike least_request, a pod holding one long prompt scores
+// higher than a pod holding two short ones, so long prompts are spread by
+// their cost rather than by count. The prefix cache is not consulted.
+//
+// The policy is stateless apart from the read-only tracker handle; the router
+// that owns the tracker charges and releases it around each request. Obtain an
+// instance via NewTokenLoadPrefillPolicy.
+type tokenLoadPrefillPolicy struct {
+	tracker *TokenLoadTracker
+}
+
+// NewTokenLoadPrefillPolicy returns a token_load PrefillScorePolicy reading
+// from tracker.
+func NewTokenLoadPrefillPolicy(tracker *TokenLoadTracker) PrefillScorePolicy {
+	return &tokenLoadPrefillPolicy{tracker: tracker}
+}
+
+// Prepare returns a tokenLoadScorer; no tokenization or cache lookup is performed.
+func (p *tokenLoadPrefillPolicy) Prepare(_ *types.RoutingContext, _ []*v1.Pod, _ map[string]struct{}) (PrefillScorer, error) {
+	return tokenLoadScorer{tracker: p.tracker}, nil
+}
+
+func (p *tokenLoadPrefillPolicy) Name() string { return PrefillScorePolicyTokenLoad }
+
+// UsesTokenLoad reports whether policy scores from a TokenLoadTracker, i.e.
+// whether the router must charge the tracker for requests scored by it.
+func UsesTokenLoad(policy PrefillScorePolicy) bool {
+	return policy != nil && policy.Name() == PrefillScorePolicyTokenLoad
+}
+
+// tokenLoadScorer is the request-scoped scorer produced by tokenLoadPrefillPolicy.
+type tokenLoadScorer struct {
+	tracker *TokenLoadTracker
+}
+
+// PrefixHashes returns nil because this policy does not use the prefix cache.
+func (s tokenLoadScorer) PrefixHashes() []uint64 { return nil }
+
+func (s tokenLoadScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
+	if s.tracker == nil {
+		// No ledger to read; every pod ties and the caller's tie-break applies.
+		return 0
+	}
+	score := s.tracker.GetPriority(pod.Name)
+	if klog.V(4).Enabled() {
+		active, kv := s.tracker.GetLoad(pod.Name)
+		klog.V(4).InfoS("prefill_score", "pod_name", pod.Name,
+			"policy", PrefillScorePolicyTokenLoad,
+			"score", score, "active_tokens", active, "kv_tokens", kv,
+			"running_reqs", reqCnt)
+	}
 	return score
 }

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer_token_load_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer_token_load_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func tokenLoadTestPod(name string) *v1.Pod {
+	return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace}}
+}
+
+func TestTokenLoadPrefillPolicy_ScoresFromTracker(t *testing.T) {
+	tracker := newTokenLoadTracker(TokenLoadConfig{KVWeight: 0.5, RequestCost: 0}, nil)
+	policy := NewTokenLoadPrefillPolicy(tracker)
+	assert.Equal(t, PrefillScorePolicyTokenLoad, policy.Name())
+	assert.True(t, UsesTokenLoad(policy))
+	assert.False(t, UsesTokenLoad(NewLeastRequestPrefillPolicy()))
+	assert.False(t, UsesTokenLoad(nil))
+
+	podA, podB := tokenLoadTestPod("pod-a"), tokenLoadTestPod("pod-b")
+	tracker.AcquirePrefill("long", podA.Name, 8000)
+	tracker.AcquirePrefill("short-1", podB.Name, 100)
+	tracker.AcquirePrefill("short-2", podB.Name, 100)
+	tracker.ReleaseTokens("short-1")
+
+	ctx := types.NewRoutingContext(context.Background(), "pd", testModelName, testMessage, "req-1", "")
+	scorer, err := policy.Prepare(ctx, []*v1.Pod{podA, podB}, map[string]struct{}{podA.Name: {}, podB.Name: {}})
+	require.NoError(t, err)
+	assert.Nil(t, scorer.PrefixHashes(), "token_load does not use the prefix cache")
+
+	// Request counts passed by the router are ignored: only the token ledger
+	// decides, and the pod with one long prompt scores worse than the pod
+	// with two short ones.
+	assert.Equal(t, float64(8000+0.5*8000), scorer.ScorePod(podA, 1, 2))
+	assert.Equal(t, float64(100+0.5*200), scorer.ScorePod(podB, 2, 2))
+	assert.Equal(t, float64(0), scorer.ScorePod(tokenLoadTestPod("idle"), 0, 2))
+}
+
+func TestTokenLoadPrefillPolicy_NilTrackerScoresZero(t *testing.T) {
+	policy := NewTokenLoadPrefillPolicy(nil)
+	ctx := types.NewRoutingContext(context.Background(), "pd", testModelName, testMessage, "req-1", "")
+	scorer, err := policy.Prepare(ctx, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), scorer.ScorePod(tokenLoadTestPod("pod-a"), 3, 3))
+}

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
@@ -108,6 +108,11 @@ type TokenLoadTracker struct {
 	entries      sync.Map // map[string]*tokenLoadEntry, request ID → charge
 
 	cfg TokenLoadConfig
+	// stopCh is closed by Close to stop the janitor; janitorDone is closed by
+	// the janitor when it has stopped.
+	stopCh      chan struct{}
+	janitorDone chan struct{}
+	closeOnce   sync.Once
 	// clock is injectable so unit tests can age entries without sleeping.
 	clock func() time.Time
 }
@@ -145,7 +150,16 @@ func NewTokenLoadTrackerWithConfig(cfg TokenLoadConfig) *TokenLoadTracker {
 // newTokenLoadTracker builds a tracker without a janitor goroutine; tests use
 // it with a fake clock and drive sweepExpired directly.
 func newTokenLoadTracker(cfg TokenLoadConfig, clock func() time.Time) *TokenLoadTracker {
-	return &TokenLoadTracker{cfg: cfg, clock: clock}
+	return &TokenLoadTracker{cfg: cfg, clock: clock, stopCh: make(chan struct{})}
+}
+
+// Close stops the janitor goroutine, if one was started, and returns once it
+// has exited. Charges and counters stay readable. Safe to call more than once.
+func (t *TokenLoadTracker) Close() {
+	t.closeOnce.Do(func() { close(t.stopCh) })
+	if t.janitorDone != nil {
+		<-t.janitorDone
+	}
 }
 
 // Config returns the tracker's tunables.
@@ -250,13 +264,20 @@ func (t *TokenLoadTracker) addKV(pod string, delta float64) {
 		value, []string{"pod_name"}, pod)
 }
 
-// startJanitor runs sweepExpired every interval for the life of the process.
+// startJanitor runs sweepExpired every interval until Close is called.
 func (t *TokenLoadTracker) startJanitor(interval time.Duration) {
+	t.janitorDone = make(chan struct{})
 	go func() {
+		defer close(t.janitorDone)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
-		for range ticker.C {
-			t.sweepExpired()
+		for {
+			select {
+			case <-ticker.C:
+				t.sweepExpired()
+			case <-t.stopCh:
+				return
+			}
 		}
 	}()
 }
@@ -288,9 +309,13 @@ func (t *TokenLoadTracker) sweepExpired() int {
 }
 
 // addFloat atomically adds delta to the float64 stored under key, clamps the
-// result at zero, and returns the new value.
+// result at zero, and returns the new value. The counter is only allocated
+// the first time a pod is seen; later calls take the read path.
 func addFloat(m *sync.Map, key string, delta float64) float64 {
-	v, _ := m.LoadOrStore(key, &atomic.Uint64{})
+	v, ok := m.Load(key)
+	if !ok {
+		v, _ = m.LoadOrStore(key, &atomic.Uint64{})
+	}
 	a := v.(*atomic.Uint64)
 	for {
 		old := a.Load()

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
@@ -96,10 +96,12 @@ func DefaultTokenLoadConfig() TokenLoadConfig {
 //     returns.
 //  3. ReleaseKVCache(requestID): kv -= cost, when the whole request completes.
 //
-// Every Release is idempotent per request ID and the counters are clamped at
-// zero, so a duplicate release can never drive a pod negative. A charge whose
-// release never arrives (the completion path was skipped) is force-released by
-// the TTL janitor so it cannot pin load on a pod forever.
+// The two releases may arrive in either order; each subtracts its part once,
+// and the request is forgotten as soon as both parts are released. Releases
+// are idempotent per request ID and the counters are clamped at zero, so a
+// duplicate release can never drive a pod negative. A charge whose release
+// never arrives (the completion path was skipped) is force-released by the
+// TTL janitor so it cannot pin load on a pod forever.
 //
 // All methods are safe for concurrent use. Reads do not allocate.
 type TokenLoadTracker struct {
@@ -123,9 +125,16 @@ type tokenLoadEntry struct {
 	pod        string
 	cost       float64
 	acquiredAt time.Time
-	// tokensReleased flips once when ReleaseTokens runs, so neither a second
-	// ReleaseTokens nor the janitor subtracts the active charge again.
+	// tokensReleased and kvReleased each flip once, when the matching release
+	// runs, so neither a repeated release nor the janitor subtracts a part of
+	// the charge twice. The entry leaves the ledger once both are set.
 	tokensReleased atomic.Bool
+	kvReleased     atomic.Bool
+}
+
+// released reports whether both parts of the charge have been released.
+func (e *tokenLoadEntry) released() bool {
+	return e.tokensReleased.Load() && e.kvReleased.Load()
 }
 
 // NewTokenLoadTracker creates a tracker with DefaultTokenLoadConfig and starts
@@ -181,12 +190,19 @@ func EstimatePromptTokens(reqBody []byte) int {
 }
 
 // AcquirePrefill charges cost to both the active and the resident-KV counter
-// of pod and records the charge under requestID for later release. A second
-// AcquirePrefill for the same requestID replaces the first charge without
-// releasing it; callers pair every acquire with a release.
+// of pod and records the charge under requestID for later release. Request
+// IDs are unique per request, so a second AcquirePrefill for the same
+// requestID is a caller bug; it is tolerated by releasing whatever the
+// earlier charge still holds before the new one replaces it, with a warning.
 func (t *TokenLoadTracker) AcquirePrefill(requestID, pod string, cost float64) {
 	entry := &tokenLoadEntry{pod: pod, cost: cost, acquiredAt: t.now()}
-	t.entries.Store(requestID, entry)
+	if prev, loaded := t.entries.Swap(requestID, entry); loaded {
+		old := prev.(*tokenLoadEntry)
+		klog.Warningf("token_load_tracker re-acquire for request_id=%s: releasing earlier charge pod_name=%s cost=%g before charging pod_name=%s cost=%g",
+			requestID, old.pod, old.cost, pod, cost)
+		t.releaseTokens(requestID, old)
+		t.releaseKV(requestID, old)
+	}
 	t.addActive(pod, cost)
 	t.addKV(pod, cost)
 	klog.V(4).InfoS("token_load_acquired", "request_id", requestID, "pod_name", pod, "cost", cost)
@@ -196,31 +212,51 @@ func (t *TokenLoadTracker) AcquirePrefill(requestID, pod string, cost float64) {
 // Call it when the prefill HTTP call returns. The KV charge stays until
 // ReleaseKVCache. No-op for an unknown request ID or a repeated call.
 func (t *TokenLoadTracker) ReleaseTokens(requestID string) {
-	v, ok := t.entries.Load(requestID)
-	if !ok {
-		return
+	if v, ok := t.entries.Load(requestID); ok {
+		t.releaseTokens(requestID, v.(*tokenLoadEntry))
 	}
-	entry := v.(*tokenLoadEntry)
+}
+
+// ReleaseKVCache subtracts requestID's charge from its pod's resident-KV
+// counter. Call it when the request completes. It does not touch the active
+// counter: a request that completes while its prefill call is somehow still
+// outstanding keeps that charge, and stays in the ledger, until ReleaseTokens
+// or the janitor. No-op for an unknown request ID or a repeated call.
+func (t *TokenLoadTracker) ReleaseKVCache(requestID string) {
+	if v, ok := t.entries.Load(requestID); ok {
+		t.releaseKV(requestID, v.(*tokenLoadEntry))
+	}
+}
+
+// releaseTokens releases the active part of entry, once.
+func (t *TokenLoadTracker) releaseTokens(requestID string, entry *tokenLoadEntry) {
 	if !entry.tokensReleased.CompareAndSwap(false, true) {
 		return
 	}
 	t.addActive(entry.pod, -entry.cost)
 	klog.V(4).InfoS("token_load_tokens_released", "request_id", requestID, "pod_name", entry.pod, "cost", entry.cost)
+	t.forgetIfReleased(requestID, entry)
 }
 
-// ReleaseKVCache subtracts requestID's charge from its pod's resident-KV
-// counter and forgets the request. Call it when the request completes. It
-// does not touch the active counter: a request that completes while its
-// prefill call is somehow still outstanding keeps that charge until
-// ReleaseTokens or the janitor. No-op for an unknown request ID.
-func (t *TokenLoadTracker) ReleaseKVCache(requestID string) {
-	v, ok := t.entries.LoadAndDelete(requestID)
-	if !ok {
+// releaseKV releases the resident-KV part of entry, once.
+func (t *TokenLoadTracker) releaseKV(requestID string, entry *tokenLoadEntry) {
+	if !entry.kvReleased.CompareAndSwap(false, true) {
 		return
 	}
-	entry := v.(*tokenLoadEntry)
 	t.addKV(entry.pod, -entry.cost)
 	klog.V(4).InfoS("token_load_kv_released", "request_id", requestID, "pod_name", entry.pod, "cost", entry.cost)
+	t.forgetIfReleased(requestID, entry)
+}
+
+// forgetIfReleased drops entry from the ledger once both of its parts are
+// released. Each release sets its own flag before checking both, so whichever
+// of two concurrent releases finishes last sees both flags and deletes. The
+// delete is keyed on the entry pointer, so it never removes a newer charge
+// that replaced this one under the same request ID.
+func (t *TokenLoadTracker) forgetIfReleased(requestID string, entry *tokenLoadEntry) {
+	if entry.released() {
+		t.entries.CompareAndDelete(requestID, entry)
+	}
 }
 
 // ReleaseAll releases whatever requestID still holds on both counters and
@@ -299,9 +335,11 @@ func (t *TokenLoadTracker) sweepExpired() int {
 		requestID := key.(string)
 		klog.Warningf("token_load_tracker force-releasing stale charge: request_id=%s pod_name=%s cost=%g age_seconds=%.0f ttl_seconds=%.0f",
 			requestID, entry.pod, entry.cost, age.Seconds(), t.cfg.TTL.Seconds())
-		// The releases re-check the entry under the map's own atomics, so a
-		// concurrent normal release between Range and here is harmless.
-		t.ReleaseAll(requestID)
+		// Release this entry, not whatever is under requestID now: the flags
+		// make a concurrent normal release harmless, and a re-acquire that
+		// replaced the entry in the meantime must keep its own charge.
+		t.releaseTokens(requestID, entry)
+		t.releaseKV(requestID, entry)
 		released++
 		return true
 	})

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pd
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/vllm-project/aibrix/pkg/metrics"
+	"github.com/vllm-project/aibrix/pkg/utils"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// DefaultTokenLoadKVWeight is the default weight of resident KV tokens in
+	// the token-load priority. A prefill pod keeps a request's KV blocks until
+	// the decoder has pulled them, so resident KV still costs the pod something
+	// after the prefill call itself has returned, but less than active compute.
+	DefaultTokenLoadKVWeight = 0.3
+
+	// DefaultTokenLoadRequestCost is the default fixed per-request cost in
+	// tokens. It models scheduling and KV-transfer setup work that does not
+	// scale with prompt length and keeps very short prompts from looking free.
+	DefaultTokenLoadRequestCost = 3500
+
+	// DefaultTokenLoadTTLSeconds bounds how long a charge may stay outstanding
+	// before the janitor force-releases it. It must exceed the longest
+	// legitimate request; an hour leaves a wide margin while still capping the
+	// damage a leaked entry can do. The environment variable must be positive;
+	// a TTL of 0 in TokenLoadConfig disables the janitor.
+	DefaultTokenLoadTTLSeconds = 3600
+
+	// tokenLoadJanitorInterval is the scan period of the TTL janitor.
+	tokenLoadJanitorInterval = 60 * time.Second
+
+	// bytesPerTokenEstimate is the prompt-size heuristic used when the router
+	// has no token count for the request: one token per four bytes of request
+	// body, the same estimate the vLLM PD proxy examples use.
+	bytesPerTokenEstimate = 4
+)
+
+// TokenLoadConfig holds the tunables of a TokenLoadTracker.
+type TokenLoadConfig struct {
+	// KVWeight is the weight of resident KV tokens in GetPriority.
+	KVWeight float64
+	// RequestCost is the fixed per-request cost added to every charge, in tokens.
+	RequestCost float64
+	// TTL is the maximum age of an outstanding charge; 0 disables the janitor.
+	TTL time.Duration
+}
+
+// DefaultTokenLoadConfig returns the defaults, overridden by the
+// AIBRIX_TOKEN_LOAD_KV_WEIGHT, AIBRIX_TOKEN_LOAD_REQUEST_COST and
+// AIBRIX_TOKEN_LOAD_TTL_SECONDS environment variables. Each must be positive;
+// an unset, empty or invalid value keeps the default.
+func DefaultTokenLoadConfig() TokenLoadConfig {
+	return TokenLoadConfig{
+		KVWeight:    utils.LoadEnvFloat("AIBRIX_TOKEN_LOAD_KV_WEIGHT", DefaultTokenLoadKVWeight),
+		RequestCost: utils.LoadEnvFloat("AIBRIX_TOKEN_LOAD_REQUEST_COST", DefaultTokenLoadRequestCost),
+		TTL:         time.Duration(utils.LoadEnvInt("AIBRIX_TOKEN_LOAD_TTL_SECONDS", DefaultTokenLoadTTLSeconds)) * time.Second,
+	}
+}
+
+// TokenLoadTracker keeps a token-weighted ledger of the prefill load the
+// router has assigned to each prefill pod. It is the state behind the
+// token_load prefill score policy.
+//
+// Two counters are kept per pod:
+//
+//   - active tokens: prompts the pod is computing right now;
+//   - kv tokens: prompts whose KV cache is still resident on the pod because
+//     the decoder has not finished pulling it.
+//
+// The lifecycle of a prefill request is
+//
+//  1. AcquirePrefill(requestID, pod, cost): both counters += cost. The router
+//     calls this under the same lock as the pod selection, so concurrent
+//     selections see each other's charges.
+//  2. ReleaseTokens(requestID): active -= cost, when the prefill HTTP call
+//     returns.
+//  3. ReleaseKVCache(requestID): kv -= cost, when the whole request completes.
+//
+// Every Release is idempotent per request ID and the counters are clamped at
+// zero, so a duplicate release can never drive a pod negative. A charge whose
+// release never arrives (the completion path was skipped) is force-released by
+// the TTL janitor so it cannot pin load on a pod forever.
+//
+// All methods are safe for concurrent use. Reads do not allocate.
+type TokenLoadTracker struct {
+	activeTokens sync.Map // map[string]*atomic.Uint64 (float64 bits), pod name → tokens
+	kvTokens     sync.Map // map[string]*atomic.Uint64 (float64 bits), pod name → tokens
+	entries      sync.Map // map[string]*tokenLoadEntry, request ID → charge
+
+	cfg TokenLoadConfig
+	// clock is injectable so unit tests can age entries without sleeping.
+	clock func() time.Time
+}
+
+// tokenLoadEntry records one AcquirePrefill so the releases subtract exactly
+// what was charged.
+type tokenLoadEntry struct {
+	pod        string
+	cost       float64
+	acquiredAt time.Time
+	// tokensReleased flips once when ReleaseTokens runs, so neither a second
+	// ReleaseTokens nor the janitor subtracts the active charge again.
+	tokensReleased atomic.Bool
+}
+
+// NewTokenLoadTracker creates a tracker with DefaultTokenLoadConfig and starts
+// its TTL janitor when the TTL is positive.
+func NewTokenLoadTracker() *TokenLoadTracker {
+	return NewTokenLoadTrackerWithConfig(DefaultTokenLoadConfig())
+}
+
+// NewTokenLoadTrackerWithConfig creates a tracker with an explicit config and
+// starts its TTL janitor when cfg.TTL is positive.
+func NewTokenLoadTrackerWithConfig(cfg TokenLoadConfig) *TokenLoadTracker {
+	t := newTokenLoadTracker(cfg, time.Now)
+	if cfg.TTL > 0 {
+		t.startJanitor(tokenLoadJanitorInterval)
+	}
+	klog.InfoS("token_load_tracker created",
+		"kv_weight", cfg.KVWeight, "request_cost", cfg.RequestCost,
+		"ttl_seconds", int(cfg.TTL.Seconds()), "janitor_enabled", cfg.TTL > 0)
+	return t
+}
+
+// newTokenLoadTracker builds a tracker without a janitor goroutine; tests use
+// it with a fake clock and drive sweepExpired directly.
+func newTokenLoadTracker(cfg TokenLoadConfig, clock func() time.Time) *TokenLoadTracker {
+	return &TokenLoadTracker{cfg: cfg, clock: clock}
+}
+
+// Config returns the tracker's tunables.
+func (t *TokenLoadTracker) Config() TokenLoadConfig { return t.cfg }
+
+// PrefillCost returns the load charged for a prefill of promptTokens tokens:
+// the fixed per-request cost plus the prompt length.
+func (t *TokenLoadTracker) PrefillCost(promptTokens int) float64 {
+	if promptTokens < 0 {
+		promptTokens = 0
+	}
+	return t.cfg.RequestCost + float64(promptTokens)
+}
+
+// EstimatePromptTokens estimates the prompt length of a request from its body
+// size when no token count is available.
+func EstimatePromptTokens(reqBody []byte) int {
+	return len(reqBody) / bytesPerTokenEstimate
+}
+
+// AcquirePrefill charges cost to both the active and the resident-KV counter
+// of pod and records the charge under requestID for later release. A second
+// AcquirePrefill for the same requestID replaces the first charge without
+// releasing it; callers pair every acquire with a release.
+func (t *TokenLoadTracker) AcquirePrefill(requestID, pod string, cost float64) {
+	entry := &tokenLoadEntry{pod: pod, cost: cost, acquiredAt: t.now()}
+	t.entries.Store(requestID, entry)
+	t.addActive(pod, cost)
+	t.addKV(pod, cost)
+	klog.V(4).InfoS("token_load_acquired", "request_id", requestID, "pod_name", pod, "cost", cost)
+}
+
+// ReleaseTokens subtracts requestID's charge from its pod's active counter.
+// Call it when the prefill HTTP call returns. The KV charge stays until
+// ReleaseKVCache. No-op for an unknown request ID or a repeated call.
+func (t *TokenLoadTracker) ReleaseTokens(requestID string) {
+	v, ok := t.entries.Load(requestID)
+	if !ok {
+		return
+	}
+	entry := v.(*tokenLoadEntry)
+	if !entry.tokensReleased.CompareAndSwap(false, true) {
+		return
+	}
+	t.addActive(entry.pod, -entry.cost)
+	klog.V(4).InfoS("token_load_tokens_released", "request_id", requestID, "pod_name", entry.pod, "cost", entry.cost)
+}
+
+// ReleaseKVCache subtracts requestID's charge from its pod's resident-KV
+// counter and forgets the request. Call it when the request completes. It
+// does not touch the active counter: a request that completes while its
+// prefill call is somehow still outstanding keeps that charge until
+// ReleaseTokens or the janitor. No-op for an unknown request ID.
+func (t *TokenLoadTracker) ReleaseKVCache(requestID string) {
+	v, ok := t.entries.LoadAndDelete(requestID)
+	if !ok {
+		return
+	}
+	entry := v.(*tokenLoadEntry)
+	t.addKV(entry.pod, -entry.cost)
+	klog.V(4).InfoS("token_load_kv_released", "request_id", requestID, "pod_name", entry.pod, "cost", entry.cost)
+}
+
+// ReleaseAll releases whatever requestID still holds on both counters and
+// forgets the request. Use it on terminal paths where nothing of the request
+// can remain on the pod (prefill failure, request completion).
+func (t *TokenLoadTracker) ReleaseAll(requestID string) {
+	t.ReleaseTokens(requestID)
+	t.ReleaseKVCache(requestID)
+}
+
+// GetLoad returns pod's current active and resident-KV token counters.
+// Unknown pods report 0, 0.
+func (t *TokenLoadTracker) GetLoad(pod string) (activeTokens, kvTokens float64) {
+	return loadFloat(&t.activeTokens, pod), loadFloat(&t.kvTokens, pod)
+}
+
+// GetPriority returns pod's token-load priority, lower is better:
+//
+//	active_tokens + kv_weight * kv_tokens
+func (t *TokenLoadTracker) GetPriority(pod string) float64 {
+	active, kv := t.GetLoad(pod)
+	return active + t.cfg.KVWeight*kv
+}
+
+func (t *TokenLoadTracker) now() time.Time {
+	if t.clock == nil {
+		return time.Now()
+	}
+	return t.clock()
+}
+
+func (t *TokenLoadTracker) addActive(pod string, delta float64) {
+	value := addFloat(&t.activeTokens, pod, delta)
+	metrics.SetGaugeMetric(metrics.PDTokenLoadActiveTokens, metrics.GetMetricHelp(metrics.PDTokenLoadActiveTokens),
+		value, []string{"pod_name"}, pod)
+}
+
+func (t *TokenLoadTracker) addKV(pod string, delta float64) {
+	value := addFloat(&t.kvTokens, pod, delta)
+	metrics.SetGaugeMetric(metrics.PDTokenLoadKVTokens, metrics.GetMetricHelp(metrics.PDTokenLoadKVTokens),
+		value, []string{"pod_name"}, pod)
+}
+
+// startJanitor runs sweepExpired every interval for the life of the process.
+func (t *TokenLoadTracker) startJanitor(interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			t.sweepExpired()
+		}
+	}()
+}
+
+// sweepExpired force-releases every charge older than the TTL and returns how
+// many it released. No-op when the TTL is not positive.
+func (t *TokenLoadTracker) sweepExpired() int {
+	if t.cfg.TTL <= 0 {
+		return 0
+	}
+	now := t.now()
+	released := 0
+	t.entries.Range(func(key, val any) bool {
+		entry := val.(*tokenLoadEntry)
+		age := now.Sub(entry.acquiredAt)
+		if age <= t.cfg.TTL {
+			return true
+		}
+		requestID := key.(string)
+		klog.Warningf("token_load_tracker force-releasing stale charge: request_id=%s pod_name=%s cost=%g age_seconds=%.0f ttl_seconds=%.0f",
+			requestID, entry.pod, entry.cost, age.Seconds(), t.cfg.TTL.Seconds())
+		// The releases re-check the entry under the map's own atomics, so a
+		// concurrent normal release between Range and here is harmless.
+		t.ReleaseAll(requestID)
+		released++
+		return true
+	})
+	return released
+}
+
+// addFloat atomically adds delta to the float64 stored under key, clamps the
+// result at zero, and returns the new value.
+func addFloat(m *sync.Map, key string, delta float64) float64 {
+	v, _ := m.LoadOrStore(key, &atomic.Uint64{})
+	a := v.(*atomic.Uint64)
+	for {
+		old := a.Load()
+		next := math.Float64frombits(old) + delta
+		if next < 0 {
+			next = 0
+		}
+		if a.CompareAndSwap(old, math.Float64bits(next)) {
+			return next
+		}
+	}
+}
+
+func loadFloat(m *sync.Map, key string) float64 {
+	v, ok := m.Load(key)
+	if !ok {
+		return 0
+	}
+	return math.Float64frombits(v.(*atomic.Uint64).Load())
+}

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
@@ -46,7 +46,9 @@ const (
 	// a TTL of 0 in TokenLoadConfig disables the janitor.
 	DefaultTokenLoadTTLSeconds = 3600
 
-	// tokenLoadJanitorInterval is the scan period of the TTL janitor.
+	// tokenLoadJanitorInterval is the scan period of the janitor, which
+	// force-releases charges older than the TTL and prunes idle pods. It also
+	// bounds how long a pod must be idle before it is pruned.
 	tokenLoadJanitorInterval = 60 * time.Second
 
 	// bytesPerTokenEstimate is the prompt-size heuristic used when the router
@@ -101,13 +103,21 @@ func DefaultTokenLoadConfig() TokenLoadConfig {
 // are idempotent per request ID and the counters are clamped at zero, so a
 // duplicate release can never drive a pod negative. A charge whose release
 // never arrives (the completion path was skipped) is force-released by the
-// TTL janitor so it cannot pin load on a pod forever.
+// TTL janitor so it cannot pin load on a pod forever. The janitor also drops
+// the counters and gauge series of pods that saw no traffic for a whole
+// sweep interval, so pod churn does not grow the ledger without bound.
 //
 // All methods are safe for concurrent use. Reads do not allocate.
 type TokenLoadTracker struct {
-	activeTokens sync.Map // map[string]*atomic.Uint64 (float64 bits), pod name → tokens
-	kvTokens     sync.Map // map[string]*atomic.Uint64 (float64 bits), pod name → tokens
+	activeTokens sync.Map // map[string]*podCounter, pod name → tokens
+	kvTokens     sync.Map // map[string]*podCounter, pod name → tokens
 	entries      sync.Map // map[string]*tokenLoadEntry, request ID → charge
+
+	// countersMu serialises the janitor's pruning of idle pods (write lock)
+	// with counter updates (read lock), so a counter and its gauge series are
+	// never dropped between a writer's update and its gauge refresh. Reads of
+	// the counters take no lock.
+	countersMu sync.RWMutex
 
 	cfg TokenLoadConfig
 	// stopCh is closed by Close to stop the janitor; janitorDone is closed by
@@ -136,6 +146,19 @@ type tokenLoadEntry struct {
 func (e *tokenLoadEntry) released() bool {
 	return e.tokensReleased.Load() && e.kvReleased.Load()
 }
+
+// podCounter is one per-pod token counter: the bits of a float64 value and a
+// flag that records any write since the janitor last looked, so the janitor
+// can tell a pod that is merely between requests from one that is gone.
+type podCounter struct {
+	bits    atomic.Uint64
+	touched atomic.Bool
+}
+
+func (c *podCounter) load() float64 { return math.Float64frombits(c.bits.Load()) }
+
+// tokenLoadGaugeLabels is the label set of the per-pod gauges.
+var tokenLoadGaugeLabels = []string{"pod_name"}
 
 // NewTokenLoadTracker creates a tracker with DefaultTokenLoadConfig and starts
 // its TTL janitor when the TTL is positive.
@@ -289,18 +312,25 @@ func (t *TokenLoadTracker) now() time.Time {
 }
 
 func (t *TokenLoadTracker) addActive(pod string, delta float64) {
-	value := addFloat(&t.activeTokens, pod, delta)
-	metrics.SetGaugeMetric(metrics.PDTokenLoadActiveTokens, metrics.GetMetricHelp(metrics.PDTokenLoadActiveTokens),
-		value, []string{"pod_name"}, pod)
+	t.addCounter(&t.activeTokens, metrics.PDTokenLoadActiveTokens, pod, delta)
 }
 
 func (t *TokenLoadTracker) addKV(pod string, delta float64) {
-	value := addFloat(&t.kvTokens, pod, delta)
-	metrics.SetGaugeMetric(metrics.PDTokenLoadKVTokens, metrics.GetMetricHelp(metrics.PDTokenLoadKVTokens),
-		value, []string{"pod_name"}, pod)
+	t.addCounter(&t.kvTokens, metrics.PDTokenLoadKVTokens, pod, delta)
 }
 
-// startJanitor runs sweepExpired every interval until Close is called.
+// addCounter adds delta to pod's counter in m and publishes the result as the
+// gauge metricName. The shared lock only excludes the janitor's pruning;
+// writers still run concurrently with each other.
+func (t *TokenLoadTracker) addCounter(m *sync.Map, metricName, pod string, delta float64) {
+	t.countersMu.RLock()
+	defer t.countersMu.RUnlock()
+	value := addFloat(m, pod, delta)
+	metrics.SetGaugeMetric(metricName, metrics.GetMetricHelp(metricName), value, tokenLoadGaugeLabels, pod)
+}
+
+// startJanitor runs sweepExpired and pruneIdle every interval until Close is
+// called.
 func (t *TokenLoadTracker) startJanitor(interval time.Duration) {
 	t.janitorDone = make(chan struct{})
 	go func() {
@@ -311,6 +341,7 @@ func (t *TokenLoadTracker) startJanitor(interval time.Duration) {
 			select {
 			case <-ticker.C:
 				t.sweepExpired()
+				t.pruneIdle()
 			case <-t.stopCh:
 				return
 			}
@@ -346,22 +377,72 @@ func (t *TokenLoadTracker) sweepExpired() int {
 	return released
 }
 
+// pruneIdle drops the counters and gauge series of every pod that has been
+// idle since the previous call, meaning both counters are zero and neither
+// was written in between, and returns how many pods it dropped. Pods come
+// and go under autoscaling and rollouts; without pruning each one would keep
+// two counters and two gauge series on the gateway forever. A pruned pod is
+// re-created, from zero, by its next charge.
+func (t *TokenLoadTracker) pruneIdle() int {
+	t.countersMu.Lock()
+	defer t.countersMu.Unlock()
+
+	pods := map[string]struct{}{}
+	collect := func(key, _ any) bool {
+		pods[key.(string)] = struct{}{}
+		return true
+	}
+	t.activeTokens.Range(collect)
+	t.kvTokens.Range(collect)
+
+	pruned := 0
+	for pod := range pods {
+		// Clear both flags before deciding, so a pod that is active on one
+		// counter is re-examined from scratch next time.
+		active := idleCounter(&t.activeTokens, pod)
+		kv := idleCounter(&t.kvTokens, pod)
+		if !active || !kv {
+			continue
+		}
+		t.activeTokens.Delete(pod)
+		t.kvTokens.Delete(pod)
+		metrics.DeleteGaugeMetric(metrics.PDTokenLoadActiveTokens, tokenLoadGaugeLabels, pod)
+		metrics.DeleteGaugeMetric(metrics.PDTokenLoadKVTokens, tokenLoadGaugeLabels, pod)
+		pruned++
+		klog.V(4).InfoS("token_load_pod_pruned", "pod_name", pod)
+	}
+	return pruned
+}
+
+// idleCounter reports whether pod's counter in m is zero and was not written
+// since the last call, and clears the written flag. A missing counter is idle.
+func idleCounter(m *sync.Map, pod string) bool {
+	v, ok := m.Load(pod)
+	if !ok {
+		return true
+	}
+	c := v.(*podCounter)
+	touched := c.touched.Swap(false)
+	return !touched && c.load() == 0
+}
+
 // addFloat atomically adds delta to the float64 stored under key, clamps the
 // result at zero, and returns the new value. The counter is only allocated
 // the first time a pod is seen; later calls take the read path.
 func addFloat(m *sync.Map, key string, delta float64) float64 {
 	v, ok := m.Load(key)
 	if !ok {
-		v, _ = m.LoadOrStore(key, &atomic.Uint64{})
+		v, _ = m.LoadOrStore(key, &podCounter{})
 	}
-	a := v.(*atomic.Uint64)
+	c := v.(*podCounter)
 	for {
-		old := a.Load()
+		old := c.bits.Load()
 		next := math.Float64frombits(old) + delta
 		if next < 0 {
 			next = 0
 		}
-		if a.CompareAndSwap(old, math.Float64bits(next)) {
+		if c.bits.CompareAndSwap(old, math.Float64bits(next)) {
+			c.touched.Store(true)
 			return next
 		}
 	}
@@ -372,5 +453,5 @@ func loadFloat(m *sync.Map, key string) float64 {
 	if !ok {
 		return 0
 	}
-	return math.Float64frombits(v.(*atomic.Uint64).Load())
+	return v.(*podCounter).load()
 }

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
@@ -263,6 +263,31 @@ func TestTokenLoadTracker_JanitorDoesNotDoubleReleaseTokens(t *testing.T) {
 	assertLoad(t, tr, "pod-a", 0, 0)
 }
 
+func TestTokenLoadTracker_CloseStopsJanitor(t *testing.T) {
+	tr := NewTokenLoadTrackerWithConfig(testTokenLoadConfig())
+	require.NotNil(t, tr.janitorDone, "a positive TTL starts the janitor")
+
+	done := make(chan struct{})
+	go func() {
+		tr.Close()
+		tr.Close() // idempotent
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return: janitor still running")
+	}
+
+	// The tracker stays usable after Close.
+	tr.AcquirePrefill("req-1", "pod-a", 1000)
+	assertLoad(t, tr, "pod-a", 1000, 1000)
+
+	// Close on a tracker without a janitor returns immediately.
+	noJanitor, _ := newTestTokenLoadTracker(t, testTokenLoadConfig())
+	noJanitor.Close()
+}
+
 func TestTokenLoadTracker_JanitorDisabledWithZeroTTL(t *testing.T) {
 	cfg := testTokenLoadConfig()
 	cfg.TTL = 0

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
@@ -1,0 +1,323 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2"
+)
+
+// testTokenLoadConfig keeps the arithmetic in the assertions easy to follow:
+// weight 0.5, no fixed cost, one-minute TTL.
+func testTokenLoadConfig() TokenLoadConfig {
+	return TokenLoadConfig{KVWeight: 0.5, RequestCost: 0, TTL: time.Minute}
+}
+
+// fakeClock is an injectable clock for the janitor tests.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func newTestTokenLoadTracker(t *testing.T, cfg TokenLoadConfig) (*TokenLoadTracker, *fakeClock) {
+	t.Helper()
+	clock := newFakeClock()
+	return newTokenLoadTracker(cfg, clock.Now), clock
+}
+
+func assertLoad(t *testing.T, tr *TokenLoadTracker, pod string, wantActive, wantKV float64) {
+	t.Helper()
+	active, kv := tr.GetLoad(pod)
+	assert.Equalf(t, wantActive, active, "%s active tokens", pod)
+	assert.Equalf(t, wantKV, kv, "%s kv tokens", pod)
+}
+
+func TestTokenLoadTracker_Lifecycle(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	assertLoad(t, tr, "pod-a", 0, 0)
+	assert.Equal(t, float64(0), tr.GetPriority("pod-a"), "unknown pod is idle")
+
+	tr.AcquirePrefill("req-1", "pod-a", 1000)
+	assertLoad(t, tr, "pod-a", 1000, 1000)
+	assert.Equal(t, float64(1000+0.5*1000), tr.GetPriority("pod-a"))
+
+	// Prefill returned: compute charge gone, KV still resident.
+	tr.ReleaseTokens("req-1")
+	assertLoad(t, tr, "pod-a", 0, 1000)
+	assert.Equal(t, float64(0.5*1000), tr.GetPriority("pod-a"))
+
+	// Request completed: KV charge gone too.
+	tr.ReleaseKVCache("req-1")
+	assertLoad(t, tr, "pod-a", 0, 0)
+	_, tracked := tr.entries.Load("req-1")
+	assert.False(t, tracked, "completed request must be forgotten")
+}
+
+func TestTokenLoadTracker_ChargesArePerPod(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	tr.AcquirePrefill("req-1", "pod-a", 8000)
+	tr.AcquirePrefill("req-2", "pod-b", 100)
+	tr.AcquirePrefill("req-3", "pod-b", 100)
+
+	// One long prompt outweighs two short ones, which is the point of the policy.
+	assertLoad(t, tr, "pod-a", 8000, 8000)
+	assertLoad(t, tr, "pod-b", 200, 200)
+	assert.Greater(t, tr.GetPriority("pod-a"), tr.GetPriority("pod-b"))
+
+	tr.ReleaseAll("req-1")
+	assertLoad(t, tr, "pod-a", 0, 0)
+	assertLoad(t, tr, "pod-b", 200, 200)
+}
+
+func TestTokenLoadTracker_ReleasesAreIdempotent(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	tr.AcquirePrefill("req-1", "pod-a", 500)
+	tr.AcquirePrefill("req-2", "pod-a", 500)
+
+	tr.ReleaseTokens("req-1")
+	tr.ReleaseTokens("req-1")
+	assertLoad(t, tr, "pod-a", 500, 1000)
+
+	tr.ReleaseKVCache("req-1")
+	tr.ReleaseKVCache("req-1")
+	tr.ReleaseAll("req-1")
+	assertLoad(t, tr, "pod-a", 500, 500)
+
+	// ReleaseAll twice on a request whose tokens were never released.
+	tr.ReleaseAll("req-2")
+	tr.ReleaseAll("req-2")
+	assertLoad(t, tr, "pod-a", 0, 0)
+}
+
+func TestTokenLoadTracker_UnknownRequestIsNoop(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, testTokenLoadConfig())
+	tr.AcquirePrefill("req-1", "pod-a", 300)
+
+	tr.ReleaseTokens("never-acquired")
+	tr.ReleaseKVCache("never-acquired")
+	tr.ReleaseAll("never-acquired")
+
+	assertLoad(t, tr, "pod-a", 300, 300)
+	assertLoad(t, tr, "never-seen-pod", 0, 0)
+}
+
+func TestTokenLoadTracker_CountersClampAtZero(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	// A negative delta with nothing charged must not produce a negative
+	// counter that would make the pod look better than idle.
+	assert.Equal(t, float64(0), addFloat(&tr.activeTokens, "pod-a", -42))
+	assert.Equal(t, float64(0), loadFloat(&tr.activeTokens, "pod-a"))
+
+	assert.Equal(t, float64(10), addFloat(&tr.activeTokens, "pod-a", 10))
+	assert.Equal(t, float64(0), addFloat(&tr.activeTokens, "pod-a", -25))
+}
+
+func TestTokenLoadTracker_ReacquireSameRequestReplacesCharge(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	tr.AcquirePrefill("req-1", "pod-a", 100)
+	tr.AcquirePrefill("req-1", "pod-b", 200)
+	assertLoad(t, tr, "pod-a", 100, 100)
+	assertLoad(t, tr, "pod-b", 200, 200)
+
+	// Only the latest charge is tracked; the release subtracts that one.
+	tr.ReleaseAll("req-1")
+	assertLoad(t, tr, "pod-a", 100, 100)
+	assertLoad(t, tr, "pod-b", 0, 0)
+}
+
+func TestTokenLoadTracker_PrefillCostAndEstimate(t *testing.T) {
+	tr := newTokenLoadTracker(TokenLoadConfig{KVWeight: 0.3, RequestCost: 3500}, nil)
+
+	assert.Equal(t, float64(3500), tr.PrefillCost(0), "empty prompt still costs the fixed part")
+	assert.Equal(t, float64(3500+1200), tr.PrefillCost(1200))
+	assert.Equal(t, float64(3500), tr.PrefillCost(-7), "negative token counts are treated as zero")
+
+	assert.Equal(t, 0, EstimatePromptTokens(nil))
+	assert.Equal(t, 0, EstimatePromptTokens([]byte("abc")))
+	assert.Equal(t, 25, EstimatePromptTokens(bytes.Repeat([]byte("x"), 100)))
+
+	// Defaults are wired into the public constructor.
+	cfg := NewTokenLoadTrackerWithConfig(TokenLoadConfig{KVWeight: 0.3, RequestCost: 3500}).Config()
+	assert.Equal(t, 0.3, cfg.KVWeight)
+	assert.Equal(t, float64(3500), cfg.RequestCost)
+	assert.Equal(t, time.Duration(0), cfg.TTL)
+}
+
+func TestTokenLoadTracker_DefaultConfigFromEnv(t *testing.T) {
+	t.Setenv("AIBRIX_TOKEN_LOAD_KV_WEIGHT", "0.7")
+	t.Setenv("AIBRIX_TOKEN_LOAD_REQUEST_COST", "100")
+	t.Setenv("AIBRIX_TOKEN_LOAD_TTL_SECONDS", "42")
+
+	cfg := DefaultTokenLoadConfig()
+	assert.Equal(t, 0.7, cfg.KVWeight)
+	assert.Equal(t, float64(100), cfg.RequestCost)
+	assert.Equal(t, 42*time.Second, cfg.TTL)
+
+	t.Setenv("AIBRIX_TOKEN_LOAD_KV_WEIGHT", "not-a-number")
+	t.Setenv("AIBRIX_TOKEN_LOAD_REQUEST_COST", "")
+	t.Setenv("AIBRIX_TOKEN_LOAD_TTL_SECONDS", "0")
+	cfg = DefaultTokenLoadConfig()
+	assert.Equal(t, DefaultTokenLoadKVWeight, cfg.KVWeight, "invalid value falls back to the default")
+	assert.Equal(t, float64(DefaultTokenLoadRequestCost), cfg.RequestCost, "empty value falls back to the default")
+	assert.Equal(t, DefaultTokenLoadTTLSeconds*time.Second, cfg.TTL, "non-positive value falls back to the default")
+}
+
+func TestTokenLoadTracker_JanitorReleasesStaleCharges(t *testing.T) {
+	var logs bytes.Buffer
+	klog.LogToStderr(false)
+	klog.SetOutput(&logs)
+	defer func() {
+		klog.Flush()
+		klog.SetOutput(io.Discard)
+		klog.LogToStderr(true)
+	}()
+
+	tr, clock := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	tr.AcquirePrefill("stale", "pod-a", 1000)
+	clock.Advance(30 * time.Second)
+	tr.AcquirePrefill("fresh", "pod-a", 10)
+	assertLoad(t, tr, "pod-a", 1010, 1010)
+
+	// Nothing is older than the TTL yet.
+	assert.Equal(t, 0, tr.sweepExpired())
+	assertLoad(t, tr, "pod-a", 1010, 1010)
+
+	// 61s after "stale", 31s after "fresh": only the former is over the TTL.
+	clock.Advance(31 * time.Second)
+	assert.Equal(t, 1, tr.sweepExpired())
+	assertLoad(t, tr, "pod-a", 10, 10)
+	_, tracked := tr.entries.Load("stale")
+	assert.False(t, tracked)
+	_, tracked = tr.entries.Load("fresh")
+	assert.True(t, tracked)
+
+	klog.Flush()
+	assert.Contains(t, logs.String(), "force-releasing stale charge")
+	assert.Contains(t, logs.String(), "request_id=stale")
+	assert.Contains(t, logs.String(), "pod_name=pod-a")
+
+	// A sweep after the normal release of "fresh" finds nothing.
+	tr.ReleaseAll("fresh")
+	clock.Advance(time.Hour)
+	assert.Equal(t, 0, tr.sweepExpired())
+	assertLoad(t, tr, "pod-a", 0, 0)
+}
+
+func TestTokenLoadTracker_JanitorDoesNotDoubleReleaseTokens(t *testing.T) {
+	tr, clock := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	tr.AcquirePrefill("req-1", "pod-a", 1000)
+	tr.AcquirePrefill("req-2", "pod-a", 1000)
+	// req-1's prefill returned long ago, only its KV charge is outstanding.
+	tr.ReleaseTokens("req-1")
+	assertLoad(t, tr, "pod-a", 1000, 2000)
+
+	clock.Advance(2 * time.Minute)
+	assert.Equal(t, 2, tr.sweepExpired())
+	// req-2's active charge and both KV charges go; req-1's active charge
+	// must not be subtracted a second time.
+	assertLoad(t, tr, "pod-a", 0, 0)
+}
+
+func TestTokenLoadTracker_JanitorDisabledWithZeroTTL(t *testing.T) {
+	cfg := testTokenLoadConfig()
+	cfg.TTL = 0
+	tr, clock := newTestTokenLoadTracker(t, cfg)
+
+	tr.AcquirePrefill("req-1", "pod-a", 1000)
+	clock.Advance(365 * 24 * time.Hour)
+	assert.Equal(t, 0, tr.sweepExpired())
+	assertLoad(t, tr, "pod-a", 1000, 1000)
+}
+
+func TestTokenLoadTracker_ConcurrentChargesBalance(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	const (
+		workers    = 16
+		perWorker  = 200
+		cost       = 7.0
+		totalCount = workers * perWorker
+	)
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				tr.AcquirePrefill(fmt.Sprintf("w%d-r%d", w, i), "pod-a", cost)
+			}
+		}(w)
+	}
+	wg.Wait()
+	assertLoad(t, tr, "pod-a", totalCount*cost, totalCount*cost)
+
+	// Release tokens and KV from different goroutines, some of them twice.
+	for w := 0; w < workers; w++ {
+		wg.Add(2)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				tr.ReleaseTokens(fmt.Sprintf("w%d-r%d", w, i))
+				tr.ReleaseTokens(fmt.Sprintf("w%d-r%d", w, i))
+			}
+		}(w)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				tr.ReleaseAll(fmt.Sprintf("w%d-r%d", w, i))
+			}
+		}(w)
+	}
+	wg.Wait()
+	assertLoad(t, tr, "pod-a", 0, 0)
+
+	count := 0
+	tr.entries.Range(func(_, _ any) bool { count++; return true })
+	require.Equal(t, 0, count, "every request must be forgotten after release")
+}

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
@@ -155,17 +155,75 @@ func TestTokenLoadTracker_CountersClampAtZero(t *testing.T) {
 }
 
 func TestTokenLoadTracker_ReacquireSameRequestReplacesCharge(t *testing.T) {
+	var logs bytes.Buffer
+	klog.LogToStderr(false)
+	klog.SetOutput(&logs)
+	defer func() {
+		klog.Flush()
+		klog.SetOutput(io.Discard)
+		klog.LogToStderr(true)
+	}()
+
 	tr, _ := newTestTokenLoadTracker(t, testTokenLoadConfig())
 
+	// A re-acquire is a caller bug, but it must not leak the first charge.
 	tr.AcquirePrefill("req-1", "pod-a", 100)
 	tr.AcquirePrefill("req-1", "pod-b", 200)
-	assertLoad(t, tr, "pod-a", 100, 100)
+	assertLoad(t, tr, "pod-a", 0, 0)
 	assertLoad(t, tr, "pod-b", 200, 200)
+	klog.Flush()
+	assert.Contains(t, logs.String(), "re-acquire for request_id=req-1")
 
 	// Only the latest charge is tracked; the release subtracts that one.
 	tr.ReleaseAll("req-1")
-	assertLoad(t, tr, "pod-a", 100, 100)
+	assertLoad(t, tr, "pod-a", 0, 0)
 	assertLoad(t, tr, "pod-b", 0, 0)
+	_, tracked := tr.entries.Load("req-1")
+	assert.False(t, tracked)
+
+	// A partially released charge gives back only what it still holds.
+	tr.AcquirePrefill("req-2", "pod-a", 100)
+	tr.ReleaseTokens("req-2")
+	tr.AcquirePrefill("req-3", "pod-a", 50)
+	assertLoad(t, tr, "pod-a", 50, 150)
+	tr.AcquirePrefill("req-2", "pod-b", 10)
+	assertLoad(t, tr, "pod-a", 50, 50)
+	assertLoad(t, tr, "pod-b", 10, 10)
+}
+
+func TestTokenLoadTracker_KVReleasedBeforeTokens(t *testing.T) {
+	tr, clock := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	// The request completes while its prefill call is still outstanding: the
+	// KV part goes, the active part stays and the entry stays with it.
+	tr.AcquirePrefill("req-1", "pod-a", 100)
+	tr.ReleaseKVCache("req-1")
+	assertLoad(t, tr, "pod-a", 100, 0)
+	_, tracked := tr.entries.Load("req-1")
+	assert.True(t, tracked, "entry must survive until the active part is released too")
+
+	tr.ReleaseKVCache("req-1") // idempotent
+	assertLoad(t, tr, "pod-a", 100, 0)
+
+	tr.ReleaseTokens("req-1")
+	assertLoad(t, tr, "pod-a", 0, 0)
+	_, tracked = tr.entries.Load("req-1")
+	assert.False(t, tracked, "entry is forgotten once both parts are released")
+
+	// ReleaseAll after a KV-first release gives back only the active part.
+	tr.AcquirePrefill("req-2", "pod-a", 100)
+	tr.ReleaseKVCache("req-2")
+	tr.ReleaseAll("req-2")
+	assertLoad(t, tr, "pod-a", 0, 0)
+
+	// The janitor does not subtract an already released KV part again.
+	tr.AcquirePrefill("req-3", "pod-a", 100)
+	tr.AcquirePrefill("req-4", "pod-a", 100)
+	tr.ReleaseKVCache("req-3")
+	assertLoad(t, tr, "pod-a", 200, 100)
+	clock.Advance(2 * time.Minute)
+	assert.Equal(t, 2, tr.sweepExpired())
+	assertLoad(t, tr, "pod-a", 0, 0)
 }
 
 func TestTokenLoadTracker_PrefillCostAndEstimate(t *testing.T) {

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
@@ -24,8 +24,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/aibrix/pkg/metrics"
 	"k8s.io/klog/v2"
 )
 
@@ -355,6 +357,143 @@ func TestTokenLoadTracker_JanitorDisabledWithZeroTTL(t *testing.T) {
 	clock.Advance(365 * 24 * time.Hour)
 	assert.Equal(t, 0, tr.sweepExpired())
 	assertLoad(t, tr, "pod-a", 1000, 1000)
+}
+
+// tokenLoadSeriesPublished reports whether the default registry currently
+// exports a series of metricName for pod.
+func tokenLoadSeriesPublished(t *testing.T, metricName, pod string) bool {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != metricName {
+			continue
+		}
+		for _, m := range family.GetMetric() {
+			for _, label := range m.GetLabel() {
+				if label.GetName() == "pod_name" && label.GetValue() == pod {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func assertPodTracked(t *testing.T, tr *TokenLoadTracker, pod string, want bool) {
+	t.Helper()
+	_, active := tr.activeTokens.Load(pod)
+	_, kv := tr.kvTokens.Load(pod)
+	assert.Equal(t, want, active, "active counter for %s tracked", pod)
+	assert.Equal(t, want, kv, "kv counter for %s tracked", pod)
+	assert.Equal(t, want, tokenLoadSeriesPublished(t, metrics.PDTokenLoadActiveTokens, pod), "active series for %s", pod)
+	assert.Equal(t, want, tokenLoadSeriesPublished(t, metrics.PDTokenLoadKVTokens, pod), "kv series for %s", pod)
+}
+
+func TestTokenLoadTracker_JanitorPrunesIdlePods(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	tr.AcquirePrefill("req-1", "prune-a", 100)
+	tr.AcquirePrefill("req-2", "prune-b", 100)
+	tr.ReleaseAll("req-1")
+	assertPodTracked(t, tr, "prune-a", true)
+	assertPodTracked(t, tr, "prune-b", true)
+
+	// prune-a was written since the last sweep, so it is only observed idle;
+	// prune-b still carries a charge.
+	assert.Equal(t, 0, tr.pruneIdle())
+	assertPodTracked(t, tr, "prune-a", true)
+
+	// Traffic between sweeps keeps a pod alive even if it is back at zero.
+	tr.AcquirePrefill("req-3", "prune-a", 10)
+	tr.ReleaseAll("req-3")
+	assert.Equal(t, 0, tr.pruneIdle())
+	assertPodTracked(t, tr, "prune-a", true)
+
+	// A full quiet interval at zero gets the pod pruned; a pod with a
+	// charge outstanding is never pruned, however long it stays untouched.
+	assert.Equal(t, 1, tr.pruneIdle())
+	assertPodTracked(t, tr, "prune-a", false)
+	assertPodTracked(t, tr, "prune-b", true)
+	assertLoad(t, tr, "prune-a", 0, 0)
+	assertLoad(t, tr, "prune-b", 100, 100)
+
+	// The next charge re-creates the pod from zero.
+	tr.AcquirePrefill("req-4", "prune-a", 7)
+	assertPodTracked(t, tr, "prune-a", true)
+	assertLoad(t, tr, "prune-a", 7, 7)
+
+	// A pod whose KV part is still resident is not pruned either.
+	tr.ReleaseTokens("req-2")
+	assert.Equal(t, 0, tr.pruneIdle())
+	assert.Equal(t, 0, tr.pruneIdle())
+	assertPodTracked(t, tr, "prune-b", true)
+	tr.ReleaseKVCache("req-2")
+	assert.Equal(t, 0, tr.pruneIdle())
+	assert.Equal(t, 1, tr.pruneIdle())
+	assertPodTracked(t, tr, "prune-b", false)
+}
+
+func TestTokenLoadTracker_JanitorPrunesAfterForceRelease(t *testing.T) {
+	tr, clock := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	// A leaked charge on a pod that is gone: the sweep releases it, and the
+	// pod is pruned once nothing has touched it for another interval.
+	tr.AcquirePrefill("leaked", "prune-c", 100)
+	clock.Advance(2 * time.Minute)
+	assert.Equal(t, 1, tr.sweepExpired())
+	assert.Equal(t, 0, tr.pruneIdle())
+	assert.Equal(t, 1, tr.pruneIdle())
+	assertPodTracked(t, tr, "prune-c", false)
+}
+
+func TestTokenLoadTracker_PruneRacesWithCharges(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, testTokenLoadConfig())
+
+	const (
+		workers   = 8
+		perWorker = 500
+		cost      = 3.0
+	)
+	stop := make(chan struct{})
+	var pruner sync.WaitGroup
+	pruner.Add(1)
+	go func() {
+		defer pruner.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				tr.pruneIdle()
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				id := fmt.Sprintf("race-w%d-r%d", w, i)
+				tr.AcquirePrefill(id, "prune-race", cost)
+				tr.ReleaseTokens(id)
+				tr.ReleaseKVCache(id)
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(stop)
+	pruner.Wait()
+
+	// Every charge was balanced by its releases whether or not the pruner
+	// dropped the counters in between, so nothing is left on the pod, and
+	// at most two more quiet sweeps drop it (the pruner may already have).
+	assertLoad(t, tr, "prune-race", 0, 0)
+	tr.pruneIdle()
+	tr.pruneIdle()
+	assertPodTracked(t, tr, "prune-race", false)
 }
 
 func TestTokenLoadTracker_ConcurrentChargesBalance(t *testing.T) {

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -100,7 +100,7 @@ var (
 	aibrixPromptLengthBucketing bool = utils.LoadEnvBool("AIBRIX_PROMPT_LENGTH_BUCKETING", false)
 	// KV transfer backend: "shfs" (GPU/SHFS) or "nixl" (Neuron)
 	aibrixKVConnectorType string = utils.LoadEnv("AIBRIX_KV_CONNECTOR_TYPE", KVConnectorTypeSHFS)
-	// prefill pod scoring strategy: "prefix_cache" or "least_request"
+	// prefill pod scoring strategy: "prefix_cache", "least_request", "conductor" or "token_load"
 	aibrixPrefillScorePolicy string = utils.LoadEnv("AIBRIX_PREFILL_SCORE_POLICY", pd.PrefillScorePolicyPrefixCache)
 	// decode pod scoring strategy: "load_balancing" or "least_request"
 	aibrixDecodeScorePolicy string = utils.LoadEnv("AIBRIX_DECODE_SCORE_POLICY", pd.ScorePolicyLoadBalancing)
@@ -108,6 +108,15 @@ var (
 
 // loadBalancingDecodePolicy is shared for nil-policy fallback and invalid-score fallback (stateless type).
 var loadBalancingDecodePolicy = pd.LoadBalancingDecodePolicy{}
+
+// validPrefillScorePolicies lists the accepted AIBRIX_PREFILL_SCORE_POLICY /
+// routingConfig.prefillScorePolicy values, for log lines.
+var validPrefillScorePolicies = []string{
+	pd.PrefillScorePolicyPrefixCache,
+	pd.PrefillScorePolicyLeastRequest,
+	pd.PrefillScorePolicyConductor,
+	pd.PrefillScorePolicyTokenLoad,
+}
 
 func init() {
 	Register(RouterPD, NewPDRouter)
@@ -168,10 +177,12 @@ func (r *pdRouter) effectiveScorePolicies(routingCtx *types.RoutingContext) (pd.
 			prefill = newPrefixCachePrefillPolicy(r.prefixCacheIndexer)
 		case pd.PrefillScorePolicyConductor:
 			prefill = newConductorPrefillPolicy(r.prefixCacheIndexer, r.cache)
+		case pd.PrefillScorePolicyTokenLoad:
+			prefill = pd.NewTokenLoadPrefillPolicy(r.tokenLoadTracker)
 		default:
 			klog.InfoS("unknown prefillScorePolicy in routingConfig, keeping env-based policy",
 				"request_id", routingCtx.RequestID, "value", s,
-				"valid", []string{pd.PrefillScorePolicyPrefixCache, pd.PrefillScorePolicyLeastRequest, pd.PrefillScorePolicyConductor})
+				"valid", validPrefillScorePolicies)
 			prefill = r.prefillPolicy
 		}
 	}
@@ -207,6 +218,14 @@ type pdRouter struct {
 	podSelector           selector.PodSelector
 	prefillExecutor       prefill.PrefillExecutor
 
+	// tokenLoadTracker is the token-weighted prefill ledger read by the
+	// token_load policy. It is charged in filterPrefillDecodePods for requests
+	// scored by that policy, released by the prefill executor when the prefill
+	// call returns, and released fully on request completion through the
+	// cache.RequestTracker callbacks (see DoneRequestCount). nil in routers
+	// built without one (tests); every access is nil-guarded.
+	tokenLoadTracker *pd.TokenLoadTracker
+
 	// selectMu makes "read every candidate's tracked load, pick the best,
 	// register the pick" one atomic step in filterPrefillDecodePods. Without
 	// it, concurrent requests in a burst all read the same pre-burst tracker
@@ -238,6 +257,9 @@ func NewPDRouter() (types.Router, error) {
 	}
 
 	sharedPrefixTable := prefixcacheindexer.GetSharedPrefixHashTable()
+	// One tracker per router, created unconditionally so that a routingConfig
+	// can switch a model to token_load without a gateway restart.
+	tokenLoadTracker := pd.NewTokenLoadTracker()
 
 	var policy pd.PrefillScorePolicy
 	switch aibrixPrefillScorePolicy {
@@ -247,9 +269,11 @@ func NewPDRouter() (types.Router, error) {
 		policy = newPrefixCachePrefillPolicy(sharedPrefixTable)
 	case pd.PrefillScorePolicyConductor:
 		policy = newConductorPrefillPolicy(sharedPrefixTable, c)
+	case pd.PrefillScorePolicyTokenLoad:
+		policy = pd.NewTokenLoadPrefillPolicy(tokenLoadTracker)
 	default:
 		klog.InfoS("pd_router unknown AIBRIX_PREFILL_SCORE_POLICY, using prefix_cache",
-			"value", aibrixPrefillScorePolicy, "valid", []string{pd.PrefillScorePolicyPrefixCache, pd.PrefillScorePolicyLeastRequest})
+			"value", aibrixPrefillScorePolicy, "valid", validPrefillScorePolicies)
 		policy = newPrefixCachePrefillPolicy(sharedPrefixTable)
 	}
 	klog.InfoS("pd_router prefill score policy", "policy", policy.Name())
@@ -279,15 +303,58 @@ func NewPDRouter() (types.Router, error) {
 		prefixCacheIndexer:    sharedPrefixTable,
 		prefillRequestTracker: pd.NewPrefillRequestTracker(),
 		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
+		tokenLoadTracker:      tokenLoadTracker,
 		httpClient:            httpClient,
 		prefixUpdateCh:        make(chan prefixUpdateJob, 1024),
 		selectionCounts:       make(map[string]int64),
 	}
 	r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
-	r.prefillExecutor = prefill.NewDefaultExecutor(httpClient, r.prefillRequestTracker, prefillRequestTimeout)
+	r.prefillExecutor = prefill.NewDefaultExecutor(httpClient, r.prefillRequestTracker, prefillRequestTimeout,
+		prefill.WithTokenLoadTracker(tokenLoadTracker))
+	// Request completion is only observable through the cache's request
+	// tracker callbacks; that is where the resident-KV charge is released.
+	c.RegisterRequestTracker(r)
 
 	r.startPrefixUpdater()
 	return r, nil
+}
+
+// AddRequestCount implements cache.RequestTracker. The pd router charges its
+// ledgers at selection time (filterPrefillDecodePods), so there is nothing to
+// do here.
+func (r *pdRouter) AddRequestCount(_ *types.RoutingContext, _ string, _ string) int64 { return 0 }
+
+// DoneRequestCount implements cache.RequestTracker: the request is finished,
+// so nothing of it can still be resident on its prefill pod. The callbacks
+// fire for every gateway request, not only pd-routed ones; unknown request
+// IDs are a cheap no-op. ctx may be nil (request cancelled before routing).
+func (r *pdRouter) DoneRequestCount(_ *types.RoutingContext, requestID string, _ string, _ int64) {
+	r.releaseTokenLoad(requestID)
+}
+
+// DoneRequestTrace implements cache.RequestTracker; see DoneRequestCount.
+func (r *pdRouter) DoneRequestTrace(_ *types.RoutingContext, requestID string, _ string, _, _, _ int64) {
+	r.releaseTokenLoad(requestID)
+}
+
+// chargeTokenLoad charges the request's estimated prefill cost to pod when
+// policy scores from the token-load tracker. Called under selectMu right after
+// the prefill registration so the next selection sees this charge.
+func (r *pdRouter) chargeTokenLoad(routingCtx *types.RoutingContext, pod *v1.Pod, policy pd.PrefillScorePolicy) {
+	if r.tokenLoadTracker == nil || !pd.UsesTokenLoad(policy) {
+		return
+	}
+	cost := r.tokenLoadTracker.PrefillCost(pd.EstimatePromptTokens(routingCtx.ReqBody))
+	r.tokenLoadTracker.AcquirePrefill(routingCtx.RequestID, pod.Name, cost)
+}
+
+// releaseTokenLoad drops whatever the request still holds on the token-load
+// tracker: the terminal paths (prefill failure, request completion).
+func (r *pdRouter) releaseTokenLoad(requestID string) {
+	if r.tokenLoadTracker == nil {
+		return
+	}
+	r.tokenLoadTracker.ReleaseAll(requestID)
 }
 
 func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) (string, error) {
@@ -329,6 +396,7 @@ func (r *pdRouter) Route(ctx *types.RoutingContext, readyPodList types.PodList) 
 		if err != nil {
 			// Remove is a no-op if the executor already cleaned up (e.g. sync HTTP failure).
 			r.prefillRequestTracker.RemovePrefillRequest(ctx.RequestID)
+			r.releaseTokenLoad(ctx.RequestID)
 			metrics.EmitMetricToPrometheus(ctx, nil, metrics.GatewayPrefillRequestFailTotal, &metrics.SimpleMetricValue{Value: 1.0},
 				map[string]string{"status": pdRoutePrefillRequestError, "status_code": "500"})
 			klog.ErrorS(err, pdRoutePrefillRequestError, "request_id", ctx.RequestID)
@@ -383,7 +451,8 @@ type Scores struct {
 //     combined score.
 //
 //  7. Register — the chosen decode pod is recorded in pendingDecodeTracker and the
-//     chosen prefill pod in prefillRequestTracker before returning, so the next
+//     chosen prefill pod in prefillRequestTracker (and, under the token_load
+//     policy, charged to tokenLoadTracker) before returning, so the next
 //     selection sees this one. Steps 3b-7 read tracker state and run under
 //     selectMu; steps 1-3a and the policy Prepare step (tokenization, prefix
 //     matching) run before the lock is taken. Route owns the matching removals.
@@ -479,6 +548,7 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 	// Register while still holding selectMu so the next selection counts this one.
 	r.pendingDecodeTracker.AddPendingDecode(routingCtx.RequestID, selectedDecode.Name)
 	r.prefillRequestTracker.AddPrefillRequest(routingCtx.RequestID, selectedPrefill.Name)
+	r.chargeTokenLoad(routingCtx, selectedPrefill, prefillPol)
 	return selectedPrefill, selectedDecode, nil
 }
 

--- a/pkg/plugins/gateway/algorithms/pd_token_load_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_token_load_test.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/prefill"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd/selector"
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
+	v1 "k8s.io/api/core/v1"
+)
+
+// tokenLoadTestConfig has no fixed per-request cost, so a request's charge is
+// exactly len(body)/4 and the assertions below can be read off the bodies.
+var tokenLoadTestConfig = pd.TokenLoadConfig{KVWeight: 0.5, RequestCost: 0, TTL: 0}
+
+// newTokenLoadTestRouter builds a pd router on the token_load policy whose
+// prefill calls go through client, mirroring NewPDRouter's wiring of the
+// tracker into the policy and the executor.
+func newTokenLoadTestRouter(client *http.Client) (*pdRouter, *pd.TokenLoadTracker) {
+	tokenLoad := pd.NewTokenLoadTrackerWithConfig(tokenLoadTestConfig)
+	tracker := pd.NewPrefillRequestTracker()
+	r := &pdRouter{
+		cache:                 cache.NewForTest(),
+		prefillPolicy:         pd.NewTokenLoadPrefillPolicy(tokenLoad),
+		decodePolicy:          pd.LoadBalancingDecodePolicy{},
+		prefillRequestTracker: tracker,
+		pendingDecodeTracker:  pd.NewPendingDecodeTracker(),
+		tokenLoadTracker:      tokenLoad,
+		httpClient:            client,
+		prefixUpdateCh:        make(chan prefixUpdateJob, 1024),
+		selectionCounts:       map[string]int64{},
+	}
+	r.podSelector = selector.NewDefaultSelector(r.filterPrefillDecodePods)
+	r.prefillExecutor = prefill.NewDefaultExecutor(client, tracker, prefillRequestTimeout, prefill.WithTokenLoadTracker(tokenLoad))
+	return r, tokenLoad
+}
+
+// tokenLoadRequest builds a vLLM chat request whose body is padded to exactly
+// bodyBytes bytes, i.e. bodyBytes/4 estimated prompt tokens.
+func tokenLoadRequest(t *testing.T, requestID string, bodyBytes int) *types.RoutingContext {
+	t.Helper()
+	const frame = `{"messages":[{"role":"user","content":""}],"stream":true}`
+	require.Greater(t, bodyBytes, len(frame))
+	body := strings.Replace(frame, `"content":""`, `"content":"`+strings.Repeat("x", bodyBytes-len(frame))+`"`, 1)
+	require.Len(t, body, bodyBytes)
+
+	ctx := types.NewRoutingContext(context.Background(), "pd", "token-load-model", "x", requestID, "user")
+	ctx.Engine = "vllm"
+	ctx.ReqPath = testChatCompletionsPath
+	ctx.ReqBody = []byte(body)
+	return ctx
+}
+
+// waitForActiveTokens polls until the sum of active tokens over pods equals
+// want, i.e. until the in-flight prefills charged so far are all visible.
+func waitForActiveTokens(t *testing.T, tracker *pd.TokenLoadTracker, pods []*v1.Pod, want float64) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		total := 0.0
+		for _, pod := range pods {
+			active, _ := tracker.GetLoad(pod.Name)
+			total += active
+		}
+		if total == want {
+			return
+		}
+		require.Truef(t, time.Now().Before(deadline), "active tokens stuck at %g, want %g", total, want)
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestPDRouter_TokenLoadSpreadsByPromptCost holds one long prefill open and
+// then routes two short prompts. Under least_request the second short prompt
+// would go to the pod holding the long one (both pods have one request);
+// under token_load both short prompts go to the other pod because two short
+// prompts cost far less than one long one. The test then walks the charge
+// through its lifecycle: prefill return releases the active part, request
+// completion (the cache.RequestTracker callback) releases the resident KV.
+func TestPDRouter_TokenLoadSpreadsByPromptCost(t *testing.T) {
+	const (
+		longBytes  = 40_000 // 10_000 tokens
+		shortBytes = 400    // 100 tokens
+	)
+	prefillPods := []*v1.Pod{
+		burstPod("prefill-0", "prefill", "127.0.0.1"),
+		burstPod("prefill-1", "prefill", "127.0.0.2"),
+	}
+	decodePod := burstPod("decode-0", "decode", "127.0.0.100")
+	podList := &utils.PodArray{Pods: append(append([]*v1.Pod{}, prefillPods...), decodePod)}
+
+	gate := make(chan struct{})
+	r, tokenLoad := newTokenLoadTestRouter(&http.Client{Transport: &gatedTransport{gate: gate}})
+
+	longCtx := tokenLoadRequest(t, "long", longBytes)
+	shortCtxs := []*types.RoutingContext{
+		tokenLoadRequest(t, "short-0", shortBytes),
+		tokenLoadRequest(t, "short-1", shortBytes),
+	}
+
+	errs := make(chan error, 3)
+	go func() { _, err := r.Route(longCtx, podList); errs <- err }()
+	waitForActiveTokens(t, tokenLoad, prefillPods, longBytes/4)
+
+	for i, ctx := range shortCtxs {
+		go func(ctx *types.RoutingContext) { _, err := r.Route(ctx, podList); errs <- err }(ctx)
+		waitForActiveTokens(t, tokenLoad, prefillPods, longBytes/4+float64(i+1)*shortBytes/4)
+	}
+
+	// While everything is held: the long prompt is alone on its pod and both
+	// short prompts share the other one. (The routing contexts are still owned
+	// by the parked Route calls, so the ledger is what is inspected here.)
+	longPod, shortPod := prefillPods[0].Name, prefillPods[1].Name
+	if active, _ := tokenLoad.GetLoad(longPod); active != longBytes/4 {
+		longPod, shortPod = shortPod, longPod
+	}
+	active, kv := tokenLoad.GetLoad(longPod)
+	assert.Equal(t, float64(longBytes/4), active)
+	assert.Equal(t, float64(longBytes/4), kv)
+	active, kv = tokenLoad.GetLoad(shortPod)
+	assert.Equal(t, float64(2*shortBytes/4), active)
+	assert.Equal(t, float64(2*shortBytes/4), kv)
+
+	// Prefill calls return: active charges drop, KV stays resident.
+	close(gate)
+	for i := 0; i < 3; i++ {
+		require.NoError(t, <-errs)
+	}
+	assert.Equal(t, longPod, longCtx.RespHeaders[HeaderPrefillTargetPod])
+	for _, ctx := range shortCtxs {
+		assert.Equalf(t, shortPod, ctx.RespHeaders[HeaderPrefillTargetPod], "%s must avoid the pod holding the long prompt", ctx.RequestID)
+	}
+	for _, pod := range prefillPods {
+		active, kv := tokenLoad.GetLoad(pod.Name)
+		assert.Equalf(t, float64(0), active, "%s active tokens after prefill returned", pod.Name)
+		assert.Greaterf(t, kv, float64(0), "%s kv tokens must stay resident until completion", pod.Name)
+	}
+	assert.Equal(t, float64(0.5*longBytes/4), tokenLoad.GetPriority(longPod), "only weighted KV is left")
+
+	// Request completion via the cache.RequestTracker callbacks clears the
+	// KV charge; unknown request IDs and a nil context are harmless.
+	r.DoneRequestCount(nil, "long", longCtx.Model, 0)
+	r.DoneRequestTrace(nil, "short-0", longCtx.Model, 0, 0, 0)
+	r.DoneRequestCount(nil, "never-routed", longCtx.Model, 0)
+	_, kv = tokenLoad.GetLoad(longPod)
+	assert.Equal(t, float64(0), kv)
+	_, kv = tokenLoad.GetLoad(shortPod)
+	assert.Equal(t, float64(shortBytes/4), kv, "short-1 has not completed yet")
+
+	r.DoneRequestCount(nil, "short-1", longCtx.Model, 0)
+	_, kv = tokenLoad.GetLoad(shortPod)
+	assert.Equal(t, float64(0), kv)
+	assert.Equal(t, int64(0), r.AddRequestCount(longCtx, "long", longCtx.Model))
+}
+
+// failingTransport fails every prefill call.
+type failingTransport struct{}
+
+func (failingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		_ = req.Body.Close()
+	}
+	return nil, errors.New("prefill pod unreachable")
+}
+
+// TestPDRouter_TokenLoadReleasedOnPrefillFailure checks that a failed prefill
+// leaves nothing charged: the executor releases the active part when the
+// call returns and Route's error path releases the rest.
+func TestPDRouter_TokenLoadReleasedOnPrefillFailure(t *testing.T) {
+	prefillPod := burstPod("prefill-0", "prefill", "127.0.0.1")
+	podList := &utils.PodArray{Pods: []*v1.Pod{prefillPod, burstPod("decode-0", "decode", "127.0.0.100")}}
+	r, tokenLoad := newTokenLoadTestRouter(&http.Client{Transport: failingTransport{}})
+
+	_, err := r.Route(tokenLoadRequest(t, "doomed", 4000), podList)
+	require.Error(t, err)
+
+	active, kv := tokenLoad.GetLoad(prefillPod.Name)
+	assert.Equal(t, float64(0), active)
+	assert.Equal(t, float64(0), kv)
+	assert.Equal(t, 0, r.prefillRequestTracker.GetPrefillRequestCountsForPod(prefillPod.Name))
+}
+
+// TestPDRouter_TokenLoadChargedOnlyForTokenLoadPolicy checks that the tracker
+// is left alone when another policy scores the request, and that
+// routingConfig can switch a request to token_load on a router whose env
+// default is a different policy.
+func TestPDRouter_TokenLoadChargedOnlyForTokenLoadPolicy(t *testing.T) {
+	prefillPod := burstPod("prefill-0", "prefill", "127.0.0.1")
+	decodePod := burstPod("decode-0", "decode", "127.0.0.100")
+	readyPods := []*v1.Pod{prefillPod, decodePod}
+
+	gate := make(chan struct{})
+	close(gate) // prefill returns immediately
+	r, tokenLoad := newTokenLoadTestRouter(&http.Client{Transport: &gatedTransport{gate: gate}})
+	r.prefillPolicy = pd.NewLeastRequestPrefillPolicy()
+
+	_, _, err := r.filterPrefillDecodePods(tokenLoadRequest(t, "least-request", 4000), readyPods)
+	require.NoError(t, err)
+	active, kv := tokenLoad.GetLoad(prefillPod.Name)
+	assert.Equal(t, float64(0), active, "least_request must not charge the token-load tracker")
+	assert.Equal(t, float64(0), kv)
+
+	ctx := tokenLoadRequest(t, "via-routing-config", 4000)
+	ctx.ConfigProfile = &types.ResolvedConfigProfile{
+		RoutingConfig: json.RawMessage(fmt.Sprintf(`{"prefillScorePolicy":%q}`, pd.PrefillScorePolicyTokenLoad)),
+	}
+	pre, _, err := r.effectiveScorePolicies(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, pd.PrefillScorePolicyTokenLoad, pre.Name())
+
+	_, _, err = r.filterPrefillDecodePods(ctx, readyPods)
+	require.NoError(t, err)
+	active, kv = tokenLoad.GetLoad(prefillPod.Name)
+	assert.Equal(t, float64(1000), active, "token_load selected through routingConfig charges the tracker")
+	assert.Equal(t, float64(1000), kv)
+}

--- a/test/e2e/gateway/pd/helpers_test.go
+++ b/test/e2e/gateway/pd/helpers_test.go
@@ -23,8 +23,10 @@ var e2eConfig = framework.LoadConfig()
 var (
 	gatewayURL                            = e2eConfig.GatewayURL
 	apiKey                                = e2eConfig.APIKey
+	gatewayNamespace                      = e2eConfig.GatewayNamespace
 	initializeClient                      = framework.InitializeClient
 	createOpenAIClientWithRoutingStrategy = framework.NewOpenAIClientWithRoutingStrategy
+	createOpenAIClientWithConfigProfile   = framework.NewOpenAIClientWithConfigProfile
 	validateAllPodsAreReady               = framework.ValidateAllPodsAreReady
 	waitForPDDisaggregationRouting        = framework.WaitForPDDisaggregationRouting
 	waitForPDCombinedRouting              = framework.WaitForPDCombinedRouting

--- a/test/e2e/gateway/pd/pd_token_load_test.go
+++ b/test/e2e/gateway/pd/pd_token_load_test.go
@@ -207,7 +207,9 @@ func TestPDDisaggregationVLLMTokenLoad(t *testing.T) {
 			if g.podName != podName {
 				continue
 			}
-			found = true
+			if g.metric == metrics.PDTokenLoadKVTokens {
+				found = true
+			}
 			assert.Zero(t, g.value, "%s should be released after the request completed", g)
 		}
 		assert.True(t, found, "prefill pod %s served a token_load request but no %s series was published for it",

--- a/test/e2e/gateway/pd/pd_token_load_test.go
+++ b/test/e2e/gateway/pd/pd_token_load_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/vllm-project/aibrix/pkg/metrics"
+)
+
+const (
+	// tokenLoadConfigProfile is the model.aibrix.ai/config profile declared in
+	// development/app/config/mock/vllm-pd-config.yaml that selects
+	// routingConfig.prefillScorePolicy=token_load for the llama2-7b-vllm PD model.
+	tokenLoadConfigProfile = "token-load"
+
+	gatewayPluginsLabelSelector = "app=gateway-plugins"
+	gatewayPluginsMetricsPort   = "8080"
+	gatewayPluginsMetricsPath   = "metrics"
+)
+
+// tokenLoadGauge is one pd_token_load_* series scraped from one gateway-plugins pod.
+type tokenLoadGauge struct {
+	gateway string
+	metric  string
+	podName string
+	value   float64
+}
+
+func (g tokenLoadGauge) String() string {
+	return fmt.Sprintf("%s{pod_name=%q}=%g on %s", g.metric, g.podName, g.value, g.gateway)
+}
+
+// listGatewayPluginPods returns the running gateway-plugins pods. The e2e
+// deployment runs more than one replica and every replica keeps its own
+// token-load ledger, so metrics have to be scraped from all of them.
+func listGatewayPluginPods(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientset) []corev1.Pod {
+	t.Helper()
+	pods, err := k8sClient.CoreV1().Pods(gatewayNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: gatewayPluginsLabelSelector,
+	})
+	require.NoError(t, err)
+	running := make([]corev1.Pod, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			running = append(running, pod)
+		}
+	}
+	require.NotEmpty(t, running, "no running gateway-plugins pods found in namespace %s", gatewayNamespace)
+	return running
+}
+
+// scrapeTokenLoadGauges reads /metrics from every gateway-plugins pod through
+// the API server proxy and returns the pd_token_load_active_tokens and
+// pd_token_load_kv_tokens series it finds.
+func scrapeTokenLoadGauges(
+	ctx context.Context, k8sClient *kubernetes.Clientset, gatewayPods []corev1.Pod,
+) ([]tokenLoadGauge, error) {
+	var gauges []tokenLoadGauge
+	for _, gw := range gatewayPods {
+		raw, err := k8sClient.CoreV1().Pods(gatewayNamespace).ProxyGet(
+			"http", gw.Name, gatewayPluginsMetricsPort, gatewayPluginsMetricsPath, nil,
+		).DoRaw(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("scrape %s: %w", gw.Name, err)
+		}
+		var parser expfmt.TextParser
+		families, err := parser.TextToMetricFamilies(bytes.NewReader(raw))
+		if err != nil {
+			return nil, fmt.Errorf("parse metrics from %s: %w", gw.Name, err)
+		}
+		for _, name := range []string{metrics.PDTokenLoadActiveTokens, metrics.PDTokenLoadKVTokens} {
+			family, ok := families[name]
+			if !ok {
+				continue
+			}
+			for _, m := range family.GetMetric() {
+				g := tokenLoadGauge{gateway: gw.Name, metric: name, value: m.GetGauge().GetValue()}
+				for _, label := range m.GetLabel() {
+					if label.GetName() == "pod_name" {
+						g.podName = label.GetValue()
+					}
+				}
+				gauges = append(gauges, g)
+			}
+		}
+	}
+	return gauges, nil
+}
+
+// TestPDDisaggregationVLLMTokenLoad verifies the token_load prefill score policy
+// end to end: selecting it through a model config profile keeps PD routing
+// working, every prefill pod it routes to is charged in the gateway's token
+// ledger (visible as pd_token_load_* gauges labelled with that pod), and the
+// charges are released once the requests complete, so nothing leaks.
+//
+// The mock engines answer in milliseconds and the e2e gateway runs several
+// replicas with independent ledgers, so the load-steering behaviour itself is
+// covered by the router unit tests; this test pins the wiring.
+func TestPDDisaggregationVLLMTokenLoad(t *testing.T) {
+	const iterations = 6
+	ctx := context.Background()
+
+	waitForPDDisaggregationRouting(t, modelNameVLLM)
+
+	k8sClient, _ := initializeClient(ctx, t)
+	gatewayPods := listGatewayPluginPods(t, ctx, k8sClient)
+
+	longPrompt := strings.Repeat("token load e2e prompt ", 300)
+	shortPrompt := "token load e2e short prompt"
+
+	var dst *http.Response
+	client := createOpenAIClientWithConfigProfile(gatewayURL, apiKey, tokenLoadConfigProfile,
+		option.WithResponseInto(&dst))
+
+	prefillPods := map[string]struct{}{}
+	for i := 0; i < iterations; i++ {
+		prompt := shortPrompt
+		if i%2 == 0 {
+			prompt = longPrompt
+		}
+		_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage(prompt)},
+			Model:    modelNameVLLM,
+		})
+		require.NoError(t, err, "token_load PD chat completion request %d failed", i)
+
+		assert.Equal(t, "pd", dst.Header.Get("routing-strategy"),
+			"request %d: config profile %q should resolve to PD routing", i, tokenLoadConfigProfile)
+		prefillPod := dst.Header.Get("prefill-target-pod")
+		decodePod := dst.Header.Get("target-pod")
+		require.NotEmpty(t, prefillPod, "request %d: prefill-target-pod header must be set", i)
+		require.NotEmpty(t, decodePod, "request %d: target-pod header must be set", i)
+		assert.NotEqual(t, prefillPod, decodePod, "request %d: prefill and decode pods should differ", i)
+		prefillPods[prefillPod] = struct{}{}
+		t.Logf("request %d — prefill: %s, decode: %s", i, prefillPod, decodePod)
+	}
+
+	// Every prefill pod that served a request must have been charged on the
+	// gateway replica that routed it, and all charges must be back at zero
+	// once the responses have been delivered.
+	var lastGauges []tokenLoadGauge
+	err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			gauges, err := scrapeTokenLoadGauges(ctx, k8sClient, gatewayPods)
+			if err != nil {
+				t.Logf("waiting for gateway metrics: %v", err)
+				return false, nil
+			}
+			lastGauges = gauges
+
+			charged := map[string]bool{}
+			settled := true
+			for _, g := range gauges {
+				if _, ok := prefillPods[g.podName]; !ok {
+					continue
+				}
+				if g.metric == metrics.PDTokenLoadKVTokens {
+					charged[g.podName] = true
+				}
+				if g.value != 0 {
+					settled = false
+				}
+			}
+			if len(charged) != len(prefillPods) || !settled {
+				t.Logf("waiting for token_load gauges (charged %d/%d prefill pods, settled=%v)",
+					len(charged), len(prefillPods), settled)
+				return false, nil
+			}
+			return true, nil
+		})
+	require.NoError(t, err, "token_load gauges did not settle; last scrape: %v", lastGauges)
+
+	for podName := range prefillPods {
+		found := false
+		for _, g := range lastGauges {
+			if g.podName != podName {
+				continue
+			}
+			found = true
+			assert.Zero(t, g.value, "%s should be released after the request completed", g)
+		}
+		assert.True(t, found, "prefill pod %s served a token_load request but no %s series was published for it",
+			podName, metrics.PDTokenLoadKVTokens)
+	}
+	t.Logf("token_load gauges after %d requests: %v", iterations, lastGauges)
+}


### PR DESCRIPTION
## Pull Request Description

First of the two PRs proposed in #2680: the `token_load` prefill score policy and the ledger behind it. (`hybrid_cache_load` and the new-tokens cost model follow in a second PR stacked on this one.)

### Why

`least_request` scores prefill pods by in-flight request count, so a 100-token prompt and a 30k-token prompt are the same unit of load. Under mixed prompt lengths a pod that drew a few long prompts keeps receiving new requests until its count catches up with its neighbours, which shows up as a TTFT tail on those pods. #2680 has the full motivation and the design.

### What

**`pd.TokenLoadTracker`** (`pd/token_load_tracker.go`) keeps two per-pod counters:

- `active_tokens`: prompt tokens of the prefills the pod is computing now
- `kv_tokens`: prompt tokens whose KV cache is still resident on the pod (decode has not finished with the request)

Charge lifecycle:

1. `AcquirePrefill` in `filterPrefillDecodePods`, under `selectMu` right after `AddPrefillRequest`, so concurrent selections see each other's charges. Cost = `request_cost + len(body)/4`.
2. `ReleaseTokens` when the prefill HTTP call returns, from `DefaultExecutor` at the same point where it removes the `PrefillRequestTracker` registration (sync and async paths).
3. `ReleaseKVCache` when the request completes. The router registers itself as a `cache.RequestTracker` (same mechanism `PowerOfTwoRouter` uses) and releases in `DoneRequestCount` / `DoneRequestTrace`. Route's prefill-failure path releases everything.

Releases are idempotent per request ID and may arrive in either order (each part of a charge has its own once-flag; the entry is dropped once both are set), counters clamp at zero, and a TTL janitor force-releases (with a warning log) any charge whose release never arrived, so a leaked entry cannot pin load on a pod forever. A re-acquire under a request ID that is still tracked releases the earlier charge first and logs a warning. The janitor also prunes pods that have been at zero and untouched for a whole sweep interval (one minute), dropping their counters and gauge series, so pod churn does not grow the ledger; writers hold the read side of an RWMutex around update + gauge set, the janitor the write side while pruning, and counter reads stay lock-free.

**`token_load` policy** (`pd/prefill_scorer.go`): `score = active_tokens + kv_weight × kv_tokens`, lower is better. No tokenizer, no prefix-cache lookup. Selectable via `AIBRIX_PREFILL_SCORE_POLICY=token_load` or `routingConfig.prefillScorePolicy`; the tracker is created once per router so the routingConfig path works without a restart. Other policies never touch the tracker (`chargeTokenLoad` is gated on the effective policy).

**Config** (all positive; invalid values keep the default):

| Variable | Default | |
|---|---|---|
| `AIBRIX_TOKEN_LOAD_KV_WEIGHT` | `0.3` | weight of resident KV tokens |
| `AIBRIX_TOKEN_LOAD_REQUEST_COST` | `3500` | fixed per-request cost in tokens |
| `AIBRIX_TOKEN_LOAD_TTL_SECONDS` | `3600` | max age of an outstanding charge |

**Metrics**: `pd_token_load_active_tokens` and `pd_token_load_kv_tokens` gauges labelled by `pod_name`, set from `pkg/metrics` like the other gateway metrics; `pkg/metrics` gains a label-based `DeleteGaugeMetric` (sibling of `DeleteGaugeMetricForPod`) so the series of a pruned pod stop being exported. (The RFC sketched them as `aibrix_gateway_pd_token_load_*`; I followed the bare-name convention of `gateway_metrics.go` instead. Happy to rename if maintainers prefer the prefixed form.)

**Docs**: new "Token Load Scoring Policy" section in `pd-disaggregation.rst`, plus the policy lists and env table.

### Notes for reviewers

- `prefill.NewDefaultExecutor` gains a variadic `ExecutorOption`; existing callers are unchanged.
- The prompt-token estimate is `len(ReqBody)/4` on purpose: it costs nothing and only the ranking matters. The second PR replaces it with a per-session new-tokens estimate where a session id is available.
- The formula and the `3500` request cost come from the benchmark in #2680, where `0.0345 × (tokens + 3480)` was the fitted prefill cost; dropping the multiplier keeps the ranking.

### Testing

- `pd/token_load_tracker_test.go`: lifecycle, per-pod isolation, idempotent releases, clamp at zero, unknown IDs, KV-before-tokens release order, re-acquire releases the earlier charge, cost/estimate, env config, janitor with a fake clock (stale vs fresh, no double-subtract of an already-released part, TTL 0 disables), idle-pod pruning (touched pods and pods with a charge survive, pruned pods lose both series and are re-created by the next charge, pruning after a force-release), pruning racing acquire/release, concurrent acquire/release.
- `pkg/metrics/custom_metrics_test.go`: `DeleteGaugeMetric` (label order, unknown series, mismatched labels).
- `pd/prefill_scorer_token_load_test.go`: policy name, scores read from the tracker and ignore request counts, nil `PrefixHashes`, nil-tracker fallback.
- `pd_token_load_test.go` (router level, gated prefill transport): one long prompt held open, two short prompts both land on the other pod (least_request would split them); active charges drop when the gate opens while KV stays; `DoneRequestCount`/`DoneRequestTrace` clear KV; prefill failure leaves nothing charged; `least_request` does not charge the tracker; `routingConfig.prefillScorePolicy=token_load` charges it.
- `test/e2e/gateway/pd/pd_token_load_test.go` (`TestPDDisaggregationVLLMTokenLoad`): the vLLM PD mock roles declare a `token-load` config profile (`routingConfig.prefillScorePolicy=token_load`); requests sent with `config-profile: token-load` must still get distinct prefill/decode pods, and the `pd_token_load_*` gauges scraped from every gateway-plugins replica must show each prefill pod that served a request charged and then back at zero once the responses complete. The steering behaviour itself stays in the router unit tests: the mock engines answer in milliseconds and the e2e gateway runs two replicas with independent ledgers.
- `go test -race ./pkg/plugins/gateway/algorithms/pd/... ./pkg/plugins/gateway/algorithms/ ./pkg/metrics/...` and `golangci-lint` (v2.13.1) pass locally.

## Related Issues

Part of #2680 (second PR to follow).

Co-authored with @zhutong196.

