### PR TITLE
[Misc] Batch: Add HTTPX telemetry and call-site instrumentation.

### DIFF
--- a/python/aibrix/aibrix/batch/client/channel.py
+++ b/python/aibrix/aibrix/batch/client/channel.py
@@ -112,19 +112,12 @@ class HttpChannel:
             "requesting inference", url=url, model=request.payload.get("model")
         )  # type: ignore[call-arg]
         try:
+            post_kwargs = {"json": request.payload, "timeout": self._timeout_config}
             if isinstance(client, HTTPXClientWrapper):
-                response = await client.post(
-                    url,
-                    json=request.payload,
-                    timeout=self._timeout_config,
-                    telemetry_call_site="batch.client.channel.HttpChannel.send",
+                post_kwargs["telemetry_call_site"] = (
+                    "batch.client.channel.HttpChannel.send"
                 )
-            else:
-                response = await client.post(
-                    url,
-                    json=request.payload,
-                    timeout=self._timeout_config,
-                )
+            response = await client.post(url, **post_kwargs)  # type: ignore[arg-type]
         except httpx.TimeoutException as ex:
             # repr, not str: httpx timeout exceptions often stringify to an
             # empty message, which would leave the log with a bare URL.

--- a/python/aibrix/aibrix/batch/client/channel.py
+++ b/python/aibrix/aibrix/batch/client/channel.py
@@ -29,11 +29,13 @@ import httpx
 
 from aibrix.batch.client.errors import InferenceError, InferenceErrorCode
 from aibrix.logger import init_logger
+from aibrix.metadata.core import HTTPXClientWrapper
 
 logger = init_logger(__name__)
 
 Response = Dict[str, Any]
 _MAX_ERROR_BODY_CHARS = 4096
+_HTTPXLikeClient = HTTPXClientWrapper | httpx.AsyncClient
 
 # Idle connections must be discarded before the server's own keep-alive timeout,
 # not at the same moment. httpx defaults to 5s and so does uvicorn: under
@@ -86,7 +88,7 @@ class HttpChannel:
         base_url: str,
         *,
         timeout: float = 30.0,
-        client: Optional[httpx.AsyncClient] = None,
+        client: Optional[_HTTPXLikeClient] = None,
     ) -> None:
         self._base_url = base_url
         self._timeout = timeout
@@ -110,9 +112,19 @@ class HttpChannel:
             "requesting inference", url=url, model=request.payload.get("model")
         )  # type: ignore[call-arg]
         try:
-            response = await client.post(
-                url, json=request.payload, timeout=self._timeout_config
-            )
+            if isinstance(client, HTTPXClientWrapper):
+                response = await client.post(
+                    url,
+                    json=request.payload,
+                    timeout=self._timeout_config,
+                    telemetry_call_site="batch.client.channel.HttpChannel.send",
+                )
+            else:
+                response = await client.post(
+                    url,
+                    json=request.payload,
+                    timeout=self._timeout_config,
+                )
         except httpx.TimeoutException as ex:
             # repr, not str: httpx timeout exceptions often stringify to an
             # empty message, which would leave the log with a bare URL.
@@ -152,16 +164,17 @@ class HttpChannel:
                 retryable=False,
             ) from ex
 
-    def _ensure_client(self) -> httpx.AsyncClient:
+    def _ensure_client(self) -> _HTTPXLikeClient:
         if self._client is None:
-            self._client = httpx.AsyncClient(
+            self._client = HTTPXClientWrapper(
+                client_id=f"http-channel-{self._base_url}",
                 limits=httpx.Limits(
                     # Restate httpx's own defaults: constructing Limits() to set
                     # keepalive_expiry alone would reset these two to unbounded.
                     max_connections=100,
                     max_keepalive_connections=20,
                     keepalive_expiry=_KEEPALIVE_EXPIRY_SECONDS,
-                )
+                ),
             )
         return self._client
 

--- a/python/aibrix/aibrix/batch/job_driver/runtime/ssh_launch.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/ssh_launch.py
@@ -172,19 +172,18 @@ class SSHLaunchRuntime(RuntimeBase, abc.ABC):
         url = self._base_url(handle) + "/health"
         loop = asyncio.get_event_loop()
         deadline = loop.time() + self._ready_timeout_s
+        # Since _wait_ready is a short-lived polling loop, enabling telemetry for
+        # this ephemeral client is unnecessary and will flood the logs with
+        # telemetry summaries and task lifecycle logs.
+        # We should disable telemetry for this client by setting telemetry_enabled=False.
         async with HTTPXClientWrapper(
             client_id="ssh-launch-ready",
             timeout=10.0,
+            telemetry_enabled=False,
         ) as client:
             while True:
                 try:
-                    resp = await client.get(
-                        url,
-                        telemetry_call_site=(
-                            "batch.job_driver.runtime.ssh_launch."
-                            "SSHLaunchRuntime._wait_ready"
-                        ),
-                    )
+                    resp = await client.get(url)
                     if resp.status_code == 200:
                         return
                 except Exception:
@@ -200,18 +199,14 @@ class SSHLaunchRuntime(RuntimeBase, abc.ABC):
     ) -> None:
         del reason
         url = self._base_url(handle) + "/health"
+        # For the same reason as _wait_ready, we disable telemetry for this client.
         async with HTTPXClientWrapper(
             client_id="ssh-launch-liveness",
             timeout=10.0,
+            telemetry_enabled=False,
         ) as client:
             try:
-                resp = await client.get(
-                    url,
-                    telemetry_call_site=(
-                        "batch.job_driver.runtime.ssh_launch."
-                        "SSHLaunchRuntime._check_liveness"
-                    ),
-                )
+                resp = await client.get(url)
             except Exception as ex:
                 raise RuntimeError(f"vLLM liveness check failed at {url}: {ex}") from ex
         if resp.status_code != 200:

--- a/python/aibrix/aibrix/batch/job_driver/runtime/ssh_launch.py
+++ b/python/aibrix/aibrix/batch/job_driver/runtime/ssh_launch.py
@@ -16,11 +16,10 @@ import shlex
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
-import httpx
-
 from aibrix.batch.client.sources.static import GatewayEndpointSource
 from aibrix.batch.job_driver.runtime import Endpoint, RuntimeBase
 from aibrix.batch.job_entity import BatchJob
+from aibrix.metadata.core import HTTPXClientWrapper
 
 
 @dataclass(slots=True)
@@ -173,10 +172,19 @@ class SSHLaunchRuntime(RuntimeBase, abc.ABC):
         url = self._base_url(handle) + "/health"
         loop = asyncio.get_event_loop()
         deadline = loop.time() + self._ready_timeout_s
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with HTTPXClientWrapper(
+            client_id="ssh-launch-ready",
+            timeout=10.0,
+        ) as client:
             while True:
                 try:
-                    resp = await client.get(url)
+                    resp = await client.get(
+                        url,
+                        telemetry_call_site=(
+                            "batch.job_driver.runtime.ssh_launch."
+                            "SSHLaunchRuntime._wait_ready"
+                        ),
+                    )
                     if resp.status_code == 200:
                         return
                 except Exception:
@@ -192,9 +200,18 @@ class SSHLaunchRuntime(RuntimeBase, abc.ABC):
     ) -> None:
         del reason
         url = self._base_url(handle) + "/health"
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with HTTPXClientWrapper(
+            client_id="ssh-launch-liveness",
+            timeout=10.0,
+        ) as client:
             try:
-                resp = await client.get(url)
+                resp = await client.get(
+                    url,
+                    telemetry_call_site=(
+                        "batch.job_driver.runtime.ssh_launch."
+                        "SSHLaunchRuntime._check_liveness"
+                    ),
+                )
             except Exception as ex:
                 raise RuntimeError(f"vLLM liveness check failed at {url}: {ex}") from ex
         if resp.status_code != 200:

--- a/python/aibrix/aibrix/batch/worker.py
+++ b/python/aibrix/aibrix/batch/worker.py
@@ -73,13 +73,16 @@ class LLMHealthChecker:
         )  # type: ignore[call-arg]
 
         start_time = time.time()
-        async with HTTPXClientWrapper(client_id="batch-worker-health") as client:
+        # Since wait_for_ready is a one-off startup polling loop for in-pod execution,
+        # enabling telemetry for this ephemeral client is unnecessary.
+        async with HTTPXClientWrapper(
+            client_id="batch-worker-health", telemetry_enabled=False
+        ) as client:
             while time.time() - start_time < self.timeout:
                 try:
                     response = await client.get(
                         self.health_url,
                         timeout=5.0,
-                        telemetry_call_site="batch.worker.LLMHealthChecker.wait_for_ready",
                     )
                     if response.status_code == 200:
                         logger.info("vLLM service is ready")

--- a/python/aibrix/aibrix/batch/worker.py
+++ b/python/aibrix/aibrix/batch/worker.py
@@ -48,6 +48,7 @@ from aibrix.batch.job_entity import (
 from aibrix.batch.state import JobMetaInfo
 from aibrix.context.infra import InfrastructureContext
 from aibrix.logger import init_logger
+from aibrix.metadata.core import HTTPXClientWrapper
 
 logger = init_logger(__name__)
 
@@ -72,10 +73,14 @@ class LLMHealthChecker:
         )  # type: ignore[call-arg]
 
         start_time = time.time()
-        async with httpx.AsyncClient() as client:
+        async with HTTPXClientWrapper(client_id="batch-worker-health") as client:
             while time.time() - start_time < self.timeout:
                 try:
-                    response = await client.get(self.health_url, timeout=5.0)
+                    response = await client.get(
+                        self.health_url,
+                        timeout=5.0,
+                        telemetry_call_site="batch.worker.LLMHealthChecker.wait_for_ready",
+                    )
                     if response.status_code == 200:
                         logger.info("vLLM service is ready")
                         return True

--- a/python/aibrix/aibrix/envs.py
+++ b/python/aibrix/aibrix/envs.py
@@ -36,6 +36,12 @@ def _parse_int_or_none(value: Optional[str]) -> Optional[int]:
     return int(value)
 
 
+def _parse_float(value: Optional[str], default: float) -> float:
+    if value is None:
+        return default
+    return float(value)
+
+
 # Model Download Related Config
 
 # Downloader Default Directory
@@ -155,3 +161,19 @@ INFERENCE_ENGINE_ENDPOINT = os.getenv(
 )
 INFERENCE_ENGINE_API_KEY = os.getenv("INFERENCE_ENGINE_API_KEY")
 INFERENCE_TASK_TIMEOUT = int(os.getenv("INFERENCE_TASK_TIMEOUT", "600"))
+
+# Metadata HTTPX client config
+CORE_HTTPX_ASYNC_CLIENT_TIMEOUT_SECOND = _parse_float(
+    os.getenv("AIBRIX_HTTPX_ASYNC_CLIENT_TIMEOUT_SECOND"),
+    10.0,
+)
+CORE_HTTPX_CLIENT_TELEMETRY_ENABLED = _is_true(
+    os.getenv("AIBRIX_HTTPX_CLIENT_TELEMETRY_ENABLED", "0")
+)
+CORE_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS = max(
+    _parse_float(
+        os.getenv("AIBRIX_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS"),
+        60.0,
+    ),
+    15.0,
+)

--- a/python/aibrix/aibrix/envs.py
+++ b/python/aibrix/aibrix/envs.py
@@ -162,15 +162,27 @@ INFERENCE_ENGINE_ENDPOINT = os.getenv(
 INFERENCE_ENGINE_API_KEY = os.getenv("INFERENCE_ENGINE_API_KEY")
 INFERENCE_TASK_TIMEOUT = int(os.getenv("INFERENCE_TASK_TIMEOUT", "600"))
 
-# Metadata HTTPX client config
+# Metadata service HTTPX client config.
+#
+# Telemetry helps diagnose client-side load and failure modes in the shared
+# metadata HTTPX AsyncClient: request volume, concurrency, latency, and
+# exception spikes become visible in logs without requiring a separate metrics
+# backend. These settings are referenced when `metadata.app.build_app()`
+# instantiates the shared `HTTPXClientWrapper`, when
+# `metadata.app.build_app_arg_parser()` exposes CLI defaults, and when
+# `metadata.core.httpx_client` falls back to env-backed telemetry defaults.
+#
+# Metadata shared HTTPX AsyncClient timeout in seconds.
 CORE_HTTPX_ASYNC_CLIENT_TIMEOUT_SECOND = _parse_float(
     os.getenv("AIBRIX_HTTPX_ASYNC_CLIENT_TIMEOUT_SECOND"),
     10.0,
 )
-CORE_HTTPX_CLIENT_TELEMETRY_ENABLED = _is_true(
+# Metadata shared HTTPX AsyncClient telemetry logging toggle.
+CORE_HTTPX_ASYNC_CLIENT_TELEMETRY_ENABLED = _is_true(
     os.getenv("AIBRIX_HTTPX_CLIENT_TELEMETRY_ENABLED", "0")
 )
-CORE_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS = max(
+# Metadata shared HTTPX AsyncClient telemetry emission interval in seconds.
+CORE_HTTPX_ASYNC_CLIENT_TELEMETRY_INTERVAL_SECONDS = max(
     _parse_float(
         os.getenv("AIBRIX_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS"),
         60.0,

--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -449,7 +449,7 @@ def nullable_str(val: str):
     return val
 
 
-def main():
+def build_app_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=f"Run {settings.PROJECT_NAME}")
     parser.add_argument("--host", type=nullable_str, default=None, help="host name")
     parser.add_argument("--port", type=int, default=8090, help="port number")
@@ -518,6 +518,23 @@ def main():
             "deployment with a redis metastore for crash-safe long-running batches."
         ),
     )
+    return parser
+
+
+def build_app_args(**overrides: Any) -> argparse.Namespace:
+    """Build a metadata-service CLI namespace with parser-backed defaults.
+
+    Tests can override only the fields they care about while staying aligned
+    with the authoritative parser when new CLI flags are added.
+    """
+    args = build_app_arg_parser().parse_args([])
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def main():
+    parser = build_app_arg_parser()
     args = parser.parse_args()
 
     if args.disable_file_api and not args.disable_batch_api:

--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -456,7 +456,7 @@ def build_app_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--httpx-telemetry",
         action=argparse.BooleanOptionalAction,
-        default=envs.CORE_HTTPX_CLIENT_TELEMETRY_ENABLED,
+        default=envs.CORE_HTTPX_ASYNC_CLIENT_TELEMETRY_ENABLED,
         help=(
             "Enable HTTPX client telemetry logging. Defaults to "
             "AIBRIX_HTTPX_CLIENT_TELEMETRY_ENABLED."
@@ -465,7 +465,7 @@ def build_app_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--httpx-telemetry-interval-seconds",
         type=float,
-        default=envs.CORE_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS,
+        default=envs.CORE_HTTPX_ASYNC_CLIENT_TELEMETRY_INTERVAL_SECONDS,
         help=(
             "Telemetry summary interval for the shared metadata HTTPX client. "
             "Defaults to AIBRIX_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS."

--- a/python/aibrix/aibrix/metadata/app.py
+++ b/python/aibrix/aibrix/metadata/app.py
@@ -26,6 +26,7 @@ from kubernetes import client as k8s_client
 from kubernetes import config
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
+from aibrix import envs
 from aibrix.batch import BatchDriver
 from aibrix.batch.client import (
     EndpointSource,
@@ -274,7 +275,11 @@ def build_app(args: argparse.Namespace, params={}):
             # Local debug
             config.load_kube_config()
 
-    app.state.httpx_client_wrapper = HTTPXClientWrapper()
+    app.state.httpx_client_wrapper = HTTPXClientWrapper(
+        timeout=envs.CORE_HTTPX_ASYNC_CLIENT_TIMEOUT_SECOND,
+        telemetry_enabled=args.httpx_telemetry,
+        telemetry_interval_seconds=args.httpx_telemetry_interval_seconds,
+    )
 
     # Normalize HTTPException responses to OpenAI's top-level
     # ``{"error": {message, type, param, code}}`` shape so that the
@@ -448,6 +453,24 @@ def main():
     parser = argparse.ArgumentParser(description=f"Run {settings.PROJECT_NAME}")
     parser.add_argument("--host", type=nullable_str, default=None, help="host name")
     parser.add_argument("--port", type=int, default=8090, help="port number")
+    parser.add_argument(
+        "--httpx-telemetry",
+        action=argparse.BooleanOptionalAction,
+        default=envs.CORE_HTTPX_CLIENT_TELEMETRY_ENABLED,
+        help=(
+            "Enable HTTPX client telemetry logging. Defaults to "
+            "AIBRIX_HTTPX_CLIENT_TELEMETRY_ENABLED."
+        ),
+    )
+    parser.add_argument(
+        "--httpx-telemetry-interval-seconds",
+        type=float,
+        default=envs.CORE_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS,
+        help=(
+            "Telemetry summary interval for the shared metadata HTTPX client. "
+            "Defaults to AIBRIX_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS."
+        ),
+    )
     parser.add_argument(
         "--enable-fastapi-docs",
         action="store_true",

--- a/python/aibrix/aibrix/metadata/core/httpx_client.py
+++ b/python/aibrix/aibrix/metadata/core/httpx_client.py
@@ -45,11 +45,11 @@ _LATENCY_BUCKET_UPPER_BOUNDS_SECONDS = _build_latency_bucket_bounds()
 
 
 def _telemetry_interval_seconds() -> float:
-    return envs.CORE_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS
+    return envs.CORE_HTTPX_ASYNC_CLIENT_TELEMETRY_INTERVAL_SECONDS
 
 
 def _telemetry_enabled() -> bool:
-    return envs.CORE_HTTPX_CLIENT_TELEMETRY_ENABLED
+    return envs.CORE_HTTPX_ASYNC_CLIENT_TELEMETRY_ENABLED
 
 
 def _round_optional(value: Optional[float]) -> Optional[float]:

--- a/python/aibrix/aibrix/metadata/core/httpx_client.py
+++ b/python/aibrix/aibrix/metadata/core/httpx_client.py
@@ -241,12 +241,22 @@ class HTTPXClientWrapper:
         )
         self._telemetry_task: Optional[asyncio.Task[None]] = None
         self._telemetry_stats = _HTTPXTelemetryStats()
+        self._last_telemetry_emitted_at: Optional[float] = None
+        self._stopped = False
 
     def start(self):
         """Instantiate the client. Call from the FastAPI startup hook."""
+        if self._stopped:
+            raise RuntimeError(
+                "HTTPXClientWrapper cannot be reused after stop(); create a new wrapper"
+            )
         if self.async_client is None:
             self.async_client = httpx.AsyncClient(**self._client_kwargs)
             self._telemetry_stats = _HTTPXTelemetryStats()
+            try:
+                self._last_telemetry_emitted_at = asyncio.get_running_loop().time()
+            except RuntimeError:
+                self._last_telemetry_emitted_at = None
             logger.info(
                 "httpx.AsyncClient instantiated.",
                 client_id=self.client_id,
@@ -258,6 +268,7 @@ class HTTPXClientWrapper:
 
     async def stop(self):
         """Gracefully shutdown. Call from FastAPI shutdown hook."""
+        self._stopped = True
         if self._telemetry_task is not None:
             self._telemetry_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -272,9 +283,20 @@ class HTTPXClientWrapper:
             client_id=self.client_id,
         )  # type: ignore[call-arg]
         if self._telemetry_enabled:
+            try:
+                now = asyncio.get_running_loop().time()
+                elapsed = max(
+                    now - (self._last_telemetry_emitted_at or now),
+                    1e-9,
+                )
+            except RuntimeError:
+                now = None
+                elapsed = max(self._telemetry_interval_seconds, 1.0)
             self._emit_telemetry(
-                final=True, elapsed=max(self._telemetry_interval_seconds, 1.0)
+                final=True,
+                elapsed=elapsed,
             )
+            self._last_telemetry_emitted_at = now
         await self.async_client.aclose()
         self.async_client = None
         logger.info("httpx.AsyncClient closed", client_id=self.client_id)  # type: ignore[call-arg]
@@ -470,10 +492,11 @@ class HTTPXClientWrapper:
 
     async def _log_telemetry(self) -> None:
         while True:
-            started = asyncio.get_running_loop().time()
             await asyncio.sleep(self._telemetry_interval_seconds)
-            elapsed = max(asyncio.get_running_loop().time() - started, 1e-9)
+            now = asyncio.get_running_loop().time()
+            elapsed = max(now - (self._last_telemetry_emitted_at or now), 1e-9)
             self._emit_telemetry(final=False, elapsed=elapsed)
+            self._last_telemetry_emitted_at = now
 
     def _emit_telemetry(self, *, final: bool, elapsed: float) -> None:
         if not self._telemetry_enabled:

--- a/python/aibrix/aibrix/metadata/core/httpx_client.py
+++ b/python/aibrix/aibrix/metadata/core/httpx_client.py
@@ -11,34 +11,505 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
+import bisect
+import contextlib
+from collections import Counter
+from dataclasses import dataclass, field
+from itertools import count
+from typing import Optional
+
 import httpx
 
+from aibrix import envs
 from aibrix.logger import init_logger
 
 logger = init_logger(__name__)
 
+_CLIENT_ID_COUNTER = count(1)
+_LATENCY_BUCKET_MAX_SECONDS = 600.0
+_LATENCY_BUCKET_MIN_SECONDS = 0.001
+
+
+def _build_latency_bucket_bounds() -> tuple[float, ...]:
+    bounds: list[float] = []
+    current = _LATENCY_BUCKET_MIN_SECONDS
+    while current < _LATENCY_BUCKET_MAX_SECONDS:
+        bounds.append(round(current, 6))
+        current *= 2
+    bounds.append(_LATENCY_BUCKET_MAX_SECONDS)
+    return tuple(bounds)
+
+
+_LATENCY_BUCKET_UPPER_BOUNDS_SECONDS = _build_latency_bucket_bounds()
+
+
+def _telemetry_interval_seconds() -> float:
+    return envs.CORE_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS
+
+
+def _telemetry_enabled() -> bool:
+    return envs.CORE_HTTPX_CLIENT_TELEMETRY_ENABLED
+
+
+def _round_optional(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    return round(value, 6)
+
+
+@dataclass(slots=True)
+class _HTTPXTelemetrySnapshot:
+    started: int
+    completed: int
+    failed: int
+    inflight: int
+    max_inflight: int
+    window_started: int
+    window_completed: int
+    window_failed: int
+    p50_latency_seconds: Optional[float]
+    p95_latency_seconds: Optional[float]
+    exception_types: dict[str, int]
+    latency_histogram: tuple[int, ...]
+    call_sites: tuple["_HTTPXTelemetryCallSiteSnapshot", ...]
+
+
+@dataclass(slots=True)
+class _HTTPXTelemetryCallSiteStats:
+    started: int = 0
+    completed: int = 0
+    failed: int = 0
+    inflight: int = 0
+    exception_types: Counter[str] = field(default_factory=Counter)
+
+
+@dataclass(slots=True)
+class _HTTPXTelemetryCallSiteSnapshot:
+    call_site: str
+    started: int
+    completed: int
+    failed: int
+    inflight: int
+    exception_types: dict[str, int]
+
+
+@dataclass(slots=True)
+class _HTTPXTelemetryStats:
+    started: int = 0
+    completed: int = 0
+    failed: int = 0
+    inflight: int = 0
+    max_inflight: int = 0
+    window_started: int = 0
+    window_completed: int = 0
+    window_failed: int = 0
+    _window_latency_histogram: list[int] = field(
+        default_factory=lambda: [0] * (len(_LATENCY_BUCKET_UPPER_BOUNDS_SECONDS) + 1)
+    )
+    _window_exception_types: Counter[str] = field(default_factory=Counter)
+    _call_sites: dict[str, _HTTPXTelemetryCallSiteStats] = field(default_factory=dict)
+
+    def record_start(self, *, call_site: Optional[str] = None) -> None:
+        self.started += 1
+        self.window_started += 1
+        self.inflight += 1
+        self.max_inflight = max(self.max_inflight, self.inflight)
+        if call_site is not None:
+            site_stats = self._call_sites.setdefault(
+                call_site,
+                _HTTPXTelemetryCallSiteStats(),
+            )
+            site_stats.started += 1
+            site_stats.inflight += 1
+
+    def record_completion(
+        self,
+        *,
+        failed: bool,
+        latency_seconds: float,
+        call_site: Optional[str] = None,
+        exception_type: Optional[str] = None,
+    ) -> None:
+        self.completed += 1
+        self.window_completed += 1
+        if failed:
+            self.failed += 1
+            self.window_failed += 1
+        self.inflight = max(self.inflight - 1, 0)
+        normalized_latency = max(latency_seconds, 0.0)
+        bucket_index = bisect.bisect_left(
+            _LATENCY_BUCKET_UPPER_BOUNDS_SECONDS,
+            normalized_latency,
+        )
+        self._window_latency_histogram[bucket_index] += 1
+        if failed and exception_type is not None:
+            self._window_exception_types[exception_type] += 1
+        if call_site is not None:
+            site_stats = self._call_sites.setdefault(
+                call_site,
+                _HTTPXTelemetryCallSiteStats(),
+            )
+            site_stats.completed += 1
+            if failed:
+                site_stats.failed += 1
+                if exception_type is not None:
+                    site_stats.exception_types[exception_type] += 1
+            site_stats.inflight = max(site_stats.inflight - 1, 0)
+
+    def snapshot(self, *, reset_window: bool) -> _HTTPXTelemetrySnapshot:
+        snapshot = _HTTPXTelemetrySnapshot(
+            started=self.started,
+            completed=self.completed,
+            failed=self.failed,
+            inflight=self.inflight,
+            max_inflight=self.max_inflight,
+            window_started=self.window_started,
+            window_completed=self.window_completed,
+            window_failed=self.window_failed,
+            p50_latency_seconds=self._histogram_percentile(0.50),
+            p95_latency_seconds=self._histogram_percentile(0.95),
+            exception_types=dict(sorted(self._window_exception_types.items())),
+            latency_histogram=tuple(self._window_latency_histogram),
+            call_sites=tuple(self._call_site_snapshots()),
+        )
+        if reset_window:
+            self.window_started = 0
+            self.window_completed = 0
+            self.window_failed = 0
+            self._window_latency_histogram = [0] * (
+                len(_LATENCY_BUCKET_UPPER_BOUNDS_SECONDS) + 1
+            )
+            self._window_exception_types = Counter()
+            self._call_sites = {}
+        return snapshot
+
+    def _histogram_percentile(self, percentile: float) -> Optional[float]:
+        total = sum(self._window_latency_histogram)
+        if total <= 0:
+            return None
+        target = max(1, int(total * percentile + 0.999999))
+        cumulative = 0
+        for bucket_index, bucket_count in enumerate(self._window_latency_histogram):
+            cumulative += bucket_count
+            if cumulative >= target:
+                if bucket_index < len(_LATENCY_BUCKET_UPPER_BOUNDS_SECONDS):
+                    return _LATENCY_BUCKET_UPPER_BOUNDS_SECONDS[bucket_index]
+                return _LATENCY_BUCKET_MAX_SECONDS
+        return _LATENCY_BUCKET_MAX_SECONDS
+
+    def _call_site_snapshots(self) -> list[_HTTPXTelemetryCallSiteSnapshot]:
+        snapshots: list[_HTTPXTelemetryCallSiteSnapshot] = []
+        for call_site, stats in sorted(
+            self._call_sites.items(),
+            key=lambda item: (item[1].failed, item[1].completed, item[0]),
+            reverse=True,
+        ):
+            snapshots.append(
+                _HTTPXTelemetryCallSiteSnapshot(
+                    call_site=call_site,
+                    started=stats.started,
+                    completed=stats.completed,
+                    failed=stats.failed,
+                    inflight=stats.inflight,
+                    exception_types=dict(sorted(stats.exception_types.items())),
+                )
+            )
+        return snapshots
+
 
 class HTTPXClientWrapper:
-    async_client = None
+    async_client: Optional[httpx.AsyncClient] = None
+
+    def __init__(
+        self,
+        *,
+        client_id: Optional[str] = None,
+        telemetry_enabled: Optional[bool] = None,
+        telemetry_interval_seconds: Optional[float] = None,
+        **client_kwargs,
+    ) -> None:
+        self.client_id = client_id or f"httpx-client-{next(_CLIENT_ID_COUNTER):04d}"
+        self._client_kwargs = client_kwargs
+        self._telemetry_enabled = (
+            telemetry_enabled if telemetry_enabled is not None else _telemetry_enabled()
+        )
+        self._telemetry_interval_seconds = (
+            max(telemetry_interval_seconds, 0.0)
+            if telemetry_interval_seconds is not None
+            else _telemetry_interval_seconds()
+        )
+        self._telemetry_task: Optional[asyncio.Task[None]] = None
+        self._telemetry_stats = _HTTPXTelemetryStats()
 
     def start(self):
         """Instantiate the client. Call from the FastAPI startup hook."""
-        self.async_client = httpx.AsyncClient()
-        logger.info("httpx.AsyncClient instantiated.", id=id(self.async_client))
+        if self.async_client is None:
+            self.async_client = httpx.AsyncClient(**self._client_kwargs)
+            self._telemetry_stats = _HTTPXTelemetryStats()
+            logger.info(
+                "httpx.AsyncClient instantiated.",
+                client_id=self.client_id,
+                id=id(self.async_client),
+                telemetry_enabled=self._telemetry_enabled,
+                telemetry_interval_seconds=self._telemetry_interval_seconds,
+            )  # type: ignore[call-arg]
+        self._ensure_telemetry_task()
 
     async def stop(self):
         """Gracefully shutdown. Call from FastAPI shutdown hook."""
+        if self._telemetry_task is not None:
+            self._telemetry_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._telemetry_task
+            self._telemetry_task = None
+        if self.async_client is None:
+            return
         logger.debug(
             "httpx.async_client.status",
             is_closed=self.async_client.is_closed,
             id=id(self.async_client),
-        )
+            client_id=self.client_id,
+        )  # type: ignore[call-arg]
+        if self._telemetry_enabled:
+            self._emit_telemetry(
+                final=True, elapsed=max(self._telemetry_interval_seconds, 1.0)
+            )
         await self.async_client.aclose()
         self.async_client = None
-        logger.info("httpx.AsyncClient closed")
+        logger.info("httpx.AsyncClient closed", client_id=self.client_id)  # type: ignore[call-arg]
 
     def __call__(self):
         """Calling the instantiated HTTPXClientWrapper returns the wrapped singleton."""
         # Ensure we don't use it if not started / running
         assert self.async_client is not None
         return self.async_client
+
+    def __getattr__(self, name: str):
+        self.start()
+        assert self.async_client is not None
+        return getattr(self.async_client, name)
+
+    @property
+    def is_closed(self) -> bool:
+        return self.async_client.is_closed if self.async_client is not None else True
+
+    async def aclose(self) -> None:
+        await self.stop()
+
+    async def __aenter__(self) -> "HTTPXClientWrapper":
+        self.start()
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        del args
+        await self.stop()
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        telemetry_call_site: Optional[str] = None,
+        **kwargs,
+    ) -> httpx.Response:
+        self.start()
+        assert self.async_client is not None
+        start_time = asyncio.get_running_loop().time()
+        if self._telemetry_enabled:
+            self._telemetry_stats.record_start(call_site=telemetry_call_site)
+        failed = False
+        exception_type: Optional[str] = None
+        try:
+            return await self.async_client.request(method, url, **kwargs)
+        except Exception as exc:
+            failed = True
+            exception_type = type(exc).__name__
+            if telemetry_call_site is not None:
+                logger.debug(
+                    "HTTPX request failed",
+                    client_id=self.client_id,
+                    call_site=telemetry_call_site,
+                    method=method,
+                    url=url,
+                    exception_type=exception_type,
+                )  # type: ignore[call-arg]
+            raise
+        finally:
+            if self._telemetry_enabled:
+                self._telemetry_stats.record_completion(
+                    failed=failed,
+                    latency_seconds=asyncio.get_running_loop().time() - start_time,
+                    call_site=telemetry_call_site,
+                    exception_type=exception_type,
+                )
+
+    @contextlib.asynccontextmanager
+    async def stream(
+        self,
+        method: str,
+        url: str,
+        *,
+        telemetry_call_site: Optional[str] = None,
+        **kwargs,
+    ):
+        self.start()
+        assert self.async_client is not None
+        start_time = asyncio.get_running_loop().time()
+        if self._telemetry_enabled:
+            self._telemetry_stats.record_start(call_site=telemetry_call_site)
+        failed = False
+        exception_type: Optional[str] = None
+        try:
+            async with self.async_client.stream(method, url, **kwargs) as response:
+                yield response
+        except Exception as exc:
+            failed = True
+            exception_type = type(exc).__name__
+            if telemetry_call_site is not None:
+                logger.debug(
+                    "HTTPX stream failed",
+                    client_id=self.client_id,
+                    call_site=telemetry_call_site,
+                    method=method,
+                    url=url,
+                    exception_type=exception_type,
+                )  # type: ignore[call-arg]
+            raise
+        finally:
+            if self._telemetry_enabled:
+                self._telemetry_stats.record_completion(
+                    failed=failed,
+                    latency_seconds=asyncio.get_running_loop().time() - start_time,
+                    call_site=telemetry_call_site,
+                    exception_type=exception_type,
+                )
+
+    async def get(
+        self, url: str, *, telemetry_call_site: Optional[str] = None, **kwargs
+    ) -> httpx.Response:
+        return await self.request(
+            "GET",
+            url,
+            telemetry_call_site=telemetry_call_site,
+            **kwargs,
+        )
+
+    async def post(
+        self, url: str, *, telemetry_call_site: Optional[str] = None, **kwargs
+    ) -> httpx.Response:
+        return await self.request(
+            "POST",
+            url,
+            telemetry_call_site=telemetry_call_site,
+            **kwargs,
+        )
+
+    async def put(
+        self, url: str, *, telemetry_call_site: Optional[str] = None, **kwargs
+    ) -> httpx.Response:
+        return await self.request(
+            "PUT",
+            url,
+            telemetry_call_site=telemetry_call_site,
+            **kwargs,
+        )
+
+    async def delete(
+        self, url: str, *, telemetry_call_site: Optional[str] = None, **kwargs
+    ) -> httpx.Response:
+        return await self.request(
+            "DELETE",
+            url,
+            telemetry_call_site=telemetry_call_site,
+            **kwargs,
+        )
+
+    async def patch(
+        self, url: str, *, telemetry_call_site: Optional[str] = None, **kwargs
+    ) -> httpx.Response:
+        return await self.request(
+            "PATCH",
+            url,
+            telemetry_call_site=telemetry_call_site,
+            **kwargs,
+        )
+
+    async def head(
+        self, url: str, *, telemetry_call_site: Optional[str] = None, **kwargs
+    ) -> httpx.Response:
+        return await self.request(
+            "HEAD",
+            url,
+            telemetry_call_site=telemetry_call_site,
+            **kwargs,
+        )
+
+    async def options(
+        self, url: str, *, telemetry_call_site: Optional[str] = None, **kwargs
+    ) -> httpx.Response:
+        return await self.request(
+            "OPTIONS",
+            url,
+            telemetry_call_site=telemetry_call_site,
+            **kwargs,
+        )
+
+    def _ensure_telemetry_task(self) -> None:
+        if (
+            not self._telemetry_enabled
+            or self._telemetry_interval_seconds <= 0
+            or self._telemetry_task is not None
+        ):
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._telemetry_task = asyncio.create_task(self._log_telemetry())
+
+    async def _log_telemetry(self) -> None:
+        while True:
+            started = asyncio.get_running_loop().time()
+            await asyncio.sleep(self._telemetry_interval_seconds)
+            elapsed = max(asyncio.get_running_loop().time() - started, 1e-9)
+            self._emit_telemetry(final=False, elapsed=elapsed)
+
+    def _emit_telemetry(self, *, final: bool, elapsed: float) -> None:
+        if not self._telemetry_enabled:
+            return
+        snapshot = self._telemetry_stats.snapshot(reset_window=True)
+        elapsed = max(elapsed, 1e-9)
+        logger.info(
+            "HTTPX client telemetry summary",
+            client_id=self.client_id,
+            final=final,
+            started_qps=round(snapshot.window_started / elapsed, 3),
+            completed_qps=round(snapshot.window_completed / elapsed, 3),
+            failed_qps=round(snapshot.window_failed / elapsed, 3),
+            inflight=snapshot.inflight,
+            max_inflight=snapshot.max_inflight,
+            started=snapshot.started,
+            completed=snapshot.completed,
+            failed=snapshot.failed,
+            window_started=snapshot.window_started,
+            window_completed=snapshot.window_completed,
+            window_failed=snapshot.window_failed,
+            p50_latency_seconds=_round_optional(snapshot.p50_latency_seconds),
+            p95_latency_seconds=_round_optional(snapshot.p95_latency_seconds),
+            exception_types=snapshot.exception_types,
+            latency_histogram=snapshot.latency_histogram,
+            is_closed=self.is_closed,
+        )  # type: ignore[call-arg]
+        for call_site_snapshot in snapshot.call_sites:
+            logger.debug(
+                "HTTPX client telemetry by call site",
+                client_id=self.client_id,
+                final=final,
+                call_site=call_site_snapshot.call_site,
+                started=call_site_snapshot.started,
+                completed=call_site_snapshot.completed,
+                failed=call_site_snapshot.failed,
+                inflight=call_site_snapshot.inflight,
+                exception_types=call_site_snapshot.exception_types,
+            )  # type: ignore[call-arg]

--- a/python/aibrix/tests/batch/conftest.py
+++ b/python/aibrix/tests/batch/conftest.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import asyncio
 import copy
 import json
@@ -38,7 +37,7 @@ from aibrix.batch.client.errors import InferenceError, InferenceErrorCode
 from aibrix.batch.client.sources import NoopEndpointSource
 from aibrix.batch.job_driver.base import BaseJobDriver
 from aibrix.logger import init_logger
-from aibrix.metadata.app import build_app
+from aibrix.metadata.app import build_app, build_app_args
 from aibrix.metadata.setting import settings
 from aibrix.storage import StorageType
 from tests.batch.job_driver.runtime.deployment_backend import (
@@ -478,10 +477,7 @@ def create_test_app(
     settings.STORAGE_TYPE, settings.METASTORE_TYPE = storage_type, metastore_type
     # Create app
     app = build_app(
-        argparse.Namespace(
-            host=None,
-            port=8090,
-            enable_fastapi_docs=False,
+        build_app_args(
             disable_batch_api=False,
             disable_file_api=False,
             enable_k8s_support=enable_k8s_support,

--- a/python/aibrix/tests/batch/job_driver/runtime/test_ssh_launch.py
+++ b/python/aibrix/tests/batch/job_driver/runtime/test_ssh_launch.py
@@ -130,7 +130,10 @@ async def test_wait_ready_polls_until_200():
 
         return R()
 
-    with patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=fake_get)):
+    with patch(
+        "aibrix.batch.job_driver.runtime.ssh_launch.HTTPXClientWrapper.get",
+        new=AsyncMock(side_effect=fake_get),
+    ):
         await rt._wait_ready(_handle())
     assert calls["n"] >= 3
 
@@ -145,7 +148,10 @@ async def test_wait_ready_times_out():
 
         return R()
 
-    with patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=always_503)):
+    with patch(
+        "aibrix.batch.job_driver.runtime.ssh_launch.HTTPXClientWrapper.get",
+        new=AsyncMock(side_effect=always_503),
+    ):
         with pytest.raises(TimeoutError):
             await rt._wait_ready(_handle())
 
@@ -162,7 +168,10 @@ async def test_check_liveness_accepts_healthy_endpoint():
 
         return R()
 
-    with patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=healthy)):
+    with patch(
+        "aibrix.batch.job_driver.runtime.ssh_launch.HTTPXClientWrapper.get",
+        new=AsyncMock(side_effect=healthy),
+    ):
         await rt._check_liveness(_handle())
 
 
@@ -178,7 +187,10 @@ async def test_check_liveness_rejects_unhealthy_endpoint():
 
         return R()
 
-    with patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=unhealthy)):
+    with patch(
+        "aibrix.batch.job_driver.runtime.ssh_launch.HTTPXClientWrapper.get",
+        new=AsyncMock(side_effect=unhealthy),
+    ):
         with pytest.raises(RuntimeError, match="returned 503"):
             await rt._check_liveness(_handle())
 

--- a/python/aibrix/tests/metadata/conftest.py
+++ b/python/aibrix/tests/metadata/conftest.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 import pytest
 
+from aibrix import envs
 from aibrix.metadata.app import build_app
 from aibrix.metadata.setting import settings
 from aibrix.storage import StorageType
@@ -76,6 +77,8 @@ def create_test_app(disable_batch_api: bool = False, disable_file_api: bool = Fa
             argparse.Namespace(
                 host=None,
                 port=8090,
+                httpx_telemetry=False,
+                httpx_telemetry_interval_seconds=envs.CORE_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS,
                 enable_fastapi_docs=False,
                 enable_k8s_support=False,
                 disable_batch_api=disable_batch_api,

--- a/python/aibrix/tests/metadata/conftest.py
+++ b/python/aibrix/tests/metadata/conftest.py
@@ -20,15 +20,13 @@ implementations. K8s and kopf are disabled so the suite runs without
 any external infrastructure.
 """
 
-import argparse
 import sys
 import tempfile
 from pathlib import Path
 
 import pytest
 
-from aibrix import envs
-from aibrix.metadata.app import build_app
+from aibrix.metadata.app import build_app, build_app_args
 from aibrix.metadata.setting import settings
 from aibrix.storage import StorageType
 
@@ -70,16 +68,9 @@ def create_test_app(disable_batch_api: bool = False, disable_file_api: bool = Fa
     settings.STORAGE_TYPE = StorageType.LOCAL
     settings.METASTORE_TYPE = StorageType.LOCAL
     try:
-        # Keep the synthetic CLI namespace aligned with build_app()'s
-        # current argument surface while staying on the local dry-run path
-        # used by metadata HTTP tests.
         app = build_app(
-            argparse.Namespace(
-                host=None,
-                port=8090,
+            build_app_args(
                 httpx_telemetry=False,
-                httpx_telemetry_interval_seconds=envs.CORE_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS,
-                enable_fastapi_docs=False,
                 enable_k8s_support=False,
                 disable_batch_api=disable_batch_api,
                 disable_file_api=disable_file_api,

--- a/python/aibrix/tests/metadata/test_app_integration.py
+++ b/python/aibrix/tests/metadata/test_app_integration.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import os
 from unittest.mock import patch
 
@@ -23,7 +22,7 @@ from fastapi.testclient import TestClient
 os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing")
 
 from aibrix.batch.state import JobStore
-from aibrix.metadata.app import build_app
+from aibrix.metadata.app import build_app, build_app_args
 from aibrix.metadata.setting import settings
 from aibrix.storage import StorageType
 
@@ -31,15 +30,13 @@ from aibrix.storage import StorageType
 def _args(**overrides):
     defaults = {
         "httpx_telemetry": False,
-        "httpx_telemetry_interval_seconds": 60.0,
-        "enable_fastapi_docs": False,
         "enable_k8s_support": True,
         "disable_batch_api": True,
         "disable_file_api": True,
         "dry_run": False,
     }
     defaults.update(overrides)
-    return argparse.Namespace(**defaults)
+    return build_app_args(**defaults)
 
 
 @pytest.fixture(autouse=True)

--- a/python/aibrix/tests/metadata/test_app_integration.py
+++ b/python/aibrix/tests/metadata/test_app_integration.py
@@ -30,6 +30,8 @@ from aibrix.storage import StorageType
 
 def _args(**overrides):
     defaults = {
+        "httpx_telemetry": False,
+        "httpx_telemetry_interval_seconds": 60.0,
         "enable_fastapi_docs": False,
         "enable_k8s_support": True,
         "disable_batch_api": True,
@@ -88,6 +90,19 @@ def test_build_app_without_batch(_mock_k8s_config_loading):
 
     assert hasattr(app.state, "httpx_client_wrapper")
     assert not hasattr(app.state, "batch_driver")
+
+
+def test_build_app_wires_httpx_telemetry_settings(_mock_k8s_config_loading):
+    args = _args(
+        enable_k8s_support=False,
+        httpx_telemetry=True,
+        httpx_telemetry_interval_seconds=12.5,
+    )
+
+    app = build_app(args)
+
+    assert app.state.httpx_client_wrapper._telemetry_enabled is True
+    assert app.state.httpx_client_wrapper._telemetry_interval_seconds == 12.5
 
 
 def test_build_app_batch_no_global_inference_endpoint(

--- a/python/aibrix/tests/metadata/test_httpx_client.py
+++ b/python/aibrix/tests/metadata/test_httpx_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -119,3 +119,69 @@ async def test_httpx_wrapper_context_manager_starts_and_stops():
 
     assert wrapper.async_client is None
     assert wrapper.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_httpx_wrapper_cannot_be_reused_after_stop():
+    wrapper = HTTPXClientWrapper(
+        client_id="test-wrapper-stopped",
+        telemetry_interval_seconds=0,
+    )
+
+    with patch(
+        "httpx.AsyncClient.request",
+        new=AsyncMock(return_value=httpx.Response(200, json={"ok": True})),
+    ):
+        response = await wrapper.request("GET", "https://example.com/healthz")
+
+    assert response.status_code == 200
+
+    await wrapper.stop()
+
+    with pytest.raises(RuntimeError, match="cannot be reused after stop"):
+        await wrapper.request("GET", "https://example.com/healthz")
+
+    with pytest.raises(RuntimeError, match="cannot be reused after stop"):
+        _ = wrapper.headers
+
+
+@pytest.mark.asyncio
+async def test_httpx_wrapper_stop_uses_actual_elapsed_time_for_final_telemetry():
+    wrapper = HTTPXClientWrapper(
+        client_id="test-wrapper-final-elapsed",
+        telemetry_enabled=True,
+        telemetry_interval_seconds=60,
+    )
+
+    wrapper.start()
+    assert wrapper.async_client is not None
+
+    wrapper._telemetry_stats.record_start(
+        call_site="tests.metadata.test_httpx_client.final_elapsed"
+    )
+    wrapper._telemetry_stats.record_completion(
+        failed=False,
+        latency_seconds=0.1,
+        call_site="tests.metadata.test_httpx_client.final_elapsed",
+    )
+    wrapper._last_telemetry_emitted_at = 100.0
+
+    with (
+        patch.object(wrapper.async_client, "aclose", new=AsyncMock()),
+        patch(
+            "aibrix.metadata.core.httpx_client.asyncio.get_running_loop",
+            return_value=MagicMock(time=MagicMock(return_value=100.25)),
+        ),
+        patch("aibrix.metadata.core.httpx_client.logger.info") as mock_info,
+    ):
+        await wrapper.stop()
+
+    telemetry_call = next(
+        call
+        for call in mock_info.call_args_list
+        if call.args and call.args[0] == "HTTPX client telemetry summary"
+    )
+    assert telemetry_call.kwargs["final"] is True
+    assert telemetry_call.kwargs["started_qps"] == 4.0
+    assert telemetry_call.kwargs["completed_qps"] == 4.0
+    assert telemetry_call.kwargs["failed_qps"] == 0.0

--- a/python/aibrix/tests/metadata/test_httpx_client.py
+++ b/python/aibrix/tests/metadata/test_httpx_client.py
@@ -1,0 +1,121 @@
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from aibrix.metadata.core import HTTPXClientWrapper
+
+
+@pytest.mark.asyncio
+async def test_httpx_wrapper_request_records_telemetry():
+    wrapper = HTTPXClientWrapper(
+        client_id="test-wrapper",
+        telemetry_enabled=True,
+        telemetry_interval_seconds=0,
+    )
+
+    with patch(
+        "httpx.AsyncClient.request",
+        new=AsyncMock(return_value=httpx.Response(200, json={"ok": True})),
+    ):
+        response = await wrapper.request(
+            "GET",
+            "https://example.com/healthz",
+            telemetry_call_site="tests.metadata.test_httpx_client.success",
+        )
+
+    assert response.status_code == 200
+    assert wrapper._telemetry_stats.started == 1
+    assert wrapper._telemetry_stats.completed == 1
+    assert wrapper._telemetry_stats.failed == 0
+    assert wrapper._telemetry_stats.inflight == 0
+    snapshot = wrapper._telemetry_stats.snapshot(reset_window=False)
+    assert len(snapshot.call_sites) == 1
+    assert (
+        snapshot.call_sites[0].call_site == "tests.metadata.test_httpx_client.success"
+    )
+    assert snapshot.p50_latency_seconds is not None
+    assert snapshot.p95_latency_seconds is not None
+    assert sum(snapshot.latency_histogram) == 1
+
+    await wrapper.stop()
+
+
+@pytest.mark.asyncio
+async def test_httpx_wrapper_request_records_failure():
+    wrapper = HTTPXClientWrapper(
+        client_id="test-wrapper-failure",
+        telemetry_enabled=True,
+        telemetry_interval_seconds=0,
+    )
+
+    with patch(
+        "httpx.AsyncClient.request",
+        new=AsyncMock(side_effect=httpx.ConnectError("boom")),
+    ):
+        with pytest.raises(httpx.ConnectError):
+            await wrapper.request(
+                "GET",
+                "https://example.com/healthz",
+                telemetry_call_site="tests.metadata.test_httpx_client.failure",
+            )
+
+    assert wrapper._telemetry_stats.started == 1
+    assert wrapper._telemetry_stats.completed == 1
+    assert wrapper._telemetry_stats.failed == 1
+    assert wrapper._telemetry_stats.inflight == 0
+    snapshot = wrapper._telemetry_stats.snapshot(reset_window=False)
+    assert len(snapshot.call_sites) == 1
+    assert (
+        snapshot.call_sites[0].call_site == "tests.metadata.test_httpx_client.failure"
+    )
+    assert snapshot.call_sites[0].exception_types == {"ConnectError": 1}
+    assert snapshot.exception_types == {"ConnectError": 1}
+
+    await wrapper.stop()
+
+
+@pytest.mark.asyncio
+async def test_httpx_wrapper_emits_debug_telemetry_by_call_site():
+    wrapper = HTTPXClientWrapper(
+        client_id="test-wrapper-debug",
+        telemetry_enabled=True,
+        telemetry_interval_seconds=0,
+    )
+
+    with patch(
+        "httpx.AsyncClient.request",
+        new=AsyncMock(return_value=httpx.Response(200, json={"ok": True})),
+    ):
+        await wrapper.request(
+            "GET",
+            "https://example.com/healthz",
+            telemetry_call_site="tests.metadata.test_httpx_client.debug",
+        )
+
+    with patch("aibrix.metadata.core.httpx_client.logger.debug") as mock_debug:
+        wrapper._emit_telemetry(final=False, elapsed=1.0)
+
+    mock_debug.assert_called_once()
+    _, kwargs = mock_debug.call_args
+    assert kwargs["client_id"] == "test-wrapper-debug"
+    assert kwargs["call_site"] == "tests.metadata.test_httpx_client.debug"
+    assert kwargs["failed"] == 0
+    assert kwargs["exception_types"] == {}
+
+    await wrapper.stop()
+
+
+@pytest.mark.asyncio
+async def test_httpx_wrapper_context_manager_starts_and_stops():
+    wrapper = HTTPXClientWrapper(
+        client_id="test-wrapper-context",
+        telemetry_interval_seconds=0,
+    )
+
+    async with wrapper as managed:
+        assert managed.async_client is not None
+        assert managed.is_closed is False
+
+    assert wrapper.async_client is None
+    assert wrapper.is_closed is True

--- a/python/aibrix/tests/metadata/test_metrics_integration.py
+++ b/python/aibrix/tests/metadata/test_metrics_integration.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import asyncio
 import os
 from unittest.mock import patch
@@ -22,7 +21,7 @@ from prometheus_client import generate_latest
 
 os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing")
 
-from aibrix.metadata.app import build_app
+from aibrix.metadata.app import build_app, build_app_args
 from aibrix.metadata.core.metrics import MetricsConfig, setup_metrics, shutdown_metrics
 from aibrix.metadata.setting import load_metrics_config, settings
 from aibrix.metadata.store import RedisMetadataStore
@@ -31,14 +30,13 @@ from tests.fake.redis import FakeRedisClient
 
 def _args(**overrides):
     defaults = {
-        "enable_fastapi_docs": False,
         "enable_k8s_support": False,
         "disable_batch_api": True,
         "disable_file_api": True,
         "dry_run": False,
     }
     defaults.update(overrides)
-    return argparse.Namespace(**defaults)
+    return build_app_args(**defaults)
 
 
 def test_metrics_endpoint_exposes_metadata_http_metrics(monkeypatch):

--- a/python/aibrix/tests/metadata/test_models_api.py
+++ b/python/aibrix/tests/metadata/test_models_api.py
@@ -33,7 +33,7 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing")
 # Try importing, skip tests if dependencies missing
 try:
     from aibrix.metadata.api.v1.models import K8sModelDiscovery
-    from aibrix.metadata.app import build_app
+    from aibrix.metadata.app import build_app, build_app_args
     from tests.metadata.conftest import create_test_app
 
     DEPENDENCIES_AVAILABLE = True
@@ -312,8 +312,6 @@ class TestModelsAPI:
         no-trailing-slash path explicitly (mirroring files.py / batch.py); a bare
         /v1/models otherwise 404s instead of getting a 307 redirect.
         """
-        from argparse import Namespace
-
         from kubernetes import config as k8s_config
 
         mock_incluster_config.side_effect = k8s_config.ConfigException("Not in cluster")
@@ -332,8 +330,7 @@ class TestModelsAPI:
             "items": []
         }
 
-        args = Namespace(
-            enable_fastapi_docs=False,
+        args = build_app_args(
             disable_batch_api=True,
             disable_file_api=True,
             enable_k8s_support=True,


### PR DESCRIPTION
## Pull Request Description

Today we can see that HTTPX traffic exists, but we have limited visibility into:
- where the traffic originates
- whether failures cluster in a specific call path
- whether client-side pressure is building up via in-flight growth
- whether stress shows up as latency, retries, or transport exceptions

This telemetry gives us a lightweight way to diagnose HTTPX behavior without introducing a separate metrics backend dependency.

### What changed

- extend `HTTPXClientWrapper` with request-level telemetry collection
- record aggregate counters for started, completed, failed, inflight, and max inflight requests
- emit latency histograms plus p50/p95 summaries
- track exception types and per-call-site request stats
- add explicit `client_id`, `telemetry_enabled`, and `telemetry_interval_seconds` configuration
- support wrapper usage through `request()` helpers, async context-manager methods, and delegated client attributes
- log periodic telemetry summaries and final shutdown summaries

### Config and wiring

- add metadata HTTPX config in `aibrix/envs.py`
- expose metadata service flags:
  - `--httpx-telemetry` / `--no-httpx-telemetry`
  - `--httpx-telemetry-interval-seconds`
- read env-backed defaults from:
  - `AIBRIX_HTTPX_ASYNC_CLIENT_TIMEOUT_SECOND`
  - `AIBRIX_HTTPX_CLIENT_TELEMETRY_ENABLED`
  - `AIBRIX_HTTPX_CLIENT_TELEMETRY_INTERVAL_SECONDS`
- wire the metadata app’s shared HTTPX client through the new telemetry settings

### Call-site instrumentation

Add `telemetry_call_site` tags for HTTPX usage in:
- metadata shared client
- batch `HttpChannel.send`
- batch worker LLM readiness checks
- SSH launch runtime readiness and liveness probes

This makes it easier to identify which code paths are driving load, failures, or latency spikes.

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>