### PR TITLE
feat: add vLLM-Omni video generation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,8 +213,9 @@ python-ci:
 ##@ Build
 
 .PHONY: build
-build: manifests generate fmt vet ## Build manager binary.
+build: manifests generate fmt vet ## Build manager and gateway-plugins binaries.
 	go build -o bin/manager cmd/controllers/main.go
+	go build -o bin/gateway-plugins cmd/plugins/main.go
 
 .PHONY: build-controller-manager
 build-controller-manager: manifests generate fmt vet ## Build controller-manager binary without ZMQ.

--- a/config/gateway/gateway-plugin/gateway-plugin.yaml
+++ b/config/gateway/gateway-plugin/gateway-plugin.yaml
@@ -209,6 +209,9 @@ spec:
         - path:
             type: PathPrefix
             value: /v1/video/generations
+        - path:
+            type: PathPrefix
+            value: /v1/videos
       backendRefs:
         - name: aibrix-gateway-plugins
           port: 50052
@@ -232,4 +235,4 @@ spec:
           body: Buffered
         response:
           body: Streamed
-      messageTimeout: 60s
+      messageTimeout: 600s

--- a/config/gateway/gateway.yaml
+++ b/config/gateway/gateway.yaml
@@ -125,7 +125,7 @@ spec:
                 regex: .*
         route:  
           cluster: original_destination_cluster
-          timeout: 120s  # Increase route timeout
+          timeout: 600s
         typed_per_filter_config:
           "envoy.filters.http.ext_proc/envoyextensionpolicy/aibrix-system/aibrix-gateway-plugins-extension-policy/extproc/0":
             "@type": "type.googleapis.com/envoy.config.route.v3.FilterConfig"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,7 +59,7 @@ spec:
             memory: 64Mi
         env:
           - name: AIBRIX_GATEWAY_TIMEOUT_SECONDS
-            value: "120"
+            value: "600"
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
 ---

--- a/deployment/local/configs/envoy.yaml
+++ b/deployment/local/configs/envoy.yaml
@@ -93,7 +93,7 @@ static_resources:
                       grpc_service:
                         envoy_grpc:
                           cluster_name: gateway_ext_proc
-                        timeout: 30s
+                        timeout: 600s
                       processing_mode:
                         request_header_mode: SEND
                         request_body_mode: BUFFERED
@@ -101,7 +101,7 @@ static_resources:
                         response_body_mode: STREAMED
                         request_trailer_mode: SKIP
                         response_trailer_mode: SKIP
-                      message_timeout: 60s
+                      message_timeout: 600s
                       failure_mode_allow: false
 
                   - name: envoy.filters.http.router

--- a/docs/source/features/vllm-omni.rst
+++ b/docs/source/features/vllm-omni.rst
@@ -1,0 +1,281 @@
+.. _vllm-omni-serving:
+
+===================================
+vLLM-Omni Multi-Modal Serving
+===================================
+
+`vLLM-Omni <https://docs.vllm.ai/projects/vllm-omni/en/stable/>`_ extends vLLM's OpenAI-compatible serving to non-text modalities — image generation/editing, speech and general audio, and video generation — behind the same ``vllm serve`` entrypoint you already use for LLMs. AIBrix's gateway understands these endpoints natively: it routes requests to the right backend pods and, for video generation specifically, keeps track of which pod owns each in-progress job so follow-up calls land back on it.
+
+This guide walks through deploying a vLLM-Omni video generation model — `Wan-AI/Wan2.1-VACE-1.3B-diffusers <https://huggingface.co/Wan-AI/Wan2.1-VACE-1.3B-diffusers>`_ — and driving it through AIBrix's gateway, both synchronously and as an async job you poll and download.
+
+.. note::
+    The sample manifest referenced in this guide lives at `samples/vllm_omni/wan2.1-vace-1.3b.yaml <https://github.com/vllm-project/aibrix/blob/main/samples/vllm_omni/wan2.1-vace-1.3b.yaml>`_ in the AIBrix repository. A text+audio example (`Qwen/Qwen2.5-Omni-7B <https://huggingface.co/Qwen/Qwen2.5-Omni-7B>`_) is also available at `samples/vllm_omni/qwen2-5-omni-7b.yaml <https://github.com/vllm-project/aibrix/blob/main/samples/vllm_omni/qwen2-5-omni-7b.yaml>`_.
+
+----
+
+How It Works
+------------
+
+A vLLM-Omni pod is started the same way as any other model in AIBrix — a ``Deployment`` labeled with ``model.aibrix.ai/name`` and a matching ``Service`` — with one difference: passing ``--omni`` to ``vllm serve``. That flag auto-detects the model's task from its architecture and exposes the matching OpenAI-compatible endpoint (``/v1/images/generations``, ``/v1/audio/speech``, ``/v1/videos``, ...).
+
+The stock gateway already matches ``/v1/videos`` on the reserved HTTPRoute (so requests reach ext_proc before a ``model`` header exists) and uses 600s Envoy / ext_proc / model-HTTPRoute timeouts so synchronous generation can finish. If you installed an older AIBrix release, add a PathPrefix ``/v1/videos`` match to ``aibrix-reserved-router`` and set ``AIBRIX_GATEWAY_TIMEOUT_SECONDS=600`` on the controller-manager.
+
+Video generation needs a bit more from the gateway than a stateless chat completion does. Because a generated video is written to local disk on whichever pod created it, the gateway has to remember that pod-to-job mapping and route follow-up calls back to the exact same pod:
+
+.. code-block:: text
+
+    POST /v1/videos              ──►  routed to any ready pod for the model (normal routing)
+                                       gateway records: video_id → owning pod
+
+    GET  /v1/videos/{id}         ──►  pinned back to the owning pod (only it has the job)
+    GET  /v1/videos/{id}/content ──►  pinned back to the owning pod
+    DELETE /v1/videos/{id}       ──►  pinned back to the owning pod, mapping evicted
+
+    GET  /v1/videos?model=X      ──►  gateway fans out to every ready pod for X and merges
+                                       their individual job lists (no single owning pod for "list")
+
+This mapping is kept in-memory per gateway replica and, when the gateway is configured with Redis, written through to Redis too — so a job created via one gateway replica can still be polled or fetched through a different replica. An unknown, expired, or no-longer-live video ID returns ``404`` rather than routing nowhere.
+
+``POST /v1/videos/sync`` and image/audio endpoints don't need any of this: they're a single request/response, so ordinary model-based routing is enough.
+
+----
+
+Prerequisites
+-------------
+
+Before you begin, make sure you have:
+
+- A running Kubernetes cluster with `AIBrix installed <https://github.com/vllm-project/aibrix>`_ (includes Envoy Gateway).
+- ``kubectl`` configured to talk to your cluster.
+- A GPU node (one GPU is enough for the 1.3B-parameter Wan model used below).
+- ``jq`` and ``curl`` for the examples below.
+
+----
+
+Step 1 — Deploy the Video Generation Model
+-------------------------------------------
+
+.. literalinclude:: ../../../samples/vllm_omni/wan2.1-vace-1.3b.yaml
+   :language: yaml
+
+Apply it and wait for the pod to become ready. The model is loaded from the host path ``/data00/models/Wan2.1-VACE-1.3B-diffusers`` (mounted at ``/models``), so the weights must already be present on the node:
+
+.. code-block:: bash
+
+    kubectl apply -f samples/vllm_omni/wan2.1-vace-1.3b.yaml
+    kubectl rollout status deployment/wan21-vace-13b
+
+.. tip::
+    To serve a different vLLM-Omni model (a different video model, or an image/audio one like ``qwen2-5-omni-7b.yaml``), swap the container's ``vllm serve <model>`` argument, ``--served-model-name``, and the ``model.aibrix.ai/name``/Service name — the request shape stays the same as long as the model belongs to the same task family. See vLLM-Omni's `supported models list <https://docs.vllm.ai/projects/vllm-omni/en/stable/>`_.
+
+----
+
+Step 2 — Access the Gateway
+-----------------------------
+
+Port-forward the Envoy service to test locally:
+
+.. code-block:: bash
+
+    export ENVOY_SERVICE=$(kubectl get svc -n envoy-gateway-system \
+      --selector=gateway.envoyproxy.io/owning-gateway-namespace=aibrix-system,gateway.envoyproxy.io/owning-gateway-name=aibrix-eg \
+      -o jsonpath='{.items[0].metadata.name}')
+
+    kubectl port-forward -n envoy-gateway-system "svc/${ENVOY_SERVICE}" 8080:80
+
+    BASE="http://localhost:8080"
+
+In production, use the LoadBalancer external IP instead:
+
+.. code-block:: bash
+
+    LB_IP=$(kubectl get svc -n envoy-gateway-system \
+      -l "gateway.envoyproxy.io/owning-gateway-name=aibrix-eg" \
+      -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}')
+
+    BASE="http://${LB_IP}"
+
+----
+
+Step 3 — Generate a Video Synchronously
+------------------------------------------
+
+``POST /v1/videos/sync`` blocks until generation completes and returns the raw MP4 bytes directly. Both video endpoints take ``multipart/form-data`` — do **not** set ``-H "Content-Type: application/json"``.
+
+.. code-block:: bash
+
+    curl -X POST "$BASE/v1/videos/sync" \
+      --max-time 600 \
+      -H "routing-strategy: random" \
+      -F "model=wan21-vace-13b" \
+      -F "prompt=A drone shot flying over a misty mountain range at sunrise" \
+      -F "negative_prompt=blurry, low quality, distorted, static, flickering, artifacts" \
+      -F "width=832" \
+      -F "height=480" \
+      -F "num_frames=81" \
+      -F "fps=16" \
+      -F "num_inference_steps=30" \
+      -F "guidance_scale=5.0" \
+      -F "flow_shift=5.0" \
+      -F "seed=42" \
+      -o output.mp4
+
+**Image-to-video**: VACE also supports using a reference image as the starting frame — pass it via ``input_reference``:
+
+.. code-block:: bash
+
+    curl -X POST "$BASE/v1/videos/sync" \
+      --max-time 600 \
+      -H "routing-strategy: random" \
+      -F "model=wan21-vace-13b" \
+      -F "prompt=The mountain landscape in this photo comes alive with drifting clouds and swaying trees" \
+      -F "input_reference=@landscape.png" \
+      -F "num_frames=81" \
+      -F "fps=16" \
+      -o output.mp4
+
+----
+
+Step 4 — Generate a Video Asynchronously
+--------------------------------------------
+
+For longer generations, ``POST /v1/videos`` returns immediately with a job ID while generation continues in the background — poll for status and fetch the result once it's done.
+
+**Submit the job:**
+
+.. code-block:: bash
+
+    video_id=$(curl -s "$BASE/v1/videos" \
+      -F "model=wan21-vace-13b" \
+      -F "prompt=A drone shot flying over a misty mountain range at sunrise" \
+      -F "negative_prompt=blurry, low quality, distorted, static, flickering, artifacts" \
+      -F "width=832" \
+      -F "height=480" \
+      -F "num_frames=81" \
+      -F "fps=16" \
+      -F "num_inference_steps=30" \
+      -F "guidance_scale=5.0" \
+      -F "flow_shift=5.0" \
+      -F "seed=42" \
+      | jq -r '.id')
+
+    echo "video_id=$video_id"
+
+The raw response (before extracting ``.id``) looks like this. The same shape is returned by the poll step below, with ``status``, ``progress``, and ``completed_at`` updated as generation proceeds:
+
+.. code-block:: json
+
+    {
+      "id": "video_gen_cf8bcaf5bccc43f6926a689c9bb7312a",
+      "object": "video",
+      "model": "wan21-vace-13b",
+      "prompt": "A drone shot flying over a misty mountain range at sunrise",
+      "status": "queued",
+      "size": "832x480",
+      "progress": 0,
+      "seconds": "5",
+      "quality": "default",
+      "completed_at": null,
+      "created_at": 1788892979,
+      "remixed_from_video_id": null,
+      "error": null,
+      "media_type": "video/mp4",
+      "expires_at": null,
+      "file_name": null,
+      "inference_time_s": null,
+      "stage_durations": {},
+      "peak_memory_mb": 0.0,
+      "action": null
+    }
+
+**Poll status** until it reports ``completed`` or ``failed``. This request is transparently pinned to the pod that created the job, regardless of which pod would normally be picked by the gateway's routing policy:
+
+.. code-block:: bash
+
+    watch -n 15 "curl -s $BASE/v1/videos/$video_id | jq ."
+
+**Download the result** once ``completed``:
+
+.. code-block:: bash
+
+    curl -L "$BASE/v1/videos/${video_id}/content" -o output.mp4
+
+**List all jobs for a model** instead of polling one by ID (``model`` is required):
+
+.. code-block:: bash
+
+    curl -s "$BASE/v1/videos?model=wan21-vace-13b" | jq .
+
+**Delete a job** once you no longer need it:
+
+.. code-block:: bash
+
+    curl -X DELETE "$BASE/v1/videos/${video_id}"
+
+----
+
+Endpoint Reference
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Endpoint
+     - Method
+     - Behavior
+   * - ``/v1/videos``
+     - POST
+     - Create an async video generation job. Returns a job ID immediately.
+   * - ``/v1/videos``
+     - GET
+     - List jobs for a model. Requires a ``model`` query parameter; fans out across every ready pod for that model.
+   * - ``/v1/videos/sync``
+     - POST
+     - Create a job and block until it completes; returns the video bytes directly.
+   * - ``/v1/videos/{id}``
+     - GET
+     - Poll a job's status. Pinned to the pod that created it.
+   * - ``/v1/videos/{id}/content``
+     - GET
+     - Download the completed video. Pinned to the pod that created it.
+   * - ``/v1/videos/{id}``
+     - DELETE
+     - Delete a job and its stored video. Pinned to the pod that created it; the mapping is evicted after a 2xx or 404 response so a failed delete can still be retried.
+
+----
+
+Troubleshooting
+----------------
+
+**``GET``/``DELETE`` on a video ID returns 404**
+
+The job ID is unknown to the gateway, has passed its retention window, or its owning pod is no longer ready (e.g. it was rescheduled). Once a pod is gone, the video it generated is gone with it — resubmit the job.
+
+**``POST /v1/videos/sync`` returns 504 / ext_proc timeout**
+
+Synchronous generation can take several minutes. Current AIBrix defaults are 600s for the reserved-router ext_proc ``messageTimeout``, the ORIGINAL_DST route, and model HTTPRoutes (``AIBRIX_GATEWAY_TIMEOUT_SECONDS``). Older installs used 60s/120s and will abort first; raise those three timeouts to at least 600s.
+
+**``GET /v1/videos`` (list) returns 400**
+
+The ``model`` query parameter is required — the gateway needs it to know which pods to fan out to: ``curl -s "$BASE/v1/videos?model=wan21-vace-13b"``.
+
+**Job created on one gateway replica can't be found via another**
+
+This cross-replica lookup relies on AIBrix's gateway being configured with Redis. Without Redis, the video-job-to-pod mapping only lives in the replica that handled the ``POST /v1/videos`` call.
+
+**Pod takes a long time to become ready**
+
+Confirm the weights exist on the node at ``/data00/models/Wan2.1-VACE-1.3B-diffusers``. Loading a video diffusion model into GPU memory can still take a few minutes. Watch progress with:
+
+.. code-block:: bash
+
+    kubectl logs -f deployment/wan21-vace-13b
+
+----
+
+Sample Files
+-------------
+
+- `samples/vllm_omni/wan2.1-vace-1.3b.yaml <https://github.com/vllm-project/aibrix/blob/main/samples/vllm_omni/wan2.1-vace-1.3b.yaml>`_ — Deployment and Service for the video generation example used in this guide
+- `samples/vllm_omni/qwen2-5-omni-7b.yaml <https://github.com/vllm-project/aibrix/blob/main/samples/vllm_omni/qwen2-5-omni-7b.yaml>`_ — text+audio vLLM-Omni example

--- a/docs/source/features/vllm-omni.rst
+++ b/docs/source/features/vllm-omni.rst
@@ -24,7 +24,8 @@ Video generation needs a bit more from the gateway than a stateless chat complet
 
 .. code-block:: text
 
-    POST /v1/videos              ──►  routed to any ready pod for the model (normal routing)
+    POST /v1/videos              ──►  gateway selects a pod for the model (least-request,
+                                       even without an explicit routing-strategy header)
                                        gateway records: video_id → owning pod
 
     GET  /v1/videos/{id}         ──►  pinned back to the owning pod (only it has the job)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -89,6 +89,7 @@ Documentation
    features/gateway-plugins.rst
    features/pd-disaggregation.rst
    features/semantic-router.rst
+   features/vllm-omni.rst
 
 .. toctree::
    :maxdepth: 1

--- a/pkg/controller/modelrouter/modelrouter_controller.go
+++ b/pkg/controller/modelrouter/modelrouter_controller.go
@@ -72,6 +72,8 @@ var modelPaths = []string{
 	"/v1/classify",
 	"/generate",
 	"/generatevideo",
+	"/v1/video",
+	"/v1/videos",
 	"/v1/audio/transcriptions",
 	"/v1/audio/translations",
 }
@@ -304,7 +306,7 @@ func (m *ModelRouter) createHTTPRoute(namespace string, labels map[string]string
 						},
 					},
 					Timeouts: &gatewayv1.HTTPRouteTimeouts{
-						Request: ptr.To(gatewayv1.Duration(fmt.Sprintf("%ds", utils.LoadEnvInt("AIBRIX_GATEWAY_TIMEOUT_SECONDS", 120)))),
+						Request: ptr.To(gatewayv1.Duration(fmt.Sprintf("%ds", utils.LoadEnvInt("AIBRIX_GATEWAY_TIMEOUT_SECONDS", 600)))),
 					},
 				},
 			},

--- a/pkg/plugins/gateway/algorithms/pd/prefill/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -241,7 +242,15 @@ func (e *DefaultExecutor) executeHTTP(url string, routingCtx *types.RoutingConte
 		return nil, fmt.Errorf("failed to create http prefill request: %w", err)
 	}
 
+	// ReqHeaders is populated from Envoy and includes HTTP/2 pseudo-headers
+	// such as ":method". net/http rejects those names on the outbound HTTP/1
+	// prefill call (invalid header field name), which fails every PD route
+	// before the prefill pod is contacted. Combined routing never makes this
+	// call, so only the prefill/decode path would 503.
 	for key, value := range routingCtx.ReqHeaders {
+		if !forwardablePrefillHeader(key) {
+			continue
+		}
 		req.Header.Set(key, value)
 	}
 	req.Header.Set("content-type", "application/json")
@@ -284,4 +293,11 @@ func (e *DefaultExecutor) executeHTTP(url string, routingCtx *types.RoutingConte
 	}
 
 	return responseData, nil
+}
+
+// forwardablePrefillHeader reports whether key can be copied onto the
+// outbound prefill HTTP request. Envoy :pseudo-headers are not valid HTTP/1
+// field names and must be dropped.
+func forwardablePrefillHeader(key string) bool {
+	return key != "" && !strings.HasPrefix(key, ":")
 }

--- a/pkg/plugins/gateway/algorithms/pd/prefill/default_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefill
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
+	"github.com/vllm-project/aibrix/pkg/types"
+)
+
+func TestExecuteHTTPSkipsEnvoyPseudoHeaders(t *testing.T) {
+	var gotMethod, gotAuth, gotStrategy string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Header.Get(":method")
+		gotAuth = r.Header.Get("Authorization")
+		gotStrategy = r.Header.Get("routing-strategy")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer srv.Close()
+
+	exec := NewDefaultExecutor(srv.Client(), pd.NewPrefillRequestTracker(), 5).(*DefaultExecutor)
+	got, err := exec.executeHTTP(srv.URL, &types.RoutingContext{
+		Context:   context.Background(),
+		RequestID: "req-1",
+		ReqHeaders: map[string]string{
+			":method":          "POST",
+			"authorization":    "Bearer test",
+			"routing-strategy": "pd",
+		},
+	}, []byte(`{"model":"m"}`))
+	require.NoError(t, err)
+	assert.Equal(t, true, got["ok"])
+	assert.Empty(t, gotMethod, "HTTP/2 pseudo-headers must not be forwarded")
+	assert.Equal(t, "Bearer test", gotAuth)
+	assert.Equal(t, "pd", gotStrategy)
+}

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -85,6 +85,11 @@ type Server struct {
 	httprouteCache      sync.Map
 	httprouteCacheTTL   time.Duration
 	httprouteSFGroup    singleflight.Group
+	// videoJobCache maps a vLLM-Omni async video_id to the pod that owns it (see
+	// gateway_video_routing.go). Local in-memory cache, warmed from and
+	// write-through to redisClient (when configured) so any gateway replica can
+	// resolve a video_id created by a different replica.
+	videoJobCache sync.Map
 	// Broadcast channel for server-initiated shutdown
 	shutdownCh   <-chan struct{}
 	shutdown     chan struct{}
@@ -217,7 +222,7 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 	routing.Init()
 
 	shutdown := make(chan struct{})
-	return &Server{
+	s := &Server{
 		redisClient:         redisClient,
 		ratelimiter:         r,
 		modelRateLimiter:    mr,
@@ -231,6 +236,8 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 		shutdownCh:          shutdown,
 		shutdown:            shutdown,
 	}
+	s.startVideoJobCacheSync(shutdown)
+	return s
 }
 
 func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
@@ -436,7 +443,7 @@ func (s *Server) handleProcessingRequest(st *processState, req *extProcPb.Proces
 
 	switch req.Request.(type) {
 	case *extProcPb.ProcessingRequest_RequestHeaders:
-		resp, st.user, st.rpm, st.routerCtx = s.HandleRequestHeaders(st.ctx, st.requestID, st.rootSpan, req)
+		resp, st.user, st.rpm, st.routerCtx, st.traceTerm = s.HandleRequestHeaders(st.ctx, st.requestID, st.rootSpan, req)
 		if st.routerCtx != nil {
 			st.model = st.routerCtx.Model
 			st.routerCtx.Span = st.rootSpan

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -49,20 +49,28 @@ func (s *Server) HandleRequestBody(ctx context.Context, routingCtx *types.Routin
 	ctx, span := tracer.Start(ctx, "process.handle_request_body")
 	defer span.End()
 
+	// Async video job follow-ups (GET status/content, DELETE) carry their routing
+	// key -- video_id -- in the path, not the (often empty) body. The generated
+	// video only exists on the pod that created it, so this bypasses the normal
+	// model-based routing below and pins directly back to that pod.
+	if videoID, isSubResource := extractVideoIDFromPath(requestPath); isSubResource {
+		return s.handleVideoJobSubResource(ctx, routingCtx, requestID, requestPath, videoID, body.RequestBody.GetBody())
+	}
+
 	var model, message string
 	var stream bool
 	var routingAlgorithm types.RoutingAlgorithm
 	var errRes *extProcPb.ProcessingResponse
 
-	// Check if this is a multipart request (audio endpoints)
+	// Check if this is a multipart request (audio endpoints, vLLM-Omni video generation)
 	contentType := routingCtx.ReqHeaders[contentTypeKey]
-	if isAudioRequest(requestPath) && isMultipartRequest(contentType) {
-		// Parse multipart form data for audio endpoints
+	if isMultipartFormPath(requestPath) && isMultipartRequest(contentType) {
+		// Parse multipart form data for audio/video endpoints
 		model, stream, errRes = parseMultipartFormData(requestID, contentType, body.RequestBody.GetBody())
 		if errRes != nil {
 			return errRes, model, stream, term
 		}
-		message = "" // Audio requests don't have a text message for token counting
+		message = "" // Audio/video requests don't have a text message for token counting
 	} else {
 		// Use existing JSON validation for other endpoints
 		model, message, stream, errRes = validateRequestBody(requestID, requestPath, body.RequestBody.GetBody(), user)

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -66,7 +66,7 @@ func (s *Server) HandleRequestBody(ctx context.Context, routingCtx *types.Routin
 	contentType := routingCtx.ReqHeaders[contentTypeKey]
 	if isMultipartFormPath(requestPath) && isMultipartRequest(contentType) {
 		// Parse multipart form data for audio/video endpoints
-		model, stream, errRes = parseMultipartFormData(requestID, contentType, body.RequestBody.GetBody())
+		model, stream, errRes = parseMultipartFormData(requestID, requestPath, contentType, body.RequestBody.GetBody())
 		if errRes != nil {
 			return errRes, model, stream, term
 		}
@@ -112,6 +112,20 @@ func (s *Server) HandleRequestBody(ctx context.Context, routingCtx *types.Routin
 			klog.ErrorS(nil, "incorrect routing strategy", "requestID", requestID, "routing-strategy", strategy)
 			return buildErrorResponse(envoyTypePb.StatusCode_BadRequest, fmt.Sprintf("incorrect routing strategy %s", strategy), "", "", HeaderErrorRouting, "true"), model, stream, term
 		}
+		routingCtx.Algorithm = routingAlgorithm
+	}
+
+	// The async video job (POST /v1/videos) must always be pinned to the pod that
+	// creates it: the generated video lives on that pod's local disk, and
+	// recordVideoJobPodFromResponse (called from HandleResponseBody) records
+	// routingCtx's target pod so follow-up GET/DELETE calls can be routed back to
+	// it. RouterNotSet delegates routing to the HTTPRoute/k8s Service below and
+	// never calls SetTargetPod, which would leave that pod mapping unrecorded and
+	// block recordVideoJobPodFromResponse's TargetPod() call until the request's
+	// context is done. Force a real algorithm here regardless of the client's
+	// routing-strategy header (or lack of one).
+	if routingAlgorithm == routing.RouterNotSet && pathWithoutQuery(requestPath) == PathVideos {
+		routingAlgorithm = routing.RouterLeastRequest
 		routingCtx.Algorithm = routingAlgorithm
 	}
 

--- a/pkg/plugins/gateway/gateway_req_body_test.go
+++ b/pkg/plugins/gateway/gateway_req_body_test.go
@@ -883,6 +883,77 @@ func TestHandleRequestBody_ModelRPSNotConsumedOnRoutingFailure(t *testing.T) {
 	mockModelRL.AssertExpectations(t)
 }
 
+// TestHandleRequestBody_AsyncVideoJobWithoutRoutingStrategyGetsPinned guards against a
+// regression where POST /v1/videos submitted without a routing-strategy header (the
+// out-of-the-box default, and what the async example in docs/source/features/vllm-omni.rst
+// uses) fell into the RouterNotSet branch, which never calls SetTargetPod. That left
+// recordVideoJobPodFromResponse's routerCtx.TargetPod() call (see gateway_video_routing.go)
+// blocking until the request's context was done, and the video_id -> pod mapping never
+// recorded -- breaking all follow-up GET/DELETE calls for that job.
+func TestHandleRequestBody_AsyncVideoJobWithoutRoutingStrategyGetsPinned(t *testing.T) {
+	cache.InitForTest()
+	routingalgorithms.Init()
+
+	mockCache := &MockCache{Cache: cache.NewForTest()}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns-a"},
+		Status: v1.PodStatus{
+			PodIP:      "1.2.3.4",
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+		},
+	}
+	podList := &utils.PodArray{Pods: []*v1.Pod{pod}}
+
+	mockCache.On("HasModel", "wan2.1").Return(true)
+	mockCache.On("ListPodsByModel", "wan2.1").Return(podList, nil)
+	mockCache.On("AddRequestCount", mock.Anything, mock.Anything, "wan2.1").Return(int64(1))
+	mockCache.On("GetMetricValueByPod", mock.Anything, mock.Anything, mock.Anything).
+		Return(&metrics.SimpleMetricValue{Value: 0}, nil).Maybe()
+
+	server := &Server{cache: mockCache}
+
+	body, contentType := buildMultipartForm(t, map[string]string{"model": "wan2.1", "prompt": "a cat"})
+	req := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestBody{
+			RequestBody: &extProcPb.HttpBody{Body: body},
+		},
+	}
+
+	routingCtx := types.NewRoutingContext(context.Background(), "", "", "", "test-request-id", "test-user")
+	routingCtx.ReqPath = PathVideos
+	routingCtx.ReqHeaders[contentTypeKey] = contentType
+	// Deliberately no routing-strategy header: this is the RouterNotSet default.
+
+	resp, model, stream, term := server.HandleRequestBody(context.Background(), routingCtx, "test-request-id", req, utils.User{Name: "test-user"})
+
+	require.NotNil(t, resp)
+	require.Nil(t, resp.GetImmediateResponse(), "async video job submission must not be rejected")
+	assert.Equal(t, "wan2.1", model)
+	assert.False(t, stream)
+	assert.Equal(t, int64(1), term)
+	assert.Equal(t, routingalgorithms.RouterLeastRequest, routingCtx.Algorithm,
+		"POST /v1/videos must not stay on RouterNotSet's HTTPRoute passthrough")
+
+	// TargetPod() must already be set -- it must not need to wait on ctx.Done() to unblock.
+	done := make(chan *v1.Pod, 1)
+	go func() { done <- routingCtx.TargetPod() }()
+	select {
+	case targetPod := <-done:
+		require.NotNil(t, targetPod)
+		assert.Equal(t, "pod-a", targetPod.Name)
+	case <-time.After(time.Second):
+		t.Fatal("TargetPod() blocked: the async video job was never pinned to a pod")
+	}
+
+	foundTargetPod := false
+	for _, h := range resp.GetRequestBody().GetResponse().GetHeaderMutation().GetSetHeaders() {
+		if h.Header.Key == HeaderTargetPod {
+			foundTargetPod = true
+		}
+	}
+	assert.True(t, foundTargetPod, "HeaderTargetPod must be set so envoy pins the request to the recorded pod")
+}
+
 // registerTestRouter registers the shared TestRouterAlgorithm mock router so a
 // request can be routed with it. Idempotent across tests.
 func registerTestRouter(mockRouter *mockRouter) {

--- a/pkg/plugins/gateway/gateway_req_headers.go
+++ b/pkg/plugins/gateway/gateway_req_headers.go
@@ -18,6 +18,7 @@ package gateway
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -38,14 +39,15 @@ import (
 const (
 	userKey          = "user"
 	pathKey          = ":path"
+	methodKey        = ":method"
 	authorizationKey = "authorization"
 	contentTypeKey   = "content-type"
 )
 
-func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, rootSpan trace.Span, req *extProcPb.ProcessingRequest) (*extProcPb.ProcessingResponse, utils.User, int64, *types.RoutingContext) {
+func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, rootSpan trace.Span, req *extProcPb.ProcessingRequest) (*extProcPb.ProcessingResponse, utils.User, int64, *types.RoutingContext, int64) {
 	var username, requestPath string
 	var user utils.User
-	var rpm int64
+	var rpm, term int64
 	var err error
 	var errRes *extProcPb.ProcessingResponse
 	var routingCtx *types.RoutingContext
@@ -62,6 +64,8 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, roo
 			username = string(n.RawValue)
 		case pathKey:
 			requestPath = string(n.RawValue)
+		case methodKey:
+			reqHeaders[n.Key] = string(n.RawValue)
 		case authorizationKey:
 			reqHeaders[n.Key] = string(n.RawValue)
 		case HeaderExternalFilter:
@@ -101,7 +105,7 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, roo
 				"Incorrect API key provided",
 				ErrorCodeInvalidAPIKey,
 				"api_key",
-			), utils.User{}, rpm, nil
+			), utils.User{}, rpm, nil, term
 		}
 	}
 
@@ -117,13 +121,13 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, roo
 				[]*configPb.HeaderValueOption{{Header: &configPb.HeaderValue{
 					Key: HeaderErrorUser, RawValue: []byte("true"),
 				}}},
-				err.Error(), "", ""), utils.User{}, rpm, routingCtx
+				err.Error(), "", ""), utils.User{}, rpm, routingCtx, term
 		}
 
 		rpm, errRes, err = s.checkLimits(ctx, user)
 		if errRes != nil {
 			klog.ErrorS(err, "error on checking limits", "requestID", requestID, "username", username)
-			return errRes, utils.User{}, rpm, routingCtx
+			return errRes, utils.User{}, rpm, routingCtx, term
 		}
 	}
 
@@ -131,6 +135,29 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, roo
 	routingCtx.ReqPath = requestPath
 	routingCtx.ReqHeaders = reqHeaders
 	routingCtx.ReqConfigProfile = reqConfigProfile
+
+	// Async video job follow-ups (GET status/content, DELETE) carry their routing
+	// key -- video_id -- in the path, not the (often empty/absent) body. Envoy's
+	// ext_proc filter only invokes RequestBody processing when the request
+	// actually has a body, so a bodyless request must be pinned here, at
+	// RequestHeaders, or it never gets pinned at all (see
+	// handleVideoJobSubResourceHeaders for the full explanation). When a body IS
+	// coming (EndOfStream false), HandleRequestBody's existing handling covers it.
+	if h.RequestHeaders.EndOfStream {
+		if videoID, isSubResource := extractVideoIDFromPath(requestPath); isSubResource {
+			resp, videoTerm := s.handleVideoJobSubResourceHeaders(ctx, routingCtx, requestID, requestPath, videoID)
+			return resp, user, rpm, routingCtx, videoTerm
+		}
+		// GET /v1/videos (list, no video_id) is fanned out across all of a
+		// model's pods and answered directly here -- see handleVideoListHeaders
+		// for why this can't be a normal single-pod routing decision.
+		if model, isListPath := parseVideoListRequest(requestPath); isListPath && reqHeaders[methodKey] == http.MethodGet {
+			if model == "" {
+				return videoListModelRequiredResponse(), user, rpm, routingCtx, term
+			}
+			return s.handleVideoListHeaders(requestID, model), user, rpm, routingCtx, term
+		}
+	}
 
 	headers := []*configPb.HeaderValueOption{}
 	headers = append(headers, &configPb.HeaderValueOption{
@@ -168,5 +195,5 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, roo
 				},
 			},
 		},
-	}, user, rpm, routingCtx
+	}, user, rpm, routingCtx, term
 }

--- a/pkg/plugins/gateway/gateway_req_headers.go
+++ b/pkg/plugins/gateway/gateway_req_headers.go
@@ -155,6 +155,7 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, roo
 			if model == "" {
 				return videoListModelRequiredResponse(), user, rpm, routingCtx, term
 			}
+			routingCtx.Model = model
 			return s.handleVideoListHeaders(requestID, model), user, rpm, routingCtx, term
 		}
 	}

--- a/pkg/plugins/gateway/gateway_req_headers_test.go
+++ b/pkg/plugins/gateway/gateway_req_headers_test.go
@@ -373,7 +373,7 @@ func Test_handleRequestHeaders(t *testing.T) {
 			}
 
 			rootSpan := trace.SpanFromContext(context.Background())
-			resp, user, rpm, routingCtx := server.HandleRequestHeaders(
+			resp, user, rpm, routingCtx, _ := server.HandleRequestHeaders(
 				context.Background(),
 				fallbackRequestID,
 				rootSpan,
@@ -426,7 +426,7 @@ func TestHandleRequestHeaders_PrefersRootSpanTraceIDOverTraceparent(t *testing.T
 
 	server := &Server{}
 	requestID := rootSpan.SpanContext().TraceID().String()
-	_, _, _, routingCtx := server.HandleRequestHeaders(ctx, requestID, rootSpan, req)
+	_, _, _, routingCtx, _ := server.HandleRequestHeaders(ctx, requestID, rootSpan, req)
 
 	if assert.NotNil(t, routingCtx) {
 		assert.Equal(t, rootTraceID, routingCtx.RequestID)
@@ -456,7 +456,7 @@ func TestHandleRequestHeadersBearerTokenAuth(t *testing.T) {
 		}
 
 		rootSpan := trace.SpanFromContext(context.TODO())
-		resp, user, rpm, routingCtx := server.HandleRequestHeaders(context.Background(), "test-request-id", rootSpan, req)
+		resp, user, rpm, routingCtx, _ := server.HandleRequestHeaders(context.Background(), "test-request-id", rootSpan, req)
 
 		assert.Nil(t, resp.GetImmediateResponse())
 		assert.Equal(t, utils.User{}, user)
@@ -484,7 +484,7 @@ func TestHandleRequestHeadersBearerTokenAuth(t *testing.T) {
 		}
 
 		rootSpan := trace.SpanFromContext(context.TODO())
-		resp, user, rpm, routingCtx := server.HandleRequestHeaders(context.Background(), "test-request-id", rootSpan, req)
+		resp, user, rpm, routingCtx, _ := server.HandleRequestHeaders(context.Background(), "test-request-id", rootSpan, req)
 
 		assert.Equal(t, envoyTypePb.StatusCode_Unauthorized, resp.GetImmediateResponse().GetStatus().GetCode())
 		assert.Equal(t, utils.User{}, user)
@@ -513,7 +513,7 @@ func TestHandleRequestHeadersBearerTokenAuth(t *testing.T) {
 		}
 
 		rootSpan := trace.SpanFromContext(context.TODO())
-		resp, user, rpm, routingCtx := server.HandleRequestHeaders(context.Background(), "test-request-id", rootSpan, req)
+		resp, user, rpm, routingCtx, _ := server.HandleRequestHeaders(context.Background(), "test-request-id", rootSpan, req)
 
 		assert.Equal(t, envoyTypePb.StatusCode_Unauthorized, resp.GetImmediateResponse().GetStatus().GetCode())
 		assert.Equal(t, utils.User{}, user)
@@ -541,7 +541,7 @@ func TestHandleRequestHeadersBearerTokenAuth(t *testing.T) {
 		}
 
 		rootSpan := trace.SpanFromContext(context.TODO())
-		resp, user, rpm, routingCtx := server.HandleRequestHeaders(context.Background(), "test-request-id", rootSpan, req)
+		resp, user, rpm, routingCtx, _ := server.HandleRequestHeaders(context.Background(), "test-request-id", rootSpan, req)
 
 		assert.Equal(t, envoyTypePb.StatusCode_Unauthorized, resp.GetImmediateResponse().GetStatus().GetCode())
 		assert.Equal(t, utils.User{}, user)

--- a/pkg/plugins/gateway/gateway_rsp_body.go
+++ b/pkg/plugins/gateway/gateway_rsp_body.go
@@ -279,6 +279,11 @@ func (s *Server) HandleResponseBody(ctx context.Context, routerCtx *types.Routin
 			if processingRes != nil {
 				return processingRes, complete, usage
 			}
+		} else if pathWithoutQuery(routerCtx.ReqPath) == PathVideos {
+			// Exact match only: excludes /v1/videos/sync (no follow-up calls to pin)
+			// and /v1/videos/{id} sub-resource responses (already routed by
+			// handleVideoJobSubResource, nothing new to record).
+			s.recordVideoJobPodFromResponse(ctx, requestID, routerCtx, b)
 		}
 	}
 
@@ -333,6 +338,9 @@ func isLanguageRequest(requestPath string) bool {
 	nonLanguagePrefixes := []string{
 		PathImagesGenerations,
 		PathVideoGenerations,
+		// Prefix match: also covers /v1/videos/sync and the GET/DELETE sub-resources
+		// (/v1/videos/{id}, /v1/videos/{id}/content).
+		PathVideos,
 		PathAudioTranscriptions,
 		PathAudioTranslations,
 	}

--- a/pkg/plugins/gateway/gateway_rsp_body_test.go
+++ b/pkg/plugins/gateway/gateway_rsp_body_test.go
@@ -105,6 +105,26 @@ func TestIsLanguageRequest(t *testing.T) {
 			want:        false,
 		},
 		{
+			name:        "videos create is not language",
+			requestPath: "/v1/videos",
+			want:        false,
+		},
+		{
+			name:        "videos sync is not language",
+			requestPath: "/v1/videos/sync",
+			want:        false,
+		},
+		{
+			name:        "videos status poll is not language",
+			requestPath: "/v1/videos/video_gen_abc123",
+			want:        false,
+		},
+		{
+			name:        "videos content download is not language",
+			requestPath: "/v1/videos/video_gen_abc123/content",
+			want:        false,
+		},
+		{
 			name:        "empty path is language",
 			requestPath: "",
 			want:        true,

--- a/pkg/plugins/gateway/gateway_rsp_headers.go
+++ b/pkg/plugins/gateway/gateway_rsp_headers.go
@@ -69,10 +69,11 @@ func (s *Server) HandleResponseHeaders(ctx context.Context, routerCtx *types.Rou
 				processingErrorCode = 500
 				break
 			}
-			if code != 200 {
+			if code < 200 || code >= 300 {
 				isProcessingError = true
 				processingErrorCode = code
 			}
+			s.maybeForgetVideoJobAfterDelete(ctx, routerCtx, code)
 			headers = buildEnvoyProxyHeaders(headers, headerValue.Key, string(headerValue.RawValue))
 			break
 		}

--- a/pkg/plugins/gateway/gateway_rsp_headers_test.go
+++ b/pkg/plugins/gateway/gateway_rsp_headers_test.go
@@ -94,6 +94,23 @@ func Test_HandleResponseHeaders(t *testing.T) {
 			},
 		},
 		{
+			name:           "non-200 success (204)",
+			routingCtx:     createRoutingCtx(true, nil),
+			responseStatus: "204",
+			expected: testResponse{
+				processingErrorCode: 0,
+				isProcessingError:   false,
+				headers: []*configPb.HeaderValueOption{
+					{Header: &configPb.HeaderValue{Key: HeaderWentIntoReqHeaders, RawValue: []byte("true")}},
+					{Header: &configPb.HeaderValue{Key: HeaderRequestID, RawValue: []byte("test-req-id")}},
+					{Header: &configPb.HeaderValue{Key: "routing-strategy", RawValue: []byte("random")}},
+					{Header: &configPb.HeaderValue{Key: HeaderTargetPod, RawValue: []byte("test-pod")}},
+					{Header: &configPb.HeaderValue{Key: HeaderTargetPodIP, RawValue: []byte("10.0.0.1:8000")}},
+					{Header: &configPb.HeaderValue{Key: ":status", RawValue: []byte("204")}},
+				},
+			},
+		},
+		{
 			name:           "error response (500)",
 			routingCtx:     createRoutingCtx(true, nil),
 			responseStatus: "500",

--- a/pkg/plugins/gateway/gateway_video_routing.go
+++ b/pkg/plugins/gateway/gateway_video_routing.go
@@ -1,0 +1,622 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bytedance/sonic"
+	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/redis/go-redis/v9"
+	"github.com/tidwall/gjson"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
+)
+
+// defaultVideoJobTTL is used when the create response omits expires_at. Pinning
+// also forgets the mapping as soon as the owning pod is gone; this TTL only
+// covers a job that is never polled or deleted.
+const defaultVideoJobTTL = 7 * 24 * time.Hour
+
+// videoJobAffinityLabel is the routing-strategy header value for a request
+// already pinned to a video job's pod. It is not a registered
+// types.RoutingAlgorithm and never goes through the algorithm registry.
+const videoJobAffinityLabel = "video-job-affinity"
+
+// videoJobRedisKeyPrefix namespaces video-job pod mappings in the shared Redis
+// keyspace.
+const videoJobRedisKeyPrefix = "aibrix:gateway:video_job:"
+
+func videoJobRedisKey(videoID string) string {
+	return videoJobRedisKeyPrefix + videoID
+}
+
+const (
+	// videoJobCacheSyncInterval bounds how stale this replica's local cache can
+	// be vs Redis. A still-valid local hit skips the Redis fallback, so without
+	// this a forget on another replica (DELETE, pod-gone) would stay invisible
+	// until the local entry's own TTL — which can be days.
+	videoJobCacheSyncInterval = 60 * time.Second
+	// videoJobCacheSyncBatchSize bounds how many keys share one MGET round-trip.
+	videoJobCacheSyncBatchSize = 200
+)
+
+// startVideoJobCacheSync periodically reconciles this replica's local
+// videoJobCache against Redis: missing keys are evicted, changed values are
+// refreshed. It only walks IDs already cached locally. A whole-batch Redis
+// error leaves the local cache untouched (a failed read is not a miss). Stops
+// when stopCh is closed.
+func (s *Server) startVideoJobCacheSync(stopCh <-chan struct{}) {
+	if s.redisClient == nil {
+		return
+	}
+	ticker := time.NewTicker(videoJobCacheSyncInterval)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				s.syncVideoJobCacheFromRedis()
+			case <-stopCh:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (s *Server) syncVideoJobCacheFromRedis() {
+	var videoIDs []string
+	s.videoJobCache.Range(func(key, _ any) bool {
+		if id, ok := key.(string); ok {
+			videoIDs = append(videoIDs, id)
+		}
+		return true
+	})
+	if len(videoIDs) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), videoJobCacheSyncInterval)
+	defer cancel()
+
+	for batchStart := 0; batchStart < len(videoIDs); batchStart += videoJobCacheSyncBatchSize {
+		idChunk := videoIDs[batchStart:min(batchStart+videoJobCacheSyncBatchSize, len(videoIDs))]
+
+		keys := make([]string, len(idChunk))
+		for i, id := range idChunk {
+			keys[i] = videoJobRedisKey(id)
+		}
+		vals, err := s.redisClient.MGet(ctx, keys...).Result()
+		if err != nil {
+			klog.V(4).ErrorS(err, "failed to refresh video job cache from redis", "batchStart", batchStart, "batchLen", len(idChunk))
+			continue
+		}
+
+		for i, id := range idChunk {
+			raw, ok := vals[i].(string)
+			if !ok {
+				// Nil or unexpected type: Redis no longer vouches for this mapping.
+				s.videoJobCache.Delete(id)
+				continue
+			}
+			var entry videoJobCacheEntry
+			if err := sonic.UnmarshalString(raw, &entry); err != nil {
+				klog.V(4).ErrorS(err, "failed to unmarshal video job entry during cache sync", "videoID", id)
+				continue
+			}
+			s.videoJobCache.Store(id, entry)
+		}
+	}
+}
+
+// videoJobCacheEntry is the video_id -> owning-pod mapping. The generated
+// video lives on that pod's local disk, so follow-up GET/DELETE must return
+// there. JSON tags are the Redis value shared across gateway replicas.
+type videoJobCacheEntry struct {
+	PodName      string    `json:"pod_name"`
+	PodNamespace string    `json:"pod_namespace"`
+	Model        string    `json:"model"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+// rememberVideoJobPod stores videoID's owning pod locally and, when Redis is
+// configured, write-through with the same TTL. ttl is expires_at when the
+// backend reported one, otherwise defaultVideoJobTTL.
+func (s *Server) rememberVideoJobPod(ctx context.Context, videoID, podName, podNamespace, model string, ttl time.Duration) {
+	if videoID == "" || podName == "" {
+		return
+	}
+	if ttl <= 0 {
+		ttl = defaultVideoJobTTL
+	}
+	entry := videoJobCacheEntry{
+		PodName:      podName,
+		PodNamespace: podNamespace,
+		Model:        model,
+		ExpiresAt:    time.Now().Add(ttl),
+	}
+	s.videoJobCache.Store(videoID, entry)
+
+	if s.redisClient == nil {
+		return
+	}
+	payload, err := sonic.Marshal(entry)
+	if err != nil {
+		klog.ErrorS(err, "failed to marshal video job entry for redis", "videoID", videoID)
+		return
+	}
+	if err := s.redisClient.Set(ctx, videoJobRedisKey(videoID), string(payload), ttl).Err(); err != nil {
+		klog.ErrorS(err, "failed to persist video job pod to redis", "videoID", videoID)
+	}
+}
+
+// lookupVideoJobPod returns the pod that owns videoID, or ok=false if the
+// mapping is unknown or expired. Expired local entries are evicted on read.
+// A local miss falls back to Redis (cross-replica) and warms the local cache.
+func (s *Server) lookupVideoJobPod(ctx context.Context, videoID string) (podName, podNamespace, model string, ok bool) {
+	if cached, found := s.videoJobCache.Load(videoID); found {
+		entry, ok := cached.(videoJobCacheEntry)
+		if !ok {
+			s.videoJobCache.Delete(videoID)
+		} else if time.Now().Before(entry.ExpiresAt) {
+			return entry.PodName, entry.PodNamespace, entry.Model, true
+		} else {
+			s.videoJobCache.Delete(videoID)
+		}
+	}
+
+	if s.redisClient == nil {
+		return "", "", "", false
+	}
+
+	val, err := s.redisClient.Get(ctx, videoJobRedisKey(videoID)).Result()
+	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			klog.ErrorS(err, "failed to look up video job pod in redis", "videoID", videoID)
+		}
+		return "", "", "", false
+	}
+	var entry videoJobCacheEntry
+	if err := sonic.UnmarshalString(val, &entry); err != nil {
+		klog.ErrorS(err, "failed to unmarshal video job entry from redis", "videoID", videoID)
+		return "", "", "", false
+	}
+	if time.Now().After(entry.ExpiresAt) {
+		// Redis EX should already have reaped this; don't resurrect on clock skew.
+		return "", "", "", false
+	}
+
+	s.videoJobCache.Store(videoID, entry)
+	return entry.PodName, entry.PodNamespace, entry.Model, true
+}
+
+// forgetVideoJobPod drops videoID from the local cache and Redis (pod gone, or
+// a DELETE that already succeeded).
+func (s *Server) forgetVideoJobPod(ctx context.Context, videoID string) {
+	s.videoJobCache.Delete(videoID)
+	if s.redisClient == nil {
+		return
+	}
+	if err := s.redisClient.Del(ctx, videoJobRedisKey(videoID)).Err(); err != nil {
+		klog.ErrorS(err, "failed to delete video job pod from redis", "videoID", videoID)
+	}
+}
+
+// extractVideoIDFromPath returns the {id} of /v1/videos/{id} or
+// /v1/videos/{id}/content. Bare /v1/videos and /v1/videos/sync have no id to pin.
+func extractVideoIDFromPath(requestPath string) (videoID string, ok bool) {
+	const prefix = PathVideos + "/"
+	requestPath = pathWithoutQuery(requestPath)
+	if !strings.HasPrefix(requestPath, prefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(requestPath, prefix)
+	if idx := strings.IndexByte(rest, '/'); idx >= 0 {
+		rest = rest[:idx]
+	}
+	if rest == "" || rest == "sync" {
+		return "", false
+	}
+	return rest, true
+}
+
+// videoNotFoundResponse builds the 404 returned when a video_id is unknown,
+// expired, or its owning pod is no longer available.
+func videoNotFoundResponse(videoID string) *extProcPb.ProcessingResponse {
+	return buildErrorResponse(envoyTypePb.StatusCode_NotFound,
+		fmt.Sprintf("video %s not found", videoID), ErrorCodeVideoNotFound, "",
+		HeaderErrorVideoNotFound, "true")
+}
+
+// parseVideoListRequest reports whether requestPath is the bare /v1/videos
+// list path (not a {id} sub-resource) and the value of its model query
+// parameter, which may be empty.
+func parseVideoListRequest(requestPath string) (model string, isListPath bool) {
+	path, query, _ := strings.Cut(requestPath, "?")
+	if path != PathVideos {
+		return "", false
+	}
+	values, err := url.ParseQuery(query)
+	if err != nil {
+		return "", true
+	}
+	return values.Get("model"), true
+}
+
+// videoListModelRequiredResponse is the 400 for GET /v1/videos without model.
+// A standalone vLLM-Omni server has one implicit model; this gateway does not.
+func videoListModelRequiredResponse() *extProcPb.ProcessingResponse {
+	return buildErrorResponse(envoyTypePb.StatusCode_BadRequest,
+		"'model' query parameter is required to list video jobs", "", "model",
+		HeaderErrorRequestBodyProcessing, "true")
+}
+
+// videoListFanoutTimeout bounds how long GET /v1/videos waits on the slowest
+// pod before merging whatever succeeded. Total failure is a 503, not an empty list.
+const videoListFanoutTimeout = 5 * time.Second
+
+// videoListFanoutMaxConcurrency caps parallel pod fetches so a large replica
+// set cannot open unbounded outbound connections from the gateway plugin.
+const videoListFanoutMaxConcurrency = 16
+
+// videoListFanoutMaxBodyBytes caps a single pod's list response. A malformed
+// or malicious backend must not be able to OOM the gateway via io.ReadAll.
+const videoListFanoutMaxBodyBytes = 1 << 20 // 1 MiB
+
+// videoListFanoutClient is reused across requests (connection pooling) for the
+// GET /v1/videos fan-out below; it makes no other outbound calls.
+var videoListFanoutClient = &http.Client{Timeout: videoListFanoutTimeout}
+
+// podAddress is the routable ip:port for model on pod (ModelClaim port, then
+// the model.aibrix.ai/port label). SetTargetPod/TargetAddress are one-shot per
+// request, so the list fan-out cannot reuse them per pod.
+func podAddress(requestID, model string, pod *v1.Pod) string {
+	if port, ok := utils.ModelClaimPortForPod(pod, model); ok {
+		if port > 0 {
+			return net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(port))
+		}
+		return ""
+	}
+	return net.JoinHostPort(pod.Status.PodIP, strconv.FormatInt(utils.GetModelPortForPod(requestID, pod), 10))
+}
+
+// handleVideoListHeaders serves GET /v1/videos by fanning out to every
+// routable pod for model and merging their job lists. List has no owning
+// pod — each replica only knows jobs on its own disk — so the plugin acts as
+// the HTTP client and returns an ImmediateResponse instead of pinning via
+// Envoy. Individual pod failures are skipped; if every routable pod fails
+// (or none are routable), this returns 503 so an outage is not an empty list.
+func (s *Server) handleVideoListHeaders(requestID, model string) *extProcPb.ProcessingResponse {
+	podsArr, errResp := s.validateModelAvailability(requestID, model)
+	if errResp != nil {
+		return errResp
+	}
+	pods := utils.FilterRoutablePods(podsArr.All())
+	if len(pods) == 0 {
+		klog.ErrorS(nil, "video list fan-out has no routable pods", "requestID", requestID, "model", model)
+		return buildErrorResponse(envoyTypePb.StatusCode_ServiceUnavailable,
+			fmt.Sprintf("no ready pod available to list video jobs for model %s", model),
+			ErrorCodeServiceUnavailable, "", HeaderErrorNoModelBackends, "true")
+	}
+
+	type podResult struct {
+		podName string
+		data    []byte
+		err     error
+	}
+	results := make([]podResult, len(pods))
+
+	fanoutCtx, cancel := context.WithTimeout(context.Background(), videoListFanoutTimeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, videoListFanoutMaxConcurrency)
+	for i, pod := range pods {
+		results[i].podName = pod.Name
+		addr := podAddress(requestID, model, pod)
+		if addr == "" {
+			results[i].err = fmt.Errorf("pod %s has no routable address", pod.Name)
+			continue
+		}
+		wg.Add(1)
+		go func(i int, addr string) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					results[i].err = fmt.Errorf("panic fetching video list from pod: %v", r)
+					klog.ErrorS(nil, "panic recovered in video list fan-out goroutine", "requestID", requestID, "model", model, "pod", results[i].podName, "panic", r)
+				}
+			}()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-fanoutCtx.Done():
+				results[i].err = fanoutCtx.Err()
+				return
+			}
+			data, err := fetchPodVideoList(fanoutCtx, addr)
+			results[i].data = data
+			results[i].err = err
+		}(i, addr)
+	}
+	wg.Wait()
+
+	merged := make([]json.RawMessage, 0, len(pods))
+	failed := 0
+	for _, r := range results {
+		if r.err != nil {
+			failed++
+			klog.V(2).ErrorS(r.err, "video list fan-out to pod failed, skipping", "requestID", requestID, "model", model, "pod", r.podName)
+			continue
+		}
+		merged = append(merged, extractVideoListItems(r.data)...)
+	}
+
+	if failed == len(pods) {
+		klog.ErrorS(nil, "video list fan-out failed for every pod", "requestID", requestID, "model", model, "pods", len(pods))
+		return buildErrorResponse(envoyTypePb.StatusCode_ServiceUnavailable,
+			fmt.Sprintf("failed to list video jobs from any pod for model %s", model),
+			ErrorCodeServiceUnavailable, "", HeaderErrorNoModelBackends, "true")
+	}
+
+	respBody, err := sonic.Marshal(map[string]any{"object": "list", "data": merged})
+	if err != nil {
+		klog.ErrorS(err, "failed to marshal merged video list", "requestID", requestID, "model", model)
+		return buildErrorResponse(envoyTypePb.StatusCode_InternalServerError, "failed to marshal merged video list", "", "", HeaderErrorResponseUnknown, "true")
+	}
+
+	klog.InfoS("video list fan-out complete", "requestID", requestID, "model", model, "pods", len(pods), "failed", failed, "merged", len(merged))
+
+	return &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_ImmediateResponse{
+			ImmediateResponse: &extProcPb.ImmediateResponse{
+				Status: &envoyTypePb.HttpStatus{Code: envoyTypePb.StatusCode_OK},
+				Headers: &extProcPb.HeaderMutation{
+					SetHeaders: buildEnvoyProxyHeaders(nil, "Content-Type", "application/json"),
+				},
+				Body: string(respBody),
+			},
+		},
+	}
+}
+
+// fetchPodVideoList GETs /v1/videos on addr (the pod, not Envoy). No model
+// query is sent: a single vLLM-Omni server has one implicit model.
+func fetchPodVideoList(ctx context.Context, addr string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+addr+PathVideos, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := videoListFanoutClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, videoListFanoutMaxBodyBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > videoListFanoutMaxBodyBytes {
+		return nil, fmt.Errorf("video list response exceeds %d bytes", videoListFanoutMaxBodyBytes)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return body, nil
+}
+
+// extractVideoListItems returns job objects from a pod's list body: an
+// OpenAI {"data": [...]} envelope or a bare array. Other shapes yield nil so
+// one malformed pod does not fail the merge.
+func extractVideoListItems(body []byte) []json.RawMessage {
+	data := gjson.GetBytes(body, "data")
+	if !data.Exists() {
+		data = gjson.ParseBytes(body)
+	}
+	if !data.IsArray() {
+		return nil
+	}
+	items := data.Array()
+	out := make([]json.RawMessage, len(items))
+	for i, item := range items {
+		out[i] = json.RawMessage(item.Raw)
+	}
+	return out
+}
+
+// pinVideoJobSubResource looks up videoID's pod, applies RPS, and returns
+// header mutations that pin the request via ORIGINAL_DST. On error, RPS is
+// rolled back if it was incremented; AddRequestCount is not called. Used from
+// both the RequestBody and RequestHeaders pin paths.
+func (s *Server) pinVideoJobSubResource(ctx context.Context, routingCtx *types.RoutingContext, requestID, requestPath, videoID string) (headers []*configPb.HeaderValueOption, model string, term int64, errResp *extProcPb.ProcessingResponse) {
+	var podName, podNamespace string
+	var ok bool
+	podName, podNamespace, model, ok = s.lookupVideoJobPod(ctx, videoID)
+	if !ok {
+		klog.ErrorS(nil, "unknown or expired video job", "requestID", requestID, "videoID", videoID)
+		return nil, "", term, videoNotFoundResponse(videoID)
+	}
+
+	pod, err := s.cache.GetPod(podName, podNamespace)
+	if err != nil || !utils.IsPodReady(pod) {
+		s.forgetVideoJobPod(ctx, videoID)
+		klog.ErrorS(err, "video job's pod is no longer available", "requestID", requestID, "videoID", videoID, "podName", podName, "podNamespace", podNamespace)
+		return nil, model, term, videoNotFoundResponse(videoID)
+	}
+
+	routingCtx.Model = model
+	routingCtx.SetTargetPod(pod)
+	targetPodIP := routingCtx.TargetAddress()
+	if targetPodIP == "" {
+		s.forgetVideoJobPod(ctx, videoID)
+		klog.ErrorS(nil, "video job's pod has no routable address", "requestID", requestID, "videoID", videoID, "podName", podName)
+		return nil, model, term, videoNotFoundResponse(videoID)
+	}
+
+	applyConfigProfile(routingCtx, []*v1.Pod{pod})
+
+	if errRes := s.enforceModelRPS(ctx, model, routingCtx); errRes != nil {
+		return nil, model, term, errRes
+	}
+	needsRollback := true
+	defer func() {
+		if needsRollback {
+			s.decrModelRPS(ctx, model, routingCtx)
+		}
+	}()
+
+	headers = buildEnvoyProxyHeaders(make([]*configPb.HeaderValueOption, 0, 3),
+		HeaderRoutingStrategy, videoJobAffinityLabel,
+		HeaderTargetPod, targetPodIP,
+		"X-Request-Id", routingCtx.RequestID)
+
+	klog.InfoS("request_start", "request_id", requestID, "request_path", requestPath, "model", model,
+		"routing_strategy", videoJobAffinityLabel, "target_pod", podName, "target_pod_ip", targetPodIP)
+
+	needsRollback = false
+	routingCtx.RequestEndTime = time.Now()
+	term = s.cache.AddRequestCount(routingCtx, requestID, model)
+
+	return headers, model, term, nil
+}
+
+// maybeForgetVideoJobAfterDelete drops the mapping after a DELETE 2xx or 404.
+// 5xx keeps it so the client can retry the same sticky route. Called from
+// HandleResponseHeaders once upstream status is known, not at pin time.
+func (s *Server) maybeForgetVideoJobAfterDelete(ctx context.Context, routerCtx *types.RoutingContext, statusCode int) {
+	if routerCtx == nil || routerCtx.ReqHeaders[methodKey] != http.MethodDelete {
+		return
+	}
+	if !((statusCode >= 200 && statusCode < 300) || statusCode == http.StatusNotFound) {
+		return
+	}
+	videoID, ok := extractVideoIDFromPath(routerCtx.ReqPath)
+	if !ok {
+		return
+	}
+	s.forgetVideoJobPod(ctx, videoID)
+	klog.InfoS("video job pod mapping evicted on delete", "requestID", routerCtx.RequestID, "videoID", videoID, "status", statusCode)
+}
+
+// handleVideoJobSubResource pins a video_id follow-up at the RequestBody
+// phase. Bodyless GET/DELETE never reach here; those are pinned in
+// handleVideoJobSubResourceHeaders.
+func (s *Server) handleVideoJobSubResource(ctx context.Context, routingCtx *types.RoutingContext, requestID, requestPath, videoID string, reqBody []byte) (*extProcPb.ProcessingResponse, string, bool, int64) {
+	routingCtx.ReqBody = reqBody
+
+	headers, model, term, errResp := s.pinVideoJobSubResource(ctx, routingCtx, requestID, requestPath, videoID)
+	if errResp != nil {
+		return errResp, model, false, term
+	}
+
+	headers = buildEnvoyProxyHeaders(headers, "content-length", strconv.Itoa(len(routingCtx.ReqBody)))
+
+	return &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_RequestBody{
+			RequestBody: &extProcPb.BodyResponse{
+				Response: &extProcPb.CommonResponse{
+					HeaderMutation: &extProcPb.HeaderMutation{
+						SetHeaders: headers,
+					},
+					BodyMutation: &extProcPb.BodyMutation{
+						Mutation: &extProcPb.BodyMutation_Body{
+							Body: routingCtx.ReqBody,
+						},
+					},
+				},
+			},
+		},
+	}, model, false, term
+}
+
+// handleVideoJobSubResourceHeaders pins a bodyless GET/DELETE at RequestHeaders.
+// ext_proc BUFFERED mode never sends RequestBody when there is no body, so
+// without this the routing-strategy/target-pod headers would never be set.
+// Only called when EndOfStream is true; otherwise the body-phase pin runs.
+func (s *Server) handleVideoJobSubResourceHeaders(ctx context.Context, routingCtx *types.RoutingContext, requestID, requestPath, videoID string) (*extProcPb.ProcessingResponse, int64) {
+	headers, _, term, errResp := s.pinVideoJobSubResource(ctx, routingCtx, requestID, requestPath, videoID)
+	if errResp != nil {
+		return errResp, term
+	}
+
+	return &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_RequestHeaders{
+			RequestHeaders: &extProcPb.HeadersResponse{
+				Response: &extProcPb.CommonResponse{
+					HeaderMutation: &extProcPb.HeaderMutation{
+						SetHeaders: headers,
+					},
+					ClearRouteCache: true,
+				},
+			},
+		},
+	}, term
+}
+
+// recordVideoJobPodFromResponse buffers a POST /v1/videos response and, at
+// EndOfStream, records the owning pod from the JSON id. Uses the same
+// requestBuffers map as processLanguageResponse; a given requestID is only
+// one of those paths.
+func (s *Server) recordVideoJobPodFromResponse(ctx context.Context, requestID string, routerCtx *types.RoutingContext, b *extProcPb.ProcessingRequest_ResponseBody) {
+	buf, _ := requestBuffers.LoadOrStore(requestID, &bytes.Buffer{})
+	buffer := buf.(*bytes.Buffer)
+	buffer.Write(b.ResponseBody.GetBody())
+
+	if !b.ResponseBody.EndOfStream {
+		return
+	}
+	requestBuffers.Delete(requestID)
+
+	pod := routerCtx.TargetPod()
+	if pod == nil {
+		return
+	}
+
+	body := buffer.Bytes()
+	videoID := gjson.GetBytes(body, "id").String()
+	if videoID == "" {
+		return
+	}
+
+	ttl := defaultVideoJobTTL
+	if expiresAt := gjson.GetBytes(body, "expires_at"); expiresAt.Exists() {
+		if d := time.Until(time.Unix(expiresAt.Int(), 0)); d > 0 {
+			ttl = d
+		}
+	}
+
+	s.rememberVideoJobPod(ctx, videoID, pod.Name, pod.Namespace, routerCtx.Model, ttl)
+	klog.InfoS("video job pod recorded", "requestID", requestID, "videoID", videoID, "podName", pod.Name, "ttl", ttl)
+}

--- a/pkg/plugins/gateway/gateway_video_routing.go
+++ b/pkg/plugins/gateway/gateway_video_routing.go
@@ -126,8 +126,10 @@ func (s *Server) syncVideoJobCacheFromRedis() {
 		for i, id := range idChunk {
 			raw, ok := vals[i].(string)
 			if !ok {
-				// Nil or unexpected type: Redis no longer vouches for this mapping.
-				s.videoJobCache.Delete(id)
+				// Nil or unexpected type: either Redis genuinely no longer vouches
+				// for this mapping, or this replica's own write to it is still
+				// pending/failed -- handleVideoJobCacheSyncMiss tells those apart.
+				s.handleVideoJobCacheSyncMiss(ctx, id)
 				continue
 			}
 			var entry videoJobCacheEntry
@@ -135,8 +137,31 @@ func (s *Server) syncVideoJobCacheFromRedis() {
 				klog.V(4).ErrorS(err, "failed to unmarshal video job entry during cache sync", "videoID", id)
 				continue
 			}
-			s.videoJobCache.Store(id, entry)
+			s.videoJobCache.Store(id, videoJobCacheItem{entry: entry, confirmed: true})
 		}
+	}
+}
+
+// handleVideoJobCacheSyncMiss reacts to videoID being absent from Redis during
+// a sync pass. A previously confirmed entry (this replica successfully wrote
+// or read it from Redis at some point) is evicted: Redis no longer vouches
+// for it, most likely a DELETE or a forgotten pod on another replica. An
+// entry that was never confirmed means this replica's own write to Redis is
+// still pending or failed outright -- a nil read says nothing about whether
+// that mapping is still valid, so it's retried here instead of being dropped
+// as the only surviving copy (see the confirmed field on videoJobCacheItem).
+func (s *Server) handleVideoJobCacheSyncMiss(ctx context.Context, videoID string) {
+	cached, found := s.videoJobCache.Load(videoID)
+	if !found {
+		return
+	}
+	item, ok := cached.(videoJobCacheItem)
+	if !ok || item.confirmed || !time.Now().Before(item.entry.ExpiresAt) {
+		s.videoJobCache.Delete(videoID)
+		return
+	}
+	if s.persistVideoJobToRedis(ctx, videoID, item.entry, time.Until(item.entry.ExpiresAt)) {
+		s.videoJobCache.Store(videoID, videoJobCacheItem{entry: item.entry, confirmed: true})
 	}
 }
 
@@ -148,6 +173,36 @@ type videoJobCacheEntry struct {
 	PodNamespace string    `json:"pod_namespace"`
 	Model        string    `json:"model"`
 	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+// videoJobCacheItem is what's actually stored in Server.videoJobCache.
+// confirmed is local-only bookkeeping (never marshaled to Redis) recording
+// whether entry is known to exist in Redis. See handleVideoJobCacheSyncMiss
+// for why that distinction matters.
+type videoJobCacheItem struct {
+	entry     videoJobCacheEntry
+	confirmed bool
+}
+
+// persistVideoJobToRedis write-throughs entry to Redis under videoID's key
+// and reports whether Redis now has it. A false return (no redisClient, a
+// marshal error, or a Set error -- both logged here) means the caller's local
+// copy is this replica's only copy, and a later Redis miss for videoID must
+// not be read as proof the mapping was deleted elsewhere.
+func (s *Server) persistVideoJobToRedis(ctx context.Context, videoID string, entry videoJobCacheEntry, ttl time.Duration) bool {
+	if s.redisClient == nil {
+		return false
+	}
+	payload, err := sonic.Marshal(entry)
+	if err != nil {
+		klog.ErrorS(err, "failed to marshal video job entry for redis", "videoID", videoID)
+		return false
+	}
+	if err := s.redisClient.Set(ctx, videoJobRedisKey(videoID), string(payload), ttl).Err(); err != nil {
+		klog.ErrorS(err, "failed to persist video job pod to redis", "videoID", videoID)
+		return false
+	}
+	return true
 }
 
 // rememberVideoJobPod stores videoID's owning pod locally and, when Redis is
@@ -166,19 +221,13 @@ func (s *Server) rememberVideoJobPod(ctx context.Context, videoID, podName, podN
 		Model:        model,
 		ExpiresAt:    time.Now().Add(ttl),
 	}
-	s.videoJobCache.Store(videoID, entry)
 
-	if s.redisClient == nil {
-		return
-	}
-	payload, err := sonic.Marshal(entry)
-	if err != nil {
-		klog.ErrorS(err, "failed to marshal video job entry for redis", "videoID", videoID)
-		return
-	}
-	if err := s.redisClient.Set(ctx, videoJobRedisKey(videoID), string(payload), ttl).Err(); err != nil {
-		klog.ErrorS(err, "failed to persist video job pod to redis", "videoID", videoID)
-	}
+	// Write-through to Redis before the local Store below: syncVideoJobCacheFromRedis
+	// walks locally-cached IDs and evicts unconfirmed entries when this fails, so
+	// storing locally first would open a window where a concurrent sync tick sees
+	// this videoID still missing from Redis and evicts/retries prematurely.
+	confirmed := s.persistVideoJobToRedis(ctx, videoID, entry, ttl)
+	s.videoJobCache.Store(videoID, videoJobCacheItem{entry: entry, confirmed: confirmed})
 }
 
 // lookupVideoJobPod returns the pod that owns videoID, or ok=false if the
@@ -186,11 +235,11 @@ func (s *Server) rememberVideoJobPod(ctx context.Context, videoID, podName, podN
 // A local miss falls back to Redis (cross-replica) and warms the local cache.
 func (s *Server) lookupVideoJobPod(ctx context.Context, videoID string) (podName, podNamespace, model string, ok bool) {
 	if cached, found := s.videoJobCache.Load(videoID); found {
-		entry, ok := cached.(videoJobCacheEntry)
-		if !ok {
+		item, itemOK := cached.(videoJobCacheItem)
+		if !itemOK {
 			s.videoJobCache.Delete(videoID)
-		} else if time.Now().Before(entry.ExpiresAt) {
-			return entry.PodName, entry.PodNamespace, entry.Model, true
+		} else if time.Now().Before(item.entry.ExpiresAt) {
+			return item.entry.PodName, item.entry.PodNamespace, item.entry.Model, true
 		} else {
 			s.videoJobCache.Delete(videoID)
 		}
@@ -217,7 +266,7 @@ func (s *Server) lookupVideoJobPod(ctx context.Context, videoID string) (podName
 		return "", "", "", false
 	}
 
-	s.videoJobCache.Store(videoID, entry)
+	s.videoJobCache.Store(videoID, videoJobCacheItem{entry: entry, confirmed: true})
 	return entry.PodName, entry.PodNamespace, entry.Model, true
 }
 

--- a/pkg/plugins/gateway/gateway_video_routing.go
+++ b/pkg/plugins/gateway/gateway_video_routing.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Aibrix Team.
+Copyright 2026 The Aibrix Team.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -301,11 +301,26 @@ func extractVideoIDFromPath(requestPath string) (videoID string, ok bool) {
 }
 
 // videoNotFoundResponse builds the 404 returned when a video_id is unknown,
-// expired, or its owning pod is no longer available.
+// expired, or its owning pod is confirmed gone (not found in cache, or
+// terminating). This is terminal: the mapping is forgotten before this is
+// returned, since the client has no reason to retry the same video_id.
 func videoNotFoundResponse(videoID string) *extProcPb.ProcessingResponse {
 	return buildErrorResponse(envoyTypePb.StatusCode_NotFound,
 		fmt.Sprintf("video %s not found", videoID), ErrorCodeVideoNotFound, "",
 		HeaderErrorVideoNotFound, "true")
+}
+
+// videoJobPodUnavailableResponse builds the 503 returned when a video_id's
+// owning pod is only transiently unavailable (NotReady, or no routable
+// address yet) rather than confirmed gone. Unlike videoNotFoundResponse, the
+// mapping is left in place so a retry can still land on the same pod once it
+// recovers -- the generated video lives on that pod's local disk, so pinning
+// elsewhere is not an option.
+func videoJobPodUnavailableResponse(videoID string) *extProcPb.ProcessingResponse {
+	return buildErrorResponse(envoyTypePb.StatusCode_ServiceUnavailable,
+		fmt.Sprintf("video %s's pod is temporarily unavailable, please retry", videoID),
+		ErrorCodeVideoJobPodUnavailable, "",
+		HeaderErrorVideoJobPodUnavailable, "true")
 }
 
 // parseVideoListRequest reports whether requestPath is the bare /v1/videos
@@ -526,18 +541,36 @@ func (s *Server) pinVideoJobSubResource(ctx context.Context, routingCtx *types.R
 	routingCtx.Model = model
 
 	pod, err := s.cache.GetPod(podName, podNamespace)
-	if err != nil || pod == nil || !utils.IsPodReady(pod) {
+	if err != nil || pod == nil {
+		// Not in the informer cache at all: as confirmed-gone as this gateway can
+		// observe. Forget the mapping so a later create can reuse videoID's slot
+		// (Redis keys are namespaced by videoID, not by pod).
 		s.forgetVideoJobPod(ctx, videoID)
 		klog.ErrorS(err, "video job's pod is no longer available", "requestID", requestID, "videoID", videoID, "podName", podName, "podNamespace", podNamespace)
 		return nil, model, term, videoNotFoundResponse(videoID)
+	}
+	if utils.IsPodTerminating(pod) {
+		// Has a DeletionTimestamp: won't come back under this name. Terminal,
+		// same as the cache-miss case above.
+		s.forgetVideoJobPod(ctx, videoID)
+		klog.ErrorS(nil, "video job's pod is terminating", "requestID", requestID, "videoID", videoID, "podName", podName, "podNamespace", podNamespace)
+		return nil, model, term, videoNotFoundResponse(videoID)
+	}
+	if !utils.IsPodReady(pod) {
+		// Pod exists and isn't being torn down -- a readiness flap, restart, or
+		// startup probe still pending. Keep the mapping: the video's own disk is
+		// still on this pod, and IsPodReady may well flip back on the next poll.
+		klog.InfoS("video job's pod is temporarily not ready, keeping mapping for retry", "requestID", requestID, "videoID", videoID, "podName", podName, "podNamespace", podNamespace)
+		return nil, model, term, videoJobPodUnavailableResponse(videoID)
 	}
 
 	routingCtx.SetTargetPod(pod)
 	targetPodIP := routingCtx.TargetAddress()
 	if targetPodIP == "" {
-		s.forgetVideoJobPod(ctx, videoID)
-		klog.ErrorS(nil, "video job's pod has no routable address", "requestID", requestID, "videoID", videoID, "podName", podName)
-		return nil, model, term, videoNotFoundResponse(videoID)
+		// Ready but not yet routable (e.g. IP not propagated to this cache entry):
+		// same reasoning as the NotReady branch above, keep the mapping.
+		klog.InfoS("video job's pod has no routable address yet, keeping mapping for retry", "requestID", requestID, "videoID", videoID, "podName", podName)
+		return nil, model, term, videoJobPodUnavailableResponse(videoID)
 	}
 
 	applyConfigProfile(routingCtx, []*v1.Pod{pod})

--- a/pkg/plugins/gateway/gateway_video_routing.go
+++ b/pkg/plugins/gateway/gateway_video_routing.go
@@ -470,7 +470,7 @@ func (s *Server) pinVideoJobSubResource(ctx context.Context, routingCtx *types.R
 	}
 
 	pod, err := s.cache.GetPod(podName, podNamespace)
-	if err != nil || !utils.IsPodReady(pod) {
+	if err != nil || pod == nil || !utils.IsPodReady(pod) {
 		s.forgetVideoJobPod(ctx, videoID)
 		klog.ErrorS(err, "video job's pod is no longer available", "requestID", requestID, "videoID", videoID, "podName", podName, "podNamespace", podNamespace)
 		return nil, model, term, videoNotFoundResponse(videoID)
@@ -519,7 +519,7 @@ func (s *Server) maybeForgetVideoJobAfterDelete(ctx context.Context, routerCtx *
 	if routerCtx == nil || routerCtx.ReqHeaders[methodKey] != http.MethodDelete {
 		return
 	}
-	if !((statusCode >= 200 && statusCode < 300) || statusCode == http.StatusNotFound) {
+	if (statusCode < 200 || statusCode >= 300) && statusCode != http.StatusNotFound {
 		return
 	}
 	videoID, ok := extractVideoIDFromPath(routerCtx.ReqPath)

--- a/pkg/plugins/gateway/gateway_video_routing.go
+++ b/pkg/plugins/gateway/gateway_video_routing.go
@@ -469,6 +469,13 @@ func (s *Server) pinVideoJobSubResource(ctx context.Context, routingCtx *types.R
 		return nil, "", term, videoNotFoundResponse(videoID)
 	}
 
+	// Set as soon as the model is known (even on the error returns below) so
+	// gateway.go's st.model, taken from this same routingCtx, isn't left empty --
+	// an empty model there skips emitMetricsCounterHelper(GatewayRequestModelFailTotal),
+	// which would otherwise make stale/rescheduled-pod failures invisible to
+	// gateway_request_fail metrics.
+	routingCtx.Model = model
+
 	pod, err := s.cache.GetPod(podName, podNamespace)
 	if err != nil || pod == nil || !utils.IsPodReady(pod) {
 		s.forgetVideoJobPod(ctx, videoID)
@@ -476,7 +483,6 @@ func (s *Server) pinVideoJobSubResource(ctx context.Context, routingCtx *types.R
 		return nil, model, term, videoNotFoundResponse(videoID)
 	}
 
-	routingCtx.Model = model
 	routingCtx.SetTargetPod(pod)
 	targetPodIP := routingCtx.TargetAddress()
 	if targetPodIP == "" {

--- a/pkg/plugins/gateway/gateway_video_routing_test.go
+++ b/pkg/plugins/gateway/gateway_video_routing_test.go
@@ -1,0 +1,728 @@
+/*
+Copyright 2024 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/bytedance/sonic"
+	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"go.opentelemetry.io/otel/trace"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils"
+)
+
+func newTestVideoJobRedisServer(t *testing.T) (*Server, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return &Server{redisClient: client}, mr
+}
+
+func TestExtractVideoIDFromPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		wantID string
+		wantOK bool
+	}{
+		{"base list/create path has no id", "/v1/videos", "", false},
+		{"sync path is not an id", "/v1/videos/sync", "", false},
+		{"status poll", "/v1/videos/video_gen_abc123", "video_gen_abc123", true},
+		{"content download", "/v1/videos/video_gen_abc123/content", "video_gen_abc123", true},
+		{"status poll with query", "/v1/videos/video_gen_abc123?foo=bar", "video_gen_abc123", true},
+		{"content download with variant query", "/v1/videos/video_gen_abc123/content?variant=mp4", "video_gen_abc123", true},
+		{"trailing slash with empty id", "/v1/videos/", "", false},
+		{"unrelated path", "/v1/chat/completions", "", false},
+		{"unrelated path sharing prefix", "/v1/videosomethingelse", "", false},
+		{"nested sub-path beyond content still extracts leading id", "/v1/videos/video_gen_abc123/content/extra", "video_gen_abc123", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotOK := extractVideoIDFromPath(tt.path)
+			assert.Equal(t, tt.wantOK, gotOK)
+			assert.Equal(t, tt.wantID, gotID)
+		})
+	}
+}
+
+func TestVideoJobRedisKey(t *testing.T) {
+	assert.Equal(t, "aibrix:gateway:video_job:video-1", videoJobRedisKey("video-1"))
+}
+
+// TestServer_VideoJobPodTracking exercises the local-cache-only path (redisClient
+// is nil, matching standalone/local dev mode) -- every redis-touching branch in
+// rememberVideoJobPod/lookupVideoJobPod/forgetVideoJobPod short-circuits on that
+// nil check. Redis-backed cross-replica behavior itself is covered separately by
+// the TestSyncVideoJobCacheFromRedis_* tests below, which use a real (miniredis)
+// client.
+func TestServer_VideoJobPodTracking(t *testing.T) {
+	s := &Server{}
+	ctx := context.Background()
+
+	// Unknown id.
+	_, _, _, ok := s.lookupVideoJobPod(ctx, "missing")
+	assert.False(t, ok)
+
+	// Set then get.
+	s.rememberVideoJobPod(ctx, "video-1", "pod-a", "ns-a", "wan2.1-vace-1.3b", time.Hour)
+	podName, podNamespace, model, ok := s.lookupVideoJobPod(ctx, "video-1")
+	assert.True(t, ok)
+	assert.Equal(t, "pod-a", podName)
+	assert.Equal(t, "ns-a", podNamespace)
+	assert.Equal(t, "wan2.1-vace-1.3b", model)
+
+	// Non-positive TTL falls back to the default rather than being treated as
+	// "already expired".
+	s.rememberVideoJobPod(ctx, "video-2", "pod-b", "ns-b", "m", 0)
+	_, _, _, ok = s.lookupVideoJobPod(ctx, "video-2")
+	assert.True(t, ok)
+
+	// Expired entries are evicted on read. rememberVideoJobPod itself can't produce
+	// an already-expired entry (it coerces ttl<=0 to the default, per the video-2
+	// case above), so store one directly to exercise the expiry path.
+	s.videoJobCache.Store("video-3", videoJobCacheEntry{
+		PodName: "pod-c", PodNamespace: "ns-c", Model: "m",
+		ExpiresAt: time.Now().Add(-time.Second),
+	})
+	_, _, _, ok = s.lookupVideoJobPod(ctx, "video-3")
+	assert.False(t, ok)
+	_, found := s.videoJobCache.Load("video-3")
+	assert.False(t, found, "expired entry should have been evicted on read")
+
+	// Explicit forget.
+	s.forgetVideoJobPod(ctx, "video-1")
+	_, _, _, ok = s.lookupVideoJobPod(ctx, "video-1")
+	assert.False(t, ok)
+
+	// Empty videoID/podName are no-ops, not stored.
+	s.rememberVideoJobPod(ctx, "", "pod-x", "ns-x", "m", time.Hour)
+	s.rememberVideoJobPod(ctx, "video-4", "", "ns-x", "m", time.Hour)
+	_, _, _, ok = s.lookupVideoJobPod(ctx, "")
+	assert.False(t, ok)
+	_, _, _, ok = s.lookupVideoJobPod(ctx, "video-4")
+	assert.False(t, ok)
+}
+
+func readyPod(name, namespace, ip string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Status: v1.PodStatus{
+			PodIP:      ip,
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+		},
+	}
+}
+
+// TestHandleVideoJobSubResourceHeaders_PinsKnownJob covers the fix for the bug
+// where a GET/DELETE video sub-resource request with no body never got pinned
+// to its owning pod: Envoy's ext_proc filter (request_body_mode: BUFFERED)
+// never sends a RequestBody message for a bodyless request, so pinning must
+// happen at RequestHeaders instead of (only) RequestBody.
+func TestHandleVideoJobSubResourceHeaders_PinsKnownJob(t *testing.T) {
+	mockCache := new(MockCache)
+	s := &Server{cache: mockCache}
+	ctx := context.Background()
+
+	s.rememberVideoJobPod(ctx, "video-1", "pod-a", "ns-a", "wan2.1-vace-1.3b", time.Hour)
+
+	pod := readyPod("pod-a", "ns-a", "10.0.0.5")
+	mockCache.On("GetPod", "pod-a", "ns-a").Return(pod, nil)
+	mockCache.On("AddRequestCount", mock.Anything, "req-1", "wan2.1-vace-1.3b").Return(int64(7))
+
+	routingCtx := types.NewRoutingContext(ctx, "", "", "", "req-1", "")
+	routingCtx.ReqHeaders = map[string]string{methodKey: "GET"}
+
+	resp, term := s.handleVideoJobSubResourceHeaders(ctx, routingCtx, "req-1", "/v1/videos/video-1", "video-1")
+
+	require.NotNil(t, resp.GetRequestHeaders())
+	assert.Nil(t, resp.GetImmediateResponse())
+	assert.EqualValues(t, 7, term)
+
+	headersResp := resp.GetRequestHeaders().GetResponse()
+	assert.True(t, headersResp.GetClearRouteCache(), "must clear route cache so Envoy re-evaluates the routing-strategy header match")
+
+	set := headersResp.GetHeaderMutation().GetSetHeaders()
+	assertHeaderRawValue(t, set, HeaderRoutingStrategy, videoJobAffinityLabel)
+	assertHeaderRawValue(t, set, HeaderTargetPod, "10.0.0.5:8000")
+
+	mockCache.AssertExpectations(t)
+}
+
+// TestHandleVideoJobSubResourceHeaders_UnknownVideoReturns404 verifies an
+// unknown/expired video_id still gets a proper 404 (not a hang or a bare
+// route-not-found from Envoy) when resolved at the headers phase.
+func TestHandleVideoJobSubResourceHeaders_UnknownVideoReturns404(t *testing.T) {
+	s := &Server{cache: new(MockCache)}
+	ctx := context.Background()
+	routingCtx := types.NewRoutingContext(ctx, "", "", "", "req-1", "")
+	routingCtx.ReqHeaders = map[string]string{methodKey: "GET"}
+
+	resp, term := s.handleVideoJobSubResourceHeaders(ctx, routingCtx, "req-1", "/v1/videos/does-not-exist", "does-not-exist")
+
+	require.NotNil(t, resp.GetImmediateResponse())
+	assert.Equal(t, envoyTypePb.StatusCode_NotFound, resp.GetImmediateResponse().GetStatus().GetCode())
+	assert.EqualValues(t, 0, term)
+}
+
+// TestHandleRequestHeaders_VideoStatusPoll_Bodyless reproduces the reported
+// gateway bug end-to-end through the real entry point: a GET status-poll
+// request with EndOfStream=true (Envoy's signal that no body follows) must be
+// pinned to its owning pod during header processing, since HandleRequestBody
+// will never be invoked for it.
+func TestHandleRequestHeaders_VideoStatusPoll_Bodyless(t *testing.T) {
+	mockCache := new(MockCache)
+	s := &Server{cache: mockCache}
+	ctx := context.Background()
+
+	s.rememberVideoJobPod(ctx, "video-1", "pod-a", "ns-a", "wan2.1-vace-1.3b", time.Hour)
+	pod := readyPod("pod-a", "ns-a", "10.0.0.5")
+	mockCache.On("GetPod", "pod-a", "ns-a").Return(pod, nil)
+	mockCache.On("AddRequestCount", mock.Anything, mock.Anything, "wan2.1-vace-1.3b").Return(int64(1))
+
+	req := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extProcPb.HttpHeaders{
+				Headers: &configPb.HeaderMap{Headers: []*configPb.HeaderValue{
+					{Key: pathKey, RawValue: []byte("/v1/videos/video-1")},
+					{Key: methodKey, RawValue: []byte("GET")},
+				}},
+				EndOfStream: true,
+			},
+		},
+	}
+
+	rootSpan := trace.SpanFromContext(ctx)
+	resp, _, _, routingCtx, term := s.HandleRequestHeaders(ctx, "req-1", rootSpan, req)
+
+	require.NotNil(t, resp.GetRequestHeaders(), "GET with no body must be pinned at the headers phase, not left for a body message that never arrives")
+	assert.EqualValues(t, 1, term)
+	set := resp.GetRequestHeaders().GetResponse().GetHeaderMutation().GetSetHeaders()
+	assertHeaderRawValue(t, set, HeaderRoutingStrategy, videoJobAffinityLabel)
+	assertHeaderRawValue(t, set, HeaderTargetPod, "10.0.0.5:8000")
+	assert.Equal(t, "wan2.1-vace-1.3b", routingCtx.Model)
+
+	mockCache.AssertExpectations(t)
+}
+
+// TestHandleRequestHeaders_VideoStatusPoll_WithBody ensures the new
+// EndOfStream-gated header-phase pinning doesn't fire when a body IS coming
+// (EndOfStream false): that case is left to HandleRequestBody, unchanged, so
+// this must NOT pin at headers time or set routing headers.
+func TestHandleRequestHeaders_VideoStatusPoll_WithBody(t *testing.T) {
+	mockCache := new(MockCache)
+	s := &Server{cache: mockCache}
+	ctx := context.Background()
+	s.rememberVideoJobPod(ctx, "video-1", "pod-a", "ns-a", "wan2.1-vace-1.3b", time.Hour)
+
+	req := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extProcPb.HttpHeaders{
+				Headers: &configPb.HeaderMap{Headers: []*configPb.HeaderValue{
+					{Key: pathKey, RawValue: []byte("/v1/videos/video-1")},
+					{Key: methodKey, RawValue: []byte("DELETE")},
+				}},
+				EndOfStream: false,
+			},
+		},
+	}
+
+	rootSpan := trace.SpanFromContext(ctx)
+	resp, _, _, routingCtx, term := s.HandleRequestHeaders(ctx, "req-1", rootSpan, req)
+
+	require.NotNil(t, resp.GetRequestHeaders())
+	assert.EqualValues(t, 0, term)
+	set := resp.GetRequestHeaders().GetResponse().GetHeaderMutation().GetSetHeaders()
+	for _, h := range set {
+		assert.NotEqual(t, HeaderRoutingStrategy, h.GetHeader().GetKey(), "pinning must be deferred to the body phase when a body is coming")
+		assert.NotEqual(t, HeaderTargetPod, h.GetHeader().GetKey())
+	}
+	assert.Equal(t, "", routingCtx.Model)
+
+	mockCache.AssertNotCalled(t, "GetPod", mock.Anything, mock.Anything)
+}
+
+func assertHeaderRawValue(t *testing.T, headers []*configPb.HeaderValueOption, key, want string) {
+	t.Helper()
+	for _, h := range headers {
+		if h.GetHeader().GetKey() == key {
+			assert.Equal(t, want, string(h.GetHeader().GetRawValue()))
+			return
+		}
+	}
+	t.Errorf("header %q not found in %v", key, headers)
+}
+
+// TestSyncVideoJobCacheFromRedis_RefreshesChangedEntry covers the case this sync
+// exists for: a different replica updated (or re-created) the Redis mapping --
+// here simulated by writing a different pod directly to Redis -- and this
+// replica's stale local copy must pick up the change without waiting for its
+// own (possibly days-long) local ExpiresAt.
+func TestSyncVideoJobCacheFromRedis_RefreshesChangedEntry(t *testing.T) {
+	s, _ := newTestVideoJobRedisServer(t)
+	ctx := context.Background()
+
+	s.rememberVideoJobPod(ctx, "video-1", "pod-old", "ns-a", "m", time.Hour)
+
+	fresh := videoJobCacheEntry{PodName: "pod-new", PodNamespace: "ns-b", Model: "m", ExpiresAt: time.Now().Add(time.Hour)}
+	payload, err := sonic.Marshal(fresh)
+	require.NoError(t, err)
+	require.NoError(t, s.redisClient.Set(ctx, videoJobRedisKey("video-1"), string(payload), time.Hour).Err())
+
+	s.syncVideoJobCacheFromRedis()
+
+	podName, podNamespace, _, ok := s.lookupVideoJobPod(ctx, "video-1")
+	require.True(t, ok)
+	assert.Equal(t, "pod-new", podName)
+	assert.Equal(t, "ns-b", podNamespace)
+}
+
+// TestSyncVideoJobCacheFromRedis_EvictsRedisMiss covers the DELETE/pod-gone
+// cross-replica case directly: another replica's forgetVideoJobPod removed the
+// Redis key, and this replica's local (not-yet-expired) copy must be evicted on
+// the next sync rather than continuing to serve/pin against it.
+func TestSyncVideoJobCacheFromRedis_EvictsRedisMiss(t *testing.T) {
+	s, _ := newTestVideoJobRedisServer(t)
+
+	// Store locally without ever writing to Redis, standing in for "some other
+	// replica already called forgetVideoJobPod and deleted the Redis key".
+	s.videoJobCache.Store("video-2", videoJobCacheEntry{
+		PodName: "pod-a", PodNamespace: "ns-a", Model: "m", ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	s.syncVideoJobCacheFromRedis()
+
+	_, found := s.videoJobCache.Load("video-2")
+	assert.False(t, found, "local entry must be evicted once Redis no longer has it")
+}
+
+// TestSyncVideoJobCacheFromRedis_LeavesLocalCacheUntouchedOnRedisError ensures a
+// Redis outage during the periodic sync doesn't get misread as "every key is
+// missing": that would wipe every replica's local cache (and, if it also
+// deleted from Redis, cascade into deleting jobs cluster-wide) over a transient
+// connectivity blip rather than a real forget/delete.
+func TestSyncVideoJobCacheFromRedis_LeavesLocalCacheUntouchedOnRedisError(t *testing.T) {
+	s, mr := newTestVideoJobRedisServer(t)
+	ctx := context.Background()
+
+	s.rememberVideoJobPod(ctx, "video-3", "pod-a", "ns-a", "m", time.Hour)
+	mr.Close()
+
+	s.syncVideoJobCacheFromRedis()
+
+	cached, found := s.videoJobCache.Load("video-3")
+	require.True(t, found, "local entry must survive a whole-batch redis error")
+	assert.Equal(t, "pod-a", cached.(videoJobCacheEntry).PodName)
+}
+
+func TestParseVideoListRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		wantModel  string
+		wantIsList bool
+	}{
+		{"list with model", "/v1/videos?model=wan2.1", "wan2.1", true},
+		{"list without model", "/v1/videos", "", true},
+		{"list with empty model param", "/v1/videos?model=", "", true},
+		{"list with other params first", "/v1/videos?foo=bar&model=wan2.1", "wan2.1", true},
+		{"sub-resource path is not the list", "/v1/videos/video-1", "", false},
+		{"sync path is not the list", "/v1/videos/sync", "", false},
+		{"unrelated path", "/v1/chat/completions", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model, isList := parseVideoListRequest(tt.path)
+			assert.Equal(t, tt.wantIsList, isList)
+			assert.Equal(t, tt.wantModel, model)
+		})
+	}
+}
+
+func podWithPortLabel(name, ip string, port int) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{constants.ModelLabelPort: strconv.Itoa(port)},
+		},
+		Status: v1.PodStatus{
+			PodIP:      ip,
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+		},
+	}
+}
+
+func TestPodAddress(t *testing.T) {
+	pod := podWithPortLabel("pod-a", "10.0.0.5", 9000)
+	assert.Equal(t, "10.0.0.5:9000", podAddress("req-1", "some-model", pod))
+}
+
+func TestExtractVideoListItems(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"openai-style envelope", `{"object":"list","data":[{"id":"v1"},{"id":"v2"}]}`, 2},
+		{"bare top-level array", `[{"id":"v1"}]`, 1},
+		{"empty envelope", `{"object":"list","data":[]}`, 0},
+		{"malformed body", `not json`, 0},
+		{"unrelated shape", `{"status":"ok"}`, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items := extractVideoListItems([]byte(tt.body))
+			assert.Len(t, items, tt.want)
+		})
+	}
+}
+
+// videoListPod starts an httptest server standing in for a single vLLM-Omni
+// pod's own GET /v1/videos endpoint, and returns a *v1.Pod whose
+// model.aibrix.ai/port label points podAddress at that server.
+func videoListPod(t *testing.T, name string, handler http.HandlerFunc) *v1.Pod {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	_, portStr, err := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, err)
+	var port int
+	_, err = fmt.Sscanf(portStr, "%d", &port)
+	require.NoError(t, err)
+	return podWithPortLabel(name, "127.0.0.1", port)
+}
+
+// TestHandleVideoListHeaders_FanOutMergesAcrossPods is the core coverage for
+// the fan-out design: GET /v1/videos?model=X has no video_id to pin on and no
+// single owning pod (each pod only knows about jobs it created locally), so
+// the gateway itself queries every ready pod for the model and merges their
+// individual lists into one response -- this verifies that merge actually
+// happens across more than one pod, and that a slow/erroring pod doesn't
+// block or fail the whole request.
+func TestHandleVideoListHeaders_FanOutMergesAcrossPods(t *testing.T) {
+	podA := videoListPod(t, "pod-a", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, PathVideos, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"video-a1"},{"id":"video-a2"}]}`))
+	})
+	podB := videoListPod(t, "pod-b", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"video-b1"}]}`))
+	})
+	podErr := videoListPod(t, "pod-err", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	mockCache := new(MockCache)
+	mockCache.On("HasModel", "wan2.1").Return(true)
+	mockCache.On("ListPodsByModel", "wan2.1").Return(types.PodList(&utils.PodArray{Pods: []*v1.Pod{podA, podB, podErr}}), nil)
+
+	s := &Server{cache: mockCache}
+	resp := s.handleVideoListHeaders("req-1", "wan2.1")
+
+	imm := resp.GetImmediateResponse()
+	require.NotNil(t, imm)
+	assert.Equal(t, envoyTypePb.StatusCode_OK, imm.GetStatus().GetCode())
+
+	ids := gjson.GetBytes([]byte(imm.GetBody()), "data.#.id").Array()
+	gotIDs := make([]string, len(ids))
+	for i, id := range ids {
+		gotIDs[i] = id.String()
+	}
+	assert.ElementsMatch(t, []string{"video-a1", "video-a2", "video-b1"}, gotIDs,
+		"merged list must include every successful pod's jobs and skip the erroring one, not fail the whole request")
+
+	mockCache.AssertExpectations(t)
+}
+
+func TestHandleVideoListHeaders_AllPodsFailReturnsServiceUnavailable(t *testing.T) {
+	podA := videoListPod(t, "pod-a", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	podB := videoListPod(t, "pod-b", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	mockCache := new(MockCache)
+	mockCache.On("HasModel", "wan2.1").Return(true)
+	mockCache.On("ListPodsByModel", "wan2.1").Return(types.PodList(&utils.PodArray{Pods: []*v1.Pod{podA, podB}}), nil)
+
+	s := &Server{cache: mockCache}
+	resp := s.handleVideoListHeaders("req-1", "wan2.1")
+
+	imm := resp.GetImmediateResponse()
+	require.NotNil(t, imm)
+	assert.Equal(t, envoyTypePb.StatusCode_ServiceUnavailable, imm.GetStatus().GetCode(),
+		"total fan-out failure must not look like an empty job list")
+
+	mockCache.AssertExpectations(t)
+}
+
+func TestHandleVideoListHeaders_SuccessfulEmptyListIsOK(t *testing.T) {
+	podA := videoListPod(t, "pod-a", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	})
+
+	mockCache := new(MockCache)
+	mockCache.On("HasModel", "wan2.1").Return(true)
+	mockCache.On("ListPodsByModel", "wan2.1").Return(types.PodList(&utils.PodArray{Pods: []*v1.Pod{podA}}), nil)
+
+	s := &Server{cache: mockCache}
+	resp := s.handleVideoListHeaders("req-1", "wan2.1")
+
+	imm := resp.GetImmediateResponse()
+	require.NotNil(t, imm)
+	assert.Equal(t, envoyTypePb.StatusCode_OK, imm.GetStatus().GetCode())
+	assert.Equal(t, 0, len(gjson.GetBytes([]byte(imm.GetBody()), "data").Array()))
+
+	mockCache.AssertExpectations(t)
+}
+
+func TestHandleVideoListHeaders_SkipsNonRoutablePods(t *testing.T) {
+	podReady := videoListPod(t, "pod-ready", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"video-ready"}]}`))
+	})
+	podNotReady := videoListPod(t, "pod-not-ready", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("non-routable pod must not be contacted")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	podNotReady.Status.Conditions = nil
+
+	mockCache := new(MockCache)
+	mockCache.On("HasModel", "wan2.1").Return(true)
+	mockCache.On("ListPodsByModel", "wan2.1").Return(types.PodList(&utils.PodArray{Pods: []*v1.Pod{podReady, podNotReady}}), nil)
+
+	s := &Server{cache: mockCache}
+	resp := s.handleVideoListHeaders("req-1", "wan2.1")
+
+	imm := resp.GetImmediateResponse()
+	require.NotNil(t, imm)
+	assert.Equal(t, envoyTypePb.StatusCode_OK, imm.GetStatus().GetCode())
+	ids := gjson.GetBytes([]byte(imm.GetBody()), "data.#.id").Array()
+	require.Len(t, ids, 1)
+	assert.Equal(t, "video-ready", ids[0].String())
+
+	mockCache.AssertExpectations(t)
+}
+
+func TestHandleVideoListHeaders_UnknownModelReturnsError(t *testing.T) {
+	mockCache := new(MockCache)
+	mockCache.On("HasModel", "does-not-exist").Return(false)
+
+	s := &Server{cache: mockCache}
+	resp := s.handleVideoListHeaders("req-1", "does-not-exist")
+
+	imm := resp.GetImmediateResponse()
+	require.NotNil(t, imm)
+	assert.Equal(t, envoyTypePb.StatusCode_BadRequest, imm.GetStatus().GetCode())
+}
+
+// TestHandleRequestHeaders_VideoList_RequiresModel covers the real entry
+// point: GET /v1/videos with no `model` query parameter must 400 rather than
+// silently routing nowhere (the bug this endpoint had before the fan-out was
+// added -- see extractVideoIDFromPath, which never matched the bare list path).
+func TestHandleRequestHeaders_VideoList_RequiresModel(t *testing.T) {
+	s := &Server{cache: new(MockCache)}
+	req := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extProcPb.HttpHeaders{
+				Headers: &configPb.HeaderMap{Headers: []*configPb.HeaderValue{
+					{Key: pathKey, RawValue: []byte("/v1/videos")},
+					{Key: methodKey, RawValue: []byte("GET")},
+				}},
+				EndOfStream: true,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	rootSpan := trace.SpanFromContext(ctx)
+	resp, _, _, _, _ := s.HandleRequestHeaders(ctx, "req-1", rootSpan, req)
+
+	imm := resp.GetImmediateResponse()
+	require.NotNil(t, imm)
+	assert.Equal(t, envoyTypePb.StatusCode_BadRequest, imm.GetStatus().GetCode())
+}
+
+func TestIsMultipartFormPath(t *testing.T) {
+	assert.True(t, isMultipartFormPath(PathVideos))
+	assert.True(t, isMultipartFormPath(PathVideos+"?foo=bar"))
+	assert.True(t, isMultipartFormPath(PathVideosSync))
+	assert.True(t, isMultipartFormPath(PathAudioTranscriptions))
+	assert.False(t, isMultipartFormPath(PathVideos+"/video-1"))
+	assert.False(t, isMultipartFormPath(PathChatCompletions))
+}
+
+func TestRecordVideoJobPodFromResponse_BuffersUntilEnd(t *testing.T) {
+	s := &Server{}
+	ctx := context.Background()
+	requestID := "req-record-1"
+	t.Cleanup(func() { requestBuffers.Delete(requestID) })
+
+	pod := readyPod("pod-a", "ns-a", "10.0.0.5")
+	routerCtx := types.NewRoutingContext(ctx, "", "wan2.1", "", requestID, "")
+	routerCtx.ReqPath = PathVideos
+	routerCtx.SetTargetPod(pod)
+
+	expires := time.Now().Add(time.Hour).Unix()
+	full := fmt.Sprintf(`{"id":"video-1","expires_at":%d}`, expires)
+	mid := len(full) / 2
+
+	s.recordVideoJobPodFromResponse(ctx, requestID, routerCtx, &extProcPb.ProcessingRequest_ResponseBody{
+		ResponseBody: &extProcPb.HttpBody{Body: []byte(full[:mid])},
+	})
+	_, _, _, ok := s.lookupVideoJobPod(ctx, "video-1")
+	assert.False(t, ok, "must not record until EndOfStream")
+
+	s.recordVideoJobPodFromResponse(ctx, requestID, routerCtx, &extProcPb.ProcessingRequest_ResponseBody{
+		ResponseBody: &extProcPb.HttpBody{Body: []byte(full[mid:]), EndOfStream: true},
+	})
+	podName, ns, model, ok := s.lookupVideoJobPod(ctx, "video-1")
+	require.True(t, ok)
+	assert.Equal(t, "pod-a", podName)
+	assert.Equal(t, "ns-a", ns)
+	assert.Equal(t, "wan2.1", model)
+}
+
+func TestHandleResponseBody_RecordsVideoJobWithQueryOnPath(t *testing.T) {
+	s := &Server{}
+	ctx := context.Background()
+	requestID := "req-record-query"
+	t.Cleanup(func() { requestBuffers.Delete(requestID) })
+
+	pod := readyPod("pod-a", "ns-a", "10.0.0.5")
+	routerCtx := types.NewRoutingContext(ctx, "", "wan2.1", "", requestID, "")
+	routerCtx.ReqPath = PathVideos + "?foo=bar"
+	routerCtx.RequestTime = time.Now()
+	routerCtx.SetTargetPod(pod)
+
+	req := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body:        []byte(`{"id":"video-query-1"}`),
+				EndOfStream: true,
+			},
+		},
+	}
+	_, complete, _ := s.HandleResponseBody(ctx, routerCtx, requestID, req, utils.User{}, 0, "wan2.1", false, false)
+	assert.True(t, complete)
+
+	podName, _, _, ok := s.lookupVideoJobPod(ctx, "video-query-1")
+	require.True(t, ok, "POST /v1/videos?… must still record the owning pod")
+	assert.Equal(t, "pod-a", podName)
+}
+
+func TestHandleVideoJobSubResourceHeaders_DeleteKeepsMappingUntilResponse(t *testing.T) {
+	mockCache := new(MockCache)
+	s := &Server{cache: mockCache}
+	ctx := context.Background()
+
+	s.rememberVideoJobPod(ctx, "video-1", "pod-a", "ns-a", "wan2.1-vace-1.3b", time.Hour)
+	pod := readyPod("pod-a", "ns-a", "10.0.0.5")
+	mockCache.On("GetPod", "pod-a", "ns-a").Return(pod, nil)
+	mockCache.On("AddRequestCount", mock.Anything, "req-1", "wan2.1-vace-1.3b").Return(int64(1))
+
+	routingCtx := types.NewRoutingContext(ctx, "", "", "", "req-1", "")
+	routingCtx.ReqPath = "/v1/videos/video-1"
+	routingCtx.ReqHeaders = map[string]string{methodKey: http.MethodDelete}
+
+	resp, _ := s.handleVideoJobSubResourceHeaders(ctx, routingCtx, "req-1", "/v1/videos/video-1", "video-1")
+	require.NotNil(t, resp.GetRequestHeaders())
+	_, _, _, ok := s.lookupVideoJobPod(ctx, "video-1")
+	assert.True(t, ok, "DELETE must not evict the mapping until the backend responds")
+
+	headerReq := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseHeaders{
+			ResponseHeaders: &extProcPb.HttpHeaders{
+				Headers: &configPb.HeaderMap{Headers: []*configPb.HeaderValue{
+					{Key: ":status", RawValue: []byte("500")},
+				}},
+			},
+		},
+	}
+	_, isErr, code := s.HandleResponseHeaders(ctx, routingCtx, "req-1", "wan2.1-vace-1.3b", headerReq)
+	assert.True(t, isErr)
+	assert.Equal(t, 500, code)
+	_, _, _, ok = s.lookupVideoJobPod(ctx, "video-1")
+	assert.True(t, ok, "5xx delete must leave the mapping so the client can retry")
+
+	headerReq = &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseHeaders{
+			ResponseHeaders: &extProcPb.HttpHeaders{
+				Headers: &configPb.HeaderMap{Headers: []*configPb.HeaderValue{
+					{Key: ":status", RawValue: []byte("204")},
+				}},
+			},
+		},
+	}
+	_, isErr, _ = s.HandleResponseHeaders(ctx, routingCtx, "req-1", "wan2.1-vace-1.3b", headerReq)
+	assert.False(t, isErr)
+	_, _, _, ok = s.lookupVideoJobPod(ctx, "video-1")
+	assert.False(t, ok, "2xx delete must evict the mapping")
+
+	mockCache.AssertExpectations(t)
+}
+
+func TestMaybeForgetVideoJobAfterDelete_EvictsOn404(t *testing.T) {
+	s := &Server{}
+	ctx := context.Background()
+	s.rememberVideoJobPod(ctx, "video-1", "pod-a", "ns-a", "m", time.Hour)
+
+	routingCtx := types.NewRoutingContext(ctx, "", "m", "", "req-1", "")
+	routingCtx.ReqPath = "/v1/videos/video-1?unused=1"
+	routingCtx.ReqHeaders = map[string]string{methodKey: http.MethodDelete}
+
+	s.maybeForgetVideoJobAfterDelete(ctx, routingCtx, http.StatusNotFound)
+	_, _, _, ok := s.lookupVideoJobPod(ctx, "video-1")
+	assert.False(t, ok)
+}
+
+func TestFetchPodVideoList_RejectsOversizedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(bytes.Repeat([]byte("a"), videoListFanoutMaxBodyBytes+1))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := fetchPodVideoList(context.Background(), strings.TrimPrefix(srv.URL, "http://"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}

--- a/pkg/plugins/gateway/gateway_video_routing_test.go
+++ b/pkg/plugins/gateway/gateway_video_routing_test.go
@@ -19,6 +19,7 @@ package gateway
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -199,6 +200,35 @@ func TestHandleVideoJobSubResourceHeaders_UnknownVideoReturns404(t *testing.T) {
 	require.NotNil(t, resp.GetImmediateResponse())
 	assert.Equal(t, envoyTypePb.StatusCode_NotFound, resp.GetImmediateResponse().GetStatus().GetCode())
 	assert.EqualValues(t, 0, term)
+}
+
+// TestHandleVideoJobSubResourceHeaders_PodUnavailableSetsModelForMetrics covers
+// the case where the video_id is known but its owning pod is no longer
+// available (stale/rescheduled pod). Before the fix, routingCtx.Model was only
+// set on the success path, so gateway.go's st.model (taken from this same
+// routingCtx) stayed empty and the caller's if st.model == "" check silently
+// skipped emitMetricsCounterHelper(GatewayRequestModelFailTotal, ...),
+// undercounting this failure mode in gateway_request_fail metrics even though
+// the client still correctly got a 404.
+func TestHandleVideoJobSubResourceHeaders_PodUnavailableSetsModelForMetrics(t *testing.T) {
+	mockCache := new(MockCache)
+	s := &Server{cache: mockCache}
+	ctx := context.Background()
+
+	s.rememberVideoJobPod(ctx, "video-1", "pod-a", "ns-a", "wan2.1-vace-1.3b", time.Hour)
+	mockCache.On("GetPod", "pod-a", "ns-a").Return((*v1.Pod)(nil), errors.New("pod not found"))
+
+	routingCtx := types.NewRoutingContext(ctx, "", "", "", "req-1", "")
+	routingCtx.ReqHeaders = map[string]string{methodKey: "GET"}
+
+	resp, term := s.handleVideoJobSubResourceHeaders(ctx, routingCtx, "req-1", "/v1/videos/video-1", "video-1")
+
+	require.NotNil(t, resp.GetImmediateResponse())
+	assert.Equal(t, envoyTypePb.StatusCode_NotFound, resp.GetImmediateResponse().GetStatus().GetCode())
+	assert.EqualValues(t, 0, term)
+	assert.Equal(t, "wan2.1-vace-1.3b", routingCtx.Model, "model must be attributed on routingCtx even when the pod lookup fails, so the fail-metric isn't silently dropped")
+
+	mockCache.AssertExpectations(t)
 }
 
 // TestHandleRequestHeaders_VideoStatusPoll_Bodyless reproduces the reported

--- a/pkg/plugins/gateway/gateway_video_routing_test.go
+++ b/pkg/plugins/gateway/gateway_video_routing_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Aibrix Team.
+Copyright 2026 The Aibrix Team.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -227,6 +227,69 @@ func TestHandleVideoJobSubResourceHeaders_PodUnavailableSetsModelForMetrics(t *t
 	assert.Equal(t, envoyTypePb.StatusCode_NotFound, resp.GetImmediateResponse().GetStatus().GetCode())
 	assert.EqualValues(t, 0, term)
 	assert.Equal(t, "wan2.1-vace-1.3b", routingCtx.Model, "model must be attributed on routingCtx even when the pod lookup fails, so the fail-metric isn't silently dropped")
+
+	mockCache.AssertExpectations(t)
+}
+
+// TestHandleVideoJobSubResourceHeaders_NotReadyPodReturns503AndKeepsMapping
+// covers a transiently unavailable pod (readiness flap, restart, startup
+// probe still pending): before the fix this was indistinguishable from a
+// confirmed-gone pod, evicted the mapping, and returned a permanent-looking
+// 404. It must now return a retryable 503 and leave the mapping intact so a
+// follow-up poll can still land on the same pod once it recovers.
+func TestHandleVideoJobSubResourceHeaders_NotReadyPodReturns503AndKeepsMapping(t *testing.T) {
+	mockCache := new(MockCache)
+	s := &Server{cache: mockCache}
+	ctx := context.Background()
+
+	s.rememberVideoJobPod(ctx, "video-1", "pod-a", "ns-a", "wan2.1-vace-1.3b", time.Hour)
+
+	notReadyPod := readyPod("pod-a", "ns-a", "10.0.0.5")
+	notReadyPod.Status.Conditions = nil
+	mockCache.On("GetPod", "pod-a", "ns-a").Return(notReadyPod, nil)
+
+	routingCtx := types.NewRoutingContext(ctx, "", "", "", "req-1", "")
+	routingCtx.ReqHeaders = map[string]string{methodKey: "GET"}
+
+	resp, term := s.handleVideoJobSubResourceHeaders(ctx, routingCtx, "req-1", "/v1/videos/video-1", "video-1")
+
+	require.NotNil(t, resp.GetImmediateResponse())
+	assert.Equal(t, envoyTypePb.StatusCode_ServiceUnavailable, resp.GetImmediateResponse().GetStatus().GetCode())
+	assert.EqualValues(t, 0, term)
+
+	_, _, _, ok := s.lookupVideoJobPod(ctx, "video-1")
+	assert.True(t, ok, "mapping must survive a transient NotReady pod so a retry can still resolve it")
+
+	mockCache.AssertExpectations(t)
+}
+
+// TestHandleVideoJobSubResourceHeaders_TerminatingPodReturns404AndForgetsMapping
+// covers a pod that is confirmed going away (DeletionTimestamp set): unlike
+// the NotReady case, this pod will not come back under this name, so the
+// mapping is forgotten and the client gets the terminal 404.
+func TestHandleVideoJobSubResourceHeaders_TerminatingPodReturns404AndForgetsMapping(t *testing.T) {
+	mockCache := new(MockCache)
+	s := &Server{cache: mockCache}
+	ctx := context.Background()
+
+	s.rememberVideoJobPod(ctx, "video-1", "pod-a", "ns-a", "wan2.1-vace-1.3b", time.Hour)
+
+	terminatingPod := readyPod("pod-a", "ns-a", "10.0.0.5")
+	now := metav1.Now()
+	terminatingPod.DeletionTimestamp = &now
+	mockCache.On("GetPod", "pod-a", "ns-a").Return(terminatingPod, nil)
+
+	routingCtx := types.NewRoutingContext(ctx, "", "", "", "req-1", "")
+	routingCtx.ReqHeaders = map[string]string{methodKey: "GET"}
+
+	resp, term := s.handleVideoJobSubResourceHeaders(ctx, routingCtx, "req-1", "/v1/videos/video-1", "video-1")
+
+	require.NotNil(t, resp.GetImmediateResponse())
+	assert.Equal(t, envoyTypePb.StatusCode_NotFound, resp.GetImmediateResponse().GetStatus().GetCode())
+	assert.EqualValues(t, 0, term)
+
+	_, _, _, ok := s.lookupVideoJobPod(ctx, "video-1")
+	assert.False(t, ok, "mapping must be forgotten once the pod is confirmed terminating")
 
 	mockCache.AssertExpectations(t)
 }

--- a/pkg/plugins/gateway/gateway_video_routing_test.go
+++ b/pkg/plugins/gateway/gateway_video_routing_test.go
@@ -118,10 +118,10 @@ func TestServer_VideoJobPodTracking(t *testing.T) {
 	// Expired entries are evicted on read. rememberVideoJobPod itself can't produce
 	// an already-expired entry (it coerces ttl<=0 to the default, per the video-2
 	// case above), so store one directly to exercise the expiry path.
-	s.videoJobCache.Store("video-3", videoJobCacheEntry{
+	s.videoJobCache.Store("video-3", videoJobCacheItem{entry: videoJobCacheEntry{
 		PodName: "pod-c", PodNamespace: "ns-c", Model: "m",
 		ExpiresAt: time.Now().Add(-time.Second),
-	})
+	}})
 	_, _, _, ok = s.lookupVideoJobPod(ctx, "video-3")
 	assert.False(t, ok)
 	_, found := s.videoJobCache.Load("video-3")
@@ -346,20 +346,73 @@ func TestSyncVideoJobCacheFromRedis_RefreshesChangedEntry(t *testing.T) {
 // TestSyncVideoJobCacheFromRedis_EvictsRedisMiss covers the DELETE/pod-gone
 // cross-replica case directly: another replica's forgetVideoJobPod removed the
 // Redis key, and this replica's local (not-yet-expired) copy must be evicted on
-// the next sync rather than continuing to serve/pin against it.
+// the next sync rather than continuing to serve/pin against it. The entry is
+// stored confirmed:true -- this replica previously verified it in Redis (e.g.
+// via an earlier sync or lookup), so a later miss is trustworthy evidence of a
+// genuine deletion, not an unwritten local-only entry (see the "never
+// confirmed" self-heal case in TestSyncVideoJobCacheFromRedis_SelfHealsUnconfirmedEntry).
 func TestSyncVideoJobCacheFromRedis_EvictsRedisMiss(t *testing.T) {
 	s, _ := newTestVideoJobRedisServer(t)
 
-	// Store locally without ever writing to Redis, standing in for "some other
-	// replica already called forgetVideoJobPod and deleted the Redis key".
-	s.videoJobCache.Store("video-2", videoJobCacheEntry{
-		PodName: "pod-a", PodNamespace: "ns-a", Model: "m", ExpiresAt: time.Now().Add(time.Hour),
+	s.videoJobCache.Store("video-2", videoJobCacheItem{
+		entry: videoJobCacheEntry{
+			PodName: "pod-a", PodNamespace: "ns-a", Model: "m", ExpiresAt: time.Now().Add(time.Hour),
+		},
+		confirmed: true,
 	})
 
 	s.syncVideoJobCacheFromRedis()
 
 	_, found := s.videoJobCache.Load("video-2")
-	assert.False(t, found, "local entry must be evicted once Redis no longer has it")
+	assert.False(t, found, "confirmed local entry must be evicted once Redis no longer has it")
+}
+
+// TestSyncVideoJobCacheFromRedis_SelfHealsUnconfirmedEntry covers the case
+// where this replica's own write-through to Redis failed (rememberVideoJobPod
+// logs the error but still stores locally, fail-open) or was still in flight
+// when a sync tick ran. Before this fix, the next sync's Redis miss for that
+// videoID was indistinguishable from "another replica deleted it" and evicted
+// the only surviving copy of the mapping -- causing follow-up GET/DELETE on
+// this replica to 404 a job that was still live on its pod. An unconfirmed
+// entry must instead be retried into Redis and kept.
+func TestSyncVideoJobCacheFromRedis_SelfHealsUnconfirmedEntry(t *testing.T) {
+	s, mr := newTestVideoJobRedisServer(t)
+
+	// Simulate rememberVideoJobPod's Redis write having failed: stored locally,
+	// never confirmed in Redis, and (since the write never landed) absent there.
+	entry := videoJobCacheEntry{PodName: "pod-a", PodNamespace: "ns-a", Model: "m", ExpiresAt: time.Now().Add(time.Hour)}
+	s.videoJobCache.Store("video-4", videoJobCacheItem{entry: entry, confirmed: false})
+	_, err := mr.Get(videoJobRedisKey("video-4"))
+	require.Error(t, err, "precondition: redis must not already have this key")
+
+	s.syncVideoJobCacheFromRedis()
+
+	cached, found := s.videoJobCache.Load("video-4")
+	require.True(t, found, "unconfirmed entry must survive a redis miss, not be treated as an authoritative deletion")
+	item := cached.(videoJobCacheItem)
+	assert.Equal(t, "pod-a", item.entry.PodName)
+	assert.True(t, item.confirmed, "sync must retry the write and mark the entry confirmed once it lands")
+
+	raw, err := mr.Get(videoJobRedisKey("video-4"))
+	require.NoError(t, err, "sync must have persisted the unconfirmed entry to redis")
+	assert.Contains(t, raw, "pod-a")
+}
+
+// TestSyncVideoJobCacheFromRedis_EvictsExpiredUnconfirmedEntry ensures the
+// self-heal path in TestSyncVideoJobCacheFromRedis_SelfHealsUnconfirmedEntry
+// doesn't retry forever: once an unconfirmed entry's own TTL has passed, sync
+// must evict it like any other expired entry rather than keep re-attempting
+// the Redis write.
+func TestSyncVideoJobCacheFromRedis_EvictsExpiredUnconfirmedEntry(t *testing.T) {
+	s, _ := newTestVideoJobRedisServer(t)
+
+	entry := videoJobCacheEntry{PodName: "pod-a", PodNamespace: "ns-a", Model: "m", ExpiresAt: time.Now().Add(-time.Second)}
+	s.videoJobCache.Store("video-5", videoJobCacheItem{entry: entry, confirmed: false})
+
+	s.syncVideoJobCacheFromRedis()
+
+	_, found := s.videoJobCache.Load("video-5")
+	assert.False(t, found, "expired entry must not be retried indefinitely")
 }
 
 // TestSyncVideoJobCacheFromRedis_LeavesLocalCacheUntouchedOnRedisError ensures a
@@ -378,7 +431,7 @@ func TestSyncVideoJobCacheFromRedis_LeavesLocalCacheUntouchedOnRedisError(t *tes
 
 	cached, found := s.videoJobCache.Load("video-3")
 	require.True(t, found, "local entry must survive a whole-batch redis error")
-	assert.Equal(t, "pod-a", cached.(videoJobCacheEntry).PodName)
+	assert.Equal(t, "pod-a", cached.(videoJobCacheItem).entry.PodName)
 }
 
 func TestParseVideoListRequest(t *testing.T) {

--- a/pkg/plugins/gateway/types.go
+++ b/pkg/plugins/gateway/types.go
@@ -46,7 +46,8 @@ const (
 	HeaderErrorMultipartParsing = "x-error-multipart-parsing"
 
 	// Video Job Headers
-	HeaderErrorVideoNotFound = "x-error-video-not-found"
+	HeaderErrorVideoNotFound          = "x-error-video-not-found"
+	HeaderErrorVideoJobPodUnavailable = "x-error-video-job-pod-unavailable"
 
 	// Request & Target Headers
 	HeaderWentIntoReqHeaders  = "x-went-into-req-headers"
@@ -91,11 +92,12 @@ const (
 	ErrorTypeOverloaded     = "overloaded_error"
 
 	// OpenAI Error Codes
-	ErrorCodeInvalidAPIKey      = "invalid_api_key"
-	ErrorCodeModelNotFound      = "model_not_found"
-	ErrorCodeRateLimitExceeded  = "rate_limit_exceeded"
-	ErrorCodeServiceUnavailable = "service_unavailable"
-	ErrorCodeVideoNotFound      = "video_not_found"
+	ErrorCodeInvalidAPIKey          = "invalid_api_key"
+	ErrorCodeModelNotFound          = "model_not_found"
+	ErrorCodeRateLimitExceeded      = "rate_limit_exceeded"
+	ErrorCodeServiceUnavailable     = "service_unavailable"
+	ErrorCodeVideoNotFound          = "video_not_found"
+	ErrorCodeVideoJobPodUnavailable = "video_job_pod_unavailable"
 
 	// Embedding Constraints
 	// https://github.com/openai/openai-go/blob/main/embedding.go#L126

--- a/pkg/plugins/gateway/types.go
+++ b/pkg/plugins/gateway/types.go
@@ -45,6 +45,9 @@ const (
 	// Multipart/Audio Headers
 	HeaderErrorMultipartParsing = "x-error-multipart-parsing"
 
+	// Video Job Headers
+	HeaderErrorVideoNotFound = "x-error-video-not-found"
+
 	// Request & Target Headers
 	HeaderWentIntoReqHeaders  = "x-went-into-req-headers"
 	HeaderTargetPodIP         = "target-pod-ip"
@@ -92,6 +95,7 @@ const (
 	ErrorCodeModelNotFound      = "model_not_found"
 	ErrorCodeRateLimitExceeded  = "rate_limit_exceeded"
 	ErrorCodeServiceUnavailable = "service_unavailable"
+	ErrorCodeVideoNotFound      = "video_not_found"
 
 	// Embedding Constraints
 	// https://github.com/openai/openai-go/blob/main/embedding.go#L126
@@ -113,6 +117,12 @@ const (
 	PathAudioTranslations   = "/v1/audio/translations"
 	PathRerank              = "/v1/rerank"
 	PathClassify            = "/v1/classify"
+	// PathVideos and PathVideosSync are vLLM-Omni's native Videos API (multipart/form-data),
+	// distinct from the OpenAI/Sora-shaped PathVideoGenerations (JSON) above. PathVideos also
+	// covers its GET/DELETE sub-resources (/v1/videos/{id}, /v1/videos/{id}/content) via
+	// prefix matching in isLanguageRequest and extractVideoIDFromPath.
+	PathVideos     = "/v1/videos"
+	PathVideosSync = "/v1/videos/sync"
 
 	// Engine-specific paths (xdit)
 	PathXditGenerate      = "/generate"

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -555,9 +555,17 @@ func isMultipartRequest(contentType string) bool {
 
 // parseMultipartFormData parses multipart/form-data request body and extracts the model field.
 // It returns the model name, stream flag, and any processing error response.
+//
+// requestPath is used to skip the "stream" field for vLLM-Omni's Videos API
+// (PathVideos, PathVideosSync): video creation is an async job -- HandleResponseBody
+// relies on stream being false there to reach recordVideoJobPodFromResponse, so a
+// stray stream=true field (e.g. from an SDK reusing a generic multipart helper across
+// audio/video calls) must not be allowed to route the response down the SSE branch
+// instead.
 // nolint:nakedret
-func parseMultipartFormData(requestID string, contentType string, requestBody []byte) (model string, stream bool, errRes *extProcPb.ProcessingResponse) {
+func parseMultipartFormData(requestID, requestPath, contentType string, requestBody []byte) (model string, stream bool, errRes *extProcPb.ProcessingResponse) {
 	const trueStr = "true"
+	isVideoPath := pathWithoutQuery(requestPath) == PathVideos || pathWithoutQuery(requestPath) == PathVideosSync
 
 	// Extract boundary from Content-Type
 	mediaType, params, err := mime.ParseMediaType(contentType)
@@ -604,6 +612,11 @@ func parseMultipartFormData(requestID string, contentType string, requestBody []
 			model = strings.TrimSpace(string(modelBytes))
 
 		case "stream":
+			if isVideoPath {
+				// Video creation never streams; ignore a client-supplied stream field
+				// rather than letting it flip HandleResponseBody onto the SSE branch.
+				break
+			}
 			streamBytes, err := io.ReadAll(part)
 			if err == nil {
 				streamVal := strings.TrimSpace(strings.ToLower(string(streamBytes)))

--- a/pkg/plugins/gateway/util.go
+++ b/pkg/plugins/gateway/util.go
@@ -475,9 +475,24 @@ func validateRerankRequest(requestID string, requestBody []byte) (model, message
 	return
 }
 
-// isAudioRequest returns true if the request path is an audio endpoint
-func isAudioRequest(requestPath string) bool {
-	return requestPath == PathAudioTranscriptions || requestPath == PathAudioTranslations
+// pathWithoutQuery strips the query string from an Envoy :path value. HTTP/2
+// :path includes both path and query (RFC 7540), so exact/prefix matchers must
+// cut on '?' before comparing.
+func pathWithoutQuery(requestPath string) string {
+	path, _, _ := strings.Cut(requestPath, "?")
+	return path
+}
+
+// isMultipartFormPath returns true if requestPath is an endpoint whose request
+// body is multipart/form-data rather than JSON -- audio endpoints, and
+// vLLM-Omni's Videos API create endpoints (PathVideos, PathVideosSync).
+func isMultipartFormPath(requestPath string) bool {
+	switch pathWithoutQuery(requestPath) {
+	case PathAudioTranscriptions, PathAudioTranslations, PathVideos, PathVideosSync:
+		return true
+	default:
+		return false
+	}
 }
 
 // validateClassifyRequest validates a classify request and returns the model and message.

--- a/pkg/plugins/gateway/util_test.go
+++ b/pkg/plugins/gateway/util_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package gateway
 
 import (
+	"bytes"
 	"context"
+	"mime/multipart"
 	"strings"
 	"testing"
 	"time"
@@ -27,6 +29,7 @@ import (
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
@@ -34,6 +37,19 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// buildMultipartForm encodes fields as a multipart/form-data body and returns
+// the body along with the Content-Type header (including boundary).
+func buildMultipartForm(t *testing.T, fields map[string]string) (body []byte, contentType string) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for k, v := range fields {
+		require.NoError(t, w.WriteField(k, v))
+	}
+	require.NoError(t, w.Close())
+	return buf.Bytes(), w.FormDataContentType()
+}
 
 func int64Ptr(v int64) *int64 {
 	return &v
@@ -1741,6 +1757,41 @@ func TestDeriveRoutingStrategyFromContext(t *testing.T) {
 			got, ok := deriveRoutingStrategyFromContext(tt.ctx)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}
+
+// TestParseMultipartFormData_IgnoresStreamForVideoPaths guards against a
+// client (or an SDK reusing a generic multipart helper across audio/video
+// calls) sending stream=true on the async, never-streamed Videos API. If that
+// field were honored, HandleResponseBody would take the SSE branch instead of
+// calling recordVideoJobPodFromResponse, and the video_id->pod mapping would
+// never be recorded -- breaking follow-up GET/DELETE calls with a spurious
+// "video not found".
+func TestParseMultipartFormData_IgnoresStreamForVideoPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		wantStream bool
+	}{
+		{"videos create ignores stream field", PathVideos, false},
+		{"videos sync create ignores stream field", PathVideosSync, false},
+		{"videos create with query string still ignores stream field", PathVideos + "?foo=bar", false},
+		{"audio transcription honors stream field", PathAudioTranscriptions, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, contentType := buildMultipartForm(t, map[string]string{
+				"model":  "test-model",
+				"stream": "true",
+			})
+
+			model, stream, errRes := parseMultipartFormData("req-1", tt.path, contentType, body)
+
+			assert.Nil(t, errRes)
+			assert.Equal(t, "test-model", model)
+			assert.Equal(t, tt.wantStream, stream)
 		})
 	}
 }

--- a/samples/vllm_omni/wan2.1-vace-1.3b.yaml
+++ b/samples/vllm_omni/wan2.1-vace-1.3b.yaml
@@ -18,15 +18,6 @@ spec:
         model.aibrix.ai/name: wan21-vace-13b
         model.aibrix.ai/port: "8000"
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values:
-                      - 192.168.0.7
       containers:
         - name: vllm-omni
           image: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/vllm-omni:v0.28.0  # Note: Must use vllm-omni image other than vllm-openai image

--- a/samples/vllm_omni/wan2.1-vace-1.3b.yaml
+++ b/samples/vllm_omni/wan2.1-vace-1.3b.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    model.aibrix.ai/name: wan21-vace-13b # Note: The label value `model.aibrix.ai/name` here must match with the service name.
+    model.aibrix.ai/port: "8000"
+  name: wan21-vace-13b
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      model.aibrix.ai/name: wan21-vace-13b
+      model.aibrix.ai/port: "8000"
+  template:
+    metadata:
+      labels:
+        model.aibrix.ai/name: wan21-vace-13b
+        model.aibrix.ai/port: "8000"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - 192.168.0.7
+      containers:
+        - name: vllm-omni
+          image: aibrix-container-registry-cn-beijing.cr.volces.com/aibrix/vllm-omni:v0.28.0  # Note: Must use vllm-omni image other than vllm-openai image
+          command:
+            - vllm
+            - serve
+            - /models/Wan2.1-VACE-1.3B-diffusers # Note: host path /data00/models/Wan2.1-VACE-1.3B-diffusers
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "8000"
+            - --uvicorn-log-level
+            - warning
+            - --served-model-name
+            # Note: The `--served-model-name` argument value must also match the Service name and the Deployment label `model.aibrix.ai/name`
+            - wan21-vace-13b
+            - --omni # Note: switches `vllm serve` into vLLM-Omni mode, which auto-detects this diffusion
+                     # model and exposes the OpenAI-compatible Videos API (multipart/form-data):
+                     # POST /v1/videos (async job; poll GET /v1/videos/{id}, fetch GET /v1/videos/{id}/content)
+                     # and POST /v1/videos/sync (blocks, returns raw MP4 bytes). Per-request generation
+                     # params (height, width, num_frames, guidance_scale, fps, ...) go in the request body/
+                     # form, not as server args.
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /models
+              name: models
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+      volumes:
+        - name: models
+          hostPath:
+            path: /data00/models
+            type: Directory
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wan21-vace-13b
+  namespace: default
+spec:
+  selector:
+    model.aibrix.ai/name: wan21-vace-13b
+  ports:
+    - name: serve
+      port: 8000
+      protocol: TCP
+      targetPort: 8000

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1alpha1 "github.com/vllm-project/aibrix/pkg/client/clientset/versioned"
 	crdinformers "github.com/vllm-project/aibrix/pkg/client/informers/externalversions"
 	"github.com/vllm-project/aibrix/pkg/utils"
@@ -48,6 +49,14 @@ const (
 	ModelNameVLLMBucket = "llama2-7b-vllm-bucket"
 	ModelNameSGLang     = "llama2-7b-sglang"
 	ModelNameTRTLLM     = "llama2-7b-trtllm"
+
+	// config/test runs two gateway-plugin replicas. Each has its own pod cache, so one
+	// successful PD probe is not enough after pod churn — Envoy may send the next
+	// request to the replica that has not seen the update yet.
+	pdRoutingConsecutiveSuccesses = 3
+	pdRoutingWaitTimeout          = 2 * time.Minute
+	pdChatRetryTimeout            = 30 * time.Second
+	pdChatRetryInterval           = 1 * time.Second
 )
 
 func InitializeClient(ctx context.Context, t *testing.T) (*kubernetes.Clientset, *v1alpha1.Clientset) {
@@ -194,7 +203,7 @@ func ValidateAllPodsAreReady(t *testing.T, client *kubernetes.Clientset, expecte
 		selector = labelSelector[0]
 	}
 	namespace := LoadConfig().Namespace
-	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second,
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 2*time.Minute,
 		true, func(ctx context.Context) (bool, error) {
 			podList, err := client.CoreV1().Pods(namespace).List(ctx, v1.ListOptions{LabelSelector: selector})
 			if err != nil {
@@ -209,39 +218,87 @@ func ValidateAllPodsAreReady(t *testing.T, client *kubernetes.Clientset, expecte
 			t.Logf("Waiting for %d pods to be ready. Current count: %d", expectedPodCount, len(activePods))
 			return false, nil
 		})
-	assert.NoError(t, err, "timeout waiting for all pods to be ready")
+	require.NoError(t, err, "timeout waiting for all pods to be ready")
+}
+
+// PollPDChatCompletion retries a PD chat completion until it succeeds or timeout.
+// A single 503 after pod churn is not treated as failure: Envoy may still be
+// hitting a gateway-plugin replica whose pod cache has not caught up.
+func PollPDChatCompletion(
+	t *testing.T, client openai.Client, params openai.ChatCompletionNewParams,
+) *openai.ChatCompletion {
+	t.Helper()
+	var last *openai.ChatCompletion
+	var lastErr error
+	err := wait.PollUntilContextTimeout(context.Background(), pdChatRetryInterval, pdChatRetryTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			resp, err := client.Chat.Completions.New(ctx, params)
+			if err != nil {
+				lastErr = err
+				t.Logf("retrying PD chat completion: %v", err)
+				return false, nil
+			}
+			last = resp
+			lastErr = nil
+			return true, nil
+		})
+	if lastErr != nil {
+		require.NoError(t, err, "timeout waiting for PD chat completion: %v", lastErr)
+	}
+	require.NoError(t, err, "timeout waiting for PD chat completion")
+	return last
+}
+
+func waitForConsecutivePDSuccesses(
+	t *testing.T, modelName string, attempt func(ctx context.Context) (ok bool, msg string),
+) {
+	t.Helper()
+	consecutive := 0
+	err := wait.PollUntilContextTimeout(context.Background(), pdChatRetryInterval, pdRoutingWaitTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			ok, msg := attempt(ctx)
+			if !ok {
+				consecutive = 0
+				t.Logf("%s", msg)
+				return false, nil
+			}
+			consecutive++
+			if consecutive < pdRoutingConsecutiveSuccesses {
+				t.Logf("%s (%d/%d consecutive)", msg, consecutive, pdRoutingConsecutiveSuccesses)
+				return false, nil
+			}
+			t.Logf("%s", msg)
+			return true, nil
+		})
+	require.NoError(t, err, "timeout waiting for PD routing to be ready for model %s", modelName)
 }
 
 // WaitForPDDisaggregationRouting polls until the gateway can route a PD request for modelName.
-// Pod readiness alone is not enough: the gateway pod cache may lag after pod churn.
+// Pod readiness alone is not enough: the gateway pod cache may lag after pod churn, and
+// with two plugin replicas one success can be a lucky hit on the warm replica.
 func WaitForPDDisaggregationRouting(t *testing.T, modelName string) {
 	t.Helper()
 	var dst *http.Response
 	config := LoadConfig()
 	client := NewOpenAIClientWithRoutingStrategy(config.GatewayURL, config.APIKey, "pd", option.WithResponseInto(&dst))
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 2*time.Minute,
-		true, func(ctx context.Context) (bool, error) {
-			_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
-				Messages: []openai.ChatCompletionMessageParamUnion{
-					openai.UserMessage("PD routing readiness check"),
-				},
-				Model: modelName,
-			})
-			if err != nil {
-				t.Logf("waiting for PD routing for model %s: %v", modelName, err)
-				return false, nil
-			}
-			prefillPod := dst.Header.Get("prefill-target-pod")
-			decodePod := dst.Header.Get("target-pod")
-			if prefillPod == "" || decodePod == "" || prefillPod == decodePod {
-				t.Logf("waiting for valid PD routing headers for model %s", modelName)
-				return false, nil
-			}
-			t.Logf("PD routing ready for model %s", modelName)
-			return true, nil
+	waitForConsecutivePDSuccesses(t, modelName, func(ctx context.Context) (bool, string) {
+		_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				openai.UserMessage("PD routing readiness check"),
+			},
+			Model: modelName,
 		})
-	assert.NoError(t, err, "timeout waiting for PD routing to be ready for model %s", modelName)
+		if err != nil {
+			return false, "waiting for PD routing for model " + modelName + ": " + err.Error()
+		}
+		prefillPod := dst.Header.Get("prefill-target-pod")
+		decodePod := dst.Header.Get("target-pod")
+		if prefillPod == "" || decodePod == "" || prefillPod == decodePod {
+			return false, "waiting for valid PD routing headers for model " + modelName
+		}
+		return true, "PD routing ready for model " + modelName
+	})
 }
 
 // WaitForPDCombinedRouting polls until the gateway routes a long prompt to a combined pod
@@ -252,26 +309,22 @@ func WaitForPDCombinedRouting(t *testing.T, modelName, combinedStormName, longPr
 	config := LoadConfig()
 	client := NewOpenAIClientWithRoutingStrategy(config.GatewayURL, config.APIKey, "pd", option.WithResponseInto(&dst))
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 2*time.Minute,
-		true, func(ctx context.Context) (bool, error) {
-			_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
-				Messages: []openai.ChatCompletionMessageParamUnion{
-					openai.UserMessage(longPrompt),
-				},
-				Model: modelName,
-			})
-			if err != nil {
-				t.Logf("waiting for combined PD routing for model %s: %v", modelName, err)
-				return false, nil
-			}
-			prefillPod := dst.Header.Get("prefill-target-pod")
-			decodePod := dst.Header.Get("target-pod")
-			if prefillPod != "" || decodePod == "" || !strings.Contains(decodePod, combinedStormName) {
-				t.Logf("waiting for combined routing for model %s: prefill=%s decode=%s", modelName, prefillPod, decodePod)
-				return false, nil
-			}
-			t.Logf("combined PD routing ready for model %s (decode=%s)", modelName, decodePod)
-			return true, nil
+	waitForConsecutivePDSuccesses(t, modelName, func(ctx context.Context) (bool, string) {
+		_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				openai.UserMessage(longPrompt),
+			},
+			Model: modelName,
 		})
-	assert.NoError(t, err, "timeout waiting for combined PD routing for model %s", modelName)
+		if err != nil {
+			return false, "waiting for combined PD routing for model " + modelName + ": " + err.Error()
+		}
+		prefillPod := dst.Header.Get("prefill-target-pod")
+		decodePod := dst.Header.Get("target-pod")
+		if prefillPod != "" || decodePod == "" || !strings.Contains(decodePod, combinedStormName) {
+			return false, "waiting for combined routing for model " + modelName +
+				": prefill=" + prefillPod + " decode=" + decodePod
+		}
+		return true, "combined PD routing ready for model " + modelName + " (decode=" + decodePod + ")"
+	})
 }

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -220,7 +220,7 @@ func WaitForPDDisaggregationRouting(t *testing.T, modelName string) {
 	config := LoadConfig()
 	client := NewOpenAIClientWithRoutingStrategy(config.GatewayURL, config.APIKey, "pd", option.WithResponseInto(&dst))
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second,
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 2*time.Minute,
 		true, func(ctx context.Context) (bool, error) {
 			_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
 				Messages: []openai.ChatCompletionMessageParamUnion{
@@ -252,7 +252,7 @@ func WaitForPDCombinedRouting(t *testing.T, modelName, combinedStormName, longPr
 	config := LoadConfig()
 	client := NewOpenAIClientWithRoutingStrategy(config.GatewayURL, config.APIKey, "pd", option.WithResponseInto(&dst))
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second,
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 2*time.Minute,
 		true, func(ctx context.Context) (bool, error) {
 			_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
 				Messages: []openai.ChatCompletionMessageParamUnion{

--- a/test/e2e/gateway/pd/helpers_test.go
+++ b/test/e2e/gateway/pd/helpers_test.go
@@ -30,6 +30,7 @@ var (
 	validateAllPodsAreReady               = framework.ValidateAllPodsAreReady
 	waitForPDDisaggregationRouting        = framework.WaitForPDDisaggregationRouting
 	waitForPDCombinedRouting              = framework.WaitForPDCombinedRouting
+	pollPDChatCompletion                  = framework.PollPDChatCompletion
 )
 
 const (

--- a/test/e2e/gateway/pd/pd_bucketing_test.go
+++ b/test/e2e/gateway/pd/pd_bucketing_test.go
@@ -63,13 +63,12 @@ func assertPDBucketingRoute(t *testing.T, prompt, stormName string, expectCombin
 	var dst *http.Response
 	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
 
-	chatCompletion, err := client.Chat.Completions.New(context.TODO(), openai.ChatCompletionNewParams{
+	chatCompletion := pollPDChatCompletion(t, client, openai.ChatCompletionNewParams{
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.UserMessage(prompt),
 		},
 		Model: modelNameVLLMBucket,
 	})
-	require.NoError(t, err, "PD bucketing chat completion failed for storm %s", stormName)
 	assert.Equal(t, modelNameVLLMBucket, chatCompletion.Model)
 
 	decodePod := dst.Header.Get("target-pod")
@@ -90,6 +89,37 @@ func assertPDBucketingRoute(t *testing.T, prompt, stormName string, expectCombin
 	}
 
 	t.Logf("storm=%s combined=%v — prefill: %s, decode: %s", stormName, expectCombined, prefillPod, decodePod)
+}
+
+// TestPDDisaggregationVLLMPromptLengthBucketing verifies that with
+// AIBRIX_PROMPT_LENGTH_BUCKETING enabled, the gateway routes prompts to the
+// correct StormService bucket: 0–15 and 16–32 use matching prefill/decode
+// rolesets; prompts above 32 fall back to the combined role.
+func TestPDDisaggregationVLLMPromptLengthBucketing(t *testing.T) {
+	waitForPDDisaggregationRouting(t, modelNameVLLMBucket)
+
+	shortPrompt := promptWithTokenLength(t, 10)
+	mediumPrompt := promptWithTokenLength(t, 20)
+	longPrompt := promptWithTokenLength(t, 40)
+
+	shortTokens, err := utils.TokenizeInputText(shortPrompt)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(shortTokens), 15)
+
+	mediumTokens, err := utils.TokenizeInputText(mediumPrompt)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(mediumTokens), 16)
+	require.LessOrEqual(t, len(mediumTokens), 32)
+
+	longTokens, err := utils.TokenizeInputText(longPrompt)
+	require.NoError(t, err)
+	require.Greater(t, len(longTokens), 32)
+
+	waitForPDCombinedRouting(t, modelNameVLLMBucket, bucketCombinedStorm, longPrompt)
+
+	assertPDBucketingRoute(t, shortPrompt, bucketShortStorm, false)
+	assertPDBucketingRoute(t, mediumPrompt, bucketMediumStorm, false)
+	assertPDBucketingRoute(t, longPrompt, bucketCombinedStorm, true)
 }
 
 // TestPDDisaggregationVLLMBucketDecodeDownFallbackToCombined verifies that when the
@@ -157,35 +187,4 @@ func TestPDDisaggregationVLLMBucketDecodeDownFallbackToCombined(t *testing.T) {
 	assert.True(t, strings.Contains(decodePod, bucketCombinedStorm),
 		"expected combined pod, got decode=%s", decodePod)
 	t.Logf("fallback confirmed — decode: %s", decodePod)
-}
-
-// TestPDDisaggregationVLLMPromptLengthBucketing verifies that with
-// AIBRIX_PROMPT_LENGTH_BUCKETING enabled, the gateway routes prompts to the
-// correct StormService bucket: 0–15 and 16–32 use matching prefill/decode
-// rolesets; prompts above 32 fall back to the combined role.
-func TestPDDisaggregationVLLMPromptLengthBucketing(t *testing.T) {
-	waitForPDDisaggregationRouting(t, modelNameVLLMBucket)
-
-	shortPrompt := promptWithTokenLength(t, 10)
-	mediumPrompt := promptWithTokenLength(t, 20)
-	longPrompt := promptWithTokenLength(t, 40)
-
-	shortTokens, err := utils.TokenizeInputText(shortPrompt)
-	require.NoError(t, err)
-	require.LessOrEqual(t, len(shortTokens), 15)
-
-	mediumTokens, err := utils.TokenizeInputText(mediumPrompt)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(mediumTokens), 16)
-	require.LessOrEqual(t, len(mediumTokens), 32)
-
-	longTokens, err := utils.TokenizeInputText(longPrompt)
-	require.NoError(t, err)
-	require.Greater(t, len(longTokens), 32)
-
-	waitForPDCombinedRouting(t, modelNameVLLMBucket, bucketCombinedStorm, longPrompt)
-
-	assertPDBucketingRoute(t, shortPrompt, bucketShortStorm, false)
-	assertPDBucketingRoute(t, mediumPrompt, bucketMediumStorm, false)
-	assertPDBucketingRoute(t, longPrompt, bucketCombinedStorm, true)
 }

--- a/test/e2e/gateway/pd/pd_bucketing_test.go
+++ b/test/e2e/gateway/pd/pd_bucketing_test.go
@@ -58,6 +58,8 @@ func promptWithTokenLength(t *testing.T, tokenCount int) string {
 
 func assertPDBucketingRoute(t *testing.T, prompt, stormName string, expectCombined bool) {
 	t.Helper()
+	waitForPDDisaggregationRouting(t, modelNameVLLMBucket)
+
 	var dst *http.Response
 	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
 

--- a/test/e2e/gateway/pd/pd_test.go
+++ b/test/e2e/gateway/pd/pd_test.go
@@ -31,20 +31,19 @@ import (
 
 // assertPDDisaggregation sends a single PD-routed chat completion for the given model and
 // asserts that the response carries distinct prefill-target-pod and target-pod headers.
-func assertPDDisaggregation(t *testing.T, modelName, prompt, errMsg, logPrefix string) {
+func assertPDDisaggregation(t *testing.T, modelName, prompt, logPrefix string) {
 	t.Helper()
 	waitForPDDisaggregationRouting(t, modelName)
 
 	var dst *http.Response
 	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
 
-	chatCompletion, err := client.Chat.Completions.New(context.TODO(), openai.ChatCompletionNewParams{
+	chatCompletion := pollPDChatCompletion(t, client, openai.ChatCompletionNewParams{
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.UserMessage(prompt),
 		},
 		Model: modelName,
 	})
-	require.NoError(t, err, errMsg)
 
 	assert.Equal(t, modelName, chatCompletion.Model)
 	assert.NotEmpty(t, chatCompletion.Choices, "chat completion returned no choices")
@@ -75,7 +74,6 @@ func assertPDDisaggregation(t *testing.T, modelName, prompt, errMsg, logPrefix s
 func TestPDDisaggregationVLLM(t *testing.T) {
 	assertPDDisaggregation(t, modelNameVLLM,
 		"Say this is a test for vLLM PD disaggregation",
-		"vLLM PD chat completion request failed",
 		"vLLM")
 }
 
@@ -89,7 +87,6 @@ func TestPDDisaggregationVLLM(t *testing.T) {
 func TestPDDisaggregationSGLang(t *testing.T) {
 	assertPDDisaggregation(t, modelNameSGLang,
 		"Say this is a test for SGLang PD disaggregation",
-		"SGLang PD chat completion request failed",
 		"SGLang")
 }
 
@@ -101,14 +98,13 @@ func TestPDDisaggregationSGLang(t *testing.T) {
 func TestPDDisaggregationTRTLLM(t *testing.T) {
 	assertPDDisaggregation(t, modelNameTRTLLM,
 		"Say this is a test for TensorRT-LLM PD disaggregation",
-		"TRT-LLM PD chat completion request failed",
 		"TRT-LLM")
 }
 
 // assertPDDisaggregationAfterPodDeletion deletes one pod for modelName and roleLabel,
 // waits for the gateway to notice, then verifies PD-routed requests still succeed via
 // remaining pods (requires at least two matching pods, i.e. 2x1P1D for that model).
-func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, modelName, prompt, requestErrMsg string) {
+func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, modelName, prompt string) {
 	t.Helper()
 	ctx := context.Background()
 	k8sClient, _ := initializeClient(ctx, t)
@@ -145,13 +141,12 @@ func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, modelName, 
 	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
 
 	for i := 0; i < 10; i++ {
-		_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+		_ = pollPDChatCompletion(t, client, openai.ChatCompletionNewParams{
 			Messages: []openai.ChatCompletionMessageParamUnion{
 				openai.UserMessage(prompt),
 			},
 			Model: modelName,
 		})
-		require.NoError(t, err, requestErrMsg, i)
 
 		decodePod := dst.Header.Get("target-pod")
 		prefillPod := dst.Header.Get("prefill-target-pod")
@@ -169,24 +164,10 @@ func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, modelName, 
 	}
 }
 
-// TestPDDisaggregationVLLMPrefillPodFailure verifies that with 2x1P1D setup, taking down one
-// prefill pod still allows 10 requests to succeed via the remaining complete roleset.
-func TestPDDisaggregationVLLMPrefillPodFailure(t *testing.T) {
-	assertPDDisaggregationAfterPodDeletion(t, "prefill", modelNameVLLM,
-		"PD prefill-pod-failure resilience test",
-		"request %d failed after prefill pod deletion")
-}
-
-// TestPDDisaggregationVLLMDecodePodFailure verifies that with 2x1P1D setup, taking down one
-// decode pod still allows 10 requests to succeed via the remaining complete roleset.
-func TestPDDisaggregationVLLMDecodePodFailure(t *testing.T) {
-	assertPDDisaggregationAfterPodDeletion(t, "decode", modelNameVLLM,
-		"PD decode-pod-failure resilience test",
-		"request %d failed after decode pod deletion")
-}
-
 // TestPDDisaggregationVLLMMultipleRequests sends several requests to verify that the
 // PD router consistently selects valid prefill/decode pod pairs across requests.
+// Runs before the pod-deletion tests so it is not immediately after StormService
+// recreate, when gateway-plugin caches can still disagree.
 func TestPDDisaggregationVLLMMultipleRequests(t *testing.T) {
 	const iterations = 5
 
@@ -196,13 +177,12 @@ func TestPDDisaggregationVLLMMultipleRequests(t *testing.T) {
 	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
 
 	for i := 0; i < iterations; i++ {
-		_, err := client.Chat.Completions.New(context.TODO(), openai.ChatCompletionNewParams{
+		_ = pollPDChatCompletion(t, client, openai.ChatCompletionNewParams{
 			Messages: []openai.ChatCompletionMessageParamUnion{
 				openai.UserMessage("vLLM PD disaggregation stress test message"),
 			},
 			Model: modelNameVLLM,
 		})
-		require.NoError(t, err, "vLLM PD chat completion request %d failed", i)
 
 		decodePod := dst.Header.Get("target-pod")
 		prefillPod := dst.Header.Get("prefill-target-pod")
@@ -214,4 +194,18 @@ func TestPDDisaggregationVLLMMultipleRequests(t *testing.T) {
 
 		t.Logf("request %d — prefill: %s, decode: %s", i, prefillPod, decodePod)
 	}
+}
+
+// TestPDDisaggregationVLLMPrefillPodFailure verifies that with 2x1P1D setup, taking down one
+// prefill pod still allows 10 requests to succeed via the remaining complete roleset.
+func TestPDDisaggregationVLLMPrefillPodFailure(t *testing.T) {
+	assertPDDisaggregationAfterPodDeletion(t, "prefill", modelNameVLLM,
+		"PD prefill-pod-failure resilience test")
+}
+
+// TestPDDisaggregationVLLMDecodePodFailure verifies that with 2x1P1D setup, taking down one
+// decode pod still allows 10 requests to succeed via the remaining complete roleset.
+func TestPDDisaggregationVLLMDecodePodFailure(t *testing.T) {
+	assertPDDisaggregationAfterPodDeletion(t, "decode", modelNameVLLM,
+		"PD decode-pod-failure resilience test")
 }

--- a/test/e2e/gateway/pd/pd_test.go
+++ b/test/e2e/gateway/pd/pd_test.go
@@ -33,6 +33,8 @@ import (
 // asserts that the response carries distinct prefill-target-pod and target-pod headers.
 func assertPDDisaggregation(t *testing.T, modelName, prompt, errMsg, logPrefix string) {
 	t.Helper()
+	waitForPDDisaggregationRouting(t, modelName)
+
 	var dst *http.Response
 	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
 
@@ -134,8 +136,10 @@ func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, modelName, 
 		t.Logf("%s pod %s has been recreated and cluster is back to %d pods", roleLabel, podToDelete, initialCount)
 	})
 
-	// Give the gateway time to detect the pod is gone.
+	// Give the gateway time to detect the pod is gone and re-converge on the
+	// remaining roleset before asserting on individual requests below.
 	time.Sleep(3 * time.Second)
+	waitForPDDisaggregationRouting(t, modelName)
 
 	var dst *http.Response
 	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))


### PR DESCRIPTION
## Pull Request Description
Add gateway routing for vLLM-Omni's async video generation API
(/v1/videos, /v1/videos/sync), including a pod-affinity cache that
maps a video_id to the pod that owns it so follow-up GET/DELETE
requests on the same job route back to the correct pod, with
write-through to Redis so any gateway replica can resolve a video_id
created by another replica.

Also raises the default gateway request timeout from 120s to 600s to
accommodate longer-running video generation requests, adds the
vLLM-Omni model paths to the model router, and includes a sample
config (wan2.1-vace-1.3b) and feature documentation.


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>