### PR TITLE
[Gateway] Keep crypto randomness and log formatting out of the PD selection critical section

### DIFF
--- a/pkg/plugins/gateway/algorithms/pd/decode_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/decode_scorer.go
@@ -149,12 +149,14 @@ func (LoadBalancingDecodePolicy) ScoreDecodePod(routingCtx *types.RoutingContext
 	numer := decodeLBWeightRunningReq*normalizedRunningReqs + decodeLBWeightThroughput*normalizedThroughput
 	decodeScore := numer / normalizedFreeGPUPercent
 
-	klog.V(4).InfoS("decode_score", "request_id", routingCtx.RequestID, "pod_name", pod.Name,
-		"policy", DecodePolicyLoadBalancing, "decode_score", decodeScore,
-		"score", fmt.Sprintf("(%g*%f + %g*%f) / %f", decodeLBWeightRunningReq, normalizedRunningReqs, decodeLBWeightThroughput, normalizedThroughput, normalizedFreeGPUPercent),
-		"running_reqs", in.RunningReqs, "max_running_reqs", in.MaxRequestCount,
-		"throughput", in.Throughput, "max_throughput", in.MaxThroughput,
-		"free_gpu", in.FreeGPUPercent, "max_free_gpu_usage", in.MaxFreeGPUUsage)
+	if klog.V(4).Enabled() {
+		klog.V(4).InfoS("decode_score", "request_id", routingCtx.RequestID, "pod_name", pod.Name,
+			"policy", DecodePolicyLoadBalancing, "decode_score", decodeScore,
+			"score", fmt.Sprintf("(%g*%f + %g*%f) / %f", decodeLBWeightRunningReq, normalizedRunningReqs, decodeLBWeightThroughput, normalizedThroughput, normalizedFreeGPUPercent),
+			"running_reqs", in.RunningReqs, "max_running_reqs", in.MaxRequestCount,
+			"throughput", in.Throughput, "max_throughput", in.MaxThroughput,
+			"free_gpu", in.FreeGPUPercent, "max_free_gpu_usage", in.MaxFreeGPUUsage)
+	}
 
 	return decodeScore
 }
@@ -172,8 +174,10 @@ func (LeastRequestDecodePolicy) Describe() string {
 }
 
 func (LeastRequestDecodePolicy) ScoreDecodePod(routingCtx *types.RoutingContext, pod *v1.Pod, in DecodePodInput) float64 {
-	klog.V(4).InfoS("decode_score", "request_id", routingCtx.RequestID, "pod_name", pod.Name,
-		"policy", DecodePolicyLeastRequest, "running_reqs", in.RunningReqs)
+	if klog.V(4).Enabled() {
+		klog.V(4).InfoS("decode_score", "request_id", routingCtx.RequestID, "pod_name", pod.Name,
+			"policy", DecodePolicyLeastRequest, "running_reqs", in.RunningReqs)
+	}
 
 	return in.RunningReqs
 }
@@ -210,11 +214,13 @@ func (ConductorDecodePolicy) ScoreDecodePod(routingCtx *types.RoutingContext, po
 		estimatedTBT *= DefaultGPUCachePressurePenalty
 	}
 
-	klog.V(4).InfoS("decode_score", "request_id", routingCtx.RequestID, "pod_name", pod.Name,
-		"policy", DecodePolicyConductor, "decode_score", estimatedTBT,
-		"current_tbt_ms", currentTBTMs, "running_reqs", in.RunningReqs,
-		"gpu_cache_usage", gpuCacheUsage, "throughput", in.Throughput,
-		"free_gpu_percent", in.FreeGPUPercent)
+	if klog.V(4).Enabled() {
+		klog.V(4).InfoS("decode_score", "request_id", routingCtx.RequestID, "pod_name", pod.Name,
+			"policy", DecodePolicyConductor, "decode_score", estimatedTBT,
+			"current_tbt_ms", currentTBTMs, "running_reqs", in.RunningReqs,
+			"gpu_cache_usage", gpuCacheUsage, "throughput", in.Throughput,
+			"free_gpu_percent", in.FreeGPUPercent)
+	}
 
 	return estimatedTBT
 }

--- a/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill_scorer.go
@@ -179,11 +179,13 @@ func (s *prefixCacheScorer) PrefixHashes() []uint64 { return s.hashes }
 func (s *prefixCacheScorer) ScorePod(pod *v1.Pod, reqCnt, maxRequestCount float64) float64 {
 	matchPct := float64(s.matchedPods[pod.Name])
 	score := (100-matchPct)*.1 + reqCnt/maxRequestCount
-	klog.V(4).InfoS("prefill_score", "pod_name", pod.Name,
-		"policy", PrefillScorePolicyPrefixCache,
-		"score", fmt.Sprintf("(100 - %f) * 0.1 + %f / %f", matchPct, reqCnt, maxRequestCount),
-		"prefix_match_percent", matchPct,
-		"running_reqs", reqCnt, "max_running_reqs", maxRequestCount)
+	if klog.V(4).Enabled() {
+		klog.V(4).InfoS("prefill_score", "pod_name", pod.Name,
+			"policy", PrefillScorePolicyPrefixCache,
+			"score", fmt.Sprintf("(100 - %f) * 0.1 + %f / %f", matchPct, reqCnt, maxRequestCount),
+			"prefix_match_percent", matchPct,
+			"running_reqs", reqCnt, "max_running_reqs", maxRequestCount)
+	}
 	return score
 }
 
@@ -215,9 +217,11 @@ type leastRequestScorer struct{}
 func (s leastRequestScorer) PrefixHashes() []uint64 { return nil }
 
 func (s leastRequestScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
-	klog.V(4).InfoS("prefill_score", "pod_name", pod.Name,
-		"policy", PrefillScorePolicyLeastRequest,
-		"running_reqs", reqCnt)
+	if klog.V(4).Enabled() {
+		klog.V(4).InfoS("prefill_score", "pod_name", pod.Name,
+			"policy", PrefillScorePolicyLeastRequest,
+			"running_reqs", reqCnt)
+	}
 	return reqCnt
 }
 
@@ -374,17 +378,19 @@ func (s *conductorScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64 {
 	prefillEst := s.estimatePrefill(unmatchedTokens)
 	score := queueEst + prefixEst + prefillEst
 
-	klog.V(4).InfoS("prefill_score", "pod_name", pod.Name,
-		"policy", PrefillScorePolicyConductor,
-		"score", score,
-		"running_reqs", reqCnt,
-		"total_tokens", s.totalTokens,
-		"prefix_match_percent", matchPct,
-		"matched_tokens", matchedTokens,
-		"unmatched_tokens", unmatchedTokens,
-		"queue_estimate", queueEst,
-		"prefix_estimate", prefixEst,
-		"prefill_estimate", prefillEst)
+	if klog.V(4).Enabled() {
+		klog.V(4).InfoS("prefill_score", "pod_name", pod.Name,
+			"policy", PrefillScorePolicyConductor,
+			"score", score,
+			"running_reqs", reqCnt,
+			"total_tokens", s.totalTokens,
+			"prefix_match_percent", matchPct,
+			"matched_tokens", matchedTokens,
+			"unmatched_tokens", unmatchedTokens,
+			"queue_estimate", queueEst,
+			"prefix_estimate", prefixEst,
+			"prefill_estimate", prefillEst)
+	}
 	return score
 }
 
@@ -602,10 +608,12 @@ func (s *hybridCacheLoadScorer) ScorePod(pod *v1.Pod, reqCnt, _ float64) float64
 	if load >= 1 {
 		score = load * discount
 	}
-	klog.V(4).InfoS("prefill_score", "pod_name", pod.Name,
-		"policy", PrefillScorePolicyHybridCacheLoad,
-		"score", score, "token_load", load, "discount", discount,
-		"prefix_match_percent", matchPct, "raw_match_percent", s.matchedPods[pod.Name],
-		"running_reqs", reqCnt)
+	if klog.V(4).Enabled() {
+		klog.V(4).InfoS("prefill_score", "pod_name", pod.Name,
+			"policy", PrefillScorePolicyHybridCacheLoad,
+			"score", score, "token_load", load, "discount", discount,
+			"prefix_match_percent", matchPct, "raw_match_percent", s.matchedPods[pod.Name],
+			"running_reqs", reqCnt)
+	}
 	return score
 }

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -367,10 +367,12 @@ func (r *pdRouter) chargeTokenLoad(routingCtx *types.RoutingContext, pod *v1.Pod
 	matchPct := pd.PrefixMatchPercent(scorer, pod.Name)
 	newTokens, source := r.tokenLoadTracker.NewTokens(routingCtx.Model, sessionID, promptTokens, matchPct)
 	cost := r.tokenLoadTracker.PrefillCost(newTokens)
-	klog.V(4).InfoS("pd_router token_load charge",
-		"request_id", routingCtx.RequestID, "pod_name", pod.Name, "policy", policy.Name(),
-		"prompt_tokens", promptTokens, "new_tokens", newTokens, "source", source,
-		"prefix_match_percent", matchPct, "cost", cost)
+	if klog.V(4).Enabled() {
+		klog.V(4).InfoS("pd_router token_load charge",
+			"request_id", routingCtx.RequestID, "pod_name", pod.Name, "policy", policy.Name(),
+			"prompt_tokens", promptTokens, "new_tokens", newTokens, "source", source,
+			"prefix_match_percent", matchPct, "cost", cost)
+	}
 	r.tokenLoadTracker.AcquirePrefill(routingCtx.RequestID, pod.Name, cost)
 }
 
@@ -546,10 +548,12 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 	if isImbalanced && targetPod != nil {
 		prefillPods = []*v1.Pod{targetPod}
 		decodePods = utils.FilterPodsByLabel(decodePods, PDRoleSetIdentifier, targetPod.Labels[PDRoleSetIdentifier])
-		klog.V(4).InfoS("load imbalance detected, selecting least-loaded prefill pod",
-			"request_id", routingCtx.RequestID, "selected_prefill_pod", targetPod.Name,
-			"roleset", targetPod.Labels[PDRoleSetIdentifier], "decode_pods_after_align", pdPodNames(decodePods),
-		)
+		if klog.V(4).Enabled() {
+			klog.V(4).InfoS("load imbalance detected, selecting least-loaded prefill pod",
+				"request_id", routingCtx.RequestID, "selected_prefill_pod", targetPod.Name,
+				"roleset", targetPod.Labels[PDRoleSetIdentifier], "decode_pods_after_align", pdPodNames(decodePods),
+			)
+		}
 	}
 
 	targetPod, maxRequestCount, maxThroughput, maxFreeGPUUsage, podRequestCounts, podThroughputs, podFreeGpuUsage := r.loadImbalanceSelectDecodePod(routingCtx, decodePods)
@@ -558,10 +562,12 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 		if aligned := utils.FilterPodsByLabel(prefillPods, PDRoleSetIdentifier, targetPod.Labels[PDRoleSetIdentifier]); len(aligned) > 0 {
 			prefillPods = aligned
 		}
-		klog.V(4).InfoS("load imbalance detected in decode pods",
-			"request_id", routingCtx.RequestID, "selected_decode_pod", targetPod.Name,
-			"roleset", targetPod.Labels[PDRoleSetIdentifier], "prefill_pods_after_align", pdPodNames(prefillPods),
-		)
+		if klog.V(4).Enabled() {
+			klog.V(4).InfoS("load imbalance detected in decode pods",
+				"request_id", routingCtx.RequestID, "selected_decode_pod", targetPod.Name,
+				"roleset", targetPod.Labels[PDRoleSetIdentifier], "prefill_pods_after_align", pdPodNames(prefillPods),
+			)
+		}
 	}
 
 	prefillScores, maxPrefillScore, prefixHashes := r.scorePreparedPrefillPods(routingCtx, prefillPods, prefillScorer)
@@ -585,8 +591,9 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 // in-flight prefill HTTP calls from other concurrent requests. The current request is
 // not counted yet — filterPrefillDecodePods registers it after selection completes,
 // under the same selectMu hold.
-// readyPods is shuffled before evaluation so ties among equally-loaded pods are broken
-// randomly rather than by map iteration order.
+// Ties among equally-loaded pods are broken by drawing uniformly at random from the tied
+// pod names; readyPods is only used to resolve that name back to a pod, so its order does
+// not influence the result.
 //
 // Returns one pod tied for the minimum count and imbalance=true when
 // max(count) − min(count) > aibrixPrefillLoadImbalanceMinSpread (strictly greater than).
@@ -600,7 +607,6 @@ func (r *pdRouter) loadImbalanceSelectPrefillPod(readyPods []*v1.Pod, podRequest
 	targetPods := []string{}
 	minValue := int32(math.MaxInt32)
 	maxValue := int32(math.MinInt32)
-	utils.CryptoShuffle(readyPods)
 
 	if len(podRequestCount) == 0 {
 		return targetPod, imbalance
@@ -623,7 +629,7 @@ func (r *pdRouter) loadImbalanceSelectPrefillPod(readyPods []*v1.Pod, podRequest
 	if maxValue-minValue > aibrixPrefillLoadImbalanceMinSpread && len(targetPods) > 0 {
 		targetPod, _ = utils.FilterPodByName(targetPods[rand.Intn(len(targetPods))], readyPods)
 		imbalance = true
-		if targetPod != nil {
+		if targetPod != nil && klog.V(4).Enabled() {
 			klog.V(4).InfoS("prefill request imbalance detected, selecting least-loaded pod",
 				"min_request_count", minValue, "max_request_count", maxValue,
 				"selected_prefill_pod", targetPod.Name, "roleset", targetPod.Labels[PDRoleSetIdentifier],
@@ -679,7 +685,7 @@ func (r *pdRouter) loadImbalanceSelectDecodePod(ctx *types.RoutingContext, filte
 	minObservedRequestCount := math.MaxFloat64
 	maxObservedThroughput := float64(0)
 	minObservedThroughput := math.MaxFloat64
-	utils.CryptoShuffle(filteredDecodePods)
+	utils.Shuffle(filteredDecodePods)
 
 	for _, pod := range filteredDecodePods {
 		runningReqs, runningErr := r.cache.GetMetricValueByPod(pod.Name, pod.Namespace, metrics.RealtimeNumRequestsRunning)
@@ -832,7 +838,7 @@ func (r *pdRouter) preparePrefillScorer(routingCtx *types.RoutingContext, prefil
 // it reads the current prefill request counts and scores prefillPods with an
 // already-prepared scorer. filterPrefillDecodePods calls it under selectMu.
 func (r *pdRouter) scorePreparedPrefillPods(routingCtx *types.RoutingContext, prefillPods []*v1.Pod, scorer pd.PrefillScorer) (map[string]*Scores, float64, []uint64) {
-	utils.CryptoShuffle(prefillPods)
+	utils.Shuffle(prefillPods)
 	podRequestCount := r.prefillRequestTracker.GetPrefillRequestCountsForPods(prefillPods)
 
 	var maxRequestCount float64 = 1
@@ -911,7 +917,7 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 		return out
 	}
 
-	utils.CryptoShuffle(filteredDecodePods)
+	utils.Shuffle(filteredDecodePods)
 
 	anyMetricsReady := false
 	metricsReadyByPod := make(map[string]bool, len(filteredDecodePods))
@@ -923,8 +929,15 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 		}
 	}
 
-	scoredPods := make([]string, 0, len(filteredDecodePods))
-	skippedPods := make([]string, 0, len(filteredDecodePods))
+	// The per-pod score strings exist only for the decode_score_summary log,
+	// so build them only when that log is going to be written; this runs
+	// under selectMu for every request.
+	verbose := klog.V(4).Enabled()
+	var scoredPods, skippedPods []string
+	if verbose {
+		scoredPods = make([]string, 0, len(filteredDecodePods))
+		skippedPods = make([]string, 0, len(filteredDecodePods))
+	}
 
 	for _, pod := range filteredDecodePods {
 		rolesetName := pod.Labels[PDRoleSetIdentifier]
@@ -934,10 +947,12 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 			// Once the pod's first request completes and metrics arrive, it transitions to full scoring.
 			pending := float64(r.pendingDecodeTracker.GetPendingDecodeCount(pod.Name))
 			coldScore := 1.0 + pending
-			scoredPods = append(scoredPods, fmt.Sprintf("%s:score=%.4f,roleset=%s(cold)", pod.Name, coldScore, rolesetName))
-			klog.V(4).InfoS("decode pod metrics not ready, using cold-start score",
-				"request_id", routingCtx.RequestID, "pod", pod.Name, "roleset", rolesetName,
-				"cold_score", coldScore, "pending", pending)
+			if verbose {
+				scoredPods = append(scoredPods, fmt.Sprintf("%s:score=%.4f,roleset=%s(cold)", pod.Name, coldScore, rolesetName))
+				klog.V(4).InfoS("decode pod metrics not ready, using cold-start score",
+					"request_id", routingCtx.RequestID, "pod", pod.Name, "roleset", rolesetName,
+					"cold_score", coldScore, "pending", pending)
+			}
 			if existing, exists := out.PerRoleset[rolesetName]; !exists || coldScore < existing.Score {
 				out.PerRoleset[rolesetName] = pd.RolesetDecodePick{Pod: pod, Score: coldScore}
 			}
@@ -962,15 +977,19 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 				out.FallbackUsed = true
 			}
 			if pd.InvalidDecodeScore(decodeScore) {
-				skippedPods = append(skippedPods, fmt.Sprintf("%s:invalid_score", pod.Name))
-				klog.V(4).InfoS("decode score invalid after policy and load_balancing fallback, skipping pod",
-					"request_id", routingCtx.RequestID, "pod", pod.Name, "policy", policyName,
-					"roleset", pod.Labels[PDRoleSetIdentifier])
+				if verbose {
+					skippedPods = append(skippedPods, fmt.Sprintf("%s:invalid_score", pod.Name))
+					klog.V(4).InfoS("decode score invalid after policy and load_balancing fallback, skipping pod",
+						"request_id", routingCtx.RequestID, "pod", pod.Name, "policy", policyName,
+						"roleset", pod.Labels[PDRoleSetIdentifier])
+				}
 				continue
 			}
 		}
 
-		scoredPods = append(scoredPods, fmt.Sprintf("%s:score=%.4f,roleset=%s", pod.Name, decodeScore, rolesetName))
+		if verbose {
+			scoredPods = append(scoredPods, fmt.Sprintf("%s:score=%.4f,roleset=%s", pod.Name, decodeScore, rolesetName))
+		}
 
 		if existing, exists := out.PerRoleset[rolesetName]; !exists || decodeScore < existing.Score {
 			out.PerRoleset[rolesetName] = pd.RolesetDecodePick{Pod: pod, Score: decodeScore}
@@ -980,7 +999,7 @@ func (r *pdRouter) scoreDecodePods(routingCtx *types.RoutingContext, filteredDec
 		}
 	}
 
-	if klog.V(4).Enabled() {
+	if verbose {
 		perRolesetBest := make([]string, 0, len(out.PerRoleset))
 		for roleset, pick := range out.PerRoleset {
 			perRolesetBest = append(perRolesetBest, fmt.Sprintf("%s:%s=%.4f", roleset, pick.Pod.Name, pick.Score))
@@ -1052,14 +1071,16 @@ func (r *pdRouter) finalPDScore(routingCtx *types.RoutingContext,
 			targetDecodePod = decodePick.Pod
 		}
 
-		klog.V(4).InfoS("final_score",
-			"request_id", routingCtx.RequestID, "roleset", roleset,
-			"final_score", final, "prefill_pod", prefillScore.Pod.Name,
-			"decode_pod", decodePick.Pod.Name,
-			"prefill_score", prefillScore.Score, "normalized_prefill_score", normalizedPrefillScore,
-			"decode_score", decodePick.Score, "normalized_decode_score", normalizedDecodeScore,
-			"decode_policy", decodeRun.Policy, "decode_fallback_used", decodeRun.FallbackUsed,
-		)
+		if klog.V(4).Enabled() {
+			klog.V(4).InfoS("final_score",
+				"request_id", routingCtx.RequestID, "roleset", roleset,
+				"final_score", final, "prefill_pod", prefillScore.Pod.Name,
+				"decode_pod", decodePick.Pod.Name,
+				"prefill_score", prefillScore.Score, "normalized_prefill_score", normalizedPrefillScore,
+				"decode_score", decodePick.Score, "normalized_decode_score", normalizedDecodeScore,
+				"decode_policy", decodeRun.Policy, "decode_fallback_used", decodeRun.FallbackUsed,
+			)
+		}
 	}
 
 	if targetPrefillPod == nil {
@@ -1241,7 +1262,9 @@ func (r *pdRouter) shouldPickCombined(routingCtx *types.RoutingContext, prefillP
 		}
 	}
 	if !combinedLowLoad {
-		klog.V(4).InfoS("combined_load", "requestId", routingCtx.RequestID, "prefillHighLoad", false, "decodeHighLoad", false, "combinedLowLoad", combinedLowLoad)
+		if klog.V(4).Enabled() {
+			klog.V(4).InfoS("combined_load", "requestId", routingCtx.RequestID, "prefillHighLoad", false, "decodeHighLoad", false, "combinedLowLoad", combinedLowLoad)
+		}
 		return false
 	}
 
@@ -1263,19 +1286,23 @@ func (r *pdRouter) shouldPickCombined(routingCtx *types.RoutingContext, prefillP
 		}
 	}
 
-	klog.V(4).InfoS("loads", "requestId", routingCtx.RequestID, "prefillHighLoad", prefillHighLoad, "decodeHighLoad", decodeHighLoad, "combinedLowLoad", combinedLowLoad)
+	if klog.V(4).Enabled() {
+		klog.V(4).InfoS("loads", "requestId", routingCtx.RequestID, "prefillHighLoad", prefillHighLoad, "decodeHighLoad", decodeHighLoad, "combinedLowLoad", combinedLowLoad)
+	}
 	return (prefillHighLoad || decodeHighLoad) && combinedLowLoad
 }
 
 // scoreCombinedPods returns the combined pod with the lowest request-rate score.
 // Pods are shuffled before scoring so ties are broken randomly.
 func (r *pdRouter) scoreCombinedPods(routingCtx *types.RoutingContext, combinedPods []*v1.Pod) *v1.Pod {
-	utils.CryptoShuffle(combinedPods)
+	utils.Shuffle(combinedPods)
 	var bestPod *v1.Pod
 	minScore := math.MaxFloat64
 	for _, pod := range combinedPods {
 		score := calculatePodScoreBasedOffRequestRate(routingCtx, r.cache, pod)
-		klog.V(4).InfoS("combined_pod_score", "requestId", routingCtx.RequestID, "pod_name", pod.Name, "score", score)
+		if klog.V(4).Enabled() {
+			klog.V(4).InfoS("combined_pod_score", "requestId", routingCtx.RequestID, "pod_name", pod.Name, "score", score)
+		}
 		if score < minScore {
 			minScore = score
 			bestPod = pod

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"sort"
 	"strings"
@@ -508,7 +508,7 @@ func (r *pdRouter) filterPrefillDecodePods(routingCtx *types.RoutingContext, rea
 				klog.InfoS("no bucket matches prompt length, routing to combined pod",
 					"requestId", routingCtx.RequestID, "promptLength", promptLength, "combinedPods", len(combinedPods),
 					"bucketPrefillPods", len(promptLengthBucketingPrefillPods), "bucketDecodePods", len(promptLengthBucketingDecodePods))
-				combinedPod := combinedPods[rand.Intn(len(combinedPods))]
+				combinedPod := combinedPods[rand.IntN(len(combinedPods))]
 				r.pendingDecodeTracker.AddPendingDecode(routingCtx.RequestID, combinedPod.Name)
 				return nil, combinedPod, nil
 			}
@@ -627,7 +627,7 @@ func (r *pdRouter) loadImbalanceSelectPrefillPod(readyPods []*v1.Pod, podRequest
 	}
 
 	if maxValue-minValue > aibrixPrefillLoadImbalanceMinSpread && len(targetPods) > 0 {
-		targetPod, _ = utils.FilterPodByName(targetPods[rand.Intn(len(targetPods))], readyPods)
+		targetPod, _ = utils.FilterPodByName(targetPods[rand.IntN(len(targetPods))], readyPods)
 		imbalance = true
 		if targetPod != nil && klog.V(4).Enabled() {
 			klog.V(4).InfoS("prefill request imbalance detected, selecting least-loaded pod",

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_benchmark_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_benchmark_test.go
@@ -30,7 +30,9 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/vllm-project/aibrix/pkg/cache"
 	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
@@ -326,4 +328,119 @@ func suppressKlogForBenchmark(b *testing.B) {
 		klog.SetOutput(os.Stderr)
 		klog.LogToStderr(true)
 	})
+}
+
+// BenchmarkFilterPrefillDecodePods times one full PD selection for a request:
+// policy Prepare (outside selectMu) plus everything the router does while it
+// holds selectMu (imbalance checks, prefill and decode scoring, final pairing,
+// tracker registration). With least_request the Prepare step is trivial, so
+// that sub-benchmark is effectively the cost of the selectMu critical section.
+// 4 rolesets x 2 replicas = 8 prefill + 8 decode pods, all equally loaded so
+// no imbalance fast path fires and every pod is scored.
+func BenchmarkFilterPrefillDecodePods(b *testing.B) {
+	suppressKlogForBenchmark(b)
+
+	const (
+		rolesetCount = 4
+		replicaCount = 2
+		model        = "benchmark-model"
+	)
+	prefillPods := benchmarkPDPods(VLLMEngine, "prefill", rolesetCount, replicaCount)
+	decodePods := benchmarkPDPods(VLLMEngine, "decode", rolesetCount, replicaCount)
+	readyPods := append(append([]*v1.Pod{}, prefillPods...), decodePods...)
+
+	podMetrics := make(map[string]map[string]metrics.MetricValue, len(decodePods))
+	for _, pod := range decodePods {
+		podMetrics[pod.Name] = map[string]metrics.MetricValue{
+			metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: 2},
+			metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: 512},
+			metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.3},
+		}
+	}
+	c := cache.NewWithPodsMetricsForTest(readyPods, model, podMetrics)
+
+	prefixTable := prefixcacheindexer.NewPrefixHashTable()
+	policies := []struct {
+		name   string
+		policy pd.PrefillScorePolicy
+	}{
+		{name: pd.PrefillScorePolicyLeastRequest, policy: pd.NewLeastRequestPrefillPolicy()},
+		{name: pd.PrefillScorePolicyPrefixCache, policy: newPrefixCachePrefillPolicy(prefixTable)},
+	}
+
+	for _, tc := range policies {
+		b.Run(tc.name, func(b *testing.B) {
+			tracker := pd.NewPrefillRequestTracker()
+			pending := pd.NewPendingDecodeTracker()
+			router := &pdRouter{
+				cache:                 c,
+				prefillPolicy:         tc.policy,
+				prefixCacheIndexer:    prefixTable,
+				prefillRequestTracker: tracker,
+				pendingDecodeTracker:  pending,
+				prefixUpdateCh:        make(chan prefixUpdateJob, 1024),
+				selectionCounts:       map[string]int64{},
+			}
+
+			// In production startPrefixUpdater() runs a goroutine that drains
+			// prefixUpdateCh. Without a consumer the 1024-slot buffer fills up and
+			// every later enqueuePrefixUpdate takes the drop branch and logs a
+			// warning, which is pure benchmark artefact. Drain and discard the jobs
+			// so the send stays on the normal (non-dropping) path without adding
+			// concurrent indexer writes to what is being measured.
+			updaterStop := make(chan struct{})
+			updaterDone := make(chan struct{})
+			go func() {
+				defer close(updaterDone)
+				for {
+					select {
+					case <-router.prefixUpdateCh:
+					case <-updaterStop:
+						return
+					}
+				}
+			}()
+			b.Cleanup(func() {
+				close(updaterStop)
+				<-updaterDone
+			})
+
+			ctx := types.NewRoutingContext(context.Background(), RouterPD, model,
+				strings.Repeat("filter prefill decode benchmark prompt ", 32),
+				"bench-filter-pd", "bench-user")
+			defer ctx.Delete()
+			ctx.Engine = VLLMEngine
+			ctx.ReqPath = "/v1/chat/completions"
+			ctx.ReqBody = randReqBody(4000)
+
+			// Seed the shared prefix table so the prefix_cache sub-benchmark measures
+			// the match path instead of scoring every prefill pod as a cache miss.
+			// newTokenizer() is what newPrefixCachePrefillPolicy hands the policy, so
+			// these are the hashes the policy looks up.
+			seedTokens, err := newTokenizer().TokenizeInputText(ctx.Message)
+			if err != nil {
+				b.Fatalf("tokenize prompt: %v", err)
+			}
+			seedHashes := prefixTable.GetPrefixHashes(seedTokens)
+			for i, pod := range prefillPods {
+				if i%2 == 0 {
+					prefixTable.AddPrefix(seedHashes, ctx.Model, pod.Name)
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				prefillPod, decodePod, err := router.filterPrefillDecodePods(ctx, readyPods)
+				if err != nil {
+					b.Fatalf("filterPrefillDecodePods: %v", err)
+				}
+				if prefillPod == nil || decodePod == nil {
+					b.Fatal("filterPrefillDecodePods returned a nil pod")
+				}
+				tracker.RemovePrefillRequest(ctx.RequestID)
+				pending.RemovePendingDecode(ctx.RequestID)
+			}
+		})
+	}
 }

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation_test.go
@@ -21,12 +21,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -3101,4 +3103,100 @@ func TestRoute_SGLangDuplicateFieldsRejectsBeforeSelector(t *testing.T) {
 
 	var invalidReqErr *engine.InvalidRequestError
 	assert.True(t, errors.As(err, &invalidReqErr), "must return *InvalidRequestError")
+}
+
+// setKlogVerbosity raises klog's -v level for the duration of one test and restores
+// the previous value in t.Cleanup. klog verbosity is process-wide state, so tests
+// that use this helper must not run in parallel.
+func setKlogVerbosity(t *testing.T, level string) {
+	t.Helper()
+
+	fs := flag.NewFlagSet("klog-verbosity", flag.ContinueOnError)
+	klog.InitFlags(fs)
+	vFlag := fs.Lookup("v")
+	if vFlag == nil {
+		t.Fatal("klog -v flag is not registered")
+	}
+
+	previous := vFlag.Value.String()
+	if err := vFlag.Value.Set(level); err != nil {
+		t.Fatalf("set klog verbosity to %s: %v", level, err)
+	}
+	t.Cleanup(func() {
+		if err := vFlag.Value.Set(previous); err != nil {
+			t.Errorf("restore klog verbosity to %s: %v", previous, err)
+		}
+	})
+}
+
+// TestScoreDecodePods_VerboseSummaryPopulated guards the V(4) fast path in
+// scoreDecodePods: the per-pod score strings are built only when the decode_score_summary
+// log is going to be written, so this checks they are still populated at -v=4.
+func TestScoreDecodePods_VerboseSummaryPopulated(t *testing.T) {
+	setKlogVerbosity(t, "4")
+
+	var logs bytes.Buffer
+	klog.LogToStderr(false)
+	klog.SetOutput(&logs)
+	t.Cleanup(func() {
+		klog.Flush()
+		klog.SetOutput(io.Discard)
+		klog.LogToStderr(true)
+	})
+
+	if !klog.V(4).Enabled() {
+		t.Fatal("klog V(4) is not enabled after raising verbosity")
+	}
+
+	pods := []*v1.Pod{
+		makePDPod("verbose-decode-1", "rs1", "decode", nil),
+		makePDPod("verbose-decode-2", "rs1", "decode", nil),
+		makePDPod("verbose-decode-3", "rs2", "decode", nil),
+	}
+
+	podMetrics := make(map[string]map[string]metrics.MetricValue, len(pods))
+	podRequestCounts := make(map[string]float64, len(pods))
+	podThroughputs := make(map[string]float64, len(pods))
+	podFreeGPUUsage := make(map[string]float64, len(pods))
+	for i, pod := range pods {
+		requestCount := float64(i + 1)
+		throughput := float64(512 + i*64)
+		freeGPUUsage := float64(25 + i*10)
+
+		podMetrics[pod.Name] = map[string]metrics.MetricValue{
+			metrics.RealtimeNumRequestsRunning:      &metrics.SimpleMetricValue{Value: requestCount},
+			metrics.AvgGenerationThroughputToksPerS: &metrics.SimpleMetricValue{Value: throughput},
+			metrics.KVCacheUsagePerc:                &metrics.SimpleMetricValue{Value: 0.3},
+		}
+		podRequestCounts[pod.Name] = requestCount
+		podThroughputs[pod.Name] = throughput
+		podFreeGPUUsage[pod.Name] = freeGPUUsage
+	}
+
+	router := &pdRouter{cache: cache.NewWithPodsMetricsForTest(pods, "model", podMetrics)}
+	ctx := types.NewRoutingContext(context.Background(), RouterPD, "model", "hello", "req-verbose-decode", "user")
+	defer ctx.Delete()
+
+	for _, pod := range pods {
+		if !router.decodePodMetricsReady(ctx, pod) {
+			t.Fatalf("decode pod %s should have ready metrics", pod.Name)
+		}
+	}
+
+	run := router.scoreDecodePods(ctx, pods, 3, 640, 45,
+		podRequestCounts, podThroughputs, podFreeGPUUsage, nil)
+	klog.Flush()
+
+	assert.NotEmpty(t, run.PerRoleset, "scoreDecodePods should pick one pod per roleset")
+
+	out := logs.String()
+	assert.Contains(t, out, "decode_score_summary")
+
+	match := regexp.MustCompile(`scored="([^"]*)"`).FindStringSubmatch(out)
+	if assert.NotNil(t, match, "decode_score_summary should carry a scored= field, got: %s", out) {
+		assert.NotEmpty(t, match[1], "scored= must be populated when verbosity is 4")
+		for _, pod := range pods {
+			assert.Contains(t, match[1], pod.Name, "scored= should list every scored pod")
+		}
+	}
 }

--- a/pkg/plugins/gateway/algorithms/scorer.go
+++ b/pkg/plugins/gateway/algorithms/scorer.go
@@ -39,9 +39,11 @@ func calculatePodScoreBasedOffRequestRate(routingCtx *types.RoutingContext, cach
 	decodePreallocQueue := GetPodModelMetricsSimpleValue(cache, pod.Name, pod.Namespace, modelName, metrics.NumDecodePreallocQueueReqs)
 	drainRate1m := GetPodModelMetricsSimplePrometheusValue(cache, pod.Name, pod.Namespace, modelName, metrics.DrainRate1m)
 
-	klog.V(4).InfoS("pod_metrics", "requestId",
-		routingCtx.RequestID, "podName", pod.Name, "namespace", pod.Namespace, "modelName", modelName,
-		"waitingReqs", waitingReqs, "prefillPreallocQueue", prefillPreallocQueue, "decodePreallocQueue", decodePreallocQueue, "drainRate1m", drainRate1m)
+	if klog.V(4).Enabled() {
+		klog.V(4).InfoS("pod_metrics", "requestId",
+			routingCtx.RequestID, "podName", pod.Name, "namespace", pod.Namespace, "modelName", modelName,
+			"waitingReqs", waitingReqs, "prefillPreallocQueue", prefillPreallocQueue, "decodePreallocQueue", decodePreallocQueue, "drainRate1m", drainRate1m)
+	}
 
 	return (waitingReqs + prefillPreallocQueue + decodePreallocQueue) / drainRate1m
 }

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -20,6 +20,7 @@ import (
 	crand "crypto/rand"
 	"fmt"
 	"math/big"
+	mrand "math/rand/v2"
 	"os"
 	"strconv"
 	"time"
@@ -303,6 +304,10 @@ func IsDataParallelPod(pod *v1.Pod) bool {
 	return false
 }
 
+// CryptoShuffle shuffles slice in place using crypto/rand. Every swap reads
+// the OS entropy source, so it costs a getrandom syscall and several
+// allocations per swap; use it where unpredictability matters, not on hot
+// paths. See Shuffle.
 func CryptoShuffle[T any](slice []T) {
 	n := len(slice)
 	for i := n - 1; i > 0; i-- {
@@ -310,6 +315,16 @@ func CryptoShuffle[T any](slice []T) {
 		j := int(jBig.Int64())
 		slice[i], slice[j] = slice[j], slice[i]
 	}
+}
+
+// Shuffle shuffles slice in place using math/rand/v2's process-wide generator,
+// which is safe for concurrent use and neither allocates nor enters the
+// kernel. It is the right choice for tie-breaking on request hot paths, where
+// the order only needs to be unbiased, not unpredictable.
+func Shuffle[T any](slice []T) {
+	mrand.Shuffle(len(slice), func(i, j int) {
+		slice[i], slice[j] = slice[j], slice[i]
+	})
 }
 
 func HasVolume(vols []v1.Volume, name string) bool {

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package utils
 
 import (
+	"slices"
+	"sync"
 	"testing"
 
 	"github.com/pkoukk/tiktoken-go"
@@ -37,4 +39,66 @@ func TestTokenizeInputText(t *testing.T) {
 	tke, _ := tiktoken.GetEncoding(encoding)
 	outputStr = tke.Decode(tokens)
 	assert.Equal(t, inputStr, outputStr)
+}
+
+func TestShuffle(t *testing.T) {
+	t.Run("preserves the multiset of elements", func(t *testing.T) {
+		original := []int{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5}
+		shuffled := slices.Clone(original)
+		Shuffle(shuffled)
+
+		want, got := slices.Clone(original), slices.Clone(shuffled)
+		slices.Sort(want)
+		slices.Sort(got)
+		assert.Equal(t, want, got, "Shuffle must not add, drop or alter elements")
+	})
+
+	t.Run("handles empty and single-element slices", func(t *testing.T) {
+		var nilSlice []int
+		assert.NotPanics(t, func() { Shuffle(nilSlice) })
+		assert.NotPanics(t, func() { Shuffle([]int{}) })
+
+		single := []string{"only"}
+		assert.NotPanics(t, func() { Shuffle(single) })
+		assert.Equal(t, []string{"only"}, single)
+	})
+
+	t.Run("permutes the order", func(t *testing.T) {
+		// A shuffle that never reorders would silently defeat the tie-breaking
+		// this function exists for. Returning the identity 100 times in a row
+		// has probability (1/8!)^100, so this cannot fail by chance.
+		identity := []int{0, 1, 2, 3, 4, 5, 6, 7}
+		permuted := false
+		for i := 0; i < 100 && !permuted; i++ {
+			candidate := slices.Clone(identity)
+			Shuffle(candidate)
+			permuted = !slices.Equal(candidate, identity)
+		}
+		assert.True(t, permuted, "Shuffle never changed the order in 100 attempts")
+	})
+
+	t.Run("is safe for concurrent use", func(t *testing.T) {
+		// Every goroutine owns its slice, so the only shared state is the
+		// process-wide math/rand/v2 source Shuffle draws from. Run under -race.
+		const goroutines, iterations, length = 8, 500, 10
+		sorted := make([]int, length)
+		for i := range sorted {
+			sorted[i] = i
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for g := 0; g < goroutines; g++ {
+			go func() {
+				defer wg.Done()
+				own := slices.Clone(sorted)
+				for i := 0; i < iterations; i++ {
+					Shuffle(own)
+				}
+				slices.Sort(own)
+				assert.Equal(t, sorted, own)
+			}()
+		}
+		wg.Wait()
+	})
 }


### PR DESCRIPTION
## Pull Request Description

Resolves #2690. Follow-up to #2678.

Since #2678 the PD router runs imbalance checks, prefill/decode scoring, `finalPDScore` and the tracker registrations under `selectMu`, so that region is the per-request serial floor for PD routing. Profiling it on `main` shows that most of its time is not scoring: ~38% is `utils.CryptoShuffle` (four calls per request, each swap a `getrandom` syscall plus `big.Int` allocations) and ~18% is `fmt.Sprintf` for klog V(4) arguments that are discarded at the default verbosity. Details and profile shares are in #2690.

This PR keeps both out of the lock without changing any routing decision:

1. **`utils.Shuffle`** (new, `math/rand/v2` `rand.Shuffle` on the process-wide ChaCha8 generator: concurrency-safe, zero allocations, no syscall) replaces `CryptoShuffle` for the PD router's tie-break shuffles in `loadImbalanceSelectDecodePod`, `scorePreparedPrefillPods`, `scoreDecodePods` and `scoreCombinedPods`. `CryptoShuffle` is kept (with a doc comment on its cost) and `gateway.go` still uses it; that call site is outside this change.
2. The shuffle in `loadImbalanceSelectPrefillPod` is **removed** rather than replaced: the function resolves its result by pod name (`utils.FilterPodByName` over candidates picked with `rand.Intn`) and the caller reshuffles the same slice in `scorePreparedPrefillPods`, so the slice order never affected the outcome.
3. **V(4) log construction is guarded** with `if klog.V(4).Enabled()` on the per-pod, per-request paths: the prefill `ScorePod` implementations (prefix_cache, least_request, conductor, hybrid_cache_load; token_load already had the guard), the decode `ScoreDecodePod` implementations, `scoreDecodePods` (the `scoredPods` / `skippedPods` strings are now built only when the summary line will be written), `finalPDScore`, the imbalance alignment logs, `chargeTokenLoad`, `shouldPickCombined` / `scoreCombinedPods`, and `calculatePodScoreBasedOffRequestRate` (only called from the PD router). Log keys and values are unchanged. Logs in cold branches (imbalance detected, pod skipped) are left as they were.

### Benchmarks

`pkg/plugins/gateway/algorithms`, `-benchmem -count=6`, medians, i5-12500, same window before/after. `BenchmarkFilterPrefillDecodePods` is new: one full selection against 8 prefill + 8 decode pods (4 rolesets × 2 replicas, decode metrics populated, half of the prefill pods seeded with the prompt prefix), tracker registrations undone after each iteration. With `least_request` the policy `Prepare` step is trivial, so that variant is effectively the `selectMu` region alone.

| Benchmark | before ns/op | after ns/op | B/op | allocs/op |
| --- | --- | --- | --- | --- |
| `FilterPrefillDecodePods/least_request` | 50,286 | 21,526 | 21,432 → 10,870 | 568 → 214 |
| `FilterPrefillDecodePods/prefix_cache` | 106,360 | 75,474 | 29,882 → 17,848 | 616 → 222 |
| `ScoreDecodePods` (16 pods) | 41,652 | 2,222 | 13,174 → 980 | 415 → 3 |
| `ScorePrefillPods` (16 pods) | 419,052 | 270,513 | 19,298 → 14,200 | 235 → 48 |

In isolation, shuffling an 8-element slice goes from ~6.5 µs / 21 allocs (`CryptoShuffle`) to ~0.1 µs / 0 allocs (`Shuffle`).

### Tests

- `TestShuffle` (`pkg/utils`): multiset preserved, nil/empty/single element, actually permutes, concurrent callers under `-race`.
- `TestScoreDecodePods_VerboseSummaryPopulated`: runs `scoreDecodePods` at `-v=4` and asserts the `decode_score_summary` line lists every scored pod, so a future "computed inside the guard, used outside" slip is caught.
- `BenchmarkFilterPrefillDecodePods` as above.
- `go test -race ./pkg/utils/ ./pkg/plugins/gateway/...` and `golangci-lint` pass.

### Not in this PR

- The two Prometheus counter increments in `finalPDScore` (~8% of the region, label-map construction per call) could move after the unlock; that is a slightly less mechanical change and I left it out unless maintainers want it here.
- `gateway.go` still calls `CryptoShuffle` for its per-request pod shuffle; switching it is the same one-line change if wanted.

## Related Issues

Resolves #2690

Related: #2678

## Important Notes

No routing behaviour change, no new dependency (`math/rand/v2` is in the standard library since Go 1.22; the repo pins 1.22). `utils.CryptoShuffle` is unchanged for existing callers.
