### PR TITLE
[Gateway] Add strict PD mock contracts

### DIFF
--- a/development/app/README.md
+++ b/development/app/README.md
@@ -51,6 +51,218 @@ python test_openai_endpoints.py --base-url http://localhost:8000/v1
 python test_vllm_endpoints.py --base-url http://localhost:8000
 ```
 
+### Testing PD contracts locally
+
+The PR2 mock supports explicit, connector-scoped PD contracts. These settings
+are test-only and do not change the gateway implementation. When
+`MOCK_PD_CONTRACT` is unset, the mock keeps its legacy behavior.
+
+| Environment variable | Values | Purpose |
+| --- | --- | --- |
+| `MOCK_PD_CONTRACT` | `vllm-aibrix-shfs`, `vllm-aibrix-nixl`, `sglang-http`, `trtllm-openai` | Enables strict PD request validation |
+| `MOCK_PD_ROLE` | `prefill`, `decode` | Identifies the current mock pod role |
+| `POD_NAME` | pod name | Adds a stable pod name to responses and recorder entries |
+| `LLM_ENGINE` | `vllm`, `sglang`, `trtllm` | Identifies the mock engine |
+
+A standalone process represents one pod, so start separate processes if you
+want to test both prefill and decode legs. Use `127.0.0.1` for local curl
+requests when a proxy is configured for `localhost`.
+
+Example strict SGLang prefill mock:
+
+```bash
+STANDALONE_MODE=true \
+MOCK_PD_CONTRACT=sglang-http \
+MOCK_PD_ROLE=prefill \
+LLM_ENGINE=sglang \
+POD_NAME=local-sglang-prefill \
+python app.py
+```
+
+Send a request with the required bootstrap fields:
+
+```bash
+curl -sS -i -X POST http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'x-request-id: local-sglang-1' \
+  -d '{
+    "model": "llama2-7b-sglang",
+    "messages": [{"role": "user", "content": "hello"}],
+    "bootstrap_host": "10.0.0.1",
+    "bootstrap_port": 8998,
+    "bootstrap_room": 12345,
+    "max_tokens": 8
+  }'
+```
+
+The successful response remains a normal OpenAI-compatible completion. The
+PD-specific request can be inspected through the recorder:
+
+```bash
+curl -sS \
+  'http://127.0.0.1:8000/debug/requests?request_id=local-sglang-1'
+```
+
+Each record includes the request ID, sequence, path, engine, role, headers,
+parsed JSON, status, outcome, response, and the exact raw body as base64.
+`Authorization` values are redacted before they are recorded. The debug
+endpoint is intended for internal Pod-proxy access and does not use the normal
+OpenAI Bearer-token middleware. It has no reset/delete operation; use a unique
+`x-request-id` for each test.
+
+The four strict contract modes validate these internal prefill/decode shapes:
+
+- `vllm-aibrix-shfs`: prefill receives `kv_transfer_params.do_remote_decode=true`;
+  decode receives the merged transfer fields and opaque sentinel.
+- `vllm-aibrix-nixl`: prefill must not receive the SHFS skeleton; gateway wraps
+  the complete prefill response under `disagg_prefill_resp` for decode.
+- `sglang-http`: both legs receive top-level `bootstrap_host`,
+  `bootstrap_port`, and `bootstrap_room`.
+- `trtllm-openai`: prefill uses `context_only`; decode uses `generation_only`
+  with `disagg_request_id`, `first_gen_tokens`,
+  `encoded_opaque_state`, and prompt token IDs.
+
+Request-scoped fault injection is available for failure-path testing:
+
+```bash
+# Fail only when this process has MOCK_PD_ROLE=prefill.
+curl -sS -i -X POST http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'x-request-id: local-failure-1' \
+  -H 'x-aibrix-mock-fail: prefill' \
+  -d '{"model":"llama2-7b","messages":[{"role":"user","content":"fail"}]}'
+
+# Delay the current mock request by 200 ms.
+curl -sS -i -X POST http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'x-request-id: local-delay-1' \
+  -H 'x-aibrix-mock-delay-ms: 200' \
+  -d '{"model":"llama2-7b","messages":[{"role":"user","content":"wait"}]}'
+```
+
+Matching `fail` requests return HTTP 500 and invalid delay values return HTTP
+400. Both outcomes are recorded. The delay limit is 30 seconds.
+
+### PD mock deployment in Kubernetes
+
+`config/mock/kustomization.yaml` deploys separate mock topologies for SHFS,
+NIXL, SGLang, and TRT-LLM. NIXL uses the independent model
+`llama2-7b-vllm-nixl` and the label
+`model.aibrix.ai/kv-connector-type: nixl`, so it cannot be paired with the
+default vLLM SHFS pods.
+
+```bash
+kubectl apply -k config/mock
+kubectl get stormservices -n default
+kubectl delete -k config/mock
+```
+
+The Kubernetes PD manifests set `MOCK_PD_CONTRACT` and `MOCK_PD_ROLE` on every
+prefill/decode container. The mock app does not require Redis for PR2. SGLang
+cross-pod failure state is reserved for the later PD failure e2e work.
+
+### Upstream KV connector source map
+
+The mock contracts are compatibility contracts for the gateway behavior that
+is declared in AIBrix. When an upstream engine or connector changes, check the
+HTTP schema first, then the prefill request/response code, then the decode
+consumer. Do not silently change an existing contract for a new upstream
+version; add a version- or connector-specific contract when the wire shape
+changes.
+
+#### vLLM
+
+vLLM implements KV transfer through the `kv_connector` hierarchy:
+
+```text
+vllm/distributed/kv_transfer/
+└── kv_connector/v1/
+    ├── base.py
+    ├── nixl_connector.py
+    ├── shared_storage_connector.py
+    └── mooncake/
+        └── mooncake_connector.py
+```
+
+The HTTP extension is defined in
+[`vllm/entrypoints/openai/protocol.py`](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/protocol.py).
+The connector implementations are under the
+[`v1 kv_connector directory`](https://github.com/vllm-project/vllm/tree/main/vllm/distributed/kv_transfer/kv_connector/v1).
+
+The corresponding AIBrix code is:
+
+```text
+pkg/plugins/gateway/algorithms/pd/engine/vllm.go
+pkg/plugins/gateway/algorithms/pd/transfer/resolver.go
+pkg/plugins/gateway/algorithms/pd/transfer/shfs.go
+pkg/plugins/gateway/algorithms/pd/transfer/nixl.go
+pkg/plugins/gateway/algorithms/pd/transfer/mooncake.go
+```
+
+For vLLM changes, update the SHFS or NIXL mock contract only after confirming
+which AIBrix transfer agent is selected. Do not treat every `LLM_ENGINE=vllm`
+request as having the same wire protocol.
+
+#### SGLang
+
+SGLang uses disaggregation and bootstrap fields rather than vLLM's
+`kv_connector` hierarchy:
+
+```text
+python/sglang/srt/entrypoints/openai/protocol.py
+python/sglang/srt/entrypoints/openai/serving_chat.py
+python/sglang/srt/disaggregation/prefill.py
+python/sglang/srt/disaggregation/decode.py
+```
+
+The relevant HTTP fields are top-level
+`bootstrap_host`, `bootstrap_port`, and `bootstrap_room`:
+
+- [`protocol.py`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/entrypoints/openai/protocol.py)
+- [`serving_chat.py`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/entrypoints/openai/serving_chat.py)
+- [`prefill.py`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/disaggregation/prefill.py)
+- [`decode.py`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/disaggregation/decode.py)
+
+AIBrix mutates these fields in
+`pkg/plugins/gateway/algorithms/pd/engine/sglang.go`. If SGLang changes the
+bootstrap schema, update `sglang-http` and its raw-body preservation tests.
+
+#### TensorRT-LLM
+
+TensorRT-LLM keeps the HTTP protocol and PD service in:
+
+```text
+tensorrt_llm/serve/openai_protocol.py
+tensorrt_llm/serve/openai_disagg_service.py
+tensorrt_llm/disaggregated_params.py
+```
+
+Useful upstream references:
+
+- [`openai_protocol.py`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/serve/openai_protocol.py)
+- [`openai_disagg_service.py`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/serve/openai_disagg_service.py)
+- [`disaggregated_params.py`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/disaggregated_params.py)
+
+The AIBrix implementation is
+`pkg/plugins/gateway/algorithms/pd/engine/trtllm.go`. Track
+`request_type`, `disagg_request_id`, `first_gen_tokens`,
+`encoded_opaque_state`, and `prompt_token_ids`. The HTTP response shape uses
+`choices[0].disaggregated_params`; the mock must not replace it with an
+unrelated top-level shape.
+
+When a field changes, use this maintenance path:
+
+```text
+upstream HTTP schema
+  → prefill request builder
+  → prefill response builder
+  → AIBrix gateway merge
+  → decode request validator
+```
+
+The detailed evidence and version notes are maintained in
+[`PD_CONTRACT_TRACE.md`](./PD_CONTRACT_TRACE.md).
+
 ## Mocked vLLM Basic Deployment
 
 ### Deploy the mocked app

--- a/development/app/app.py
+++ b/development/app/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, Response, jsonify
+from flask import Flask, request, Response, jsonify, make_response, g
 from flask_httpauth import HTTPTokenAuth
 from functools import wraps
 from werkzeug import serving
@@ -17,6 +17,9 @@ import os
 import uuid
 import json
 from typing import Optional
+
+from mock_recorder import RequestRecorder
+from pd_contracts import add_prompt_token_ids, parse_fault_headers, validate_or_build
 
 
 def _load_metrics_overrides():
@@ -439,7 +442,7 @@ def _mock_trtllm_prefill_disaggregated_params(data: dict) -> dict:
         "request_type": "context_only",  # gateway overrides this to generation_only for decode
         "disagg_request_id": disagg_request_id,
         "first_gen_tokens": [random.randint(100, 32000)],
-        "opaque_state": base64.b64encode(bytes(random.randint(8, 32))).decode(),
+        "encoded_opaque_state": base64.b64encode(bytes(random.randint(8, 32))).decode(),
     }
 
 
@@ -572,6 +575,298 @@ def disable_endpoint_logs():
 app = Flask(__name__)
 disable_endpoint_logs()
 
+request_recorder = RequestRecorder()
+
+
+def _mock_pd_config():
+    contract = os.getenv("MOCK_PD_CONTRACT", "")
+    role = os.getenv("MOCK_PD_ROLE", "")
+    engine = os.getenv("LLM_ENGINE")
+    if not engine:
+        engine = (
+            "vllm"
+            if contract.startswith("vllm-")
+            else "sglang"
+            if contract == "sglang-http"
+            else "trtllm"
+            if contract == "trtllm-openai"
+            else "vllm"
+        )
+    return contract, role, engine
+
+
+def _json_response_body(response):
+    if response.is_streamed:
+        return None
+    return response.get_json(silent=True)
+
+
+def _stream_response_metadata(path, payload):
+    return {
+        "object": "chat.completion.chunk" if "chat" in path else "text_completion",
+        "model": payload.get("model") if isinstance(payload, dict) else None,
+        "stream": True,
+    }
+
+
+def _safe_merge_contract_response(response, contract_result, path, payload):
+    """Merge only PD fields into a normal completion response.
+
+    A contract result may contain a complete backend body as well as explicit
+    patches. Request fields are never copied wholesale into the client-facing
+    response, and ordinary OpenAI fields remain authoritative.
+    """
+    if response.status_code >= 400:
+        return response
+
+    if response.is_streamed:
+        return response
+
+    body = response.get_json(silent=True)
+    if not isinstance(body, dict):
+        return response
+
+    contract_body = contract_result.get("body")
+    if isinstance(contract_body, dict):
+        for key in ("kv_transfer_params", "disagg_prefill_resp"):
+            if key in contract_body:
+                body[key] = contract_body[key]
+        if "opaque" in contract_body:
+            body["opaque"] = contract_body["opaque"]
+
+    protected_response_keys = {"choices", "message", "finish_reason"}
+    for key, value in contract_result.get("response_patch", {}).items():
+        if key not in protected_response_keys:
+            body[key] = value
+
+    choices = body.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+        protected_choice_keys = {"message", "finish_reason"}
+        for key, value in contract_result.get("choice_patch", {}).items():
+            if key not in protected_choice_keys:
+                choices[0][key] = value
+
+    response.set_data(json.dumps(body, ensure_ascii=False).encode("utf-8"))
+    response.content_type = "application/json"
+    return response
+
+
+def _completion_record_error(response_body):
+    if isinstance(response_body, dict):
+        error = response_body.get("error")
+        if isinstance(error, dict):
+            return error.get("message")
+    return None
+
+
+def _recorder_headers(headers):
+    sensitive_headers = {
+        "authorization",
+        "cookie",
+        "proxy-authorization",
+        "x-api-key",
+    }
+    return {
+        key: "<redacted>" if str(key).lower() in sensitive_headers else value
+        for key, value in headers.items()
+    }
+
+
+def _finalize_completion_record(
+    handle,
+    response,
+    *,
+    path,
+    payload,
+    delay_ms,
+    forced_outcome=None,
+    forced_error=None,
+):
+    status_code = response.status_code
+    response_body = (
+        _stream_response_metadata(path, payload)
+        if response.is_streamed
+        else _json_response_body(response)
+    )
+    if forced_outcome is not None:
+        outcome = forced_outcome
+    elif 400 <= status_code < 500:
+        outcome = "rejected"
+    elif status_code >= 500:
+        outcome = "failed"
+    else:
+        outcome = "success"
+    error = forced_error or _completion_record_error(response_body)
+    try:
+        request_recorder.finish(
+            handle,
+            outcome=outcome,
+            status_code=status_code,
+            response=response_body,
+            error=error,
+            delay_ms=delay_ms,
+        )
+    except Exception:
+        logger.warning(
+            "Unable to finalize mock request recorder entry; preserving HTTP response",
+            exc_info=True,
+        )
+
+
+def _recorded_completion(path):
+    def decorator(func):
+        def _start_record(raw_body, payload, contract, role, engine, request_id):
+            handle = request_recorder.start(
+                path=path,
+                headers=_recorder_headers(request.headers),
+                raw_body=raw_body,
+                parsed_json=payload,
+                pod=POD_NAME,
+                engine=engine,
+                role=role,
+                request_id=request_id,
+            )
+            g._aibrix_completion_handle = handle
+            g._aibrix_completion_payload = payload
+            g._aibrix_completion_delay_ms = 0
+            return handle
+
+        def _after_auth(*args, **kwargs):
+            raw_body = g._aibrix_completion_raw_body
+            contract, role, engine = _mock_pd_config()
+            request_id = request.headers.get("X-Request-ID")
+
+            try:
+                payload = request.json
+            except Exception as exc:
+                _start_record(raw_body, None, contract, role, engine, request_id)
+                return make_response(
+                    create_error_response(
+                        "The server had an error while processing your request. Sorry about that!",
+                        error_type="api_error",
+                        status_code=400,
+                    )
+                )
+
+            handle = _start_record(raw_body, payload, contract, role, engine, request_id)
+            try:
+                fault = parse_fault_headers(request.headers, role)
+                g._aibrix_completion_delay_ms = fault.delay_ms
+                if fault.validation_status_code != 200:
+                    return make_response(
+                        create_error_response(
+                            fault.metadata["error"],
+                            status_code=fault.validation_status_code,
+                        )
+                    )
+
+                if fault.delay_ms:
+                    time.sleep(fault.delay_ms / 1000.0)
+
+                if fault.injected_status_code is not None:
+                    message = f"mock failure injected for role {role}"
+                    return make_response(
+                        create_error_response(
+                            message,
+                            error_type="api_error",
+                            status_code=fault.injected_status_code,
+                        )
+                    )
+
+                contract_result = None
+                if contract:
+                    request_result = validate_or_build(
+                        contract,
+                        role,
+                        payload,
+                        request_id=request_id,
+                    )
+                    if request_result["status_code"] != 200:
+                        return make_response(
+                            (
+                                jsonify(request_result["body"]),
+                                request_result["status_code"],
+                            )
+                        )
+                    contract_result = request_result
+
+                response = make_response(func(*args, **kwargs))
+                if contract_result is not None:
+                    if contract == "trtllm-openai" and role == "prefill":
+                        response_body = _json_response_body(response)
+                        usage = response_body.get("usage", {}) if isinstance(response_body, dict) else {}
+                        contract_result = add_prompt_token_ids(
+                            contract_result,
+                            usage.get("prompt_tokens"),
+                        )
+                    response = _safe_merge_contract_response(
+                        response,
+                        contract_result,
+                        path,
+                        payload,
+                    )
+                return response
+            except Exception as exc:
+                logger.exception("Error in recorded completion endpoint")
+                return make_response(
+                    create_error_response(
+                        "The server had an error while processing your request. Sorry about that!",
+                        error_type="api_error",
+                        status_code=500,
+                    )
+                )
+
+        # Applying auth_required here keeps authentication in one place while
+        # letting the outer recorder capture the request before auth runs.
+        authenticated_handler = auth_required(_after_auth)
+
+        @wraps(func)
+        def wrapped(*args, **kwargs):
+            raw_body = request.get_data(cache=True)
+            g._aibrix_completion_raw_body = raw_body
+            g._aibrix_completion_handle = None
+            g._aibrix_completion_payload = None
+            g._aibrix_completion_delay_ms = 0
+            contract, role, engine = _mock_pd_config()
+            request_id = request.headers.get("X-Request-ID")
+
+            try:
+                response = make_response(authenticated_handler(*args, **kwargs))
+            except Exception as exc:
+                logger.exception("Error in recorded completion authentication")
+                if g._aibrix_completion_handle is None:
+                    _start_record(raw_body, None, contract, role, engine, request_id)
+                response = make_response(
+                    create_error_response(
+                        "The server had an error while processing your request. Sorry about that!",
+                        error_type="api_error",
+                        status_code=500,
+                    )
+                )
+
+            if g._aibrix_completion_handle is None:
+                # auth_required returned its normal 401/403 response before
+                # body parsing, fault handling, or contract validation.
+                _start_record(raw_body, None, contract, role, engine, request_id)
+
+            _finalize_completion_record(
+                g._aibrix_completion_handle,
+                response,
+                path=path,
+                payload=g._aibrix_completion_payload,
+                delay_ms=g._aibrix_completion_delay_ms,
+            )
+            return response
+
+        return wrapped
+
+    return decorator
+
+
+@app.route("/debug/requests", methods=["GET"])
+def debug_requests():
+    return jsonify(request_recorder.query(request_id=request.args.get("request_id")))
+
 
 # =============================================================================
 # HEALTH & UTILITY ENDPOINTS
@@ -679,7 +974,7 @@ def unload_lora_adapter():
 # =============================================================================
 
 @app.route("/v1/completions", methods=["POST"])
-@auth_required
+@_recorded_completion("/v1/completions")
 def completion():
     try:
         prompt = request.json.get("prompt")
@@ -824,7 +1119,8 @@ def completion():
             if metrics is not None:
                 response["metrics"] = metrics
 
-            _apply_pd_prefill_fields(response, request.json, input_tokens)
+            if os.getenv("MOCK_PD_CONTRACT") != "trtllm-openai":
+                _apply_pd_prefill_fields(response, request.json, input_tokens)
 
             _log_mock_exchange("/v1/completions", request.json, response)
             return jsonify(response), 200
@@ -841,7 +1137,7 @@ def completion():
 
 
 @app.route("/v1/chat/completions", methods=["POST"])
-@auth_required
+@_recorded_completion("/v1/chat/completions")
 def chat_completions():
     try:
         messages = request.json.get("messages")
@@ -1087,7 +1383,8 @@ def chat_completions():
             if metrics is not None:
                 response["metrics"] = metrics
 
-            _apply_pd_prefill_fields(response, request.json, input_tokens)
+            if os.getenv("MOCK_PD_CONTRACT") != "trtllm-openai":
+                _apply_pd_prefill_fields(response, request.json, input_tokens)
 
             _log_mock_exchange("/v1/chat/completions", request.json, response)
             return jsonify(response), 200

--- a/development/app/config/mock/config-profile.yaml
+++ b/development/app/config/mock/config-profile.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         adapter.model.aibrix.ai/enabled: "true"
         model.aibrix.ai/name: "qwen3-8b"
+        model.aibrix.ai/port: "8000"
         app: "mock-qwen3-8b"
       annotations:
         model.aibrix.ai/config: |

--- a/development/app/config/mock/kustomization.yaml
+++ b/development/app/config/mock/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
   - components.yaml
   - config-profile.yaml
   - vllm-pd-config.yaml
+  - nixl-pd-config.yaml
   - vllm-pd-bucketing-config.yaml
   - sglang-pd-config.yaml
   - trtllm-pd-config.yaml

--- a/development/app/config/mock/nixl-pd-config.yaml
+++ b/development/app/config/mock/nixl-pd-config.yaml
@@ -1,36 +1,29 @@
-# SGLang PD (Prefill-Decode) disaggregation mock StormService for e2e tests.
+# vLLM NIXL PD (Prefill-Decode) disaggregation mock StormService for e2e tests.
 #
-# A single StormService replica with two roles ("prefill" and "decode") backed
-# by the vllm-mock image.  The gateway PD router pairs pods from the same
-# roleset (auto-assigned by the StormService controller as "roleset-name") and
-# fires an async prefill request to the prefill pod (SGLang uses the bootstrap
-# mechanism to coordinate KV transfer) before sending the full request to the
-# decode pod.
-#
-# The prefill pod carries the model.aibrix.ai/sglang-bootstrap-port annotation
-# so the gateway knows which port the SGLang bootstrap server listens on.
+# A separate 2x1P1D topology keeps NIXL connector selection isolated from the
+# SHFS vLLM topology while preserving the same mock service conventions.
 #
 # Apply alongside components.yaml (provides mocked-app-sa and RBAC).
 apiVersion: orchestration.aibrix.ai/v1alpha1
 kind: StormService
 metadata:
-  name: mock-llama2-7b-pd-sglang
+  name: mock-llama2-7b-pd-vllm-nixl
   namespace: default
   labels:
-    model.aibrix.ai/name: "llama2-7b-sglang"
+    model.aibrix.ai/name: "llama2-7b-vllm-nixl"
     model.aibrix.ai/port: "8000"
 spec:
-  replicas: 1
+  replicas: 2
   updateStrategy:
     type: InPlaceUpdate
   stateful: true
   selector:
     matchLabels:
-      app: "mock-llama2-7b-pd-sglang"
+      app: "mock-llama2-7b-pd-vllm-nixl"
   template:
     metadata:
       labels:
-        app: "mock-llama2-7b-pd-sglang"
+        app: "mock-llama2-7b-pd-vllm-nixl"
       annotations:
         model.aibrix.ai/config: |
           {
@@ -49,16 +42,13 @@ spec:
           template:
             metadata:
               labels:
-                app: "mock-llama2-7b-pd-sglang"
-                app.kubernetes.io/name: "mock-llama2-7b-pd-sglang"
-                model.aibrix.ai/name: "llama2-7b-sglang"
+                app: "mock-llama2-7b-pd-vllm-nixl"
+                app.kubernetes.io/name: "mock-llama2-7b-pd-vllm-nixl"
+                model.aibrix.ai/name: "llama2-7b-vllm-nixl"
                 model.aibrix.ai/port: "8000"
-                model.aibrix.ai/engine: sglang
+                model.aibrix.ai/engine: vllm
+                model.aibrix.ai/kv-connector-type: nixl
                 adapter.model.aibrix.ai/enabled: "true"
-              annotations:
-                # Port of the SGLang bootstrap server used to coordinate KV transfer
-                # between prefill and decode pods. Defaults to 8998 if omitted.
-                model.aibrix.ai/sglang-bootstrap-port: "8998"
             spec:
               serviceAccountName: mocked-app-sa
               containers:
@@ -67,10 +57,8 @@ spec:
                   ports:
                     - containerPort: 8000
                   env:
-                    - name: LLM_ENGINE
-                      value: sglang
                     - name: MOCK_PD_CONTRACT
-                      value: sglang-http
+                      value: vllm-aibrix-nixl
                     - name: MOCK_PD_ROLE
                       value: prefill
                     - name: DEPLOYMENT_NAME
@@ -95,11 +83,12 @@ spec:
           template:
             metadata:
               labels:
-                app: "mock-llama2-7b-pd-sglang"
-                app.kubernetes.io/name: "mock-llama2-7b-pd-sglang"
-                model.aibrix.ai/name: "llama2-7b-sglang"
+                app: "mock-llama2-7b-pd-vllm-nixl"
+                app.kubernetes.io/name: "mock-llama2-7b-pd-vllm-nixl"
+                model.aibrix.ai/name: "llama2-7b-vllm-nixl"
                 model.aibrix.ai/port: "8000"
-                model.aibrix.ai/engine: sglang
+                model.aibrix.ai/engine: vllm
+                model.aibrix.ai/kv-connector-type: nixl
                 adapter.model.aibrix.ai/enabled: "true"
             spec:
               serviceAccountName: mocked-app-sa
@@ -109,10 +98,8 @@ spec:
                   ports:
                     - containerPort: 8000
                   env:
-                    - name: LLM_ENGINE
-                      value: sglang
                     - name: MOCK_PD_CONTRACT
-                      value: sglang-http
+                      value: vllm-aibrix-nixl
                     - name: MOCK_PD_ROLE
                       value: decode
                     - name: DEPLOYMENT_NAME

--- a/development/app/config/mock/trtllm-pd-config.yaml
+++ b/development/app/config/mock/trtllm-pd-config.yaml
@@ -46,6 +46,8 @@ spec:
           template:
             metadata:
               labels:
+                app: "mock-llama2-7b-pd-trtllm"
+                app.kubernetes.io/name: "mock-llama2-7b-pd-trtllm"
                 model.aibrix.ai/name: "llama2-7b-trtllm"
                 model.aibrix.ai/port: "8000"
                 model.aibrix.ai/engine: trtllm
@@ -60,6 +62,10 @@ spec:
                   env:
                     - name: LLM_ENGINE
                       value: trtllm
+                    - name: MOCK_PD_CONTRACT
+                      value: trtllm-openai
+                    - name: MOCK_PD_ROLE
+                      value: prefill
                     - name: DEPLOYMENT_NAME
                       valueFrom:
                         fieldRef:
@@ -82,6 +88,8 @@ spec:
           template:
             metadata:
               labels:
+                app: "mock-llama2-7b-pd-trtllm"
+                app.kubernetes.io/name: "mock-llama2-7b-pd-trtllm"
                 model.aibrix.ai/name: "llama2-7b-trtllm"
                 model.aibrix.ai/port: "8000"
                 model.aibrix.ai/engine: trtllm
@@ -96,6 +104,10 @@ spec:
                   env:
                     - name: LLM_ENGINE
                       value: trtllm
+                    - name: MOCK_PD_CONTRACT
+                      value: trtllm-openai
+                    - name: MOCK_PD_ROLE
+                      value: decode
                     - name: DEPLOYMENT_NAME
                       valueFrom:
                         fieldRef:

--- a/development/app/config/mock/vllm-pd-bucketing-config.yaml
+++ b/development/app/config/mock/vllm-pd-bucketing-config.yaml
@@ -38,6 +38,8 @@ spec:
           template:
             metadata:
               labels:
+                app: "mock-llama2-pd-bkt-sht"
+                app.kubernetes.io/name: "mock-llama2-pd-bkt-sht"
                 model.aibrix.ai/name: "llama2-7b-vllm-bucket"
                 model.aibrix.ai/port: "8000"
                 model.aibrix.ai/engine: vllm
@@ -86,6 +88,8 @@ spec:
           template:
             metadata:
               labels:
+                app: "mock-llama2-pd-bkt-sht"
+                app.kubernetes.io/name: "mock-llama2-pd-bkt-sht"
                 model.aibrix.ai/name: "llama2-7b-vllm-bucket"
                 model.aibrix.ai/port: "8000"
                 model.aibrix.ai/engine: vllm
@@ -157,6 +161,8 @@ spec:
           template:
             metadata:
               labels:
+                app: "mock-llama2-pd-bkt-med"
+                app.kubernetes.io/name: "mock-llama2-pd-bkt-med"
                 model.aibrix.ai/name: "llama2-7b-vllm-bucket"
                 model.aibrix.ai/port: "8000"
                 model.aibrix.ai/engine: vllm
@@ -205,6 +211,8 @@ spec:
           template:
             metadata:
               labels:
+                app: "mock-llama2-pd-bkt-med"
+                app.kubernetes.io/name: "mock-llama2-pd-bkt-med"
                 model.aibrix.ai/name: "llama2-7b-vllm-bucket"
                 model.aibrix.ai/port: "8000"
                 model.aibrix.ai/engine: vllm
@@ -276,6 +284,8 @@ spec:
           template:
             metadata:
               labels:
+                app: "mock-llama2-pd-bkt-comb"
+                app.kubernetes.io/name: "mock-llama2-pd-bkt-comb"
                 model.aibrix.ai/name: "llama2-7b-vllm-bucket"
                 model.aibrix.ai/port: "8000"
                 model.aibrix.ai/engine: vllm

--- a/development/app/config/mock/vllm-pd-config.yaml
+++ b/development/app/config/mock/vllm-pd-config.yaml
@@ -45,6 +45,8 @@ spec:
           template:
             metadata:
               labels:
+                app: "mock-llama2-7b-pd-vllm"
+                app.kubernetes.io/name: "mock-llama2-7b-pd-vllm"
                 model.aibrix.ai/name: "llama2-7b-vllm"
                 model.aibrix.ai/port: "8000"
                 model.aibrix.ai/engine: vllm
@@ -57,6 +59,10 @@ spec:
                   ports:
                     - containerPort: 8000
                   env:
+                    - name: MOCK_PD_CONTRACT
+                      value: vllm-aibrix-shfs
+                    - name: MOCK_PD_ROLE
+                      value: prefill
                     - name: DEPLOYMENT_NAME
                       valueFrom:
                         fieldRef:
@@ -79,6 +85,8 @@ spec:
           template:
             metadata:
               labels:
+                app: "mock-llama2-7b-pd-vllm"
+                app.kubernetes.io/name: "mock-llama2-7b-pd-vllm"
                 model.aibrix.ai/name: "llama2-7b-vllm"
                 model.aibrix.ai/port: "8000"
                 model.aibrix.ai/engine: vllm
@@ -91,6 +99,10 @@ spec:
                   ports:
                     - containerPort: 8000
                   env:
+                    - name: MOCK_PD_CONTRACT
+                      value: vllm-aibrix-shfs
+                    - name: MOCK_PD_ROLE
+                      value: decode
                     - name: DEPLOYMENT_NAME
                       valueFrom:
                         fieldRef:

--- a/development/app/mock_recorder.py
+++ b/development/app/mock_recorder.py
@@ -1,0 +1,165 @@
+"""Thread-safe, bounded request recorder for the mock OpenAI server."""
+
+import base64
+from collections import deque
+from datetime import datetime, timezone
+import math
+import threading
+import weakref
+
+
+OUTCOMES = frozenset(("success", "rejected", "failed"))
+
+
+class _RecordHandle:
+    """Opaque identity used to complete exactly one recorder entry."""
+
+    __slots__ = ("_sequence", "__weakref__")
+
+    def __init__(self, sequence):
+        self._sequence = sequence
+
+    @property
+    def sequence(self):
+        return self._sequence
+
+
+def _timestamp():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _json_safe(value, active_ids=None):
+    """Convert a value to the JSON types exposed by the debug endpoint."""
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, bytes):
+        return base64.b64encode(value).decode("ascii")
+
+    if active_ids is None:
+        active_ids = set()
+    value_id = id(value)
+    if value_id in active_ids:
+        return "<recursive value>"
+
+    active_ids.add(value_id)
+    try:
+        if isinstance(value, dict):
+            return {
+                str(key): _json_safe(item, active_ids)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple, set, frozenset)):
+            return [_json_safe(item, active_ids) for item in value]
+        return str(value)
+    finally:
+        active_ids.remove(value_id)
+
+
+class RequestRecorder:
+    """Store a bounded, JSON-serializable history of mock HTTP requests."""
+
+    def __init__(self, capacity=1000):
+        if not isinstance(capacity, int) or isinstance(capacity, bool) or capacity <= 0:
+            raise ValueError("capacity must be a positive integer")
+        self._records = deque(maxlen=capacity)
+        self._lock = threading.Lock()
+        self._next_sequence = 1
+        self._handles = weakref.WeakKeyDictionary()
+
+    def start(
+        self,
+        *,
+        path,
+        headers,
+        raw_body,
+        parsed_json,
+        pod,
+        engine,
+        role,
+        request_id=None,
+    ):
+        """Create and retain a request record, returning its completion handle."""
+        if not isinstance(raw_body, bytes):
+            raise TypeError("raw_body must be bytes")
+        headers = _json_safe(dict(headers))
+        if request_id is None:
+            request_id = next(
+                (value for key, value in headers.items() if key.lower() == "x-request-id"),
+                None,
+            )
+
+        with self._lock:
+            sequence = self._next_sequence
+            self._next_sequence += 1
+            handle = _RecordHandle(sequence)
+            self._handles[handle] = sequence
+            self._records.append(
+                {
+                    "sequence": sequence,
+                    "timestamp_started": _timestamp(),
+                    "timestamp_finished": None,
+                    "request_id": request_id,
+                    "path": path,
+                    "headers": headers,
+                    "raw_body_base64": base64.b64encode(raw_body).decode("ascii"),
+                    "parsed_json": _json_safe(parsed_json),
+                    "pod": pod,
+                    "engine": engine,
+                    "role": role,
+                    "outcome": None,
+                    "status_code": None,
+                    "error": None,
+                    "response": None,
+                    "delay_ms": None,
+                }
+            )
+        return handle
+
+    def finish(
+        self,
+        handle,
+        *,
+        outcome,
+        status_code,
+        response=None,
+        error=None,
+        delay_ms=None,
+    ):
+        """Complete a previously started record."""
+        if outcome not in OUTCOMES:
+            raise ValueError("outcome must be one of: success, rejected, failed")
+        if not isinstance(handle, _RecordHandle):
+            raise ValueError("record handle belongs to another recorder")
+
+        with self._lock:
+            sequence = self._handles.get(handle)
+            if sequence is None:
+                raise ValueError("record handle belongs to another recorder")
+            for record in self._records:
+                if record["sequence"] == sequence:
+                    if record["outcome"] is not None:
+                        raise RuntimeError("record is already finished")
+                    record.update(
+                        {
+                            "timestamp_finished": _timestamp(),
+                            "outcome": outcome,
+                            "status_code": status_code,
+                            "error": _json_safe(error),
+                            "response": _json_safe(response),
+                            "delay_ms": delay_ms,
+                        }
+                    )
+                    return
+        raise KeyError(f"record {sequence} is no longer available")
+
+    def query(self, *, request_id=None):
+        """Return independent, sequence-ordered copies of matching records."""
+        with self._lock:
+            records = [
+                _json_safe(record)
+                for record in self._records
+                if request_id is None or record["request_id"] == request_id
+            ]
+        return records

--- a/development/app/pd_contracts.py
+++ b/development/app/pd_contracts.py
@@ -1,0 +1,336 @@
+"""Pure-Python validators and response builders for gateway PD contracts."""
+
+from copy import deepcopy
+from typing import NamedTuple
+
+
+CONTRACT_VLLM_AIBRIX_SHFS = "vllm-aibrix-shfs"
+CONTRACT_VLLM_AIBRIX_NIXL = "vllm-aibrix-nixl"
+CONTRACT_SGLANG_HTTP = "sglang-http"
+CONTRACT_TRTLLM_OPENAI = "trtllm-openai"
+
+PREFILL = "prefill"
+DECODE = "decode"
+OPAQUE_SENTINEL = "aibrix-pd-contract-opaque-sentinel"
+
+_CONTRACTS = frozenset(
+    (
+        CONTRACT_VLLM_AIBRIX_SHFS,
+        CONTRACT_VLLM_AIBRIX_NIXL,
+        CONTRACT_SGLANG_HTTP,
+        CONTRACT_TRTLLM_OPENAI,
+    )
+)
+_ROLES = frozenset((PREFILL, DECODE))
+MAX_FAULT_DELAY_MS = 30_000
+
+
+class FrozenDict(dict):
+    """A JSON-serializable dict that cannot be mutated after construction."""
+
+    def __init__(self, *args, **kwargs):
+        if getattr(self, "_initialized", False):
+            raise TypeError("FrozenDict is already initialized")
+        values = dict(*args, **kwargs)
+        for key, value in values.items():
+            dict.__setitem__(self, key, value)
+        object.__setattr__(self, "_initialized", True)
+
+    def __setattr__(self, name, value):
+        raise TypeError("FrozenDict is immutable")
+
+    def _raise_immutable(self, *args, **kwargs):
+        raise TypeError("FrozenDict is immutable")
+
+    __setitem__ = _raise_immutable
+    __delitem__ = _raise_immutable
+    clear = _raise_immutable
+    pop = _raise_immutable
+    popitem = _raise_immutable
+    setdefault = _raise_immutable
+    update = _raise_immutable
+    __ior__ = _raise_immutable
+
+
+class FaultParseResult(NamedTuple):
+    """Immutable result of parsing request-scoped mock fault headers."""
+
+    delay_ms: int
+    injected_status_code: int | None
+    validation_status_code: int
+    metadata: FrozenDict
+
+
+def parse_fault_headers(headers, role):
+    """Parse fault-injection headers without sleeping or changing shared state."""
+    normalized_headers = {str(key).lower(): value for key, value in headers.items()}
+    delay_value = normalized_headers.get("x-aibrix-mock-delay-ms")
+
+    if "x-aibrix-mock-delay-ms" not in normalized_headers:
+        delay_ms = 0
+    elif isinstance(delay_value, bool):
+        return FaultParseResult(
+            delay_ms=0,
+            injected_status_code=None,
+            validation_status_code=400,
+            metadata=FrozenDict(error="invalid x-aibrix-mock-delay-ms"),
+        )
+    else:
+        try:
+            delay_ms = int(delay_value)
+        except (TypeError, ValueError):
+            return FaultParseResult(
+                delay_ms=0,
+                injected_status_code=None,
+                validation_status_code=400,
+                metadata=FrozenDict(error="invalid x-aibrix-mock-delay-ms"),
+            )
+        if str(delay_value) != str(delay_ms) or not 0 <= delay_ms <= MAX_FAULT_DELAY_MS:
+            return FaultParseResult(
+                delay_ms=0,
+                injected_status_code=None,
+                validation_status_code=400,
+                metadata=FrozenDict(error="invalid x-aibrix-mock-delay-ms"),
+            )
+
+    fail_value = normalized_headers.get("x-aibrix-mock-fail")
+    injected_status_code = 500 if fail_value in _ROLES and fail_value == role else None
+    return FaultParseResult(
+        delay_ms=delay_ms,
+        injected_status_code=injected_status_code,
+        validation_status_code=200,
+        metadata=FrozenDict(),
+    )
+
+
+def _result(
+    contract,
+    role,
+    request_id,
+    status_code,
+    body=None,
+    error=None,
+    response_patch=None,
+    choice_patch=None,
+):
+    return {
+        "status_code": status_code,
+        "metadata": {
+            "contract": contract,
+            "role": role,
+            "request_id": request_id,
+            "error": error,
+            "error_type": None,
+            "message": error,
+        },
+        "body": body,
+        "response_patch": response_patch or {},
+        "choice_patch": choice_patch or {},
+    }
+
+
+def _error(contract, role, request_id, message):
+    error_type = "invalid_contract_or_role" if "contract" in message or "role" in message else "invalid_request"
+    result = _result(contract, role, request_id, 400, error=message)
+    result["metadata"]["error_type"] = error_type
+    result["body"] = {"error": {"type": error_type, "message": message}}
+    return result
+
+
+def _require_mapping(payload, contract, role, request_id):
+    if not isinstance(payload, dict):
+        return _error(contract, role, request_id, "payload must be an object")
+    return None
+
+
+def _nested_mapping(payload, key, contract, role, request_id):
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        return None, _error(contract, role, request_id, f"missing {key}")
+    return value, None
+
+
+def _validate_shfs(contract, role, payload, request_id):
+    params, error = _nested_mapping(payload, "kv_transfer_params", contract, role, request_id)
+    if error:
+        return error
+    if role == DECODE:
+        required = (
+            "do_remote_decode",
+            "do_remote_prefill",
+            "remote_engine_id",
+            "remote_block_ids",
+            "remote_host",
+            "remote_port",
+            "opaque",
+        )
+        for key in required:
+            if key not in params:
+                return _error(contract, role, request_id, f"missing kv_transfer_params.{key}")
+        if params["do_remote_decode"] is not False:
+            return _error(contract, role, request_id, "kv_transfer_params.do_remote_decode must be false")
+        if params["do_remote_prefill"] is not True:
+            return _error(contract, role, request_id, "kv_transfer_params.do_remote_prefill must be true")
+        if not isinstance(params["remote_engine_id"], str) or not params["remote_engine_id"]:
+            return _error(contract, role, request_id, "invalid kv_transfer_params.remote_engine_id")
+        if not isinstance(params["remote_block_ids"], list) or not params["remote_block_ids"]:
+            return _error(contract, role, request_id, "invalid kv_transfer_params.remote_block_ids")
+        if not isinstance(params["remote_host"], str) or not params["remote_host"]:
+            return _error(contract, role, request_id, "invalid kv_transfer_params.remote_host")
+        if (
+            isinstance(params["remote_port"], bool)
+            or not isinstance(params["remote_port"], int)
+            or params["remote_port"] <= 0
+        ):
+            return _error(contract, role, request_id, "invalid kv_transfer_params.remote_port")
+        if params["opaque"] != OPAQUE_SENTINEL:
+            return _error(contract, role, request_id, "invalid kv_transfer_params.opaque sentinel")
+        return _result(contract, role, request_id, 200, deepcopy(payload))
+
+    if params.get("do_remote_decode") is not True:
+        return _error(contract, role, request_id, "kv_transfer_params.do_remote_decode must be true")
+    body = deepcopy(payload)
+    transfer = body["kv_transfer_params"]
+    transfer.update(
+        {
+            "do_remote_decode": False,
+            "do_remote_prefill": True,
+            "remote_engine_id": transfer.get("remote_engine_id") or "prefill-engine",
+            "remote_block_ids": transfer.get("remote_block_ids") or ["block-1"],
+            "remote_host": transfer.get("remote_host") or "prefill.example",
+            "remote_port": transfer.get("remote_port") or 8001,
+            "opaque": OPAQUE_SENTINEL,
+        }
+    )
+    return _result(contract, role, request_id, 200, body)
+
+
+def _validate_nixl(contract, role, payload, request_id):
+    if role == PREFILL:
+        params = payload.get("kv_transfer_params")
+        if isinstance(params, dict) and "do_remote_decode" in params:
+            return _error(
+                contract,
+                role,
+                request_id,
+                "nixl prefill must not contain SHFS kv_transfer_params skeleton",
+            )
+        response = deepcopy(payload)
+        response["opaque"] = OPAQUE_SENTINEL
+        # The gateway wraps the complete prefill HTTP response itself when it
+        # builds the decode request. Keep the mock response unwrapped.
+        return _result(contract, role, request_id, 200, response)
+
+    response, error = _nested_mapping(payload, "disagg_prefill_resp", contract, role, request_id)
+    if error:
+        return error
+    if response.get("opaque") != OPAQUE_SENTINEL:
+        return _error(contract, role, request_id, "missing disagg_prefill_resp.opaque sentinel")
+    return _result(contract, role, request_id, 200, deepcopy(payload))
+
+
+def _validate_sglang(contract, role, payload, request_id):
+    host = payload.get("bootstrap_host")
+    port = payload.get("bootstrap_port")
+    room = payload.get("bootstrap_room")
+    if not isinstance(host, str) or not host:
+        return _error(contract, role, request_id, "invalid bootstrap_host")
+    if isinstance(port, bool) or not isinstance(port, int) or port <= 0:
+        return _error(contract, role, request_id, "invalid bootstrap_port")
+    if isinstance(room, bool) or not isinstance(room, int) or room < 0:
+        return _error(contract, role, request_id, "invalid bootstrap_room")
+    return _result(contract, role, request_id, 200, deepcopy(payload))
+
+
+def _validate_trtllm(contract, role, payload, request_id):
+    params, error = _nested_mapping(payload, "disaggregated_params", contract, role, request_id)
+    if error:
+        return error
+    expected = "context_only" if role == PREFILL else "generation_only"
+    if params.get("request_type") != expected:
+        return _error(contract, role, request_id, f"disaggregated_params.request_type must be {expected}")
+    if role == DECODE:
+        token_ids = payload.get("prompt_token_ids")
+        if not isinstance(token_ids, list) or any(
+            isinstance(token, bool) or not isinstance(token, int) for token in token_ids
+        ):
+            return _error(contract, role, request_id, "missing prompt_token_ids")
+        for key in ("disagg_request_id", "first_gen_tokens", "encoded_opaque_state"):
+            if key not in params:
+                return _error(contract, role, request_id, f"missing disaggregated_params.{key}")
+        disagg_request_id = params["disagg_request_id"]
+        valid_request_id = (
+            isinstance(disagg_request_id, int)
+            and not isinstance(disagg_request_id, bool)
+        ) or (
+            isinstance(disagg_request_id, str)
+            and bool(disagg_request_id)
+            and disagg_request_id.lstrip("-").isdigit()
+        )
+        if not valid_request_id:
+            return _error(contract, role, request_id, "invalid disaggregated_params.disagg_request_id")
+        if not isinstance(params["first_gen_tokens"], list) or any(
+            isinstance(token, bool) or not isinstance(token, int) for token in params["first_gen_tokens"]
+        ):
+            return _error(contract, role, request_id, "invalid disaggregated_params.first_gen_tokens")
+        if not isinstance(params["encoded_opaque_state"], str):
+            return _error(contract, role, request_id, "invalid disaggregated_params.encoded_opaque_state")
+        return _result(contract, role, request_id, 200, deepcopy(payload))
+
+    prefill_params = deepcopy(params)
+    prefill_params.setdefault("first_gen_tokens", [1])
+    prefill_params.setdefault("encoded_opaque_state", OPAQUE_SENTINEL)
+    response_patch = {}
+    token_ids = payload.get("prompt_token_ids")
+    if token_ids is not None:
+        if not isinstance(token_ids, list) or any(
+            isinstance(token, bool) or not isinstance(token, int) for token in token_ids
+        ):
+            return _error(contract, role, request_id, "invalid prompt_token_ids")
+        response_patch["prompt_token_ids"] = deepcopy(token_ids)
+
+    return _result(
+        contract,
+        role,
+        request_id,
+        200,
+        response_patch=response_patch,
+        choice_patch={"disaggregated_params": prefill_params},
+    )
+
+
+def add_prompt_token_ids(result, prompt_token_count):
+    """Add gateway-facing TRT-LLM prompt IDs when the request omitted them."""
+    if result["status_code"] != 200 or not isinstance(prompt_token_count, int):
+        return result
+
+    if "prompt_token_ids" in result.get("response_patch", {}):
+        return result
+
+    enriched = deepcopy(result)
+    enriched.setdefault("response_patch", {})["prompt_token_ids"] = list(
+        range(max(prompt_token_count, 0))
+    )
+    return enriched
+
+
+def validate_or_build(contract, role, payload, request_id=None):
+    """Validate a gateway handoff and return a transport-neutral HTTP result."""
+    if not isinstance(contract, str):
+        return _error(contract, role, request_id, "contract must be a string")
+    if not isinstance(role, str) or role not in _ROLES:
+        return _error(contract, role, request_id, "role must be prefill or decode")
+    if contract and contract not in _CONTRACTS:
+        return _error(contract, role, request_id, f"unknown contract: {contract}")
+    if not contract:
+        return _result(contract, role, request_id, 200, deepcopy(payload))
+    error = _require_mapping(payload, contract, role, request_id)
+    if error:
+        return error
+    validators = {
+        CONTRACT_VLLM_AIBRIX_SHFS: _validate_shfs,
+        CONTRACT_VLLM_AIBRIX_NIXL: _validate_nixl,
+        CONTRACT_SGLANG_HTTP: _validate_sglang,
+        CONTRACT_TRTLLM_OPENAI: _validate_trtllm,
+    }
+    return validators[contract](contract, role, payload, request_id)

--- a/development/app/requirements.txt
+++ b/development/app/requirements.txt
@@ -1,6 +1,7 @@
 # Core dependencies for mocked vLLM app
 flask
 Flask-HTTPAuth==4.8.1
+PyYAML==6.0.2
 tiktoken
 
 # Optional: only needed when running in Kubernetes

--- a/development/app/test_mock_endpoints.py
+++ b/development/app/test_mock_endpoints.py
@@ -1,0 +1,610 @@
+import base64
+import importlib.util
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from mock_recorder import RequestRecorder
+
+
+APP_DIR = Path(__file__).parent
+APP_PATH = APP_DIR / "app.py"
+
+
+def load_mock_module(monkeypatch, *, contract="", role="", api_key=None):
+    module_name = "aibrix_mock_app_endpoints_under_test"
+    monkeypatch.chdir(APP_DIR)
+    monkeypatch.setenv("STANDALONE_MODE", "true")
+    monkeypatch.setenv("SIMULATION", "disabled")
+    monkeypatch.setenv("MOCK_REQUEST_DURATION_SECONDS", "0")
+    monkeypatch.setenv("MOCK_CAPACITY_AWARE_LATENCY", "false")
+    monkeypatch.setenv("MOCK_PD_CONTRACT", contract)
+    monkeypatch.setenv("MOCK_PD_ROLE", role)
+    if api_key is None:
+        monkeypatch.setattr(sys, "argv", ["app.py"])
+    else:
+        monkeypatch.setattr(sys, "argv", ["app.py", "--api_key", api_key])
+    sys.modules.pop(module_name, None)
+
+    spec = importlib.util.spec_from_file_location(module_name, APP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def post_json(client, path, payload, request_id="req-1", **headers):
+    request_headers = {"Content-Type": "application/json", "X-Request-ID": request_id}
+    request_headers.update(headers)
+    raw_body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return client.post(path, data=raw_body, headers=request_headers)
+
+
+def query_records(client, request_id):
+    response = client.get(f"/debug/requests?request_id={request_id}")
+    assert response.status_code == 200
+    return response.get_json()
+
+
+def test_legacy_completion_records_exact_raw_body_and_debug_endpoint_is_public(monkeypatch):
+    module = load_mock_module(monkeypatch, api_key="secret")
+    client = module.app.test_client()
+    raw_body = b'{ "model": "m", "prompt": "hello", "max_tokens": 1 }'
+
+    response = client.post(
+        "/v1/completions",
+        data=raw_body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Request-ID": "legacy-raw",
+            "Authorization": "Bearer secret",
+        },
+    )
+
+    assert response.status_code == 200
+    records = query_records(client, "legacy-raw")
+    assert len(records) == 1
+    record = records[0]
+    assert base64.b64decode(record["raw_body_base64"]) == raw_body
+    assert record["parsed_json"] == {"model": "m", "prompt": "hello", "max_tokens": 1}
+    assert record["path"] == "/v1/completions"
+    assert record["outcome"] == "success"
+    assert record["status_code"] == 200
+    assert record["response"]["object"] == "text_completion"
+    assert record["timestamp_finished"]
+
+    debug_response = client.get("/debug/requests?request_id=legacy-raw")
+    assert debug_response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    ["authorization", "COOKIE", "Proxy-Authorization", "x-api-key"],
+)
+def test_recorder_redacts_sensitive_headers_case_insensitively(monkeypatch, header_name):
+    module = load_mock_module(monkeypatch)
+    client = module.app.test_client()
+    secret = f"{header_name}-secret"
+    header_value = (
+        f"session={secret}" if header_name.lower() == "cookie" else secret
+    )
+
+    if header_name.lower() == "cookie":
+        client.set_cookie("session", secret)
+        response = client.post(
+            "/v1/completions",
+            data=json.dumps(
+                {"model": "m", "prompt": "hello", "max_tokens": 1},
+                separators=(",", ":"),
+            ).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "X-Request-ID": f"redact-{header_name}",
+            },
+        )
+    else:
+        response = post_json(
+            client,
+            "/v1/completions",
+            {"model": "m", "prompt": "hello", "max_tokens": 1},
+            request_id=f"redact-{header_name}",
+            **{header_name: header_value},
+        )
+
+    assert response.status_code == 200
+    record = query_records(client, f"redact-{header_name}")[0]
+    recorded_value = next(
+        value
+        for key, value in record["headers"].items()
+        if key.lower() == header_name.lower()
+    )
+    assert recorded_value == "<redacted>"
+    assert secret not in json.dumps(record)
+
+
+@pytest.mark.parametrize("status_code", [400, 500])
+def test_safe_merge_does_not_modify_error_responses(monkeypatch, status_code):
+    module = load_mock_module(monkeypatch)
+
+    with module.app.test_request_context("/"):
+        response = module.make_response(
+            module.jsonify({"error": {"message": "backend rejected"}}),
+            status_code,
+        )
+        contract_result = {
+            "body": {
+                "opaque": "contract-opaque",
+                "disagg_prefill_resp": {"should": "not merge"},
+            },
+            "response_patch": {"prompt_token_ids": [1, 2]},
+            "choice_patch": {"disaggregated_params": {"request_type": "context_only"}},
+        }
+
+        merged = module._safe_merge_contract_response(
+            response,
+            contract_result,
+            "/v1/chat/completions",
+            {"model": "m"},
+        )
+
+    assert merged.status_code == status_code
+    assert merged.get_json() == {"error": {"message": "backend rejected"}}
+
+
+def test_evicted_inflight_record_does_not_change_success_response_to_500(monkeypatch):
+    module = load_mock_module(monkeypatch)
+    module.request_recorder = RequestRecorder(capacity=1)
+    first_sleep_started = threading.Event()
+    real_sleep = time.sleep
+
+    def controlled_sleep(seconds):
+        if seconds == 0.025:
+            first_sleep_started.set()
+        real_sleep(seconds)
+
+    monkeypatch.setattr(module.time, "sleep", controlled_sleep)
+    first_result = {}
+
+    def send_first_request():
+        client = module.app.test_client()
+        first_result["response"] = post_json(
+            client,
+            "/v1/completions",
+            {"model": "m", "prompt": "first", "max_tokens": 1},
+            request_id="evicted-first",
+            **{"X-Aibrix-Mock-Delay-Ms": "25"},
+        )
+
+    first_thread = threading.Thread(target=send_first_request)
+    first_thread.start()
+    assert first_sleep_started.wait(timeout=1)
+
+    second_response = post_json(
+        module.app.test_client(),
+        "/v1/completions",
+        {"model": "m", "prompt": "second", "max_tokens": 1},
+        request_id="evicted-second",
+    )
+    first_thread.join(timeout=1)
+
+    assert not first_thread.is_alive()
+    assert first_result["response"].status_code == 200
+    assert second_response.status_code == 200
+    assert query_records(module.app.test_client(), "evicted-second")[0]["outcome"] == "success"
+
+
+@pytest.mark.parametrize("path,payload", [
+    ("/v1/completions", {"model": "m", "prompt": "hello"}),
+    ("/v1/chat/completions", {"model": "m", "messages": [{"role": "user", "content": "hello"}]}),
+])
+@pytest.mark.parametrize("authorization", [None, "Bearer wrong"])
+def test_authentication_failures_are_recorded_before_returning_401(
+    monkeypatch, path, payload, authorization
+):
+    module = load_mock_module(monkeypatch, api_key="secret")
+    client = module.app.test_client()
+    request_id = (
+        f"auth-failure-{path.rsplit('/', 1)[-1]}-"
+        f"{'missing' if authorization is None else 'wrong'}"
+    )
+    headers = {
+        "Content-Type": "application/json",
+        "X-Request-ID": request_id,
+    }
+    if authorization is not None:
+        headers["Authorization"] = authorization
+
+    response = client.post(
+        path,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+    )
+
+    assert response.status_code == 401
+    records = query_records(client, request_id)
+    assert len(records) == 1
+    assert records[0]["outcome"] == "rejected"
+    assert records[0]["status_code"] == 401
+
+
+@pytest.mark.parametrize("path", ["/v1/completions", "/v1/chat/completions"])
+@pytest.mark.parametrize("case", [
+    "malformed-json",
+    "invalid-delay",
+    "matched-fail",
+    "contract-mismatch",
+])
+def test_unauthenticated_requests_return_401_before_body_fault_or_contract_processing(
+    monkeypatch, path, case
+):
+    module = load_mock_module(
+        monkeypatch,
+        contract="vllm-aibrix-shfs",
+        role="prefill",
+        api_key="secret",
+    )
+    client = module.app.test_client()
+    sleeps = []
+    monkeypatch.setattr(module.time, "sleep", sleeps.append)
+    request_id = f"unauth-before-{path.rsplit('/', 1)[-1]}-{case}"
+    headers = {
+        "Content-Type": "application/json",
+        "X-Request-ID": request_id,
+        "Authorization": "Bearer wrong",
+    }
+    payload = {
+        "model": "m",
+        "prompt": "hello",
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    if case == "malformed-json":
+        raw_body = b'{"model":'
+    else:
+        raw_body = json.dumps(payload).encode("utf-8")
+    if case == "invalid-delay":
+        headers["X-Aibrix-Mock-Delay-Ms"] = "not-an-int"
+    elif case == "matched-fail":
+        headers["X-Aibrix-Mock-Fail"] = "prefill"
+
+    response = client.post(path, data=raw_body, headers=headers)
+
+    assert response.status_code == 401
+    record = query_records(client, request_id)[0]
+    assert record["outcome"] == "rejected"
+    assert record["status_code"] == 401
+    assert sleeps == []
+
+
+@pytest.mark.parametrize("path,payload", [
+    ("/v1/completions", {"model": "m", "prompt": "hello", "max_tokens": 1}),
+    ("/v1/chat/completions", {"model": "m", "messages": [{"role": "user", "content": "hello"}], "max_tokens": 1}),
+])
+def test_both_completion_endpoints_record_request_metadata(monkeypatch, path, payload):
+    module = load_mock_module(monkeypatch)
+    client = module.app.test_client()
+
+    response = post_json(client, path, payload, request_id=path)
+
+    assert response.status_code == 200
+    records = query_records(client, path)
+    assert len(records) == 1
+    assert records[0]["path"] == path
+    assert records[0]["engine"]
+    assert records[0]["role"] == ""
+    assert records[0]["response"]
+    assert records[0]["error"] is None
+    assert records[0]["delay_ms"] == 0
+
+
+def test_malformed_legacy_json_returns_bad_request_and_finalizes_rejected_record(monkeypatch):
+    module = load_mock_module(monkeypatch)
+    client = module.app.test_client()
+
+    response = client.post(
+        "/v1/chat/completions",
+        data=b'{"model":',
+        headers={"Content-Type": "application/json", "X-Request-ID": "bad-json"},
+    )
+
+    assert response.status_code == 400
+    record = query_records(client, "bad-json")[0]
+    assert record["parsed_json"] is None
+    assert record["outcome"] == "rejected"
+    assert record["status_code"] == 400
+    assert record["error"]
+
+
+@pytest.mark.parametrize(
+    "path,payload,ordinary_field,finish_reason",
+    [
+        (
+            "/v1/completions",
+            {
+                "model": "m",
+                "prompt": "hello",
+                "max_tokens": 1,
+                "disaggregated_params": {"request_type": "context_only"},
+            },
+            "text",
+            "length",
+        ),
+        (
+            "/v1/chat/completions",
+            {
+                "model": "m",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 1,
+                "disaggregated_params": {"request_type": "context_only"},
+            },
+            "message",
+            "stop",
+        ),
+    ],
+)
+def test_strict_trtllm_uses_contract_response_without_legacy_duplicate_fields(
+    monkeypatch, path, payload, ordinary_field, finish_reason
+):
+    module = load_mock_module(
+        monkeypatch,
+        contract="trtllm-openai",
+        role="prefill",
+    )
+
+    response = post_json(module.app.test_client(), path, payload, request_id=path)
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["prompt_token_ids"] == list(range(body["usage"]["prompt_tokens"]))
+    assert body["prompt_token_ids"]
+    assert "disaggregated_params" not in body
+    choice = body["choices"][0]
+    assert ordinary_field in choice
+    assert choice["finish_reason"] == finish_reason
+    assert choice["disaggregated_params"]["request_type"] == "context_only"
+
+
+def test_shfs_prefill_contract_builds_transfer_fields_and_records_response(monkeypatch):
+    module = load_mock_module(monkeypatch, contract="vllm-aibrix-shfs", role="prefill")
+    client = module.app.test_client()
+    payload = {
+        "model": "m",
+        "prompt": "hello",
+        "max_tokens": 1,
+        "kv_transfer_params": {"do_remote_decode": True},
+    }
+
+    response = post_json(client, "/v1/completions", payload, request_id="shfs-prefill")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    transfer = body["kv_transfer_params"]
+    assert transfer["do_remote_decode"] is False
+    assert transfer["do_remote_prefill"] is True
+    assert transfer["opaque"] == "aibrix-pd-contract-opaque-sentinel"
+    record = query_records(client, "shfs-prefill")[0]
+    assert record["role"] == "prefill"
+    assert record["outcome"] == "success"
+    assert record["response"]["kv_transfer_params"] == transfer
+
+
+def test_trtllm_prefill_merges_patches_without_overwriting_normal_choice_fields(monkeypatch):
+    module = load_mock_module(monkeypatch, contract="trtllm-openai", role="prefill")
+    client = module.app.test_client()
+    payload = {
+        "model": "m",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 1,
+        "disaggregated_params": {"request_type": "context_only"},
+    }
+
+    response = post_json(client, "/v1/chat/completions", payload, request_id="trt-prefill")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["prompt_token_ids"] == list(range(body["usage"]["prompt_tokens"]))
+    assert body["prompt_token_ids"]
+    assert "disaggregated_params" not in body
+    assert body["choices"][0]["disaggregated_params"]["request_type"] == "context_only"
+    assert body["choices"][0]["disaggregated_params"]["encoded_opaque_state"]
+    assert body["choices"][0]["message"]["role"] == "assistant"
+    assert body["choices"][0]["finish_reason"] == "stop"
+    assert query_records(client, "trt-prefill")[0]["outcome"] == "success"
+
+
+def test_legacy_trtllm_prefill_uses_http_encoded_opaque_state(monkeypatch):
+    module = load_mock_module(monkeypatch)
+    client = module.app.test_client()
+    payload = {
+        "model": "m",
+        "prompt": "hello",
+        "max_tokens": 1,
+        "disaggregated_params": {"request_type": "context_only"},
+    }
+
+    response = post_json(client, "/v1/completions", payload, request_id="legacy-trt")
+
+    assert response.status_code == 200
+    disaggregated = response.get_json()["disaggregated_params"]
+    assert disaggregated["encoded_opaque_state"]
+    assert "opaque_state" not in disaggregated
+
+
+def test_nixl_endpoint_returns_unwrapped_prefill_body_that_gateway_can_wrap(monkeypatch):
+    module = load_mock_module(monkeypatch, contract="vllm-aibrix-nixl", role="prefill")
+    client = module.app.test_client()
+    payload = {"model": "m", "prompt": "hello", "max_tokens": 1}
+
+    prefill_response = post_json(
+        client,
+        "/v1/completions",
+        payload,
+        request_id="nixl-prefill-shape",
+    )
+
+    assert prefill_response.status_code == 200
+    prefill_body = prefill_response.get_json()
+    assert "disagg_prefill_resp" not in prefill_body
+    assert prefill_body["opaque"] == "aibrix-pd-contract-opaque-sentinel"
+
+    gateway_decode_body = dict(payload)
+    gateway_decode_body["disagg_prefill_resp"] = prefill_body
+    module = load_mock_module(monkeypatch, contract="vllm-aibrix-nixl", role="decode")
+    decode_response = post_json(
+        module.app.test_client(),
+        "/v1/completions",
+        gateway_decode_body,
+        request_id="nixl-decode-shape",
+    )
+
+    assert decode_response.status_code == 200
+def test_contract_rejection_is_recorded_and_does_not_fall_through_to_success(monkeypatch):
+    module = load_mock_module(monkeypatch, contract="vllm-aibrix-shfs", role="prefill")
+    client = module.app.test_client()
+    payload = {"model": "m", "prompt": "hello", "max_tokens": 1}
+
+    response = post_json(client, "/v1/completions", payload, request_id="contract-reject")
+
+    assert response.status_code == 400
+    assert response.get_json()["error"]["type"] == "invalid_request"
+    record = query_records(client, "contract-reject")[0]
+    assert record["outcome"] == "rejected"
+    assert record["status_code"] == 400
+    assert record["response"]["error"]["type"] == "invalid_request"
+    assert record["error"]
+
+
+def test_role_mismatch_is_rejected_by_configured_contract(monkeypatch):
+    module = load_mock_module(monkeypatch, contract="trtllm-openai", role="worker")
+    client = module.app.test_client()
+
+    response = post_json(
+        client,
+        "/v1/completions",
+        {"model": "m", "prompt": "hello"},
+        request_id="bad-role",
+    )
+
+    assert response.status_code == 400
+    record = query_records(client, "bad-role")[0]
+    assert record["outcome"] == "rejected"
+    assert record["status_code"] == 400
+
+
+def test_matching_fault_fails_and_nonmatching_fault_does_not(monkeypatch):
+    module = load_mock_module(monkeypatch, contract="sglang-http", role="prefill")
+    client = module.app.test_client()
+    payload = {
+        "model": "m",
+        "prompt": "hello",
+        "max_tokens": 1,
+        "bootstrap_host": "host",
+        "bootstrap_port": 1234,
+        "bootstrap_room": 7,
+    }
+
+    failed = post_json(
+        client,
+        "/v1/completions",
+        payload,
+        request_id="fault-match",
+        **{"X-Aibrix-Mock-Fail": "prefill"},
+    )
+    unaffected = post_json(
+        client,
+        "/v1/completions",
+        payload,
+        request_id="fault-other",
+        **{"X-Aibrix-Mock-Fail": "decode"},
+    )
+
+    assert failed.status_code == 500
+    assert unaffected.status_code == 200
+    assert query_records(client, "fault-match")[0]["outcome"] == "failed"
+    assert query_records(client, "fault-other")[0]["outcome"] == "success"
+
+
+def test_valid_delay_sleeps_once_and_is_recorded(monkeypatch):
+    module = load_mock_module(monkeypatch)
+    client = module.app.test_client()
+    slept = []
+    monkeypatch.setattr(module.time, "sleep", slept.append)
+
+    response = post_json(
+        client,
+        "/v1/completions",
+        {"model": "m", "prompt": "hello", "max_tokens": 1},
+        request_id="delayed",
+        **{"X-Aibrix-Mock-Delay-Ms": "25"},
+    )
+
+    assert response.status_code == 200
+    assert 0.025 in slept
+    assert query_records(client, "delayed")[0]["delay_ms"] == 25
+
+
+def test_invalid_delay_is_bad_request_and_recorded(monkeypatch):
+    module = load_mock_module(monkeypatch)
+    client = module.app.test_client()
+
+    response = post_json(
+        client,
+        "/v1/chat/completions",
+        {"model": "m", "messages": [{"role": "user", "content": "hello"}]},
+        request_id="bad-delay",
+        **{"X-Aibrix-Mock-Delay-Ms": "not-an-int"},
+    )
+
+    assert response.status_code == 400
+    record = query_records(client, "bad-delay")[0]
+    assert record["outcome"] == "rejected"
+    assert record["status_code"] == 400
+    assert record["delay_ms"] == 0
+    assert record["error"] == "invalid x-aibrix-mock-delay-ms"
+
+
+def test_streaming_response_is_not_consumed_by_route_but_is_recorded(monkeypatch):
+    module = load_mock_module(monkeypatch)
+    client = module.app.test_client()
+
+    response = client.post(
+        "/v1/chat/completions",
+        data=json.dumps({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        }).encode(),
+        headers={"Content-Type": "application/json", "X-Request-ID": "stream"},
+        buffered=False,
+    )
+
+    assert response.status_code == 200
+    assert response.mimetype == "text/event-stream"
+    record = query_records(client, "stream")[0]
+    assert record["outcome"] == "success"
+    assert record["response"]["stream"] is True
+    response.close()
+
+
+def test_legacy_omni_image_and_audio_shapes_remain_available(monkeypatch):
+    module = load_mock_module(monkeypatch)
+    client = module.app.test_client()
+    image_payload = {
+        "model": "qwen-image",
+        "messages": [{"role": "user", "content": "draw a cat"}],
+    }
+    audio_payload = {
+        "model": "m",
+        "messages": [{"role": "user", "content": "speak"}],
+        "modalities": ["text", "audio"],
+    }
+
+    image_response = post_json(client, "/v1/chat/completions", image_payload, "omni-image")
+    audio_response = post_json(client, "/v1/chat/completions", audio_payload, "omni-audio")
+
+    assert image_response.status_code == 200
+    assert image_response.get_json()["choices"][0]["message"]["content"][0]["type"] == "image_url"
+    assert audio_response.status_code == 200
+    assert audio_response.get_json()["choices"][0]["message"]["audio"]["format"] == "wav"

--- a/development/app/test_mock_manifests.py
+++ b/development/app/test_mock_manifests.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import yaml
+
+
+APP_DIR = Path(__file__).parent
+EXPECTED_WORKLOADS = {
+    "vllm-pd-config.yaml": "mock-llama2-7b-pd-vllm",
+    "sglang-pd-config.yaml": "mock-llama2-7b-pd-sglang",
+    "trtllm-pd-config.yaml": "mock-llama2-7b-pd-trtllm",
+    "nixl-pd-config.yaml": "mock-llama2-7b-pd-vllm-nixl",
+}
+
+
+def load_yaml(path):
+    with path.open() as stream:
+        return list(yaml.safe_load_all(stream))
+
+
+def test_pd_role_pod_templates_have_workload_identity_and_app_label():
+    for filename, workload in EXPECTED_WORKLOADS.items():
+        document = load_yaml(APP_DIR / "config" / "mock" / filename)[0]
+        roles = document["spec"]["template"]["spec"]["roles"]
+
+        assert {role["name"] for role in roles} == {"prefill", "decode"}
+        for role in roles:
+            labels = role["template"]["metadata"]["labels"]
+            assert labels["app.kubernetes.io/name"] == workload
+            assert labels["app"] == workload
+            env = role["template"]["spec"]["containers"][0]["env"]
+            deployment_name = next(item for item in env if item["name"] == "DEPLOYMENT_NAME")
+            assert deployment_name["valueFrom"]["fieldRef"]["fieldPath"] == "metadata.labels['app']"
+
+
+def test_config_profile_pod_template_has_model_port_label():
+    documents = load_yaml(APP_DIR / "config" / "mock" / "config-profile.yaml")
+    deployment = next(document for document in documents if document["kind"] == "Deployment")
+
+    assert deployment["spec"]["template"]["metadata"]["labels"]["model.aibrix.ai/port"] == "8000"
+
+
+def test_bucketing_role_pod_templates_have_workload_identity_labels():
+    documents = load_yaml(APP_DIR / "config" / "mock" / "vllm-pd-bucketing-config.yaml")
+    expected = {
+        "mock-llama2-pd-bkt-sht": {"prefill", "decode"},
+        "mock-llama2-pd-bkt-med": {"prefill", "decode"},
+        "mock-llama2-pd-bkt-comb": {"all"},
+    }
+
+    for document in documents:
+        workload = document["metadata"]["name"]
+        roles = document["spec"]["template"]["spec"]["roles"]
+        assert {role["name"] for role in roles} == expected[workload]
+        for role in roles:
+            labels = role["template"]["metadata"]["labels"]
+            assert labels["app"] == workload
+            assert labels["app.kubernetes.io/name"] == workload

--- a/development/app/test_mock_recorder.py
+++ b/development/app/test_mock_recorder.py
@@ -1,0 +1,233 @@
+import base64
+import json
+from concurrent.futures import ThreadPoolExecutor
+import math
+import threading
+
+import pytest
+
+from mock_recorder import RequestRecorder, _RecordHandle
+
+
+def make_record(recorder, request_id="request-1", raw_body=b'{"prompt":"hello"}'):
+    return recorder.start(
+        path="/v1/chat/completions",
+        headers={"x-request-id": request_id, "content-type": "application/json"},
+        raw_body=raw_body,
+        parsed_json={"prompt": "hello"},
+        pod="mock-pod-0",
+        engine="vllm",
+        role="prefill",
+    )
+
+
+def test_start_and_finish_record_request_metadata_and_response():
+    recorder = RequestRecorder(capacity=4)
+    record = make_record(recorder)
+
+    recorder.finish(
+        record,
+        outcome="success",
+        status_code=200,
+        response={"choices": []},
+        delay_ms=25,
+    )
+
+    result = recorder.query(request_id="request-1")
+    assert len(result) == 1
+    assert result[0]["sequence"] == 1
+    assert result[0]["request_id"] == "request-1"
+    assert result[0]["path"] == "/v1/chat/completions"
+    assert result[0]["headers"]["x-request-id"] == "request-1"
+    assert base64.b64decode(result[0]["raw_body_base64"]) == b'{"prompt":"hello"}'
+    assert result[0]["parsed_json"] == {"prompt": "hello"}
+    assert result[0]["pod"] == "mock-pod-0"
+    assert result[0]["engine"] == "vllm"
+    assert result[0]["role"] == "prefill"
+    assert result[0]["outcome"] == "success"
+    assert result[0]["status_code"] == 200
+    assert result[0]["response"] == {"choices": []}
+    assert result[0]["delay_ms"] == 25
+    assert result[0]["timestamp_started"]
+    assert result[0]["timestamp_finished"]
+
+
+def test_sequence_is_monotonic_and_ring_buffer_evicts_oldest_record():
+    recorder = RequestRecorder(capacity=2)
+    first = make_record(recorder, request_id="request-1")
+    recorder.finish(first, outcome="success", status_code=200)
+    second = make_record(recorder, request_id="request-2")
+    recorder.finish(second, outcome="rejected", status_code=400)
+    third = make_record(recorder, request_id="request-3")
+    recorder.finish(third, outcome="failed", status_code=500)
+
+    result = recorder.query()
+    assert [entry["sequence"] for entry in result] == [2, 3]
+    assert recorder.query(request_id="request-1") == []
+
+
+def test_query_returns_json_serializable_copies():
+    recorder = RequestRecorder(capacity=2)
+    record = make_record(recorder)
+    recorder.finish(record, outcome="success", status_code=200)
+
+    result = recorder.query(request_id="request-1")
+    json.dumps(result)
+    result[0]["headers"]["x-request-id"] = "mutated"
+    assert recorder.query(request_id="request-1")[0]["headers"]["x-request-id"] == "request-1"
+
+
+def test_query_sanitizes_non_json_values_to_json_serializable_values():
+    recorder = RequestRecorder(capacity=2)
+    record = recorder.start(
+        path="/v1/chat/completions",
+        headers={"x-request-id": "request-1", "x-test": {"nested", "set"}},
+        raw_body=b"{}",
+        parsed_json={"values": {1, 2}},
+        pod="mock-pod-0",
+        engine="vllm",
+        role="decode",
+    )
+    recorder.finish(
+        record,
+        outcome="failed",
+        status_code=500,
+        error=RuntimeError("backend failed"),
+        response={"unserializable": {"value"}},
+    )
+
+    result = recorder.query()
+    json.dumps(result)
+    assert isinstance(result[0]["parsed_json"]["values"], list)
+    assert result[0]["error"] == "backend failed"
+    assert result[0]["response"]["unserializable"] == ["value"]
+
+
+def test_real_threading_lock_inputs_do_not_break_recording():
+    recorder = RequestRecorder(capacity=2)
+    input_lock = threading.Lock()
+    record = recorder.start(
+        path="/v1/chat/completions",
+        headers={"x-request-id": "request-lock", "lock": input_lock},
+        raw_body=b"{}",
+        parsed_json={"lock": input_lock},
+        pod="mock-pod-0",
+        engine="vllm",
+        role="prefill",
+    )
+    recorder.finish(
+        record,
+        outcome="failed",
+        status_code=500,
+        error=input_lock,
+        response={"lock": input_lock},
+    )
+
+    result = recorder.query(request_id="request-lock")
+    json.dumps(result)
+    assert result[0]["headers"]["lock"] == str(input_lock)
+    assert result[0]["parsed_json"]["lock"] == str(input_lock)
+    assert result[0]["error"] == str(input_lock)
+    assert result[0]["response"]["lock"] == str(input_lock)
+
+
+def test_non_finite_floats_become_json_null():
+    recorder = RequestRecorder(capacity=2)
+    record = recorder.start(
+        path="/v1/chat/completions",
+        headers={"x-request-id": "request-floats", "nan": math.nan},
+        raw_body=b"{}",
+        parsed_json={"positive_inf": math.inf, "negative_inf": -math.inf},
+        pod="mock-pod-0",
+        engine="vllm",
+        role="prefill",
+    )
+    recorder.finish(
+        record,
+        outcome="success",
+        status_code=200,
+        response={"nan": math.nan, "inf": math.inf},
+    )
+
+    result = recorder.query(request_id="request-floats")
+    json.dumps(result, allow_nan=False)
+    assert result[0]["headers"]["nan"] is None
+    assert result[0]["parsed_json"] == {"positive_inf": None, "negative_inf": None}
+    assert result[0]["response"] == {"nan": None, "inf": None}
+
+
+def test_malformed_json_can_be_recorded_with_null_parsed_json():
+    recorder = RequestRecorder(capacity=2)
+    record = recorder.start(
+        path="/v1/chat/completions",
+        headers={},
+        raw_body=b"not-json",
+        parsed_json=None,
+        pod="mock-pod-0",
+        engine="vllm",
+        role=None,
+    )
+    recorder.finish(record, outcome="rejected", status_code=400)
+
+    result = recorder.query()
+    assert result[0]["request_id"] is None
+    assert base64.b64decode(result[0]["raw_body_base64"]) == b"not-json"
+    assert result[0]["parsed_json"] is None
+    assert result[0]["outcome"] == "rejected"
+
+
+def test_concurrent_starts_finishes_and_queries_have_unique_monotonic_sequences():
+    recorder = RequestRecorder(capacity=128)
+
+    def create_request(index):
+        record = make_record(recorder, request_id=f"request-{index}")
+        recorder.query(request_id=f"request-{index}")
+        recorder.finish(record, outcome="success", status_code=200)
+        recorder.query()
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(create_request, range(32)))
+
+    sequences = [entry["sequence"] for entry in recorder.query()]
+    assert sequences == list(range(1, 33))
+    assert len(set(sequences)) == 32
+
+
+def test_finish_rejects_unknown_outcome():
+    recorder = RequestRecorder(capacity=2)
+    record = make_record(recorder)
+
+    with pytest.raises(ValueError, match="outcome"):
+        recorder.finish(record, outcome="delayed", status_code=200)
+
+
+def test_finish_rejects_handle_from_another_recorder():
+    owner = RequestRecorder(capacity=2)
+    other = RequestRecorder(capacity=2)
+    record = make_record(owner)
+
+    with pytest.raises(ValueError, match="recorder"):
+        other.finish(record, outcome="success", status_code=200)
+
+
+def test_finish_rejects_forged_handle_with_matching_sequence():
+    recorder = RequestRecorder(capacity=2)
+    record = make_record(recorder)
+    forged = _RecordHandle(record.sequence)
+
+    with pytest.raises(ValueError, match="recorder"):
+        recorder.finish(forged, outcome="success", status_code=200)
+
+    assert recorder.query()[0]["outcome"] is None
+
+
+def test_finish_is_idempotent_by_rejecting_duplicate_completion():
+    recorder = RequestRecorder(capacity=2)
+    record = make_record(recorder)
+    recorder.finish(record, outcome="success", status_code=200, response={"ok": True})
+    first_result = recorder.query()[0]
+
+    with pytest.raises(RuntimeError, match="already finished"):
+        recorder.finish(record, outcome="failed", status_code=500, response={"ok": False})
+
+    assert recorder.query()[0] == first_result

--- a/development/app/test_pd_contracts.py
+++ b/development/app/test_pd_contracts.py
@@ -1,0 +1,528 @@
+import json
+
+import pytest
+
+from pd_contracts import (
+    CONTRACT_SGLANG_HTTP,
+    CONTRACT_TRTLLM_OPENAI,
+    CONTRACT_VLLM_AIBRIX_NIXL,
+    CONTRACT_VLLM_AIBRIX_SHFS,
+    FrozenDict,
+    OPAQUE_SENTINEL,
+    parse_fault_headers,
+    validate_or_build,
+)
+
+
+def assert_ok(result):
+    assert result["status_code"] == 200
+    assert result["metadata"]["error"] is None
+    return result["body"]
+
+
+def assert_bad(result, message):
+    assert result["status_code"] == 400
+    if message:
+        assert result["metadata"]["error"] == message
+    else:
+        assert result["metadata"]["error"]
+
+
+def test_unknown_non_empty_contract_is_rejected_with_http_400_metadata():
+    result = validate_or_build("future-contract", "prefill", {})
+
+    assert_bad(result, "unknown contract: future-contract")
+
+
+@pytest.mark.parametrize("role", ["", "worker", None])
+def test_role_must_be_prefill_or_decode(role):
+    result = validate_or_build(CONTRACT_SGLANG_HTTP, role, {})
+
+    assert result["status_code"] == 400
+    assert "role" in result["metadata"]["error"]
+
+
+def test_shfs_prefill_requires_remote_decode_and_returns_transfer_fields():
+    payload = {
+        "kv_transfer_params": {"do_remote_decode": True, "request_id": "req-1"}
+    }
+
+    body = assert_ok(validate_or_build(CONTRACT_VLLM_AIBRIX_SHFS, "prefill", payload))
+    transfer = body["kv_transfer_params"]
+
+    assert transfer["do_remote_decode"] is False
+    assert transfer["do_remote_prefill"] is True
+    assert transfer["remote_engine_id"]
+    assert transfer["remote_block_ids"]
+    assert transfer["remote_host"]
+    assert transfer["remote_port"] > 0
+    assert transfer["opaque"] == OPAQUE_SENTINEL
+    assert transfer["request_id"] == "req-1"
+    assert_ok(validate_or_build(CONTRACT_VLLM_AIBRIX_SHFS, "decode", body))
+
+
+def test_shfs_prefill_replaces_null_gateway_skeleton_and_builds_decode_fixture():
+    payload = {
+        "kv_transfer_params": {
+            "do_remote_decode": True,
+            "do_remote_prefill": None,
+            "remote_engine_id": None,
+            "remote_block_ids": None,
+            "remote_host": None,
+            "remote_port": None,
+            "opaque": None,
+        }
+    }
+
+    body = assert_ok(validate_or_build(CONTRACT_VLLM_AIBRIX_SHFS, "prefill", payload))
+    transfer = body["kv_transfer_params"]
+
+    assert transfer["do_remote_decode"] is False
+    assert transfer["do_remote_prefill"] is True
+    assert transfer["remote_engine_id"]
+    assert transfer["remote_block_ids"]
+    assert transfer["remote_host"]
+    assert transfer["remote_port"] > 0
+    assert transfer["opaque"] == OPAQUE_SENTINEL
+    assert_ok(validate_or_build(CONTRACT_VLLM_AIBRIX_SHFS, "decode", body))
+
+
+def test_shfs_decode_requires_gateway_merged_transfer_fields_and_sentinel():
+    payload = {
+        "kv_transfer_params": {
+            "do_remote_decode": False,
+            "do_remote_prefill": True,
+            "remote_engine_id": "prefill-engine",
+            "remote_block_ids": ["block-1", "block-2"],
+            "remote_host": "prefill.example",
+            "remote_port": 8001,
+            "opaque": OPAQUE_SENTINEL,
+        }
+    }
+
+    assert_ok(validate_or_build(CONTRACT_VLLM_AIBRIX_SHFS, "decode", payload))
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "do_remote_decode",
+        "do_remote_prefill",
+        "remote_engine_id",
+        "remote_block_ids",
+        "remote_host",
+        "remote_port",
+        "opaque",
+    ],
+)
+def test_shfs_decode_rejects_missing_merged_field(field):
+    payload = {
+        "kv_transfer_params": {
+            "do_remote_decode": False,
+            "do_remote_prefill": True,
+            "remote_engine_id": "prefill-engine",
+            "remote_block_ids": ["block-1"],
+            "remote_host": "prefill.example",
+            "remote_port": 8001,
+            "opaque": OPAQUE_SENTINEL,
+        }
+    }
+    del payload["kv_transfer_params"][field]
+
+    assert_bad(
+        validate_or_build(CONTRACT_VLLM_AIBRIX_SHFS, "decode", payload),
+        f"missing kv_transfer_params.{field}",
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("do_remote_decode", True),
+        ("do_remote_prefill", False),
+        ("remote_engine_id", ""),
+        ("remote_block_ids", []),
+        ("remote_host", ""),
+        ("remote_port", 0),
+        ("opaque", "wrong-sentinel"),
+    ],
+)
+def test_shfs_decode_rejects_invalid_merged_field_value(field, value):
+    payload = {
+        "kv_transfer_params": {
+            "do_remote_decode": False,
+            "do_remote_prefill": True,
+            "remote_engine_id": "prefill-engine",
+            "remote_block_ids": ["block-1"],
+            "remote_host": "prefill.example",
+            "remote_port": 8001,
+            "opaque": OPAQUE_SENTINEL,
+        }
+    }
+    payload["kv_transfer_params"][field] = value
+
+    result = validate_or_build(CONTRACT_VLLM_AIBRIX_SHFS, "decode", payload)
+    assert result["status_code"] == 400
+    assert field in result["metadata"]["error"]
+
+
+def test_nixl_prefill_rejects_shfs_skeleton_and_returns_unwrapped_response_for_gateway():
+    assert_bad(
+        validate_or_build(
+            CONTRACT_VLLM_AIBRIX_NIXL,
+            "prefill",
+            {"kv_transfer_params": {"do_remote_decode": True}},
+        ),
+        "nixl prefill must not contain SHFS kv_transfer_params skeleton",
+    )
+
+    prefill_payload = {
+        "model": "m",
+        "prompt": "hello",
+        "prompt_token_ids": [1, 2],
+        "request_id": "req-2",
+    }
+    body = assert_ok(
+        validate_or_build(
+            CONTRACT_VLLM_AIBRIX_NIXL,
+            "prefill",
+            prefill_payload,
+        )
+    )
+    assert "disagg_prefill_resp" not in body
+    assert body["opaque"] == OPAQUE_SENTINEL
+    assert body["prompt_token_ids"] == [1, 2]
+
+    decode_payload = {
+        "model": "m",
+        "prompt": "hello",
+        "disagg_prefill_resp": body,
+    }
+    decoded = assert_ok(
+        validate_or_build(CONTRACT_VLLM_AIBRIX_NIXL, "decode", decode_payload)
+    )
+    assert decoded["disagg_prefill_resp"] == body
+
+
+def test_nixl_decode_requires_top_level_complete_prefill_response_and_sentinel():
+    payload = {
+        "disagg_prefill_resp": {
+            "opaque": OPAQUE_SENTINEL,
+            "prompt_token_ids": [1, 2],
+        }
+    }
+
+    assert_ok(validate_or_build(CONTRACT_VLLM_AIBRIX_NIXL, "decode", payload))
+    assert_bad(
+        validate_or_build(
+            CONTRACT_VLLM_AIBRIX_NIXL,
+            "decode",
+            {"disagg_prefill_resp": {"prompt_token_ids": [1, 2]}},
+        ),
+        "missing disagg_prefill_resp.opaque sentinel",
+    )
+
+
+@pytest.mark.parametrize("role", ["prefill", "decode"])
+def test_sglang_requires_bootstrap_fields_for_both_roles(role):
+    payload = {
+        "bootstrap_host": "127.0.0.1",
+        "bootstrap_port": 12345,
+        "bootstrap_room": 0,
+    }
+    assert_ok(validate_or_build(CONTRACT_SGLANG_HTTP, role, payload))
+    for field, value in (("bootstrap_host", ""), ("bootstrap_port", 0), ("bootstrap_room", -1)):
+        invalid = dict(payload)
+        invalid[field] = value
+        assert_bad(
+            validate_or_build(CONTRACT_SGLANG_HTTP, role, invalid),
+            f"invalid {field}",
+        )
+
+
+def test_trtllm_prefill_builds_openai_disaggregated_response():
+    payload = {
+        "disaggregated_params": {
+            "request_type": "context_only",
+            "disagg_request_id": "req-prefill",
+        },
+    }
+
+    result = validate_or_build(CONTRACT_TRTLLM_OPENAI, "prefill", payload)
+    assert_ok(result)
+
+    assert result["choice_patch"]["disaggregated_params"]["request_type"] == "context_only"
+    assert result["choice_patch"]["disaggregated_params"]["encoded_opaque_state"]
+    assert "prompt_token_ids" not in result["response_patch"]
+    assert "choices" not in result["response_patch"]
+
+
+def test_trtllm_prefill_patch_preserves_existing_openai_choice_fields():
+    result = validate_or_build(
+        CONTRACT_TRTLLM_OPENAI,
+        "prefill",
+        {"disaggregated_params": {"request_type": "context_only"}, "prompt_token_ids": [3]},
+    )
+
+    existing_choice = {"message": {"content": "hello"}, "finish_reason": "stop"}
+    merged_choice = {**existing_choice, **result["choice_patch"]}
+    merged_response = {"choices": [merged_choice], **result["response_patch"]}
+    assert merged_response["choices"][0]["message"] == existing_choice["message"]
+    assert merged_response["choices"][0]["finish_reason"] == "stop"
+    assert merged_response["choices"][0]["disaggregated_params"]["request_type"] == "context_only"
+
+
+def test_trtllm_gateway_prefill_response_without_input_prompt_ids_builds_decode_fixture():
+    prefill_request = {
+        "model": "m",
+        "messages": [{"role": "user", "content": "hello"}],
+        "disaggregated_params": {
+            "request_type": "context_only",
+            "disagg_request_id": 123456789,
+        },
+    }
+
+    prefill_result = validate_or_build(
+        CONTRACT_TRTLLM_OPENAI, "prefill", prefill_request
+    )
+    assert_ok(prefill_result)
+    prefill_response = {
+        "choices": [{
+            "message": {"role": "assistant", "content": "prefill"},
+            "finish_reason": "stop",
+            "disaggregated_params": prefill_result["choice_patch"]["disaggregated_params"],
+        }],
+        "prompt_token_ids": [11, 12, 13],
+    }
+
+    decode_request = {
+        "model": "m",
+        "messages": prefill_request["messages"],
+        "prompt_token_ids": prefill_response["prompt_token_ids"],
+        "disaggregated_params": dict(prefill_response["choices"][0]["disaggregated_params"]),
+    }
+    decode_request["disaggregated_params"]["request_type"] = "generation_only"
+
+    decoded = assert_ok(
+        validate_or_build(CONTRACT_TRTLLM_OPENAI, "decode", decode_request)
+    )
+    assert decoded["prompt_token_ids"] == [11, 12, 13]
+    assert decoded["disaggregated_params"]["request_type"] == "generation_only"
+    assert decoded["disaggregated_params"]["encoded_opaque_state"]
+
+
+@pytest.mark.parametrize(
+    "contract,role",
+    [
+        ([], "prefill"),
+        ({"contract": "not-hashable"}, "prefill"),
+        (CONTRACT_SGLANG_HTTP, []),
+        (CONTRACT_SGLANG_HTTP, {"role": "not-hashable"}),
+    ],
+)
+def test_non_string_or_unhashable_contract_and_role_return_400_result(contract, role):
+    result = validate_or_build(contract, role, {})
+    assert result["status_code"] == 400
+    assert result["metadata"]["error_type"] == "invalid_contract_or_role"
+    assert result["body"]["error"]["type"] == "invalid_contract_or_role"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"disaggregated_params": [], "prompt_token_ids": [1]},
+        {"disaggregated_params": {"request_type": 1}, "prompt_token_ids": [1]},
+        {"disaggregated_params": {"request_type": "context_only"}, "prompt_token_ids": [True]},
+        {"disaggregated_params": {"request_type": "context_only"}, "prompt_token_ids": "1"},
+    ],
+)
+def test_trtllm_prefill_rejects_invalid_field_types(payload):
+    assert_bad(validate_or_build(CONTRACT_TRTLLM_OPENAI, "prefill", payload), "")
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("disagg_request_id", True),
+        ("first_gen_tokens", ["token"]),
+        ("encoded_opaque_state", 42),
+        ("prompt_token_ids", ["token"]),
+    ],
+)
+def test_trtllm_decode_rejects_invalid_field_types(field, value):
+    payload = {
+        "disaggregated_params": {
+            "request_type": "generation_only",
+            "disagg_request_id": 3,
+            "first_gen_tokens": [5],
+            "encoded_opaque_state": "state",
+        },
+        "prompt_token_ids": [3, 4],
+    }
+    if field == "prompt_token_ids":
+        payload[field] = value
+    else:
+        payload["disaggregated_params"][field] = value
+    assert_bad(validate_or_build(CONTRACT_TRTLLM_OPENAI, "decode", payload), "")
+
+
+@pytest.mark.parametrize("request_id", [9223372036854775807, "9223372036854775807"])
+def test_trtllm_decode_accepts_gateway_numeric_disagg_request_id(request_id):
+    payload = {
+        "disaggregated_params": {
+            "request_type": "generation_only",
+            "disagg_request_id": request_id,
+            "first_gen_tokens": [5],
+            "encoded_opaque_state": "state",
+        },
+        "prompt_token_ids": [3, 4],
+    }
+
+    result = validate_or_build(CONTRACT_TRTLLM_OPENAI, "decode", payload)
+
+    assert_ok(result)
+    assert result["body"]["disaggregated_params"]["disagg_request_id"] == request_id
+
+
+def test_trtllm_decode_validates_generation_handoff_fields():
+    payload = {
+        "disaggregated_params": {
+            "request_type": "generation_only",
+            "disagg_request_id": 3,
+            "first_gen_tokens": [5],
+            "encoded_opaque_state": "state",
+        },
+        "prompt_token_ids": [3, 4],
+    }
+
+    assert_ok(validate_or_build(CONTRACT_TRTLLM_OPENAI, "decode", payload))
+    invalid = json.loads(json.dumps(payload))
+    del invalid["disaggregated_params"]["encoded_opaque_state"]
+    assert_bad(
+        validate_or_build(CONTRACT_TRTLLM_OPENAI, "decode", invalid),
+        "missing disaggregated_params.encoded_opaque_state",
+    )
+
+
+def test_metadata_includes_request_id_without_flask_dependency():
+    result = validate_or_build(
+        CONTRACT_SGLANG_HTTP,
+        "prefill",
+        {"bootstrap_host": "host", "bootstrap_port": 1, "bootstrap_room": 0},
+        request_id="req-meta",
+    )
+
+    assert result["metadata"]["request_id"] == "req-meta"
+
+
+@pytest.mark.parametrize("role", ["prefill", "decode"])
+def test_fault_header_matching_role_injects_only_that_role(role):
+    result = parse_fault_headers({"x-aibrix-mock-fail": role}, role)
+
+    assert result.delay_ms == 0
+    assert result.injected_status_code == 500
+    assert result.validation_status_code == 200
+    assert result.metadata == {}
+
+
+@pytest.mark.parametrize("role,fail_value", [("prefill", "decode"), ("decode", "prefill")])
+def test_fault_header_for_other_role_does_not_fail(role, fail_value):
+    result = parse_fault_headers({"x-aibrix-mock-fail": fail_value}, role)
+
+    assert result.injected_status_code is None
+    assert result.delay_ms == 0
+    assert result.validation_status_code == 200
+    assert result.metadata == {}
+
+
+@pytest.mark.parametrize("fail_value", ["", "worker", "PREFILL", "true", None])
+def test_invalid_fail_header_is_ignored(fail_value):
+    result = parse_fault_headers({"x-aibrix-mock-fail": fail_value}, "prefill")
+
+    assert result.injected_status_code is None
+    assert result.validation_status_code == 200
+    assert result.metadata == {}
+
+
+@pytest.mark.parametrize("delay_value,expected", [("0", 0), ("1", 1), ("30000", 30000)])
+def test_delay_header_accepts_non_negative_integer_within_limit(delay_value, expected):
+    result = parse_fault_headers({"x-aibrix-mock-delay-ms": delay_value}, "prefill")
+
+    assert result.delay_ms == expected
+    assert result.injected_status_code is None
+    assert result.validation_status_code == 200
+    assert result.metadata == {}
+
+
+@pytest.mark.parametrize("delay_value", ["-1", "30001", "1.5", "", None, True])
+def test_invalid_delay_header_returns_bad_request_metadata(delay_value):
+    result = parse_fault_headers({"x-aibrix-mock-delay-ms": delay_value}, "prefill")
+
+    assert result.validation_status_code == 400
+    assert result.delay_ms == 0
+    assert result.injected_status_code is None
+    assert result.metadata["error"] == "invalid x-aibrix-mock-delay-ms"
+
+
+def test_fault_parse_result_is_immutable_and_parser_does_not_mutate_headers():
+    headers = {"x-aibrix-mock-delay-ms": "25", "x-aibrix-mock-fail": "decode"}
+    result = parse_fault_headers(headers, "decode")
+
+    assert headers == {"x-aibrix-mock-delay-ms": "25", "x-aibrix-mock-fail": "decode"}
+    json.dumps(result._asdict())
+    assert isinstance(result.metadata, dict)
+    with pytest.raises(AttributeError):
+        result.delay_ms = 30
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda metadata: metadata.__setitem__("error", "changed"),
+        lambda metadata: metadata.update(error="changed"),
+        lambda metadata: metadata.pop("error"),
+        lambda metadata: metadata.popitem(),
+        lambda metadata: metadata.clear(),
+        lambda metadata: metadata.setdefault("other", "value"),
+        lambda metadata: metadata.__delitem__("error"),
+        lambda metadata: metadata.__ior__({"other": "value"}),
+    ],
+)
+def test_fault_result_metadata_is_deeply_immutable(mutate):
+    result = parse_fault_headers({"x-aibrix-mock-delay-ms": "invalid"}, "prefill")
+
+    with pytest.raises(TypeError, match="^FrozenDict is immutable$"):
+        mutate(result.metadata)
+    json.dumps(result._asdict())
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda value: value.__setitem__("key", "value"),
+        lambda value: value.__delitem__("error"),
+        lambda value: value.clear(),
+        lambda value: value.pop("error"),
+        lambda value: value.popitem(),
+        lambda value: value.setdefault("key", "value"),
+        lambda value: value.update(key="value"),
+        lambda value: value.__ior__({"key": "value"}),
+    ],
+)
+def test_frozen_dict_mutators_raise_the_same_immutable_error_and_remain_json_serializable(mutate):
+    value = FrozenDict(error="immutable")
+
+    with pytest.raises(TypeError, match="^FrozenDict is immutable$"):
+        mutate(value)
+
+    assert value == {"error": "immutable"}
+    json.dumps(value)
+
+
+def test_fault_result_metadata_rejects_reinitialization():
+    result = parse_fault_headers({"x-aibrix-mock-delay-ms": "invalid"}, "prefill")
+
+    with pytest.raises(TypeError):
+        result.metadata.__init__({"error": "changed"})
+    assert result.metadata == {"error": "invalid x-aibrix-mock-delay-ms"}
+    json.dumps(result._asdict())


### PR DESCRIPTION
## Summary

Part 2 of #2675.

- Add a request recorder and `GET /debug/requests?request_id=...` to the OpenAI-compatible mock app.
- Add strict SHFS, NIXL, SGLang HTTP, and TRT-LLM OpenAI PD contract validation.
- Add request-scoped failure/delay injection and an isolated NIXL StormService topology.
- Preserve legacy and vLLM-Omni behavior when `MOCK_PD_CONTRACT` is unset.

## Scope

- Changes are limited to `development/app` mock code, tests, and mock manifests.
- No gateway implementation, gateway PD e2e case, Redis dependency, or SGLang cross-pod state store is included.
- Design/implementation planning documents are intentionally not part of this PR.

## Verification

- Python mock/contract/auth tests: `113 passed`
- Existing OpenAI/Omni smoke tests: `12/12 passed`
- Python compilation: passed
- Mock Kustomize rendering: passed
- `git diff --check`: passed

Kind gateway e2e was not run locally because no Kubernetes context was available.