### PR TITLE
[Gateway] Add hybrid_cache_load prefill policy and new-tokens charge to the PD router

### DIFF
--- a/development/app/config/mock/vllm-pd-config.yaml
+++ b/development/app/config/mock/vllm-pd-config.yaml
@@ -10,6 +10,7 @@
 # profiles used by config-profile e2e tests are declared on each role:
 #   - "pd" (default): PD routing with the gateway's default prefill score policy
 #   - "token-load":   PD routing with prefillScorePolicy token_load
+#   - "hybrid-cache-load": PD routing with prefillScorePolicy hybrid_cache_load
 #
 # Apply alongside components.yaml (provides mocked-app-sa and RBAC).
 apiVersion: orchestration.aibrix.ai/v1alpha1
@@ -67,6 +68,12 @@ spec:
                         "routingConfig": {
                           "prefillScorePolicy": "token_load"
                         }
+                      },
+                      "hybrid-cache-load": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "prefillScorePolicy": "hybrid_cache_load"
+                        }
                       }
                     }
                   }
@@ -116,6 +123,12 @@ spec:
                         "routingStrategy": "pd",
                         "routingConfig": {
                           "prefillScorePolicy": "token_load"
+                        }
+                      },
+                      "hybrid-cache-load": {
+                        "routingStrategy": "pd",
+                        "routingConfig": {
+                          "prefillScorePolicy": "hybrid_cache_load"
                         }
                       }
                     }

--- a/docs/source/features/gateway-plugins.rst
+++ b/docs/source/features/gateway-plugins.rst
@@ -359,7 +359,7 @@ Target and General Headers
      - Session identifier used by ``session-affinity`` routing. The response value should be sent on subsequent requests to retain affinity.
    * - ``x-aibrix-session-key``
      - Request
-     - Caller-owned opaque session key used by ``session-affinity`` routing.
+     - Caller-owned opaque session key used by ``session-affinity`` routing and, under ``pd`` routing with the ``token_load`` or ``hybrid_cache_load`` prefill policy, to charge a multi-turn conversation only for its new tokens.
    * - ``traceparent``
      - Request, Backend request
      - W3C Trace Context propagated through requests initiated by the gateway, including prefill-decode routing.

--- a/docs/source/features/pd-disaggregation.rst
+++ b/docs/source/features/pd-disaggregation.rst
@@ -288,7 +288,7 @@ Configure the range in the pod's ``routingConfig``:
    * - ``combined``
      - ``true`` = this pod is a standard inference pod (runs both prefill and decode). Default: ``false``.
    * - ``prefillScorePolicy``
-     - How to score prefill pods. ``prefix_cache`` (default), ``least_request``, ``conductor``, or ``token_load``.
+     - How to score prefill pods. ``prefix_cache`` (default), ``least_request``, ``conductor``, ``token_load``, or ``hybrid_cache_load``.
    * - ``decodeScorePolicy``
      - How to score decode pods. ``load_balancing`` (default), ``least_request``, or ``conductor``.
 
@@ -364,7 +364,11 @@ The router keeps two per-pod counters and scores each prefill pod as (lower is b
 - ``active_tokens`` — prompt tokens of the prefill requests the pod is computing right now.
 - ``kv_tokens`` — prompt tokens whose KV cache is still resident on the pod because the decode pod has not finished with the request yet. Weighted by ``kv_weight`` (``AIBRIX_TOKEN_LOAD_KV_WEIGHT``, default ``0.3``) since resident KV costs the pod less than active compute.
 
-Each request is charged ``request_cost + prompt_tokens``, where ``request_cost`` (``AIBRIX_TOKEN_LOAD_REQUEST_COST``, default ``3500``) models the fixed scheduling and KV-transfer work that does not scale with prompt length, and ``prompt_tokens`` is estimated as one token per four bytes of request body. The prefix cache is not consulted.
+Each request is charged ``request_cost + new_tokens``, where ``request_cost`` (``AIBRIX_TOKEN_LOAD_REQUEST_COST``, default ``3500``) models the fixed scheduling and KV-transfer work that does not scale with prompt length, and ``new_tokens`` is the part of the prompt the pod actually has to compute. ``prompt_tokens`` is estimated as one token per four bytes of request body; ``new_tokens`` is derived from it by the first rule that applies:
+
+1. **Session delta.** If the request carries an ``x-session-id`` header and the gateway has seen a shorter prompt for that session (and model) recently, the charge is the growth since that prompt. Each turn of a chat resends the whole history, but the engine only computes the new turn: charging the whole prompt again would make a long conversation look several times more expensive than it is. The last prompt size of a session is kept for ``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS`` (default ``1800``).
+2. **Prefix match.** If the scoring policy looked the prompt up in the prefix cache (``hybrid_cache_load``), the charge is ``prompt_tokens × (1 − match_percent / 100)``.
+3. **Whole prompt.** Otherwise the whole prompt is charged. ``token_load`` itself does not consult the prefix cache, so without a session header this is what it charges.
 
 **Charge lifecycle**
 
@@ -418,11 +422,78 @@ Or set gateway-wide via ``AIBRIX_PREFILL_SCORE_POLICY=token_load``. The tunables
    * - ``AIBRIX_TOKEN_LOAD_TTL_SECONDS``
      - ``3600``
      - Maximum age of an outstanding charge before it is force-released.
+   * - ``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS``
+     - ``1800``
+     - How long the last prompt size of a session is remembered for the session-delta charge.
 
 **When to use token_load:**
 
 - Your prompt lengths vary widely (for example agentic or RAG traffic mixed with short chat) and you see a TTFT tail on some prefill pods under ``least_request``
 - Prefix-cache locality matters less than balancing prefill compute, or your prefix cache hit rate is low
+
+If prefix-cache locality does matter, use :ref:`hybrid_cache_load <pd-hybrid-cache-load-policy>` instead, which keeps this ledger and adds the cache lookup on top.
+
+.. _pd-hybrid-cache-load-policy:
+
+Hybrid Cache-Load Scoring Policy
+--------------------------------
+
+``hybrid_cache_load`` combines the prefix-cache lookup of ``prefix_cache`` with the token ledger of ``token_load``. ``prefix_cache`` always prefers the pod that holds the prompt's prefix, even when that pod is buried under long prompts and an idle neighbour would answer sooner; ``token_load`` ignores the cache and recomputes prefixes another pod already holds. The hybrid policy lets the cache decide between idle pods and the load decide between busy ones.
+
+.. code-block:: text
+
+    r        = match_percent / 100        (0 when below AIBRIX_MIN_MATCH_PCT)
+    discount = 1 − r² × factor
+    score    = load × discount            when load ≥ 1
+    score    = discount                   when load < 1 (idle pod)
+
+where ``load = active_tokens + kv_weight × kv_tokens`` is the same ledger ``token_load`` reads and ``factor`` is ``AIBRIX_HYBRID_CACHE_LOAD_FACTOR`` (default ``0.5``). Lower is better.
+
+- On idle pods every score is a bare discount below 1, so the pod with the best prefix match wins outright.
+- On busy pods the match only discounts the load. With the default factor a full match halves a pod's load, so a pod holding the prefix loses once it carries more than twice the load of an idle neighbour.
+- The square keeps small matches from moving the decision: a 30 % match discounts by 4.5 %, a 70 % match by 24.5 %.
+
+**Minimum match.** Prompts that share only a system prompt or a few template tokens would otherwise all attract to the pod that served the first of them. ``AIBRIX_MIN_MATCH_PCT`` (default ``0``, i.e. off) treats any match below the threshold as no match, both in the score and in the ``new_tokens`` charge. A value between ``30`` and ``60`` is a reasonable starting point when your system prompt is a small part of a typical request.
+
+The charge lifecycle, the metrics and the ``AIBRIX_TOKEN_LOAD_*`` tunables are those of :ref:`token_load <pd-token-load-policy>`; the prefix-match rule of the ``new_tokens`` estimate applies, so a pod that already holds most of the prompt is charged only for the rest. Like ``prefix_cache``, the policy needs a tokenizer (``AIBRIX_PREFIX_CACHE_TOKENIZER_TYPE``) and warms the prefix index with the selected pod after each request.
+
+**Configuration**
+
+.. code-block:: yaml
+
+    annotations:
+      model.aibrix.ai/config: |
+        {
+          "profiles": {
+            "default": {
+              "routingStrategy": "pd",
+              "routingConfig": {
+                "prefillScorePolicy": "hybrid_cache_load"
+              }
+            }
+          }
+        }
+
+Or set gateway-wide via ``AIBRIX_PREFILL_SCORE_POLICY=hybrid_cache_load``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 36 12 52
+
+   * - Variable
+     - Default
+     - Description
+   * - ``AIBRIX_HYBRID_CACHE_LOAD_FACTOR``
+     - ``0.5``
+     - Discount a full prefix match applies to a pod's load. Higher values favour cache affinity over balance.
+   * - ``AIBRIX_MIN_MATCH_PCT``
+     - ``0``
+     - Prefix-match percentage below which a match is ignored. ``0`` disables the threshold.
+
+**When to use hybrid_cache_load:**
+
+- Multi-turn or shared-prefix traffic where prefix-cache hits are worth chasing, but prompt lengths vary enough that ``prefix_cache`` leaves some pods with a TTFT tail
+- You already run ``token_load`` and want cache affinity back without giving up the load balance
 
 
 Complete Example
@@ -543,6 +614,7 @@ Each prefill pod is scored by the selected policy. Pods with a request count mor
 - ``prefix_cache`` (default): ``score = (100 − prefix_match_percent) × 0.1 + req_count / max_req_count`` — lower score means more cache hits and less load.
 - ``least_request``: ``score = req_count``.
 - ``token_load``: ``score = active_tokens + kv_weight × kv_tokens`` — the token-weighted load the router has charged to the pod; see :ref:`Token Load Scoring Policy <pd-token-load-policy>`.
+- ``hybrid_cache_load``: ``score = load × (1 − (prefix_match_percent / 100)² × factor)``, or just the discount when the pod is idle — cache affinity decides between idle pods, load between busy ones; see :ref:`Hybrid Cache-Load Scoring Policy <pd-hybrid-cache-load-policy>`.
 
 **Step 4 — Decode scoring**
 
@@ -582,16 +654,25 @@ These are set on the **gateway plugin** deployment.
      - Seconds before a prefill request to a prefill pod times out.
    * - ``AIBRIX_PREFILL_SCORE_POLICY``
      - ``prefix_cache``
-     - Default scoring policy for selecting prefill pods. ``prefix_cache``, ``least_request``, ``conductor``, or ``token_load``.
+     - Default scoring policy for selecting prefill pods. ``prefix_cache``, ``least_request``, ``conductor``, ``token_load``, or ``hybrid_cache_load``.
    * - ``AIBRIX_TOKEN_LOAD_KV_WEIGHT``
      - ``0.3``
-     - ``token_load`` only. Weight of resident KV tokens in the prefill score. Must be positive.
+     - ``token_load`` and ``hybrid_cache_load``. Weight of resident KV tokens in the prefill score. Must be positive.
    * - ``AIBRIX_TOKEN_LOAD_REQUEST_COST``
      - ``3500``
-     - ``token_load`` only. Fixed per-request cost, in tokens, added to every prefill charge. Must be positive.
+     - ``token_load`` and ``hybrid_cache_load``. Fixed per-request cost, in tokens, added to every prefill charge. Must be positive.
    * - ``AIBRIX_TOKEN_LOAD_TTL_SECONDS``
      - ``3600``
-     - ``token_load`` only. Charges older than this are force-released and logged; must exceed the longest legitimate request. Must be positive.
+     - ``token_load`` and ``hybrid_cache_load``. Charges older than this are force-released and logged; must exceed the longest legitimate request. Must be positive.
+   * - ``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS``
+     - ``1800``
+     - ``token_load`` and ``hybrid_cache_load``. How long the last prompt size of an ``x-session-id`` session is remembered for the session-delta charge. Must be positive.
+   * - ``AIBRIX_HYBRID_CACHE_LOAD_FACTOR``
+     - ``0.5``
+     - ``hybrid_cache_load`` only. Discount a full prefix match applies to a pod's token load. Must be positive.
+   * - ``AIBRIX_MIN_MATCH_PCT``
+     - ``0``
+     - ``hybrid_cache_load`` only. Prefix matches below this percentage are ignored. ``0`` disables the threshold.
    * - ``AIBRIX_DECODE_SCORE_POLICY``
      - ``load_balancing``
      - Default scoring policy for selecting decode pods. ``load_balancing``, ``least_request``, or ``conductor``.

--- a/docs/source/features/pd-disaggregation.rst
+++ b/docs/source/features/pd-disaggregation.rst
@@ -366,7 +366,7 @@ The router keeps two per-pod counters and scores each prefill pod as (lower is b
 
 Each request is charged ``request_cost + new_tokens``, where ``request_cost`` (``AIBRIX_TOKEN_LOAD_REQUEST_COST``, default ``3500``) models the fixed scheduling and KV-transfer work that does not scale with prompt length, and ``new_tokens`` is the part of the prompt the pod actually has to compute. ``prompt_tokens`` is estimated as one token per four bytes of request body; ``new_tokens`` is derived from it by the first rule that applies:
 
-1. **Session delta.** If the request carries an ``x-session-id`` header and the gateway has seen a shorter prompt for that session (and model) recently, the charge is the growth since that prompt. Each turn of a chat resends the whole history, but the engine only computes the new turn: charging the whole prompt again would make a long conversation look several times more expensive than it is. The last prompt size of a session is kept for ``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS`` (default ``1800``).
+1. **Session delta.** If the request carries an ``x-aibrix-session-key`` header (the caller-owned opaque key also used by ``session-affinity`` routing; not the gateway-issued ``x-session-id``) and the gateway has seen a shorter prompt for that key (and model) recently, the charge is the growth since that prompt. Each turn of a chat resends the whole history, but an engine that still holds the conversation's KV cache only computes the new turn: charging the whole prompt again would make a long conversation look several times more expensive than it is. The rule assumes the earlier turns are reachable from whichever prefill pod is selected, through a shared or tiered KV store, sticky routing or the pod's own prefix cache; if your prefill pods only have a local prefix cache and the router may move a conversation between them, do not send the key, or set ``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS=0`` to turn the rule off, and rely on rule 2. The last prompt size of a key is kept for ``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS`` (default ``1800``); keys longer than 256 bytes are ignored, and at most ``AIBRIX_TOKEN_LOAD_MAX_SESSIONS`` (default ``100000``) keys are remembered at once, so a client cannot grow the table without bound. Once the table is full, new keys are charged by rules 2 and 3 until the janitor forgets idle ones.
 2. **Prefix match.** If the scoring policy looked the prompt up in the prefix cache (``hybrid_cache_load``), the charge is ``prompt_tokens × (1 − match_percent / 100)``.
 3. **Whole prompt.** Otherwise the whole prompt is charged. ``token_load`` itself does not consult the prefix cache, so without a session header this is what it charges.
 
@@ -424,7 +424,10 @@ Or set gateway-wide via ``AIBRIX_PREFILL_SCORE_POLICY=token_load``. The tunables
      - Maximum age of an outstanding charge before it is force-released.
    * - ``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS``
      - ``1800``
-     - How long the last prompt size of a session is remembered for the session-delta charge.
+     - How long the last prompt size of a session is remembered for the session-delta charge. ``0`` turns the session-delta rule off.
+   * - ``AIBRIX_TOKEN_LOAD_MAX_SESSIONS``
+     - ``100000``
+     - Maximum number of sessions remembered at once; new sessions beyond it are charged without a delta.
 
 **When to use token_load:**
 
@@ -485,10 +488,10 @@ Or set gateway-wide via ``AIBRIX_PREFILL_SCORE_POLICY=hybrid_cache_load``.
      - Description
    * - ``AIBRIX_HYBRID_CACHE_LOAD_FACTOR``
      - ``0.5``
-     - Discount a full prefix match applies to a pod's load. Higher values favour cache affinity over balance.
+     - Discount a full prefix match applies to a pod's load, ``0`` to ``1``. Higher values favour cache affinity over balance; at ``1`` a fully matched pod scores ``0`` and always wins.
    * - ``AIBRIX_MIN_MATCH_PCT``
      - ``0``
-     - Prefix-match percentage below which a match is ignored. ``0`` disables the threshold.
+     - Prefix-match percentage below which a match is ignored, ``0`` to ``100``. ``0`` disables the threshold.
 
 **When to use hybrid_cache_load:**
 
@@ -666,13 +669,16 @@ These are set on the **gateway plugin** deployment.
      - ``token_load`` and ``hybrid_cache_load``. Charges older than this are force-released and logged; must exceed the longest legitimate request. Must be positive.
    * - ``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS``
      - ``1800``
-     - ``token_load`` and ``hybrid_cache_load``. How long the last prompt size of an ``x-session-id`` session is remembered for the session-delta charge. Must be positive.
+     - ``token_load`` and ``hybrid_cache_load``. How long the last prompt size of an ``x-aibrix-session-key`` session is remembered for the session-delta charge. ``0`` turns the session-delta rule off; otherwise must be positive.
+   * - ``AIBRIX_TOKEN_LOAD_MAX_SESSIONS``
+     - ``100000``
+     - ``token_load`` and ``hybrid_cache_load``. Maximum number of sessions remembered at once for the session-delta charge. Must be positive.
    * - ``AIBRIX_HYBRID_CACHE_LOAD_FACTOR``
      - ``0.5``
-     - ``hybrid_cache_load`` only. Discount a full prefix match applies to a pod's token load. Must be positive.
+     - ``hybrid_cache_load`` only. Discount a full prefix match applies to a pod's token load, ``0`` to ``1``. ``1`` makes a fully matched pod always win; ``0`` turns the discount off.
    * - ``AIBRIX_MIN_MATCH_PCT``
      - ``0``
-     - ``hybrid_cache_load`` only. Prefix matches below this percentage are ignored. ``0`` disables the threshold.
+     - ``hybrid_cache_load`` only. Prefix matches below this percentage are ignored, ``0`` to ``100``. ``0`` disables the threshold.
    * - ``AIBRIX_DECODE_SCORE_POLICY``
      - ``load_balancing``
      - Default scoring policy for selecting decode pods. ``load_balancing``, ``least_request``, or ``conductor``.

--- a/pkg/constants/gateway.go
+++ b/pkg/constants/gateway.go
@@ -20,6 +20,7 @@ const (
 	// HeaderSessionID identifies the backend selected for session-affinity routing.
 	HeaderSessionID = "x-session-id"
 
-	// HeaderSessionKey carries a caller-owned opaque key for session-affinity routing.
+	// HeaderSessionKey carries a caller-owned opaque key, used by session-affinity
+	// routing and by the PD router's session-delta prefill charge.
 	HeaderSessionKey = "x-aibrix-session-key"
 )

--- a/pkg/plugins/gateway/algorithms/multi_router_readme.md
+++ b/pkg/plugins/gateway/algorithms/multi_router_readme.md
@@ -21,7 +21,7 @@ You can configure multi-strategy routing by setting the `AIBRIX_ROUTING_ALGORITH
 * If a weight is `0`, the strategy is completely ignored.
 * If an invalid strategy is specified, the Gateway rejects the request with **400 Bad Request** instead of silently falling back to `random`.
 * `session-affinity` is treated as a soft-scoring strategy in multi-strategy mode: it boosts the matching pod, but the final weighted winner may still be a different pod. The response session header is updated to the final selected pod.
-* A caller may send an opaque application session identifier in `x-aibrix-session-key`. When no valid gateway-issued `x-session-id` target is ready, rendezvous hashing selects a stable pod for that key. This is useful for concurrent Agent turns that start before a response cookie is available. The opaque key is never returned to the client.
+* A caller may send an opaque application session identifier in `x-aibrix-session-key`. When no valid gateway-issued `x-session-id` target is ready, rendezvous hashing selects a stable pod for that key. This is useful for concurrent Agent turns that start before a response cookie is available. The opaque key is never returned to the client. The `pd` router's `token_load` and `hybrid_cache_load` prefill policies read the same key to charge a multi-turn conversation only for the tokens added since its previous turn.
 
 ## Examples
 

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
@@ -20,14 +20,14 @@ limitations under the License.
 //
 //   - prefill_scorer.go  — PrefillScorePolicy / PrefillScorer interfaces and
 //     their built-in implementations (prefix_cache, least_request, conductor,
-//     token_load).
+//     token_load, hybrid_cache_load).
 //   - decode_scorer.go   — DecodeScorePolicy / DecodeScorer interfaces and
 //     their built-in implementations (load_balancing, least_request), plus the
 //     policy registry used by AIBRIX_DECODE_SCORE_POLICY.
 //   - trackers.go        — PrefillRequestTracker and PendingDecodeTracker,
 //     which bridge the gap between pod selection and actual request start.
 //   - token_load_tracker.go — TokenLoadTracker, the token-weighted prefill
-//     load ledger behind the token_load policy.
+//     load ledger behind the token_load and hybrid_cache_load policies.
 package pd
 
 import (
@@ -37,6 +37,7 @@ import (
 	"github.com/vllm-project/aibrix/pkg/cache"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
 	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
 	"github.com/vllm-project/aibrix/pkg/utils/tokenizer"
 	v1 "k8s.io/api/core/v1"
@@ -62,6 +63,20 @@ const (
 	// routes prefill requests to the pod with the lowest token-weighted load
 	// as tracked by TokenLoadTracker, without consulting the prefix cache.
 	PrefillScorePolicyTokenLoad = "token_load"
+
+	// PrefillScorePolicyHybridCacheLoad selects the hybrid scoring policy,
+	// which discounts a pod's token-weighted load by its prefix-cache match so
+	// that cache affinity wins on idle pods and load wins on busy ones.
+	PrefillScorePolicyHybridCacheLoad = "hybrid_cache_load"
+
+	// DefaultHybridCacheLoadFactor is how much a full prefix match discounts a
+	// pod's token load under hybrid_cache_load: score = load × (1 − factor)
+	// at 100 % match.
+	DefaultHybridCacheLoadFactor = 0.5
+
+	// DefaultMinMatchPct is the prefix-match percentage below which
+	// hybrid_cache_load treats a match as no match. 0 keeps every match.
+	DefaultMinMatchPct = 0.0
 
 	// Default TTFT estimation coefficients for conductor policy.
 	// Units: time in milliseconds, tokens are unitless.
@@ -404,7 +419,14 @@ func (p *tokenLoadPrefillPolicy) Name() string { return PrefillScorePolicyTokenL
 // UsesTokenLoad reports whether policy scores from a TokenLoadTracker, i.e.
 // whether the router must charge the tracker for requests scored by it.
 func UsesTokenLoad(policy PrefillScorePolicy) bool {
-	return policy != nil && policy.Name() == PrefillScorePolicyTokenLoad
+	if policy == nil {
+		return false
+	}
+	switch policy.Name() {
+	case PrefillScorePolicyTokenLoad, PrefillScorePolicyHybridCacheLoad:
+		return true
+	}
+	return false
 }
 
 // tokenLoadScorer is the request-scoped scorer produced by tokenLoadPrefillPolicy.
@@ -428,5 +450,142 @@ func (s tokenLoadScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
 			"score", score, "active_tokens", active, "kv_tokens", kv,
 			"running_reqs", reqCnt)
 	}
+	return score
+}
+
+// PrefixMatchScorer is implemented by PrefillScorers that looked the request
+// up in the prefix cache during Prepare. The router uses it to charge only
+// the uncached part of the prompt to the token-load tracker.
+type PrefixMatchScorer interface {
+	// PrefixMatchPercent returns how much of the request's prompt (0-100) the
+	// named pod already holds in its prefix cache, or -1 when unknown.
+	PrefixMatchPercent(podName string) int
+}
+
+// PrefixMatchPercent returns the prefix-match percentage scorer reports for
+// podName, or -1 when scorer does not implement PrefixMatchScorer.
+func PrefixMatchPercent(scorer PrefillScorer, podName string) int {
+	if m, ok := scorer.(PrefixMatchScorer); ok {
+		return m.PrefixMatchPercent(podName)
+	}
+	return -1
+}
+
+// HybridCacheLoadConfig tunes the hybrid_cache_load policy.
+type HybridCacheLoadConfig struct {
+	// Factor is the discount a full prefix match applies to a pod's token
+	// load; see hybridCacheLoadPrefillPolicy for the formula.
+	Factor float64
+	// MinMatchPct is the prefix-match percentage below which a match is
+	// treated as no match, so a few shared tokens do not attract a request.
+	MinMatchPct float64
+}
+
+// DefaultHybridCacheLoadConfig returns the defaults, overridden by the
+// AIBRIX_HYBRID_CACHE_LOAD_FACTOR and AIBRIX_MIN_MATCH_PCT environment
+// variables. Each must be positive; an unset, empty or invalid value keeps the
+// default.
+func DefaultHybridCacheLoadConfig() HybridCacheLoadConfig {
+	return HybridCacheLoadConfig{
+		Factor:      utils.LoadEnvFloat("AIBRIX_HYBRID_CACHE_LOAD_FACTOR", DefaultHybridCacheLoadFactor),
+		MinMatchPct: utils.LoadEnvFloat("AIBRIX_MIN_MATCH_PCT", DefaultMinMatchPct),
+	}
+}
+
+// ClampMinMatch returns matchPct, or 0 when a positive minPct is set and
+// matchPct falls below it.
+func ClampMinMatch(matchPct int, minPct float64) int {
+	if minPct > 0 && float64(matchPct) < minPct {
+		return 0
+	}
+	return matchPct
+}
+
+// hybridCacheLoadPrefillPolicy combines the prefix-cache lookup of prefix_cache
+// with the token-weighted load of token_load:
+//
+//	r        = matchPercent / 100        (0 when below MinMatchPct)
+//	discount = 1 − r² × factor
+//	score    = load × discount           when load ≥ 1
+//	score    = discount                  when load < 1 (idle pod)
+//
+// where load = active_tokens + kv_weight × kv_tokens from the TokenLoadTracker.
+// Lower is better. On idle pods every score is below 1 and the best prefix
+// match wins outright; on busy pods the match only discounts the load, so a
+// pod holding the prefix but also a queue of long prompts loses to an idle
+// neighbour. The square keeps small matches from moving the decision.
+//
+// Obtain an instance via NewHybridCacheLoadPrefillPolicy.
+type hybridCacheLoadPrefillPolicy struct {
+	tok                tokenizer.Tokenizer
+	prefixCacheIndexer *prefixcacheindexer.PrefixHashTable
+	tracker            *TokenLoadTracker
+	cfg                HybridCacheLoadConfig
+}
+
+// NewHybridCacheLoadPrefillPolicy constructs a hybrid_cache_load
+// PrefillScorePolicy over the given tokenizer, shared prefix-hash table and
+// token-load tracker.
+func NewHybridCacheLoadPrefillPolicy(tok tokenizer.Tokenizer, prefixCacheIndexer *prefixcacheindexer.PrefixHashTable, tracker *TokenLoadTracker, cfg HybridCacheLoadConfig) PrefillScorePolicy {
+	return &hybridCacheLoadPrefillPolicy{
+		tok:                tok,
+		prefixCacheIndexer: prefixCacheIndexer,
+		tracker:            tracker,
+		cfg:                cfg,
+	}
+}
+
+// Prepare tokenizes routingCtx.Message and looks it up in the prefix cache,
+// exactly as prefix_cache does; the load side is read at ScorePod time.
+func (p *hybridCacheLoadPrefillPolicy) Prepare(routingCtx *types.RoutingContext, _ []*v1.Pod, readyPodsMap map[string]struct{}) (PrefillScorer, error) {
+	tokens, err := p.tok.TokenizeInputText(routingCtx.Message)
+	if err != nil {
+		return nil, err
+	}
+	matchedPods, hashes := p.prefixCacheIndexer.MatchPrefix(tokens, routingCtx.Model, readyPodsMap)
+	return &hybridCacheLoadScorer{
+		tracker:     p.tracker,
+		cfg:         p.cfg,
+		matchedPods: matchedPods,
+		hashes:      hashes,
+	}, nil
+}
+
+func (p *hybridCacheLoadPrefillPolicy) Name() string { return PrefillScorePolicyHybridCacheLoad }
+
+// hybridCacheLoadScorer is the request-scoped scorer produced by
+// hybridCacheLoadPrefillPolicy.
+type hybridCacheLoadScorer struct {
+	tracker     *TokenLoadTracker
+	cfg         HybridCacheLoadConfig
+	matchedPods map[string]int
+	hashes      []uint64
+}
+
+func (s *hybridCacheLoadScorer) PrefixHashes() []uint64 { return s.hashes }
+
+// PrefixMatchPercent implements PrefixMatchScorer with the clamped match, so
+// the router's charge and the score agree on what counts as cached.
+func (s *hybridCacheLoadScorer) PrefixMatchPercent(podName string) int {
+	return ClampMinMatch(s.matchedPods[podName], s.cfg.MinMatchPct)
+}
+
+func (s *hybridCacheLoadScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
+	matchPct := s.PrefixMatchPercent(pod.Name)
+	r := float64(matchPct) / 100
+	discount := 1 - r*r*s.cfg.Factor
+	load := 0.0
+	if s.tracker != nil {
+		load = s.tracker.GetPriority(pod.Name)
+	}
+	score := discount
+	if load >= 1 {
+		score = load * discount
+	}
+	klog.V(4).InfoS("prefill_score", "pod_name", pod.Name,
+		"policy", PrefillScorePolicyHybridCacheLoad,
+		"score", score, "token_load", load, "discount", discount,
+		"prefix_match_percent", matchPct, "raw_match_percent", s.matchedPods[pod.Name],
+		"running_reqs", reqCnt)
 	return score
 }

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
@@ -33,11 +33,12 @@ package pd
 import (
 	"fmt"
 	"math"
+	"os"
+	"strconv"
 
 	"github.com/vllm-project/aibrix/pkg/cache"
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
-	"github.com/vllm-project/aibrix/pkg/utils"
 	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
 	"github.com/vllm-project/aibrix/pkg/utils/tokenizer"
 	v1 "k8s.io/api/core/v1"
@@ -482,14 +483,33 @@ type HybridCacheLoadConfig struct {
 }
 
 // DefaultHybridCacheLoadConfig returns the defaults, overridden by the
-// AIBRIX_HYBRID_CACHE_LOAD_FACTOR and AIBRIX_MIN_MATCH_PCT environment
-// variables. Each must be positive; an unset, empty or invalid value keeps the
-// default.
+// AIBRIX_HYBRID_CACHE_LOAD_FACTOR (0 to 1) and AIBRIX_MIN_MATCH_PCT (0 to
+// 100) environment variables. An unset, empty or out-of-range value keeps the
+// default. A factor of 1 makes a full match score 0, so it always wins; above
+// 1 the discount would go negative, which is why the range stops there.
 func DefaultHybridCacheLoadConfig() HybridCacheLoadConfig {
 	return HybridCacheLoadConfig{
-		Factor:      utils.LoadEnvFloat("AIBRIX_HYBRID_CACHE_LOAD_FACTOR", DefaultHybridCacheLoadFactor),
-		MinMatchPct: utils.LoadEnvFloat("AIBRIX_MIN_MATCH_PCT", DefaultMinMatchPct),
+		Factor:      loadEnvFloatInRange("AIBRIX_HYBRID_CACHE_LOAD_FACTOR", DefaultHybridCacheLoadFactor, 0, 1),
+		MinMatchPct: loadEnvFloatInRange("AIBRIX_MIN_MATCH_PCT", DefaultMinMatchPct, 0, 100),
 	}
+}
+
+// loadEnvFloatInRange is utils.LoadEnvFloat for a knob whose valid values are
+// the closed range [lo, hi] rather than "positive": 0 is a valid setting of
+// both hybrid_cache_load knobs, and each has an upper bound.
+func loadEnvFloatInRange(key string, defaultValue, lo, hi float64) float64 {
+	raw := os.Getenv(key)
+	if raw == "" {
+		klog.Infof("set %s: %g, using default value", key, defaultValue)
+		return defaultValue
+	}
+	value, err := strconv.ParseFloat(raw, 64)
+	if err != nil || math.IsNaN(value) || value < lo || value > hi {
+		klog.Warningf("invalid %s: %s (valid range %g to %g), falling back to default: %g", key, raw, lo, hi, defaultValue)
+		return defaultValue
+	}
+	klog.Infof("set %s: %g", key, value)
+	return value
 }
 
 // ClampMinMatch returns matchPct, or 0 when a positive minPct is set and

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer_hybrid_cache_load_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer_hybrid_cache_load_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
+	"github.com/vllm-project/aibrix/pkg/utils/tokenizer"
+	v1 "k8s.io/api/core/v1"
+)
+
+// hybridTestMessage is 40 characters: with the character tokenizer and the
+// default 4-byte prefix block that is 10 blocks, so a pod holding the first
+// n blocks reports a 10·n % match.
+const hybridTestMessage = "0123456789abcdefghijklmnopqrstuvwxyzABCD"
+
+var hybridTestConfig = HybridCacheLoadConfig{Factor: 0.5, MinMatchPct: 0}
+
+// hybridTestFixture is a hybrid policy over a fresh prefix table and tracker.
+type hybridTestFixture struct {
+	policy  PrefillScorePolicy
+	table   *prefixcacheindexer.PrefixHashTable
+	tracker *TokenLoadTracker
+	pods    []*v1.Pod
+	ready   map[string]struct{}
+}
+
+func newHybridTestFixture(t *testing.T, cfg HybridCacheLoadConfig, podNames ...string) *hybridTestFixture {
+	t.Helper()
+	f := &hybridTestFixture{
+		table:   prefixcacheindexer.NewPrefixHashTable(),
+		tracker: newTokenLoadTracker(TokenLoadConfig{KVWeight: 0.5}, nil),
+		ready:   map[string]struct{}{},
+	}
+	f.policy = NewHybridCacheLoadPrefillPolicy(tokenizer.NewCharacterTokenizer(), f.table, f.tracker, cfg)
+	for _, name := range podNames {
+		f.pods = append(f.pods, tokenLoadTestPod(name))
+		f.ready[name] = struct{}{}
+	}
+	return f
+}
+
+// seedPrefix records the first blocks of hybridTestMessage covering matchPct
+// percent of it as resident on pod.
+func (f *hybridTestFixture) seedPrefix(t *testing.T, pod string, matchPct int) {
+	t.Helper()
+	tokens, err := tokenizer.NewCharacterTokenizer().TokenizeInputText(hybridTestMessage)
+	require.NoError(t, err)
+	_, hashes := f.table.MatchPrefix(tokens, testModelName, nil)
+	require.Len(t, hashes, 10)
+	f.table.AddPrefix(hashes[:len(hashes)*matchPct/100], testModelName, pod)
+}
+
+func (f *hybridTestFixture) prepare(t *testing.T) PrefillScorer {
+	t.Helper()
+	ctx := types.NewRoutingContext(context.Background(), "pd", testModelName, hybridTestMessage, "req-1", "")
+	scorer, err := f.policy.Prepare(ctx, f.pods, f.ready)
+	require.NoError(t, err)
+	return scorer
+}
+
+func TestHybridCacheLoadPrefillPolicy_Name(t *testing.T) {
+	f := newHybridTestFixture(t, hybridTestConfig)
+	assert.Equal(t, PrefillScorePolicyHybridCacheLoad, f.policy.Name())
+	assert.True(t, UsesTokenLoad(f.policy), "the router must charge the tracker for hybrid_cache_load")
+}
+
+// TestHybridCacheLoadPrefillPolicy_IdlePodsFollowThePrefix: with no load
+// anywhere every score is a bare discount below 1, so the best match wins.
+func TestHybridCacheLoadPrefillPolicy_IdlePodsFollowThePrefix(t *testing.T) {
+	f := newHybridTestFixture(t, hybridTestConfig, "cold", "half", "hot")
+	f.seedPrefix(t, "half", 50)
+	f.seedPrefix(t, "hot", 100)
+
+	scorer := f.prepare(t)
+	assert.NotEmpty(t, scorer.PrefixHashes(), "hashes are needed to warm the index after selection")
+	assert.Equal(t, float64(1), scorer.ScorePod(f.pods[0], 0, 0), "no match, no load: discount of 1")
+	assert.Equal(t, 1-0.25*0.5, scorer.ScorePod(f.pods[1], 0, 0), "50 % match: 1 − 0.5² × factor")
+	assert.Equal(t, 1-0.5, scorer.ScorePod(f.pods[2], 0, 0), "100 % match: 1 − factor")
+
+	assert.Equal(t, 0, PrefixMatchPercent(scorer, "cold"))
+	assert.Equal(t, 50, PrefixMatchPercent(scorer, "half"))
+	assert.Equal(t, 100, PrefixMatchPercent(scorer, "hot"))
+	assert.Equal(t, 0, PrefixMatchPercent(scorer, "unknown-pod"), "the lookup ran, so an unlisted pod is a 0 % match, not unknown")
+}
+
+// TestHybridCacheLoadPrefillPolicy_LoadOutweighsPrefix: a pod holding the
+// prefix but also a long queue loses to an idle neighbour, because the match
+// only discounts its load.
+func TestHybridCacheLoadPrefillPolicy_LoadOutweighsPrefix(t *testing.T) {
+	f := newHybridTestFixture(t, hybridTestConfig, "idle", "hot")
+	f.seedPrefix(t, "hot", 100)
+	f.tracker.AcquirePrefill("long", "hot", 8000) // priority 8000 + 0.5 × 8000
+
+	scorer := f.prepare(t)
+	assert.Equal(t, float64(1), scorer.ScorePod(f.pods[0], 0, 0))
+	assert.Equal(t, 12000*0.5, scorer.ScorePod(f.pods[1], 1, 1), "load × (1 − factor)")
+
+	// Barely loaded (below one token) still counts as idle.
+	f.tracker.ReleaseAll("long")
+	f.tracker.AcquirePrefill("tiny", "hot", 0.5)
+	assert.Equal(t, 0.5, scorer.ScorePod(f.pods[1], 1, 1))
+}
+
+func TestHybridCacheLoadPrefillPolicy_MinMatchClamp(t *testing.T) {
+	cfg := hybridTestConfig
+	cfg.MinMatchPct = 60
+	f := newHybridTestFixture(t, cfg, "weak", "strong")
+	f.seedPrefix(t, "weak", 50)
+	f.seedPrefix(t, "strong", 60)
+
+	scorer := f.prepare(t)
+	assert.Equal(t, float64(1), scorer.ScorePod(f.pods[0], 0, 0), "a match below the threshold is no match")
+	assert.InDelta(t, 1-0.36*0.5, scorer.ScorePod(f.pods[1], 0, 0), 1e-9, "a match at the threshold counts")
+	assert.Equal(t, 0, PrefixMatchPercent(scorer, "weak"), "the charge sees the same clamped match as the score")
+	assert.Equal(t, 60, PrefixMatchPercent(scorer, "strong"))
+}
+
+func TestClampMinMatch(t *testing.T) {
+	cases := []struct {
+		matchPct int
+		minPct   float64
+		want     int
+	}{
+		{0, 0, 0},
+		{30, 0, 30},
+		{30, 30, 30},
+		{29, 30, 0},
+		{100, 30, 100},
+		{50, 100, 0},
+		{50, -1, 50},
+	}
+	for _, tc := range cases {
+		assert.Equalf(t, tc.want, ClampMinMatch(tc.matchPct, tc.minPct), "ClampMinMatch(%d, %g)", tc.matchPct, tc.minPct)
+	}
+}
+
+func TestHybridCacheLoadPrefillPolicy_NilTrackerScoresByPrefixOnly(t *testing.T) {
+	table := prefixcacheindexer.NewPrefixHashTable()
+	policy := NewHybridCacheLoadPrefillPolicy(tokenizer.NewCharacterTokenizer(), table, nil, hybridTestConfig)
+	ctx := types.NewRoutingContext(context.Background(), "pd", testModelName, hybridTestMessage, "req-1", "")
+	scorer, err := policy.Prepare(ctx, nil, map[string]struct{}{"pod-a": {}})
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), scorer.ScorePod(tokenLoadTestPod("pod-a"), 3, 3))
+}
+
+func TestPrefixMatchPercent_UnsupportedScorers(t *testing.T) {
+	ctx := types.NewRoutingContext(context.Background(), "pd", testModelName, testMessage, "req-1", "")
+	for _, policy := range []PrefillScorePolicy{NewLeastRequestPrefillPolicy(), NewTokenLoadPrefillPolicy(nil)} {
+		scorer, err := policy.Prepare(ctx, nil, nil)
+		require.NoError(t, err)
+		assert.Equalf(t, -1, PrefixMatchPercent(scorer, "pod-a"), "%s has no prefix information", policy.Name())
+	}
+}
+
+func TestDefaultHybridCacheLoadConfig(t *testing.T) {
+	t.Setenv("AIBRIX_HYBRID_CACHE_LOAD_FACTOR", "0.4")
+	t.Setenv("AIBRIX_MIN_MATCH_PCT", "30")
+	cfg := DefaultHybridCacheLoadConfig()
+	assert.Equal(t, 0.4, cfg.Factor)
+	assert.Equal(t, float64(30), cfg.MinMatchPct)
+
+	t.Setenv("AIBRIX_HYBRID_CACHE_LOAD_FACTOR", strings.Repeat("x", 3))
+	t.Setenv("AIBRIX_MIN_MATCH_PCT", "0")
+	cfg = DefaultHybridCacheLoadConfig()
+	assert.Equal(t, DefaultHybridCacheLoadFactor, cfg.Factor, "invalid value falls back to the default")
+	assert.Equal(t, DefaultMinMatchPct, cfg.MinMatchPct, "0 keeps the default of no threshold")
+}

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer_hybrid_cache_load_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer_hybrid_cache_load_test.go
@@ -184,5 +184,25 @@ func TestDefaultHybridCacheLoadConfig(t *testing.T) {
 	t.Setenv("AIBRIX_MIN_MATCH_PCT", "0")
 	cfg = DefaultHybridCacheLoadConfig()
 	assert.Equal(t, DefaultHybridCacheLoadFactor, cfg.Factor, "invalid value falls back to the default")
-	assert.Equal(t, DefaultMinMatchPct, cfg.MinMatchPct, "0 keeps the default of no threshold")
+	assert.Equal(t, float64(0), cfg.MinMatchPct, "0 is a valid setting: no threshold")
+
+	// The range ends are valid; anything outside falls back.
+	t.Setenv("AIBRIX_HYBRID_CACHE_LOAD_FACTOR", "1")
+	t.Setenv("AIBRIX_MIN_MATCH_PCT", "100")
+	cfg = DefaultHybridCacheLoadConfig()
+	assert.Equal(t, float64(1), cfg.Factor)
+	assert.Equal(t, float64(100), cfg.MinMatchPct)
+	t.Setenv("AIBRIX_HYBRID_CACHE_LOAD_FACTOR", "0")
+	cfg = DefaultHybridCacheLoadConfig()
+	assert.Equal(t, float64(0), cfg.Factor, "a factor of 0 turns the discount off")
+
+	for _, tc := range []struct{ factor, minMatch string }{
+		{"1.5", "150"}, {"-0.1", "-1"}, {"NaN", "Inf"},
+	} {
+		t.Setenv("AIBRIX_HYBRID_CACHE_LOAD_FACTOR", tc.factor)
+		t.Setenv("AIBRIX_MIN_MATCH_PCT", tc.minMatch)
+		cfg = DefaultHybridCacheLoadConfig()
+		assert.Equalf(t, DefaultHybridCacheLoadFactor, cfg.Factor, "factor %q is out of range", tc.factor)
+		assert.Equalf(t, DefaultMinMatchPct, cfg.MinMatchPct, "min match %q is out of range", tc.minMatch)
+	}
 }

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
@@ -43,8 +43,13 @@ const (
 	// before the janitor force-releases it. It must exceed the longest
 	// legitimate request; an hour leaves a wide margin while still capping the
 	// damage a leaked entry can do. The environment variable must be positive;
-	// a TTL of 0 in TokenLoadConfig disables the janitor.
+	// a TTL of 0 in TokenLoadConfig disables the sweep of stale charges.
 	DefaultTokenLoadTTLSeconds = 3600
+
+	// DefaultTokenLoadSessionTTLSeconds bounds how long the last prompt size
+	// of a session is remembered for the session-delta cost estimate. It only
+	// needs to outlive the gap between two turns of one conversation.
+	DefaultTokenLoadSessionTTLSeconds = 1800
 
 	// tokenLoadJanitorInterval is the scan period of the janitor, which
 	// force-releases charges older than the TTL and prunes idle pods. It also
@@ -63,19 +68,25 @@ type TokenLoadConfig struct {
 	KVWeight float64
 	// RequestCost is the fixed per-request cost added to every charge, in tokens.
 	RequestCost float64
-	// TTL is the maximum age of an outstanding charge; 0 disables the janitor.
+	// TTL is the maximum age of an outstanding charge; 0 disables the sweep
+	// of stale charges.
 	TTL time.Duration
+	// SessionTTL is how long a session's last prompt size is remembered for
+	// the session-delta cost estimate; 0 disables session tracking.
+	SessionTTL time.Duration
 }
 
 // DefaultTokenLoadConfig returns the defaults, overridden by the
-// AIBRIX_TOKEN_LOAD_KV_WEIGHT, AIBRIX_TOKEN_LOAD_REQUEST_COST and
-// AIBRIX_TOKEN_LOAD_TTL_SECONDS environment variables. Each must be positive;
-// an unset, empty or invalid value keeps the default.
+// AIBRIX_TOKEN_LOAD_KV_WEIGHT, AIBRIX_TOKEN_LOAD_REQUEST_COST,
+// AIBRIX_TOKEN_LOAD_TTL_SECONDS and AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS
+// environment variables. Each must be positive; an unset, empty or invalid
+// value keeps the default.
 func DefaultTokenLoadConfig() TokenLoadConfig {
 	return TokenLoadConfig{
 		KVWeight:    utils.LoadEnvFloat("AIBRIX_TOKEN_LOAD_KV_WEIGHT", DefaultTokenLoadKVWeight),
 		RequestCost: utils.LoadEnvFloat("AIBRIX_TOKEN_LOAD_REQUEST_COST", DefaultTokenLoadRequestCost),
 		TTL:         time.Duration(utils.LoadEnvInt("AIBRIX_TOKEN_LOAD_TTL_SECONDS", DefaultTokenLoadTTLSeconds)) * time.Second,
+		SessionTTL:  time.Duration(utils.LoadEnvInt("AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS", DefaultTokenLoadSessionTTLSeconds)) * time.Second,
 	}
 }
 
@@ -112,6 +123,9 @@ type TokenLoadTracker struct {
 	activeTokens sync.Map // map[string]*podCounter, pod name → tokens
 	kvTokens     sync.Map // map[string]*podCounter, pod name → tokens
 	entries      sync.Map // map[string]*tokenLoadEntry, request ID → charge
+	// sessions remembers the last prompt size per (model, session) so a
+	// multi-turn continuation is charged only for what the engine computes.
+	sessions sync.Map // map[string]*tokenLoadSession, sessionKey → last prompt
 
 	// countersMu serialises the janitor's pruning of idle pods (write lock)
 	// with counter updates (read lock), so a counter and its gauge series are
@@ -160,22 +174,31 @@ func (c *podCounter) load() float64 { return math.Float64frombits(c.bits.Load())
 // tokenLoadGaugeLabels is the label set of the per-pod gauges.
 var tokenLoadGaugeLabels = []string{"pod_name"}
 
+// tokenLoadSession is the last prompt seen for one (model, session).
+type tokenLoadSession struct {
+	mu           sync.Mutex
+	promptTokens int
+	lastSeen     time.Time
+}
+
 // NewTokenLoadTracker creates a tracker with DefaultTokenLoadConfig and starts
-// its TTL janitor when the TTL is positive.
+// its TTL janitor when either TTL is positive.
 func NewTokenLoadTracker() *TokenLoadTracker {
 	return NewTokenLoadTrackerWithConfig(DefaultTokenLoadConfig())
 }
 
 // NewTokenLoadTrackerWithConfig creates a tracker with an explicit config and
-// starts its TTL janitor when cfg.TTL is positive.
+// starts its TTL janitor when cfg.TTL or cfg.SessionTTL is positive.
 func NewTokenLoadTrackerWithConfig(cfg TokenLoadConfig) *TokenLoadTracker {
 	t := newTokenLoadTracker(cfg, time.Now)
-	if cfg.TTL > 0 {
+	janitor := cfg.TTL > 0 || cfg.SessionTTL > 0
+	if janitor {
 		t.startJanitor(tokenLoadJanitorInterval)
 	}
 	klog.InfoS("token_load_tracker created",
 		"kv_weight", cfg.KVWeight, "request_cost", cfg.RequestCost,
-		"ttl_seconds", int(cfg.TTL.Seconds()), "janitor_enabled", cfg.TTL > 0)
+		"ttl_seconds", int(cfg.TTL.Seconds()), "session_ttl_seconds", int(cfg.SessionTTL.Seconds()),
+		"janitor_enabled", janitor)
 	return t
 }
 
@@ -210,6 +233,71 @@ func (t *TokenLoadTracker) PrefillCost(promptTokens int) float64 {
 // size when no token count is available.
 func EstimatePromptTokens(reqBody []byte) int {
 	return len(reqBody) / bytesPerTokenEstimate
+}
+
+// Sources of the NewTokens estimate, for logs.
+const (
+	NewTokensSourceSession     = "session_delta"
+	NewTokensSourcePrefixMatch = "prefix_match"
+	NewTokensSourcePrompt      = "prompt"
+)
+
+// NewTokens estimates how many of a request's promptTokens the selected pod
+// has to compute, the new_tokens term of the prefill cost. It returns the
+// estimate and which rule produced it:
+//
+//  1. When sessionID is set and the (model, session) was seen before with a
+//     shorter prompt, the growth since that prompt. Each turn of a
+//     conversation resends the whole history, but the engine only computes
+//     the new turn. The prompt size is recorded for the next turn, so call
+//     this once per charged request.
+//  2. Otherwise, when matchPct (0-100) is non-negative, the part of the
+//     prompt the pod's prefix cache does not cover: promptTokens × (1 −
+//     matchPct/100). Pass a negative matchPct when no match information is
+//     available.
+//  3. Otherwise the whole prompt.
+//
+// The result is never negative or larger than promptTokens.
+func (t *TokenLoadTracker) NewTokens(model, sessionID string, promptTokens, matchPct int) (int, string) {
+	if promptTokens < 0 {
+		promptTokens = 0
+	}
+	if sessionID != "" && t.cfg.SessionTTL > 0 {
+		if last, seen := t.recordSessionPrompt(model, sessionID, promptTokens); seen && promptTokens > last {
+			return promptTokens - last, NewTokensSourceSession
+		}
+	}
+	if matchPct >= 0 {
+		if matchPct > 100 {
+			matchPct = 100
+		}
+		return promptTokens * (100 - matchPct) / 100, NewTokensSourcePrefixMatch
+	}
+	return promptTokens, NewTokensSourcePrompt
+}
+
+// recordSessionPrompt stores promptTokens as the last prompt of (model,
+// session) and returns the previous value and whether there was one.
+func (t *TokenLoadTracker) recordSessionPrompt(model, sessionID string, promptTokens int) (int, bool) {
+	now := t.now()
+	v, seen := t.sessions.LoadOrStore(sessionKey(model, sessionID), &tokenLoadSession{promptTokens: promptTokens, lastSeen: now})
+	if !seen {
+		return 0, false
+	}
+	sess := v.(*tokenLoadSession)
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	last := sess.promptTokens
+	sess.promptTokens = promptTokens
+	sess.lastSeen = now
+	return last, true
+}
+
+// sessionKey qualifies a client-supplied session ID with the model: the same
+// ID may be reused against different models, and the delta only makes sense
+// against the same one.
+func sessionKey(model, sessionID string) string {
+	return model + "\x00" + sessionID
 }
 
 // AcquirePrefill charges cost to both the active and the resident-KV counter
@@ -349,13 +437,26 @@ func (t *TokenLoadTracker) startJanitor(interval time.Duration) {
 	}()
 }
 
-// sweepExpired force-releases every charge older than the TTL and returns how
-// many it released. No-op when the TTL is not positive.
+// sweepExpired force-releases every charge older than TTL and forgets every
+// session idle for longer than SessionTTL. It returns how many charges it
+// released. Each part is a no-op when its TTL is not positive.
 func (t *TokenLoadTracker) sweepExpired() int {
+	now := t.now()
+	if t.cfg.SessionTTL > 0 {
+		t.sessions.Range(func(key, val any) bool {
+			sess := val.(*tokenLoadSession)
+			sess.mu.Lock()
+			expired := now.Sub(sess.lastSeen) > t.cfg.SessionTTL
+			sess.mu.Unlock()
+			if expired {
+				t.sessions.Delete(key)
+			}
+			return true
+		})
+	}
 	if t.cfg.TTL <= 0 {
 		return 0
 	}
-	now := t.now()
 	released := 0
 	t.entries.Range(func(key, val any) bool {
 		entry := val.(*tokenLoadEntry)

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker.go
@@ -18,6 +18,9 @@ package pd
 
 import (
 	"math"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -51,6 +54,19 @@ const (
 	// needs to outlive the gap between two turns of one conversation.
 	DefaultTokenLoadSessionTTLSeconds = 1800
 
+	// DefaultTokenLoadMaxSessions bounds how many (model, session) baselines
+	// the tracker remembers at once. The session header is client-supplied,
+	// so without a bound a stream of distinct IDs could grow the table by
+	// QPS × SessionTTL entries before the janitor sweeps them. Once the
+	// table is full, new sessions are not recorded and their requests are
+	// charged by the prefix-match or whole-prompt rule instead.
+	DefaultTokenLoadMaxSessions = 100000
+
+	// maxTokenLoadSessionIDLen is the longest session ID the tracker records,
+	// the same bound session-affinity routing applies to the caller-owned
+	// session key. Longer IDs are treated as absent.
+	maxTokenLoadSessionIDLen = 256
+
 	// tokenLoadJanitorInterval is the scan period of the janitor, which
 	// force-releases charges older than the TTL and prunes idle pods. It also
 	// bounds how long a pod must be idle before it is pruned.
@@ -74,20 +90,38 @@ type TokenLoadConfig struct {
 	// SessionTTL is how long a session's last prompt size is remembered for
 	// the session-delta cost estimate; 0 disables session tracking.
 	SessionTTL time.Duration
+	// MaxSessions bounds the number of sessions remembered at once; 0 selects
+	// DefaultTokenLoadMaxSessions.
+	MaxSessions int
 }
 
 // DefaultTokenLoadConfig returns the defaults, overridden by the
 // AIBRIX_TOKEN_LOAD_KV_WEIGHT, AIBRIX_TOKEN_LOAD_REQUEST_COST,
-// AIBRIX_TOKEN_LOAD_TTL_SECONDS and AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS
-// environment variables. Each must be positive; an unset, empty or invalid
-// value keeps the default.
+// AIBRIX_TOKEN_LOAD_TTL_SECONDS, AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS and
+// AIBRIX_TOKEN_LOAD_MAX_SESSIONS environment variables. Each must be
+// positive, except that a session TTL of 0 turns session tracking off; an
+// unset, empty or invalid value keeps the default.
 func DefaultTokenLoadConfig() TokenLoadConfig {
 	return TokenLoadConfig{
 		KVWeight:    utils.LoadEnvFloat("AIBRIX_TOKEN_LOAD_KV_WEIGHT", DefaultTokenLoadKVWeight),
 		RequestCost: utils.LoadEnvFloat("AIBRIX_TOKEN_LOAD_REQUEST_COST", DefaultTokenLoadRequestCost),
 		TTL:         time.Duration(utils.LoadEnvInt("AIBRIX_TOKEN_LOAD_TTL_SECONDS", DefaultTokenLoadTTLSeconds)) * time.Second,
-		SessionTTL:  time.Duration(utils.LoadEnvInt("AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS", DefaultTokenLoadSessionTTLSeconds)) * time.Second,
+		SessionTTL:  loadSessionTTL(),
+		MaxSessions: utils.LoadEnvInt("AIBRIX_TOKEN_LOAD_MAX_SESSIONS", DefaultTokenLoadMaxSessions),
 	}
+}
+
+// loadSessionTTL reads AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS. Unlike the
+// other tunables, 0 is a valid setting here: it disables the session-delta
+// rule for deployments whose prefill pods cannot reach a conversation's
+// earlier KV cache. Anything else goes through utils.LoadEnvInt.
+func loadSessionTTL() time.Duration {
+	const key = "AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS"
+	if v, err := strconv.Atoi(strings.TrimSpace(os.Getenv(key))); err == nil && v == 0 {
+		klog.Infof("set %s: 0, session tracking disabled", key)
+		return 0
+	}
+	return time.Duration(utils.LoadEnvInt(key, DefaultTokenLoadSessionTTLSeconds)) * time.Second
 }
 
 // TokenLoadTracker keeps a token-weighted ledger of the prefill load the
@@ -125,7 +159,12 @@ type TokenLoadTracker struct {
 	entries      sync.Map // map[string]*tokenLoadEntry, request ID → charge
 	// sessions remembers the last prompt size per (model, session) so a
 	// multi-turn continuation is charged only for what the engine computes.
-	sessions sync.Map // map[string]*tokenLoadSession, sessionKey → last prompt
+	// sessionCount is its size, kept so admission can stop at MaxSessions
+	// without walking the map; sessionsFull records that the cap was hit,
+	// so the warning is logged once.
+	sessions     sync.Map // map[string]*tokenLoadSession, sessionKey → last prompt
+	sessionCount atomic.Int64
+	sessionsFull atomic.Bool
 
 	// countersMu serialises the janitor's pruning of idle pods (write lock)
 	// with counter updates (read lock), so a counter and its gauge series are
@@ -179,6 +218,10 @@ type tokenLoadSession struct {
 	mu           sync.Mutex
 	promptTokens int
 	lastSeen     time.Time
+	// deleted is set, under mu, when the janitor removes the session from
+	// the map, so a writer that loaded the pointer just before the removal
+	// re-inserts instead of refreshing an orphan.
+	deleted bool
 }
 
 // NewTokenLoadTracker creates a tracker with DefaultTokenLoadConfig and starts
@@ -198,13 +241,16 @@ func NewTokenLoadTrackerWithConfig(cfg TokenLoadConfig) *TokenLoadTracker {
 	klog.InfoS("token_load_tracker created",
 		"kv_weight", cfg.KVWeight, "request_cost", cfg.RequestCost,
 		"ttl_seconds", int(cfg.TTL.Seconds()), "session_ttl_seconds", int(cfg.SessionTTL.Seconds()),
-		"janitor_enabled", janitor)
+		"max_sessions", t.cfg.MaxSessions, "janitor_enabled", janitor)
 	return t
 }
 
 // newTokenLoadTracker builds a tracker without a janitor goroutine; tests use
 // it with a fake clock and drive sweepExpired directly.
 func newTokenLoadTracker(cfg TokenLoadConfig, clock func() time.Time) *TokenLoadTracker {
+	if cfg.MaxSessions <= 0 {
+		cfg.MaxSessions = DefaultTokenLoadMaxSessions
+	}
 	return &TokenLoadTracker{cfg: cfg, clock: clock, stopCh: make(chan struct{})}
 }
 
@@ -248,9 +294,15 @@ const (
 //
 //  1. When sessionID is set and the (model, session) was seen before with a
 //     shorter prompt, the growth since that prompt. Each turn of a
-//     conversation resends the whole history, but the engine only computes
-//     the new turn. The prompt size is recorded for the next turn, so call
-//     this once per charged request.
+//     conversation resends the whole history, but an engine that still holds
+//     the conversation's KV cache only computes the new turn. This rule
+//     therefore assumes the earlier turns are reachable from the selected
+//     pod (sticky routing, a shared or tiered KV store, or the same pod's
+//     prefix cache); callers whose deployment cannot offer that should not
+//     send a session ID. The prompt size is recorded for the next turn, so
+//     call this once per charged request. A session ID longer than 256
+//     bytes is ignored, and once MaxSessions sessions are live a new one is
+//     not recorded, so its requests fall through to the rules below.
 //  2. Otherwise, when matchPct (0-100) is non-negative, the part of the
 //     prompt the pod's prefix cache does not cover: promptTokens × (1 −
 //     matchPct/100). Pass a negative matchPct when no match information is
@@ -262,7 +314,7 @@ func (t *TokenLoadTracker) NewTokens(model, sessionID string, promptTokens, matc
 	if promptTokens < 0 {
 		promptTokens = 0
 	}
-	if sessionID != "" && t.cfg.SessionTTL > 0 {
+	if sessionID != "" && len(sessionID) <= maxTokenLoadSessionIDLen && t.cfg.SessionTTL > 0 {
 		if last, seen := t.recordSessionPrompt(model, sessionID, promptTokens); seen && promptTokens > last {
 			return promptTokens - last, NewTokensSourceSession
 		}
@@ -277,20 +329,40 @@ func (t *TokenLoadTracker) NewTokens(model, sessionID string, promptTokens, matc
 }
 
 // recordSessionPrompt stores promptTokens as the last prompt of (model,
-// session) and returns the previous value and whether there was one.
+// session) and returns the previous value and whether there was one. A new
+// session is admitted only while fewer than MaxSessions are live; otherwise
+// nothing is recorded and the caller charges by the other rules.
 func (t *TokenLoadTracker) recordSessionPrompt(model, sessionID string, promptTokens int) (int, bool) {
 	now := t.now()
-	v, seen := t.sessions.LoadOrStore(sessionKey(model, sessionID), &tokenLoadSession{promptTokens: promptTokens, lastSeen: now})
-	if !seen {
-		return 0, false
+	key := sessionKey(model, sessionID)
+	for {
+		v, loaded := t.sessions.Load(key)
+		if !loaded {
+			if t.sessionCount.Add(1) > int64(t.cfg.MaxSessions) {
+				t.sessionCount.Add(-1)
+				if t.sessionsFull.CompareAndSwap(false, true) {
+					klog.Warningf("token_load_tracker session table is full (max_sessions=%d): new sessions are charged without a session delta until the janitor sweeps idle ones", t.cfg.MaxSessions)
+				}
+				return 0, false
+			}
+			if _, raced := t.sessions.LoadOrStore(key, &tokenLoadSession{promptTokens: promptTokens, lastSeen: now}); raced {
+				t.sessionCount.Add(-1) // another writer admitted it first; read theirs
+				continue
+			}
+			return 0, false
+		}
+		sess := v.(*tokenLoadSession)
+		sess.mu.Lock()
+		if sess.deleted {
+			sess.mu.Unlock() // swept between Load and Lock; start over
+			continue
+		}
+		last := sess.promptTokens
+		sess.promptTokens = promptTokens
+		sess.lastSeen = now
+		sess.mu.Unlock()
+		return last, true
 	}
-	sess := v.(*tokenLoadSession)
-	sess.mu.Lock()
-	defer sess.mu.Unlock()
-	last := sess.promptTokens
-	sess.promptTokens = promptTokens
-	sess.lastSeen = now
-	return last, true
 }
 
 // sessionKey qualifies a client-supplied session ID with the model: the same
@@ -445,12 +517,17 @@ func (t *TokenLoadTracker) sweepExpired() int {
 	if t.cfg.SessionTTL > 0 {
 		t.sessions.Range(func(key, val any) bool {
 			sess := val.(*tokenLoadSession)
+			// The expiry check, the removal and the tombstone happen under
+			// the session lock, so a concurrent refresh either lands before
+			// the check and keeps the session, or sees the tombstone and
+			// re-inserts; it can never be lost.
 			sess.mu.Lock()
-			expired := now.Sub(sess.lastSeen) > t.cfg.SessionTTL
-			sess.mu.Unlock()
-			if expired {
+			if now.Sub(sess.lastSeen) > t.cfg.SessionTTL {
+				sess.deleted = true
 				t.sessions.Delete(key)
+				t.sessionCount.Add(-1)
 			}
+			sess.mu.Unlock()
 			return true
 		})
 	}

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -251,22 +252,33 @@ func TestTokenLoadTracker_DefaultConfigFromEnv(t *testing.T) {
 	t.Setenv("AIBRIX_TOKEN_LOAD_REQUEST_COST", "100")
 	t.Setenv("AIBRIX_TOKEN_LOAD_TTL_SECONDS", "42")
 	t.Setenv("AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS", "7")
+	t.Setenv("AIBRIX_TOKEN_LOAD_MAX_SESSIONS", "500")
 
 	cfg := DefaultTokenLoadConfig()
 	assert.Equal(t, 0.7, cfg.KVWeight)
 	assert.Equal(t, float64(100), cfg.RequestCost)
 	assert.Equal(t, 42*time.Second, cfg.TTL)
 	assert.Equal(t, 7*time.Second, cfg.SessionTTL)
+	assert.Equal(t, 500, cfg.MaxSessions)
 
 	t.Setenv("AIBRIX_TOKEN_LOAD_KV_WEIGHT", "not-a-number")
 	t.Setenv("AIBRIX_TOKEN_LOAD_REQUEST_COST", "")
 	t.Setenv("AIBRIX_TOKEN_LOAD_TTL_SECONDS", "0")
 	t.Setenv("AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS", "-1")
+	t.Setenv("AIBRIX_TOKEN_LOAD_MAX_SESSIONS", "0")
 	cfg = DefaultTokenLoadConfig()
 	assert.Equal(t, DefaultTokenLoadKVWeight, cfg.KVWeight, "invalid value falls back to the default")
 	assert.Equal(t, float64(DefaultTokenLoadRequestCost), cfg.RequestCost, "empty value falls back to the default")
 	assert.Equal(t, DefaultTokenLoadTTLSeconds*time.Second, cfg.TTL, "non-positive value falls back to the default")
-	assert.Equal(t, DefaultTokenLoadSessionTTLSeconds*time.Second, cfg.SessionTTL, "non-positive value falls back to the default")
+	assert.Equal(t, DefaultTokenLoadSessionTTLSeconds*time.Second, cfg.SessionTTL, "negative value falls back to the default")
+	assert.Equal(t, DefaultTokenLoadMaxSessions, cfg.MaxSessions, "non-positive value falls back to the default")
+
+	// 0 is the documented way to turn session tracking off.
+	t.Setenv("AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS", " 0 ")
+	assert.Equal(t, time.Duration(0), DefaultTokenLoadConfig().SessionTTL, "0 disables session tracking")
+
+	// A config without MaxSessions gets the default bound.
+	assert.Equal(t, DefaultTokenLoadMaxSessions, NewTokenLoadTrackerWithConfig(TokenLoadConfig{}).Config().MaxSessions)
 }
 
 // sessionTestConfig enables session tracking on top of testTokenLoadConfig.
@@ -344,6 +356,128 @@ func TestTokenLoadTracker_NewTokensSessionDisabled(t *testing.T) {
 	got, source := tr.NewTokens("model", "s1", 1500, -1)
 	assert.Equal(t, 1500, got, "sessions are not remembered when SessionTTL is 0")
 	assert.Equal(t, NewTokensSourcePrompt, source)
+}
+
+func TestTokenLoadTracker_NewTokensIgnoresOverlongSessionID(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, sessionTestConfig())
+
+	longID := strings.Repeat("s", maxTokenLoadSessionIDLen+1)
+	tr.NewTokens("model", longID, 1000, -1)
+	got, source := tr.NewTokens("model", longID, 1500, -1)
+	assert.Equal(t, 1500, got, "an over-long session ID is treated as no session")
+	assert.Equal(t, NewTokensSourcePrompt, source)
+	assert.Equal(t, int64(0), tr.sessionCount.Load(), "nothing is recorded for it")
+
+	maxID := strings.Repeat("s", maxTokenLoadSessionIDLen)
+	tr.NewTokens("model", maxID, 1000, -1)
+	got, source = tr.NewTokens("model", maxID, 1500, -1)
+	assert.Equal(t, 500, got, "an ID at the limit is recorded")
+	assert.Equal(t, NewTokensSourceSession, source)
+	assert.Equal(t, int64(1), tr.sessionCount.Load())
+}
+
+func TestTokenLoadTracker_SessionTableIsBounded(t *testing.T) {
+	cfg := sessionTestConfig()
+	cfg.MaxSessions = 2
+	tr, clock := newTestTokenLoadTracker(t, cfg)
+
+	tr.NewTokens("model", "s1", 1000, -1)
+	tr.NewTokens("model", "s2", 1000, -1)
+	assert.Equal(t, int64(2), tr.sessionCount.Load())
+
+	// The table is full: s3 is not recorded and keeps being charged by the
+	// other rules, while the live sessions still get their delta.
+	for i := 0; i < 3; i++ {
+		got, source := tr.NewTokens("model", "s3", 1000+500*i, 40)
+		assert.Equal(t, (1000+500*i)*60/100, got, "turn %d of an unadmitted session is charged by the prefix rule", i)
+		assert.Equal(t, NewTokensSourcePrefixMatch, source)
+	}
+	assert.Equal(t, int64(2), tr.sessionCount.Load())
+	got, source := tr.NewTokens("model", "s1", 1500, 40)
+	assert.Equal(t, 500, got)
+	assert.Equal(t, NewTokensSourceSession, source)
+
+	// Once the janitor sweeps an idle session, a new one can be admitted.
+	clock.Advance(cfg.SessionTTL + time.Minute)
+	tr.NewTokens("model", "s1", 1600, -1) // keep s1 alive
+	tr.sweepExpired()
+	assert.Equal(t, int64(1), tr.sessionCount.Load(), "s2 was swept")
+	tr.NewTokens("model", "s3", 1000, -1)
+	got, source = tr.NewTokens("model", "s3", 1500, -1)
+	assert.Equal(t, 500, got, "s3 is admitted into the freed slot")
+	assert.Equal(t, NewTokensSourceSession, source)
+	assert.Equal(t, int64(2), tr.sessionCount.Load())
+}
+
+// TestTokenLoadTracker_SweptSessionIsNotRefreshed covers the writer side of
+// the sweep race: a writer that loaded a session pointer just before the
+// janitor removed it must not refresh the orphan but start a new session.
+func TestTokenLoadTracker_SweptSessionIsNotRefreshed(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, sessionTestConfig())
+
+	tr.NewTokens("model", "s1", 1000, -1)
+	v, ok := tr.sessions.Load(sessionKey("model", "s1"))
+	require.True(t, ok)
+	orphan := v.(*tokenLoadSession)
+
+	// What sweepExpired does once it finds the session idle.
+	orphan.mu.Lock()
+	orphan.deleted = true
+	tr.sessions.Delete(sessionKey("model", "s1"))
+	tr.sessionCount.Add(-1)
+	orphan.mu.Unlock()
+
+	got, source := tr.NewTokens("model", "s1", 1500, -1)
+	assert.Equal(t, 1500, got, "the swept baseline is gone")
+	assert.Equal(t, NewTokensSourcePrompt, source)
+	v, ok = tr.sessions.Load(sessionKey("model", "s1"))
+	require.True(t, ok, "a fresh session was inserted")
+	assert.NotSame(t, orphan, v.(*tokenLoadSession))
+	assert.Equal(t, int64(1), tr.sessionCount.Load())
+	got, source = tr.NewTokens("model", "s1", 2000, -1)
+	assert.Equal(t, 500, got, "the fresh session is the new baseline")
+	assert.Equal(t, NewTokensSourceSession, source)
+}
+
+// TestTokenLoadTracker_SessionCountSurvivesConcurrentSweeps races writers
+// against the janitor and checks the live-session count against the map.
+func TestTokenLoadTracker_SessionCountSurvivesConcurrentSweeps(t *testing.T) {
+	cfg := sessionTestConfig()
+	cfg.SessionTTL = time.Millisecond
+	cfg.MaxSessions = 8
+	tr := newTokenLoadTracker(cfg, time.Now)
+
+	stop := make(chan struct{})
+	sweeperDone := make(chan struct{})
+	go func() {
+		defer close(sweeperDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				tr.sweepExpired()
+			}
+		}
+	}()
+	var writers sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		writers.Add(1)
+		go func(w int) {
+			defer writers.Done()
+			for i := 0; i < 2000; i++ {
+				tr.NewTokens("model", fmt.Sprintf("s-%d", (w*7+i)%16), 1000+i, -1)
+			}
+		}(w)
+	}
+	writers.Wait()
+	close(stop)
+	<-sweeperDone
+
+	live := 0
+	tr.sessions.Range(func(_, _ any) bool { live++; return true })
+	assert.Equal(t, int64(live), tr.sessionCount.Load(), "count matches the map after concurrent admissions and sweeps")
+	assert.LessOrEqual(t, live, cfg.MaxSessions)
 }
 
 func TestTokenLoadTracker_JanitorForgetsIdleSessions(t *testing.T) {

--- a/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/token_load_tracker_test.go
@@ -250,19 +250,123 @@ func TestTokenLoadTracker_DefaultConfigFromEnv(t *testing.T) {
 	t.Setenv("AIBRIX_TOKEN_LOAD_KV_WEIGHT", "0.7")
 	t.Setenv("AIBRIX_TOKEN_LOAD_REQUEST_COST", "100")
 	t.Setenv("AIBRIX_TOKEN_LOAD_TTL_SECONDS", "42")
+	t.Setenv("AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS", "7")
 
 	cfg := DefaultTokenLoadConfig()
 	assert.Equal(t, 0.7, cfg.KVWeight)
 	assert.Equal(t, float64(100), cfg.RequestCost)
 	assert.Equal(t, 42*time.Second, cfg.TTL)
+	assert.Equal(t, 7*time.Second, cfg.SessionTTL)
 
 	t.Setenv("AIBRIX_TOKEN_LOAD_KV_WEIGHT", "not-a-number")
 	t.Setenv("AIBRIX_TOKEN_LOAD_REQUEST_COST", "")
 	t.Setenv("AIBRIX_TOKEN_LOAD_TTL_SECONDS", "0")
+	t.Setenv("AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS", "-1")
 	cfg = DefaultTokenLoadConfig()
 	assert.Equal(t, DefaultTokenLoadKVWeight, cfg.KVWeight, "invalid value falls back to the default")
 	assert.Equal(t, float64(DefaultTokenLoadRequestCost), cfg.RequestCost, "empty value falls back to the default")
 	assert.Equal(t, DefaultTokenLoadTTLSeconds*time.Second, cfg.TTL, "non-positive value falls back to the default")
+	assert.Equal(t, DefaultTokenLoadSessionTTLSeconds*time.Second, cfg.SessionTTL, "non-positive value falls back to the default")
+}
+
+// sessionTestConfig enables session tracking on top of testTokenLoadConfig.
+func sessionTestConfig() TokenLoadConfig {
+	cfg := testTokenLoadConfig()
+	cfg.SessionTTL = 30 * time.Minute
+	return cfg
+}
+
+func TestTokenLoadTracker_NewTokensWithoutSession(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, sessionTestConfig())
+
+	cases := []struct {
+		name         string
+		promptTokens int
+		matchPct     int
+		wantTokens   int
+		wantSource   string
+	}{
+		{"no match info charges the whole prompt", 1000, -1, 1000, NewTokensSourcePrompt},
+		{"zero match charges the whole prompt", 1000, 0, 1000, NewTokensSourcePrefixMatch},
+		{"partial match charges the uncached part", 1000, 60, 400, NewTokensSourcePrefixMatch},
+		{"full match charges nothing", 1000, 100, 0, NewTokensSourcePrefixMatch},
+		{"match above 100 is clamped", 1000, 150, 0, NewTokensSourcePrefixMatch},
+		{"negative prompt is treated as empty", -5, -1, 0, NewTokensSourcePrompt},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, source := tr.NewTokens("model", "", tc.promptTokens, tc.matchPct)
+			assert.Equal(t, tc.wantTokens, got)
+			assert.Equal(t, tc.wantSource, source)
+		})
+	}
+}
+
+func TestTokenLoadTracker_NewTokensSessionDelta(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, sessionTestConfig())
+
+	// First turn: nothing to diff against, so the prefix-match rule applies.
+	got, source := tr.NewTokens("model", "s1", 1000, 40)
+	assert.Equal(t, 600, got)
+	assert.Equal(t, NewTokensSourcePrefixMatch, source)
+
+	// Second turn resends the history plus 500 new tokens: only the growth is
+	// charged, whatever the prefix cache says.
+	got, source = tr.NewTokens("model", "s1", 1500, 0)
+	assert.Equal(t, 500, got)
+	assert.Equal(t, NewTokensSourceSession, source)
+
+	// A repeated prompt has no growth to charge; fall back to the match rule.
+	got, source = tr.NewTokens("model", "s1", 1500, 90)
+	assert.Equal(t, 150, got)
+	assert.Equal(t, NewTokensSourcePrefixMatch, source)
+
+	// A shorter prompt (history trimmed, new conversation under the same ID)
+	// falls back too and becomes the new baseline.
+	got, source = tr.NewTokens("model", "s1", 800, -1)
+	assert.Equal(t, 800, got)
+	assert.Equal(t, NewTokensSourcePrompt, source)
+	got, source = tr.NewTokens("model", "s1", 1000, -1)
+	assert.Equal(t, 200, got)
+	assert.Equal(t, NewTokensSourceSession, source)
+
+	// The same session ID against another model is a different conversation.
+	got, source = tr.NewTokens("other-model", "s1", 1000, -1)
+	assert.Equal(t, 1000, got)
+	assert.Equal(t, NewTokensSourcePrompt, source)
+}
+
+func TestTokenLoadTracker_NewTokensSessionDisabled(t *testing.T) {
+	tr, _ := newTestTokenLoadTracker(t, testTokenLoadConfig()) // SessionTTL 0
+
+	got, _ := tr.NewTokens("model", "s1", 1000, -1)
+	assert.Equal(t, 1000, got)
+	got, source := tr.NewTokens("model", "s1", 1500, -1)
+	assert.Equal(t, 1500, got, "sessions are not remembered when SessionTTL is 0")
+	assert.Equal(t, NewTokensSourcePrompt, source)
+}
+
+func TestTokenLoadTracker_JanitorForgetsIdleSessions(t *testing.T) {
+	cfg := sessionTestConfig()
+	cfg.TTL = 0 // charges are never swept here; only sessions are
+	tr, clock := newTestTokenLoadTracker(t, cfg)
+
+	tr.AcquirePrefill("req-1", "pod-a", 1000)
+	tr.NewTokens("model", "fresh", 1000, -1)
+	tr.NewTokens("model", "stale", 1000, -1)
+	clock.Advance(20 * time.Minute)
+	tr.NewTokens("model", "fresh", 1200, -1) // touches the session
+
+	clock.Advance(15 * time.Minute) // stale idle for 35 min, fresh for 15
+	assert.Equal(t, 0, tr.sweepExpired())
+	assertLoad(t, tr, "pod-a", 1000, 1000)
+
+	got, source := tr.NewTokens("model", "fresh", 1500, -1)
+	assert.Equal(t, 300, got)
+	assert.Equal(t, NewTokensSourceSession, source)
+	got, source = tr.NewTokens("model", "stale", 1500, -1)
+	assert.Equal(t, 1500, got, "an idle session is forgotten and starts over")
+	assert.Equal(t, NewTokensSourcePrompt, source)
 }
 
 func TestTokenLoadTracker_JanitorReleasesStaleCharges(t *testing.T) {

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -352,16 +352,18 @@ func (r *pdRouter) DoneRequestTrace(_ *types.RoutingContext, requestID string, _
 // the prefill registration so the next selection sees this charge.
 //
 // The charge covers only the tokens pod has to compute: the growth of the
-// conversation since its previous turn when the request carries a session
-// header, otherwise the part of the prompt the pod's prefix cache does not
-// hold when scorer looked it up, otherwise the whole prompt. See
-// TokenLoadTracker.NewTokens.
+// conversation since its previous turn when the request carries the
+// caller-owned x-aibrix-session-key header, otherwise the part of the prompt
+// the pod's prefix cache does not hold when scorer looked it up, otherwise
+// the whole prompt. See TokenLoadTracker.NewTokens. The gateway-issued
+// x-session-id of session-affinity routing is deliberately not consulted:
+// it names a backend, not a conversation.
 func (r *pdRouter) chargeTokenLoad(routingCtx *types.RoutingContext, pod *v1.Pod, policy pd.PrefillScorePolicy, scorer pd.PrefillScorer) {
 	if r.tokenLoadTracker == nil || !pd.UsesTokenLoad(policy) {
 		return
 	}
 	promptTokens := pd.EstimatePromptTokens(routingCtx.ReqBody)
-	sessionID := routingCtx.ReqHeaders[constants.HeaderSessionID]
+	sessionID := routingCtx.ReqHeaders[constants.HeaderSessionKey]
 	matchPct := pd.PrefixMatchPercent(scorer, pod.Name)
 	newTokens, source := r.tokenLoadTracker.NewTokens(routingCtx.Model, sessionID, promptTokens, matchPct)
 	cost := r.tokenLoadTracker.PrefillCost(newTokens)

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -116,6 +116,7 @@ var validPrefillScorePolicies = []string{
 	pd.PrefillScorePolicyLeastRequest,
 	pd.PrefillScorePolicyConductor,
 	pd.PrefillScorePolicyTokenLoad,
+	pd.PrefillScorePolicyHybridCacheLoad,
 }
 
 func init() {
@@ -179,6 +180,8 @@ func (r *pdRouter) effectiveScorePolicies(routingCtx *types.RoutingContext) (pd.
 			prefill = newConductorPrefillPolicy(r.prefixCacheIndexer, r.cache)
 		case pd.PrefillScorePolicyTokenLoad:
 			prefill = pd.NewTokenLoadPrefillPolicy(r.tokenLoadTracker)
+		case pd.PrefillScorePolicyHybridCacheLoad:
+			prefill = newHybridCacheLoadPrefillPolicy(r.prefixCacheIndexer, r.tokenLoadTracker)
 		default:
 			klog.InfoS("unknown prefillScorePolicy in routingConfig, keeping env-based policy",
 				"request_id", routingCtx.RequestID, "value", s,
@@ -249,6 +252,10 @@ func newConductorPrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHashT
 	return pd.NewConductorPrefillPolicy(newTokenizer(), sharedPrefixTable, metricCache, pd.NewConductorPrefillPolicyConfig())
 }
 
+func newHybridCacheLoadPrefillPolicy(sharedPrefixTable *prefixcacheindexer.PrefixHashTable, tracker *pd.TokenLoadTracker) pd.PrefillScorePolicy {
+	return pd.NewHybridCacheLoadPrefillPolicy(newTokenizer(), sharedPrefixTable, tracker, pd.DefaultHybridCacheLoadConfig())
+}
+
 func NewPDRouter() (types.Router, error) {
 	c, err := cache.Get()
 	if err != nil {
@@ -258,7 +265,8 @@ func NewPDRouter() (types.Router, error) {
 
 	sharedPrefixTable := prefixcacheindexer.GetSharedPrefixHashTable()
 	// One tracker per router, created unconditionally so that a routingConfig
-	// can switch a model to token_load without a gateway restart.
+	// can switch a model to token_load or hybrid_cache_load without a gateway
+	// restart.
 	tokenLoadTracker := pd.NewTokenLoadTracker()
 
 	var policy pd.PrefillScorePolicy
@@ -271,6 +279,8 @@ func NewPDRouter() (types.Router, error) {
 		policy = newConductorPrefillPolicy(sharedPrefixTable, c)
 	case pd.PrefillScorePolicyTokenLoad:
 		policy = pd.NewTokenLoadPrefillPolicy(tokenLoadTracker)
+	case pd.PrefillScorePolicyHybridCacheLoad:
+		policy = newHybridCacheLoadPrefillPolicy(sharedPrefixTable, tokenLoadTracker)
 	default:
 		klog.InfoS("pd_router unknown AIBRIX_PREFILL_SCORE_POLICY, using prefix_cache",
 			"value", aibrixPrefillScorePolicy, "valid", validPrefillScorePolicies)
@@ -340,11 +350,25 @@ func (r *pdRouter) DoneRequestTrace(_ *types.RoutingContext, requestID string, _
 // chargeTokenLoad charges the request's estimated prefill cost to pod when
 // policy scores from the token-load tracker. Called under selectMu right after
 // the prefill registration so the next selection sees this charge.
-func (r *pdRouter) chargeTokenLoad(routingCtx *types.RoutingContext, pod *v1.Pod, policy pd.PrefillScorePolicy) {
+//
+// The charge covers only the tokens pod has to compute: the growth of the
+// conversation since its previous turn when the request carries a session
+// header, otherwise the part of the prompt the pod's prefix cache does not
+// hold when scorer looked it up, otherwise the whole prompt. See
+// TokenLoadTracker.NewTokens.
+func (r *pdRouter) chargeTokenLoad(routingCtx *types.RoutingContext, pod *v1.Pod, policy pd.PrefillScorePolicy, scorer pd.PrefillScorer) {
 	if r.tokenLoadTracker == nil || !pd.UsesTokenLoad(policy) {
 		return
 	}
-	cost := r.tokenLoadTracker.PrefillCost(pd.EstimatePromptTokens(routingCtx.ReqBody))
+	promptTokens := pd.EstimatePromptTokens(routingCtx.ReqBody)
+	sessionID := routingCtx.ReqHeaders[constants.HeaderSessionID]
+	matchPct := pd.PrefixMatchPercent(scorer, pod.Name)
+	newTokens, source := r.tokenLoadTracker.NewTokens(routingCtx.Model, sessionID, promptTokens, matchPct)
+	cost := r.tokenLoadTracker.PrefillCost(newTokens)
+	klog.V(4).InfoS("pd_router token_load charge",
+		"request_id", routingCtx.RequestID, "pod_name", pod.Name, "policy", policy.Name(),
+		"prompt_tokens", promptTokens, "new_tokens", newTokens, "source", source,
+		"prefix_match_percent", matchPct, "cost", cost)
 	r.tokenLoadTracker.AcquirePrefill(routingCtx.RequestID, pod.Name, cost)
 }
 
@@ -548,7 +572,7 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 	// Register while still holding selectMu so the next selection counts this one.
 	r.pendingDecodeTracker.AddPendingDecode(routingCtx.RequestID, selectedDecode.Name)
 	r.prefillRequestTracker.AddPrefillRequest(routingCtx.RequestID, selectedPrefill.Name)
-	r.chargeTokenLoad(routingCtx, selectedPrefill, prefillPol)
+	r.chargeTokenLoad(routingCtx, selectedPrefill, prefillPol, prefillScorer)
 	return selectedPrefill, selectedDecode, nil
 }
 

--- a/pkg/plugins/gateway/algorithms/pd_hybrid_cache_load_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_hybrid_cache_load_test.go
@@ -69,7 +69,7 @@ func hybridRequest(t *testing.T, requestID string, bodyBytes int, sessionID stri
 	ctx := tokenLoadRequest(t, requestID, bodyBytes)
 	ctx.Message = hybridTestMessage
 	if sessionID != "" {
-		ctx.ReqHeaders = map[string]string{constants.HeaderSessionID: sessionID}
+		ctx.ReqHeaders = map[string]string{constants.HeaderSessionKey: sessionID}
 	}
 	return ctx
 }

--- a/pkg/plugins/gateway/algorithms/pd_hybrid_cache_load_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_hybrid_cache_load_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
+	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
+	"github.com/vllm-project/aibrix/pkg/utils/tokenizer"
+	v1 "k8s.io/api/core/v1"
+)
+
+// hybridTestMessage is 40 characters, i.e. 10 prefix blocks under the
+// character tokenizer and the default 4-byte block, so a pod seeded with the
+// first n blocks reports a 10·n % match.
+const hybridTestMessage = "0123456789abcdefghijklmnopqrstuvwxyzABCD"
+
+// hybridTokenLoadTestConfig is tokenLoadTestConfig with session tracking on.
+var hybridTokenLoadTestConfig = pd.TokenLoadConfig{KVWeight: 0.5, RequestCost: 0, TTL: 0, SessionTTL: 30 * time.Minute}
+
+// newHybridCacheLoadTestRouter is newTokenLoadTestRouter on the
+// hybrid_cache_load policy over a private prefix table. Nothing drains
+// prefixUpdateCh, so the table only ever holds what a test seeds into it.
+func newHybridCacheLoadTestRouter(client *http.Client, cfg pd.HybridCacheLoadConfig) (*pdRouter, *pd.TokenLoadTracker, *prefixcacheindexer.PrefixHashTable) {
+	r, tokenLoad := newTokenLoadTestRouterWithConfig(client, hybridTokenLoadTestConfig)
+	table := prefixcacheindexer.NewPrefixHashTable()
+	r.prefixCacheIndexer = table
+	r.prefillPolicy = pd.NewHybridCacheLoadPrefillPolicy(tokenizer.NewCharacterTokenizer(), table, tokenLoad, cfg)
+	return r, tokenLoad, table
+}
+
+// seedHybridPrefix records the first matchPct percent of hybridTestMessage
+// as resident on pod for model.
+func seedHybridPrefix(t *testing.T, table *prefixcacheindexer.PrefixHashTable, model, pod string, matchPct int) {
+	t.Helper()
+	_, hashes := table.MatchPrefix([]byte(hybridTestMessage), model, nil)
+	require.Len(t, hashes, 10)
+	table.AddPrefix(hashes[:len(hashes)*matchPct/100], model, pod)
+}
+
+// hybridRequest is tokenLoadRequest with the prefix-matchable message and an
+// optional session header.
+func hybridRequest(t *testing.T, requestID string, bodyBytes int, sessionID string) *types.RoutingContext {
+	t.Helper()
+	ctx := tokenLoadRequest(t, requestID, bodyBytes)
+	ctx.Message = hybridTestMessage
+	if sessionID != "" {
+		ctx.ReqHeaders = map[string]string{constants.HeaderSessionID: sessionID}
+	}
+	return ctx
+}
+
+func openGateClient() *http.Client {
+	gate := make(chan struct{})
+	close(gate)
+	return &http.Client{Transport: &gatedTransport{gate: gate}}
+}
+
+// TestPDRouter_HybridCacheLoadFollowsPrefixOnIdlePods: both pods idle, one
+// holds half the prompt. The request goes there and is charged only for the
+// half the pod has to compute.
+func TestPDRouter_HybridCacheLoadFollowsPrefixOnIdlePods(t *testing.T) {
+	prefillPods := []*v1.Pod{
+		burstPod("prefill-0", "prefill", "127.0.0.1"),
+		burstPod("prefill-1", "prefill", "127.0.0.2"),
+	}
+	podList := &utils.PodArray{Pods: append(append([]*v1.Pod{}, prefillPods...), burstPod("decode-0", "decode", "127.0.0.100"))}
+	r, tokenLoad, table := newHybridCacheLoadTestRouter(openGateClient(), pd.HybridCacheLoadConfig{Factor: 0.5})
+
+	ctx := hybridRequest(t, "warm", 4000, "") // 1000 estimated prompt tokens
+	seedHybridPrefix(t, table, ctx.Model, "prefill-1", 50)
+
+	_, err := r.Route(ctx, podList)
+	require.NoError(t, err)
+	assert.Equal(t, "prefill-1", ctx.RespHeaders[HeaderPrefillTargetPod])
+	active, kv := tokenLoad.GetLoad("prefill-1")
+	assert.Equal(t, float64(0), active, "prefill has returned")
+	assert.Equal(t, float64(500), kv, "only the uncached half of the prompt is charged")
+	_, kv = tokenLoad.GetLoad("prefill-0")
+	assert.Equal(t, float64(0), kv)
+}
+
+// TestPDRouter_HybridCacheLoadLoadOutweighsPrefix: the pod holding the whole
+// prompt is also holding a long prefill, so the idle pod wins and is charged
+// the full prompt.
+func TestPDRouter_HybridCacheLoadLoadOutweighsPrefix(t *testing.T) {
+	prefillPods := []*v1.Pod{
+		burstPod("prefill-0", "prefill", "127.0.0.1"),
+		burstPod("prefill-1", "prefill", "127.0.0.2"),
+	}
+	podList := &utils.PodArray{Pods: append(append([]*v1.Pod{}, prefillPods...), burstPod("decode-0", "decode", "127.0.0.100"))}
+	r, tokenLoad, table := newHybridCacheLoadTestRouter(openGateClient(), pd.HybridCacheLoadConfig{Factor: 0.5})
+
+	ctx := hybridRequest(t, "cold", 4000, "")
+	seedHybridPrefix(t, table, ctx.Model, "prefill-1", 100)
+	tokenLoad.AcquirePrefill("long", "prefill-1", 10000)
+
+	_, err := r.Route(ctx, podList)
+	require.NoError(t, err)
+	assert.Equal(t, "prefill-0", ctx.RespHeaders[HeaderPrefillTargetPod])
+	_, kv := tokenLoad.GetLoad("prefill-0")
+	assert.Equal(t, float64(1000), kv)
+}
+
+// TestPDRouter_HybridCacheLoadSessionDelta: consecutive turns of one session
+// are charged for their growth only; another session pays for its whole
+// prompt.
+func TestPDRouter_HybridCacheLoadSessionDelta(t *testing.T) {
+	prefillPod := burstPod("prefill-0", "prefill", "127.0.0.1")
+	podList := &utils.PodArray{Pods: []*v1.Pod{prefillPod, burstPod("decode-0", "decode", "127.0.0.100")}}
+	r, tokenLoad, _ := newHybridCacheLoadTestRouter(openGateClient(), pd.HybridCacheLoadConfig{Factor: 0.5})
+
+	steps := []struct {
+		requestID string
+		bodyBytes int
+		sessionID string
+		wantKV    float64 // cumulative resident KV on the pod
+		why       string
+	}{
+		{"s1-turn-1", 4000, "s1", 1000, "first turn: whole prompt"},
+		{"s1-turn-2", 6000, "s1", 1500, "second turn: 500 new tokens"},
+		{"s1-turn-3", 6400, "s1", 1600, "third turn: 100 new tokens"},
+		{"s2-turn-1", 4000, "s2", 2600, "another session: whole prompt"},
+		{"anonymous", 4000, "", 3600, "no session header: whole prompt"},
+	}
+	for _, step := range steps {
+		_, err := r.Route(hybridRequest(t, step.requestID, step.bodyBytes, step.sessionID), podList)
+		require.NoError(t, err)
+		_, kv := tokenLoad.GetLoad(prefillPod.Name)
+		assert.Equalf(t, step.wantKV, kv, "%s: %s", step.requestID, step.why)
+	}
+}
+
+// TestPDRouter_HybridCacheLoadMinMatch: a 30 % match is treated as no match
+// once AIBRIX_MIN_MATCH_PCT-style threshold is above it, so the charge is
+// the whole prompt whichever pod wins; without the threshold the matching
+// pod wins and pays for 70 %.
+func TestPDRouter_HybridCacheLoadMinMatch(t *testing.T) {
+	prefillPods := []*v1.Pod{
+		burstPod("prefill-0", "prefill", "127.0.0.1"),
+		burstPod("prefill-1", "prefill", "127.0.0.2"),
+	}
+	podList := &utils.PodArray{Pods: append(append([]*v1.Pod{}, prefillPods...), burstPod("decode-0", "decode", "127.0.0.100"))}
+
+	for _, tc := range []struct {
+		name    string
+		minPct  float64
+		wantPod string // "" when either pod may win
+		wantKV  float64
+	}{
+		{"weak match counts by default", 0, "prefill-1", 700},
+		{"weak match ignored above the threshold", 60, "", 1000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, tokenLoad, table := newHybridCacheLoadTestRouter(openGateClient(), pd.HybridCacheLoadConfig{Factor: 0.5, MinMatchPct: tc.minPct})
+			ctx := hybridRequest(t, "req", 4000, "")
+			seedHybridPrefix(t, table, ctx.Model, "prefill-1", 30)
+
+			_, err := r.Route(ctx, podList)
+			require.NoError(t, err)
+			selected := ctx.RespHeaders[HeaderPrefillTargetPod]
+			if tc.wantPod != "" {
+				assert.Equal(t, tc.wantPod, selected)
+			}
+			_, kv := tokenLoad.GetLoad(selected)
+			assert.Equal(t, tc.wantKV, kv)
+		})
+	}
+}
+
+// TestPDRouter_HybridCacheLoadViaRoutingConfig: a routingConfig switches a
+// request on a token_load router to hybrid_cache_load, which charges too.
+func TestPDRouter_HybridCacheLoadViaRoutingConfig(t *testing.T) {
+	prefillPod := burstPod("prefill-0", "prefill", "127.0.0.1")
+	readyPods := []*v1.Pod{prefillPod, burstPod("decode-0", "decode", "127.0.0.100")}
+	r, tokenLoad := newTokenLoadTestRouter(openGateClient())
+	r.prefixCacheIndexer = prefixcacheindexer.NewPrefixHashTable()
+
+	ctx := hybridRequest(t, "via-routing-config", 4000, "")
+	ctx.ConfigProfile = &types.ResolvedConfigProfile{
+		RoutingConfig: json.RawMessage(fmt.Sprintf(`{"prefillScorePolicy":%q}`, pd.PrefillScorePolicyHybridCacheLoad)),
+	}
+	pre, _, err := r.effectiveScorePolicies(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, pd.PrefillScorePolicyHybridCacheLoad, pre.Name())
+
+	_, _, err = r.filterPrefillDecodePods(ctx, readyPods)
+	require.NoError(t, err)
+	active, kv := tokenLoad.GetLoad(prefillPod.Name)
+	assert.Equal(t, float64(1000), active)
+	assert.Equal(t, float64(1000), kv)
+}

--- a/pkg/plugins/gateway/algorithms/pd_token_load_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_token_load_test.go
@@ -45,7 +45,11 @@ var tokenLoadTestConfig = pd.TokenLoadConfig{KVWeight: 0.5, RequestCost: 0, TTL:
 // prefill calls go through client, mirroring NewPDRouter's wiring of the
 // tracker into the policy and the executor.
 func newTokenLoadTestRouter(client *http.Client) (*pdRouter, *pd.TokenLoadTracker) {
-	tokenLoad := pd.NewTokenLoadTrackerWithConfig(tokenLoadTestConfig)
+	return newTokenLoadTestRouterWithConfig(client, tokenLoadTestConfig)
+}
+
+func newTokenLoadTestRouterWithConfig(client *http.Client, cfg pd.TokenLoadConfig) (*pdRouter, *pd.TokenLoadTracker) {
+	tokenLoad := pd.NewTokenLoadTrackerWithConfig(cfg)
 	tracker := pd.NewPrefillRequestTracker()
 	r := &pdRouter{
 		cache:                 cache.NewForTest(),

--- a/test/e2e/gateway/pd/pd_hybrid_cache_load_test.go
+++ b/test/e2e/gateway/pd/pd_hybrid_cache_load_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// hybridCacheLoadConfigProfile is the model.aibrix.ai/config profile declared
+	// in development/app/config/mock/vllm-pd-config.yaml that selects
+	// routingConfig.prefillScorePolicy=hybrid_cache_load for the llama2-7b-vllm
+	// PD model.
+	hybridCacheLoadConfigProfile = "hybrid-cache-load"
+
+	// hybridCacheLoadAffinityTimeout bounds how long the repeat request may take
+	// to land on the warm prefill pod. The e2e gateway runs two replicas that
+	// exchange prefix-cache state through Redis once a second
+	// (config/test/gateway/vtc-test-env-patch.yaml), so the first repeat can hit
+	// a replica that has not yet seen the warm-up prompt.
+	hybridCacheLoadAffinityTimeout = 30 * time.Second
+	hybridCacheLoadAffinityPoll    = 2 * time.Second
+)
+
+// TestPDDisaggregationVLLMHybridCacheLoad verifies the hybrid_cache_load
+// prefill score policy end to end. Selecting it through a model config profile
+// keeps PD routing working; with every prefill pod idle the policy scores a
+// pod holding the prompt's prefix strictly below the others, so repeating a
+// prompt must route back to the prefill pod that served it first; and the
+// token-load charges the policy shares with token_load are visible as
+// pd_token_load_* gauges and released once the requests complete.
+//
+// The new_tokens charge (session delta, prefix-match discount) and the
+// load-versus-cache trade-off are not asserted here: the mock engines answer
+// in milliseconds, so the ledger is back at zero before it can be scraped,
+// and the two gateway replicas keep independent ledgers. Those rules are
+// covered by the router and tracker unit tests; this test pins the wiring
+// and the cache-affinity half of the score.
+func TestPDDisaggregationVLLMHybridCacheLoad(t *testing.T) {
+	ctx := context.Background()
+
+	waitForPDDisaggregationRouting(t, modelNameVLLM)
+
+	k8sClient, _ := initializeClient(ctx, t)
+	gatewayPods := listGatewayPluginPods(t, ctx, k8sClient)
+
+	// A fresh prompt per run so the warm-up request is a true cache miss and
+	// the repeat is decided by this run's prefix entry alone. The nonce comes
+	// first: prefix hashes are chained from the start of the prompt, so any
+	// shared leading text would already match entries left by earlier runs.
+	nonce := make([]byte, 8)
+	_, err := rand.Read(nonce)
+	require.NoError(t, err)
+	prompt := hex.EncodeToString(nonce) + " " + strings.Repeat("hybrid cache load e2e prompt body ", 40)
+
+	var dst *http.Response
+	client := createOpenAIClientWithConfigProfile(gatewayURL, apiKey, hybridCacheLoadConfigProfile,
+		option.WithResponseInto(&dst))
+
+	prefillPods := map[string]struct{}{}
+	send := func(label string) string {
+		_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage(prompt)},
+			Model:    modelNameVLLM,
+		})
+		require.NoError(t, err, "hybrid_cache_load PD chat completion (%s) failed", label)
+
+		assert.Equal(t, "pd", dst.Header.Get("routing-strategy"),
+			"%s: config profile %q should resolve to PD routing", label, hybridCacheLoadConfigProfile)
+		prefillPod := dst.Header.Get("prefill-target-pod")
+		decodePod := dst.Header.Get("target-pod")
+		require.NotEmpty(t, prefillPod, "%s: prefill-target-pod header must be set", label)
+		require.NotEmpty(t, decodePod, "%s: target-pod header must be set", label)
+		assert.NotEqual(t, prefillPod, decodePod, "%s: prefill and decode pods should differ", label)
+		prefillPods[prefillPod] = struct{}{}
+		t.Logf("%s — prefill: %s, decode: %s", label, prefillPod, decodePod)
+		return prefillPod
+	}
+
+	// Warm-up: the first request populates the prefix cache on whichever
+	// prefill pod the policy picks while nothing is cached anywhere.
+	warmPod := send("warm-up")
+
+	// Repeat the same prompt. Once the gateway replica handling the request has
+	// the warm-up's prefix entry, hybrid_cache_load scores warmPod as
+	// 1 − 1² × factor (< 1) against a bare 1 for the cold pod and must pick it.
+	var repeatPod string
+	require.Eventually(t, func() bool {
+		repeatPod = send("repeat")
+		return repeatPod == warmPod
+	}, hybridCacheLoadAffinityTimeout, hybridCacheLoadAffinityPoll,
+		"expected the repeated prompt to route back to warm prefill pod %s, last saw %s", warmPod, repeatPod)
+
+	lastGauges := assertTokenLoadGaugesSettle(t, ctx, k8sClient, gatewayPods, prefillPods, "hybrid_cache_load")
+	t.Logf("hybrid_cache_load gauges after warm-up and repeat: %v", lastGauges)
+}

--- a/test/e2e/gateway/pd/pd_token_load_test.go
+++ b/test/e2e/gateway/pd/pd_token_load_test.go
@@ -166,9 +166,19 @@ func TestPDDisaggregationVLLMTokenLoad(t *testing.T) {
 		t.Logf("request %d — prefill: %s, decode: %s", i, prefillPod, decodePod)
 	}
 
-	// Every prefill pod that served a request must have been charged on the
-	// gateway replica that routed it, and all charges must be back at zero
-	// once the responses have been delivered.
+	lastGauges := assertTokenLoadGaugesSettle(t, ctx, k8sClient, gatewayPods, prefillPods, "token_load")
+	t.Logf("token_load gauges after %d requests: %v", iterations, lastGauges)
+}
+
+// assertTokenLoadGaugesSettle waits until every pod in prefillPods has a
+// pd_token_load_* series on the gateway replica that routed to it and all of
+// those series are back at zero, then returns the final scrape. policy names
+// the prefill score policy under test for log and failure messages.
+func assertTokenLoadGaugesSettle(
+	t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientset, gatewayPods []corev1.Pod,
+	prefillPods map[string]struct{}, policy string,
+) []tokenLoadGauge {
+	t.Helper()
 	var lastGauges []tokenLoadGauge
 	err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true,
 		func(ctx context.Context) (bool, error) {
@@ -193,13 +203,13 @@ func TestPDDisaggregationVLLMTokenLoad(t *testing.T) {
 				}
 			}
 			if len(charged) != len(prefillPods) || !settled {
-				t.Logf("waiting for token_load gauges (charged %d/%d prefill pods, settled=%v)",
-					len(charged), len(prefillPods), settled)
+				t.Logf("waiting for %s gauges (charged %d/%d prefill pods, settled=%v)",
+					policy, len(charged), len(prefillPods), settled)
 				return false, nil
 			}
 			return true, nil
 		})
-	require.NoError(t, err, "token_load gauges did not settle; last scrape: %v", lastGauges)
+	require.NoError(t, err, "%s gauges did not settle; last scrape: %v", policy, lastGauges)
 
 	for podName := range prefillPods {
 		found := false
@@ -212,8 +222,8 @@ func TestPDDisaggregationVLLMTokenLoad(t *testing.T) {
 			}
 			assert.Zero(t, g.value, "%s should be released after the request completed", g)
 		}
-		assert.True(t, found, "prefill pod %s served a token_load request but no %s series was published for it",
-			podName, metrics.PDTokenLoadKVTokens)
+		assert.True(t, found, "prefill pod %s served a %s request but no %s series was published for it",
+			podName, policy, metrics.PDTokenLoadKVTokens)
 	}
-	t.Logf("token_load gauges after %d requests: %v", iterations, lastGauges)
+	return lastGauges
 }


### PR DESCRIPTION
## Pull Request Description

Second of the two PRs proposed in #2680. #2681 (`token_load`) has merged (a374e4c1) and this branch is rebased onto main, so the diff is this PR alone.

### Why

`prefix_cache` always prefers the pod that holds the prompt's prefix, even when that pod is buried under long prompts and an idle neighbour would answer sooner. `token_load` (#2681) ignores the cache and recomputes prefixes another pod already holds. Multi-turn traffic wants both: cache affinity between idle pods, load between busy ones. #2680 has the benchmark and the reasoning behind the cost model.

### What

**`hybrid_cache_load` policy** (`pd/prefill_scorer.go`): `Prepare` tokenizes and calls `MatchPrefix` exactly as `prefix_cache` does; `ScorePod` reads the same ledger as `token_load` and discounts it by the match:

```
r        = match_percent / 100   (0 when below AIBRIX_MIN_MATCH_PCT)
discount = 1 − r² × factor
score    = load × discount       when load ≥ 1, else discount
```

With no load anywhere every score is a bare discount below 1, so the best match wins outright. On busy pods a full match halves the load (default factor `0.5`), so a pod holding the prefix loses once it carries more than twice the load of an idle neighbour. The square keeps small matches from moving the decision.

**`AIBRIX_MIN_MATCH_PCT`** (default `0`, off): matches below the threshold count as no match, in the score and in the charge, so prompts that share only a system prompt are not all pulled to one pod. Applied only by `hybrid_cache_load` in this PR; adding it to `prefix_cache` is a one-liner if maintainers want it there too.

**`new_tokens` charge** (`TokenLoadTracker.NewTokens`): the token-load charge now covers only what the pod has to compute, by the first rule that applies:

1. session delta: the request carries the caller-owned `x-aibrix-session-key` and the gateway saw a shorter prompt for that (model, key) within `AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS` (default `1800`): charge the growth. Each turn resends the history but an engine that still holds the conversation's KV computes only the new turn, so the rule assumes the earlier turns are reachable from the selected prefill pod (shared or tiered KV store, sticky routing, or the pod's own prefix cache); deployments without that should not send the key, or set the TTL to `0` to turn the rule off.
2. prefix match: the scorer looked the prompt up in the prefix cache: charge `prompt_tokens × (1 − match/100)`.
3. whole prompt.

Scorers expose the match through a small optional interface (`pd.PrefixMatchScorer`); `chargeTokenLoad` takes the prepared scorer it already had in scope. `token_load` behaviour is unchanged except that it now benefits from the session rule. The session table lives in the tracker and is swept by the janitor from #2681.

**Config** (all positive; invalid values keep the default):

| Variable | Default | |
|---|---|---|
| `AIBRIX_HYBRID_CACHE_LOAD_FACTOR` | `0.5` | discount of a full prefix match, `0` to `1` |
| `AIBRIX_MIN_MATCH_PCT` | `0` | ignore matches below this percentage, `0` to `100` |
| `AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS` | `1800` | how long a session's last prompt size is remembered; `0` turns the session rule off (not in the RFC table; it exists because the session table needs a bound) |
| `AIBRIX_TOKEN_LOAD_MAX_SESSIONS` | `100000` | maximum live sessions; beyond it new sessions are charged without a delta until the janitor frees slots |

**Docs**: "Hybrid Cache-Load Scoring Policy" section, the `new_tokens` rules in the token_load section, policy lists and env table in `pd-disaggregation.rst`.

### Notes for reviewers

- `prompt_tokens` stays `len(ReqBody)/4` for both policies. The RFC said `hybrid_cache_load` would use the tokenizer's count; I dropped that because the byte encoding of `TokenizeInputText` differs per tokenizer (4 bytes per tiktoken token, 1 per character) and only the ranking matters. Easy to add later behind the same interface if wanted.
- The session key is `(model, x-aibrix-session-key)`. A shorter or equal prompt under a known session falls back to rules 2/3 and becomes the new baseline, so a reused ID does not produce a negative or stale delta. Keys over 256 bytes are ignored and the table is capped at `AIBRIX_TOKEN_LOAD_MAX_SESSIONS`, so the client-controlled header cannot grow gateway memory. The RFC named `x-session-id`; the PR switched to the existing caller-owned key after review, since `x-session-id` is the gateway-issued token of `session-affinity` routing.
- No `PrefillScorePolicy` interface change; `chargeTokenLoad` gains a parameter inside the router package only.

### Testing

- `pd/prefill_scorer_hybrid_cache_load_test.go`: discount math at 0/50/100 % with factor 0.5, load outweighing a full match, sub-token load treated as idle, min-match clamp (score and reported match agree), `ClampMinMatch` table, nil tracker, `PrefixMatchPercent` on non-prefix scorers, env config.
- `pd/token_load_tracker_test.go`: `NewTokens` without a session (no info / partial / full / clamped / negative), session delta across turns (first seen, growth, repeat, shrink, other model), session tracking off with TTL 0, janitor forgets idle sessions without touching charges, over-long IDs ignored, session cap and its release, swept session not refreshed, session count under concurrent sweeps, env config (including TTL 0 and the max-sessions bound).
- `pd_hybrid_cache_load_test.go` (router level): idle pods follow the prefix and are charged only the uncached half; a loaded pod loses despite a full match; five requests across two sessions and an anonymous one produce the expected cumulative charges; min-match threshold turns a 30 % match into a full charge; `routingConfig.prefillScorePolicy=hybrid_cache_load` on a token_load router.
- `test/e2e/gateway/pd/pd_hybrid_cache_load_test.go` (`TestPDDisaggregationVLLMHybridCacheLoad`): a new `hybrid-cache-load` config profile on the mock PD StormService selects the policy; a fresh prompt is sent once, then repeated, and the repeat must route back to the prefill pod that served the warm-up (the policy scores the pod holding the prefix strictly below an idle cold pod). The `pd_token_load_*` gauges are scraped from both gateway replicas and must have been charged for every prefill pod used and be back at zero, reusing the helper from the `token_load` e2e. The new_tokens charge itself is not observable through metrics there (the mock answers in ms), so it stays in unit tests; the gateway log at `-v=4` on a local Kind cluster built like the Installation E2E workflow shows the expected pair, warm-up `new_tokens=361 prefix_match_percent=0 cost=3861` and repeat `new_tokens=0 prefix_match_percent=100 cost=3500`, with the repeat winning at prefill score 0.5 against 1.
- `go test -race ./pkg/plugins/gateway/algorithms/pd/... ./pkg/plugins/gateway/algorithms/ ./pkg/metrics/...` and `golangci-lint` (v2.13.1) pass locally, re-run after the rebase onto main.

## Related Issues

Part of #2680. Builds on #2681.

Co-authored with @zhutong196.

