### PR TITLE
[API][CLI] Add etcd-backed service discovery for standalone gateways

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,11 +226,11 @@ build-gateway-plugins: manifests generate fmt vet ## Build gateway-plugins binar
 	CGO_LDFLAGS='-lzmq -lsodium -lpthread -lm -lstdc++' \
 	go build -tags="zmq" \
 		-ldflags='-extldflags "$(CGO_LDFLAGS)"' \
-		-o bin/gateway-plugins cmd/plugins/main.go
+		-o bin/gateway-plugins ./cmd/plugins
 
 .PHONY: build-gateway-plugins-nozmq
 build-gateway-plugins-nozmq: manifests generate fmt vet ## Build gateway-plugins binary without ZMQ (for standalone mode).
-	CGO_ENABLED=0 go build -tags="nozmq" -o bin/gateway-plugins cmd/plugins/main.go
+	CGO_ENABLED=0 go build -tags="nozmq" -o bin/gateway-plugins ./cmd/plugins
 
 .PHONY: build-console
 build-console: ## Build console API server binary.

--- a/cmd/plugins/discovery.go
+++ b/cmd/plugins/discovery.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vllm-project/aibrix/pkg/cache/discovery"
+	"sigs.k8s.io/yaml"
+)
+
+// etcdFileConfig keeps durations and certificate paths convenient for YAML/JSON
+// while the discovery provider accepts a transport-ready configuration.
+type etcdFileConfig struct {
+	Endpoints   []string `json:"endpoints"`
+	Prefix      string   `json:"prefix"`
+	DialTimeout string   `json:"dialTimeout"`
+	Username    string   `json:"username"`
+	Password    string   `json:"password"`
+	TLSCA       string   `json:"tlsCA"`
+	TLSCert     string   `json:"tlsCert"`
+	TLSKey      string   `json:"tlsKey"`
+}
+
+func validateDiscoveryFlags(standalone bool, endpointsPath, etcdPath string) error {
+	if endpointsPath != "" && etcdPath != "" {
+		return fmt.Errorf("--endpoints-config and --etcd-config are mutually exclusive")
+	}
+	if etcdPath != "" && !standalone {
+		return fmt.Errorf("--etcd-config requires --standalone")
+	}
+	if standalone && endpointsPath == "" && etcdPath == "" {
+		return fmt.Errorf("--endpoints-config or --etcd-config is required in standalone mode")
+	}
+	return nil
+}
+
+func loadEtcdConfig(path string) (discovery.EtcdConfig, error) {
+	var config discovery.EtcdConfig
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return config, fmt.Errorf("read etcd config: %w", err)
+	}
+	jsonData, err := yaml.YAMLToJSONStrict(data)
+	if err != nil {
+		return config, fmt.Errorf("invalid etcd config: expected YAML or JSON")
+	}
+	var file etcdFileConfig
+	decoder := json.NewDecoder(bytes.NewReader(jsonData))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&file); err != nil {
+		// Parser errors may contain values from a config containing credentials.
+		return config, fmt.Errorf("invalid etcd config: expected YAML or JSON with known fields and correct types")
+	}
+	if len(file.Endpoints) == 0 {
+		return config, fmt.Errorf("etcd config requires at least one endpoint")
+	}
+	var endpointScheme string
+	for _, endpoint := range file.Endpoints {
+		u, err := url.Parse(endpoint)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") ||
+			u.Hostname() == "" || u.User != nil || u.RawQuery != "" ||
+			u.Fragment != "" || (u.Path != "" && u.Path != "/") {
+			return config, fmt.Errorf("etcd endpoints must be HTTP(S) URLs without credentials, query, fragment or path")
+		}
+		// The etcd client selects one transport for all endpoints using the first URL.
+		if endpointScheme != "" && u.Scheme != endpointScheme {
+			return config, fmt.Errorf("etcd endpoints must use the same HTTP or HTTPS scheme")
+		}
+		endpointScheme = u.Scheme
+	}
+	config.Endpoints = file.Endpoints
+	config.Prefix = file.Prefix
+	if config.Prefix == "" {
+		config.Prefix = "/aibrix/endpoints/"
+	}
+	config.DialTimeout = 5 * time.Second
+	if file.DialTimeout != "" {
+		timeout, err := time.ParseDuration(file.DialTimeout)
+		if err != nil || timeout <= 0 {
+			return config, fmt.Errorf("etcd dialTimeout must be a positive duration, such as 5s")
+		}
+		config.DialTimeout = timeout
+	}
+	config.Username = file.Username
+	config.Password = file.Password
+	if file.Password != "" && file.Username == "" {
+		return config, fmt.Errorf("etcd password requires username")
+	}
+	config.TLS, err = loadEtcdTLS(file, path)
+	return config, err
+}
+
+func loadEtcdTLS(file etcdFileConfig, path string) (*tls.Config, error) {
+	if (file.TLSCert == "") != (file.TLSKey == "") {
+		return nil, fmt.Errorf("etcd tlsCert and tlsKey must be provided together")
+	}
+	if file.TLSCA == "" && file.TLSCert == "" {
+		return nil, nil
+	}
+	for _, endpoint := range file.Endpoints {
+		if !strings.HasPrefix(endpoint, "https://") {
+			return nil, fmt.Errorf("etcd TLS configuration requires HTTPS endpoints")
+		}
+	}
+
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	resolve := func(certPath string) string {
+		if filepath.IsAbs(certPath) {
+			return certPath
+		}
+		return filepath.Join(filepath.Dir(path), certPath)
+	}
+	if file.TLSCA != "" {
+		pem, err := os.ReadFile(resolve(file.TLSCA))
+		if err != nil {
+			return nil, fmt.Errorf("read etcd tlsCA: %w", err)
+		}
+		tlsConfig.RootCAs = x509.NewCertPool()
+		if !tlsConfig.RootCAs.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("etcd tlsCA contains no valid CA certificates")
+		}
+	}
+	if file.TLSCert != "" {
+		cert, err := tls.LoadX509KeyPair(resolve(file.TLSCert), resolve(file.TLSKey))
+		if err != nil {
+			return nil, fmt.Errorf("load etcd client certificate: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+	return tlsConfig, nil
+}

--- a/cmd/plugins/discovery_test.go
+++ b/cmd/plugins/discovery_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateDiscoveryFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		standalone bool
+		endpoints  string
+		etcd       string
+		wantError  string
+	}{
+		{name: "kubernetes"},
+		{name: "existing kubernetes flags", endpoints: "ignored.yaml"},
+		{name: "static", standalone: true, endpoints: "endpoints.yaml"},
+		{name: "etcd", standalone: true, etcd: "etcd.yaml"},
+		{name: "missing", standalone: true, wantError: "is required"},
+		{name: "both", standalone: true, endpoints: "endpoints.yaml", etcd: "etcd.yaml", wantError: "mutually exclusive"},
+		{name: "etcd without standalone", etcd: "etcd.yaml", wantError: "requires --standalone"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDiscoveryFlags(tc.standalone, tc.endpoints, tc.etcd)
+			if tc.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestLoadEtcdConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+	}{
+		{"yaml", "endpoints:\n  - http://127.0.0.1:2379\n"},
+		{"json", `{"endpoints":["http://127.0.0.1:2379"]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := loadEtcdConfig(writeEtcdTestFile(t, t.TempDir(), "etcd.yaml", tc.content))
+			require.NoError(t, err)
+			require.Equal(t, []string{"http://127.0.0.1:2379"}, config.Endpoints)
+			require.Equal(t, "/aibrix/endpoints/", config.Prefix)
+			require.Equal(t, 5*time.Second, config.DialTimeout)
+			require.Nil(t, config.TLS)
+		})
+	}
+	path := writeEtcdTestFile(t, t.TempDir(), "etcd.yaml", `
+endpoints: ["https://etcd.example:2379"]
+prefix: /inference/workers/
+dialTimeout: 2s
+username: gateway
+password: a-secret
+`)
+	config, err := loadEtcdConfig(path)
+	require.NoError(t, err)
+	require.Equal(t, "/inference/workers/", config.Prefix)
+	require.Equal(t, 2*time.Second, config.DialTimeout)
+	require.Equal(t, "gateway", config.Username)
+	require.Equal(t, "a-secret", config.Password)
+	// HTTPS without an explicit CA uses the client's system trust roots.
+	require.Nil(t, config.TLS)
+}
+
+func TestLoadEtcdConfigMultipleEndpoints(t *testing.T) {
+	for _, scheme := range []string{"http", "https"} {
+		t.Run(scheme, func(t *testing.T) {
+			endpoints := []string{scheme + "://etcd-1.example:2379", scheme + "://etcd-2.example:2379"}
+			content := "endpoints: [" + endpoints[0] + ", " + endpoints[1] + "]"
+			config, err := loadEtcdConfig(writeEtcdTestFile(t, t.TempDir(), "etcd.yaml", content))
+			require.NoError(t, err)
+			require.Equal(t, endpoints, config.Endpoints)
+		})
+	}
+}
+
+func TestLoadEtcdConfigRejectsInvalidConfiguration(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"empty", "", "at least one endpoint"},
+		{"null", "null", "at least one endpoint"},
+		{"malformed YAML", "endpoints: [", "invalid etcd config"},
+		{"unknown field", "endpoints: [http://localhost:2379]\npasswordTypo: secret", "invalid etcd config"},
+		{"duplicate field", "endpoints: [http://localhost:2379]\nendpoints: []", "invalid etcd config"},
+		{"wrong endpoint type", "endpoints: localhost", "invalid etcd config"},
+		{"wrong username type", "endpoints: [http://localhost:2379]\nusername: false", "invalid etcd config"},
+		{
+			"wrong password type",
+			"endpoints: [http://localhost:2379]\nusername: gateway\npassword: 1234",
+			"invalid etcd config",
+		},
+		{"empty endpoint", "endpoints: [\"\"]", "HTTP(S)"},
+		{"missing scheme", "endpoints: [localhost:2379]", "HTTP(S)"},
+		{
+			"mixed schemes HTTP first",
+			"endpoints: [http://etcd-1.example:2379, https://etcd-2.example:2379]",
+			"same HTTP or HTTPS scheme",
+		},
+		{
+			"mixed schemes HTTPS first",
+			"endpoints: [https://etcd-1.example:2379, http://etcd-2.example:2379]",
+			"same HTTP or HTTPS scheme",
+		},
+		{"credentials in URL", "endpoints: [http://user:secret@localhost:2379]", "without credentials"},
+		{"endpoint path", "endpoints: [http://localhost:2379/workers]", "HTTP(S)"},
+		{"invalid duration", "endpoints: [http://localhost:2379]\ndialTimeout: soon", "positive duration"},
+		{"zero duration", "endpoints: [http://localhost:2379]\ndialTimeout: 0s", "positive duration"},
+		{"negative duration", "endpoints: [http://localhost:2379]\ndialTimeout: -1s", "positive duration"},
+		{"password without user", "endpoints: [http://localhost:2379]\npassword: secret", "requires username"},
+		{"certificate without key", "endpoints: [https://localhost:2379]\ntlsCert: cert.pem", "provided together"},
+		{"key without certificate", "endpoints: [https://localhost:2379]\ntlsKey: key.pem", "provided together"},
+		{"TLS on HTTP", "endpoints: [http://localhost:2379]\ntlsCA: ca.pem", "HTTPS endpoints"},
+		{"missing CA file", "endpoints: [https://localhost:2379]\ntlsCA: absent.pem", "read etcd tlsCA"},
+		{
+			"missing client files",
+			"endpoints: [https://localhost:2379]\ntlsCert: absent.pem\ntlsKey: key.pem",
+			"load etcd client certificate",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loadEtcdConfig(writeEtcdTestFile(t, t.TempDir(), "etcd.yaml", tc.content))
+			require.ErrorContains(t, err, tc.want)
+			require.NotContains(t, err.Error(), "secret")
+		})
+	}
+	_, err := loadEtcdConfig(filepath.Join(t.TempDir(), "missing.yaml"))
+	require.ErrorContains(t, err, "read etcd config")
+}
+
+func TestLoadEtcdConfigTLS(t *testing.T) {
+	dir := t.TempDir()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "etcd-config-test"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	writeEtcdTestFile(t, dir, "ca.pem", certPEM)
+	writeEtcdTestFile(t, dir, "client.pem", certPEM)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	writeEtcdTestFile(t, dir, "client-key.pem", string(keyPEM))
+	path := writeEtcdTestFile(t, dir, "etcd.yaml", `
+endpoints: ["https://localhost:2379"]
+tlsCA: ca.pem
+tlsCert: client.pem
+tlsKey: client-key.pem
+`)
+	config, err := loadEtcdConfig(path)
+	require.NoError(t, err)
+	require.NotNil(t, config.TLS)
+	require.False(t, config.TLS.InsecureSkipVerify)
+	require.Equal(t, uint16(tls.VersionTLS12), config.TLS.MinVersion)
+	require.Len(t, config.TLS.Certificates, 1)
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	_, err = parsed.Verify(x509.VerifyOptions{
+		Roots: config.TLS.RootCAs, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	})
+	require.NoError(t, err)
+
+	// An absolute CA path works, and an explicit CA alone does not require mTLS.
+	absoluteCAConfig := "endpoints: [https://localhost:2379]\ntlsCA: " + filepath.Join(dir, "ca.pem") + "\n"
+	path = writeEtcdTestFile(t, dir, "etcd.yaml", absoluteCAConfig)
+	config, err = loadEtcdConfig(path)
+	require.NoError(t, err)
+	require.Empty(t, config.TLS.Certificates)
+
+	writeEtcdTestFile(t, dir, "ca.pem", "not a certificate")
+	_, err = loadEtcdConfig(path)
+	require.ErrorContains(t, err, "no valid CA certificates")
+
+	// Certificate verification stays enabled when using only a client key pair.
+	path = writeEtcdTestFile(t, dir, "etcd.yaml", `
+endpoints: ["https://localhost:2379"]
+tlsCert: client.pem
+tlsKey: client-key.pem
+`)
+	config, err = loadEtcdConfig(path)
+	require.NoError(t, err)
+	require.Nil(t, config.TLS.RootCAs)
+	require.False(t, config.TLS.InsecureSkipVerify)
+}
+
+func writeEtcdTestFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}

--- a/cmd/plugins/main.go
+++ b/cmd/plugins/main.go
@@ -59,6 +59,7 @@ var (
 	metricsAddr     string // deprecated: use httpAddr
 	standalone      bool
 	endpointsConfig string
+	etcdConfig      string
 )
 
 func main() {
@@ -67,7 +68,9 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "", "[Deprecated] Use --http-bind-address instead.")
 	flag.BoolVar(&standalone, "standalone", false, "Run in standalone mode without Kubernetes.")
 	flag.StringVar(&endpointsConfig, "endpoints-config", "",
-		"Path to endpoints config file (required in standalone mode).")
+		"Path to static endpoints config file (standalone mode).")
+	flag.StringVar(&etcdConfig, "etcd-config", "",
+		"Path to etcd discovery config file (standalone mode; mutually exclusive with --endpoints-config).")
 	klog.InitFlags(flag.CommandLine)
 	defer klog.Flush()
 	flag.Parse()
@@ -82,9 +85,9 @@ func main() {
 		}
 	}
 
-	// Validate standalone mode flags
-	if standalone && endpointsConfig == "" {
-		klog.Fatal("--endpoints-config is required when running in standalone mode")
+	// Validate discovery mode before initializing external clients.
+	if err := validateDiscoveryFlags(standalone, endpointsConfig, etcdConfig); err != nil {
+		klog.Fatal(err)
 	}
 
 	redisClient := utils.GetRedisClient()
@@ -121,9 +124,20 @@ func main() {
 	var discoveryProvider discovery.Provider
 
 	if standalone {
-		// Standalone mode: use file-based discovery
+		// Standalone mode: select the configured discovery backend.
 		klog.Info("Running in standalone mode")
-		discoveryProvider = discovery.NewStaticProvider(endpointsConfig)
+		if etcdConfig != "" {
+			etcdOptions, err := loadEtcdConfig(etcdConfig)
+			if err != nil {
+				klog.Fatalf("Invalid etcd discovery configuration: %v", err)
+			}
+			discoveryProvider, err = discovery.NewEtcdProvider(etcdOptions)
+			if err != nil {
+				klog.Fatalf("Failed to initialize etcd discovery: %v", err)
+			}
+		} else {
+			discoveryProvider = discovery.NewStaticProvider(endpointsConfig)
+		}
 	} else {
 		// Kubernetes mode: load config and create clients
 		var err error

--- a/deployment/local/configs/etcd.yaml
+++ b/deployment/local/configs/etcd.yaml
@@ -1,0 +1,18 @@
+# AIBrix Gateway etcd discovery configuration.
+# Start the gateway with:
+#   bin/gateway-plugins --standalone --etcd-config=deployment/local/configs/etcd.yaml
+# Register workers under prefix using the schema in pkg/cache/discovery/README.md.
+endpoints:
+  - "http://127.0.0.1:2379"
+prefix: "/aibrix/endpoints/"
+dialTimeout: "5s"
+
+# Keep credentials in this file, not command-line arguments.
+# username: gateway
+# password: "replace-with-your-password"
+
+# For TLS, use https:// endpoints. Paths are relative to this config file,
+# or absolute paths. Omitting tlsCA uses the system trust roots.
+# tlsCA: ca.pem
+# tlsCert: gateway-client.pem
+# tlsKey: gateway-client-key.pem

--- a/docs/source/features/kv-event-sync.rst
+++ b/docs/source/features/kv-event-sync.rst
@@ -164,7 +164,7 @@ AIBrix uses conditional compilation to manage ZMQ dependencies:
 .. code-block:: bash
 
    # Build with ZMQ support
-   go build -tags="zmq" ./cmd/plugins/main.go
+   go build -tags="zmq" ./cmd/plugins
    
    # Docker build with ZMQ
    make docker-build-gateway-plugins  # Automatically includes ZMQ

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/vmihailenco/msgpack/v5 v5.4.1
+	go.etcd.io/etcd/api/v3 v3.5.17
+	go.etcd.io/etcd/client/v3 v3.5.17
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.28.0
@@ -77,6 +79,8 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
@@ -136,6 +140,7 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.5.17 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,10 @@ github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b h1:ga8SEFjZ60pxLcmhnTh
 github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/coreos/go-oidc/v3 v3.11.0 h1:Ia3MxdwpSw702YW0xgfmP1GVCMA9aEFWu12XUZ3/OtI=
 github.com/coreos/go-oidc/v3 v3.11.0/go.mod h1:gE3LgjOgFoHi9a4ce4/tJczr0Ai2/BoDhf0r5lltWI0=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
+github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -98,6 +102,7 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -334,6 +339,12 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
+go.etcd.io/etcd/api/v3 v3.5.17 h1:cQB8eb8bxwuxOilBpMJAEo8fAONyrdXTHUNcMd8yT1w=
+go.etcd.io/etcd/api/v3 v3.5.17/go.mod h1:d1hvkRuXkts6PmaYk2Vrgqbv7H4ADfAKhyJqHNLJCB4=
+go.etcd.io/etcd/client/pkg/v3 v3.5.17 h1:XxnDXAWq2pnxqx76ljWwiQ9jylbpC4rvkAeRVOUKKVw=
+go.etcd.io/etcd/client/pkg/v3 v3.5.17/go.mod h1:4DqK1TKacp/86nJk4FLQqo6Mn2vvQFBmruW3pP14H/w=
+go.etcd.io/etcd/client/v3 v3.5.17 h1:o48sINNeWz5+pjy/Z0+HKpj/xSnBkuVhVvXkjEXbqZY=
+go.etcd.io/etcd/client/v3 v3.5.17/go.mod h1:j2d4eXTHWkT2ClBgnnEPm/Wuu7jsqku41v9DZ3OtjQo=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0 h1:9G6E0TXzGFVfTnawRzrPl83iHOAV7L8NJiR8RSGYV1g=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0/go.mod h1:azvtTADFQJA8mX80jIH/akaE7h+dbm/sVuaHqN13w74=
 go.opentelemetry.io/otel v1.28.0 h1:/SqNcYk+idO0CxKEUOtKQClMK/MimZihKYMruSMViUo=

--- a/pkg/cache/discovery/README.md
+++ b/pkg/cache/discovery/README.md
@@ -19,7 +19,7 @@ Registers a callback for resource changes and starts watching. The provider call
 
 - **StaticProvider**: reads config, delivers all endpoints as `EventAdd` via the handler, returns. No ongoing changes.
 - **KubernetesProvider**: wires the handler directly into informer callbacks. Events (including the initial list phase) flow to the handler immediately. After `WaitForCacheSync`, does a post-sync reconcile to fix ordering, then returns. Informer callbacks continue invoking the handler for ongoing changes.
-- **Consul/etcd providers**: starts a watch/poll loop in a goroutine, calls handler from that goroutine.
+- **EtcdProvider**: loads the initial snapshot, then watches the next revision in a goroutine and calls the handler for changes.
 
 `Watch` should return once the provider has reached a consistent ready state (e.g., initial sync complete, config loaded). This ensures the cache is warm before the gateway starts accepting traffic.
 
@@ -60,6 +60,123 @@ models:
 
 The `rolesets` structure expresses the pairing between prefill and decode workers. The PD routing algorithm selects the roleset first and then chooses the best prefill+decode pair within the same roleset. `endpoints` and `rolesets` are mutually exclusive per model.
 
+### EtcdProvider (`etcd.go`)
+
+Watches an etcd v3 key prefix for inference worker registrations. Select it in
+standalone mode with a YAML or JSON configuration file:
+
+```bash
+bin/gateway-plugins --standalone \
+  --etcd-config=deployment/local/configs/etcd.yaml
+```
+
+`--etcd-config` requires `--standalone` and is mutually exclusive with
+`--endpoints-config`. Static discovery remains selected when
+`--endpoints-config` is supplied. The gateway still needs an Envoy proxy for
+inference requests; the [local deployment](../../../deployment/local) provides
+an Envoy configuration.
+
+```yaml
+endpoints:
+  - "https://etcd.example:2379"
+prefix: "/aibrix/endpoints/"
+dialTimeout: "5s"
+username: gateway
+password: "replace-with-your-password"
+tlsCA: ca.pem
+# Supply both fields for mutual TLS:
+# tlsCert: gateway-client.pem
+# tlsKey: gateway-client-key.pem
+```
+
+The file requires at least one HTTP(S) endpoint. `prefix` defaults to
+`/aibrix/endpoints/`, and `dialTimeout` defaults to `5s`. Unknown fields and
+invalid types are rejected. Credentials belong in the config file, not endpoint
+URLs or CLI arguments. Restrict access to files containing credentials, for
+example with `chmod 600`. Certificate paths are relative to the configuration
+file unless absolute. TLS settings require HTTPS endpoints, and `tlsCert` and
+`tlsKey` must be supplied together. Server certificates and hostnames are
+verified; omitting `tlsCA` uses the system trust roots.
+
+Each key below the prefix represents one worker. Its value is a JSON object:
+
+| Field | Meaning |
+| --- | --- |
+| `model` | Required model name used for routing. |
+| `address` | Required worker `host:port`; use `[IPv6]:port` for IPv6. Port must be 1–65535. |
+| `engine` | Optional engine label, such as `vllm`, `sglang`, or `trtllm`. |
+| `role` | Optional `prefill` or `decode`; requires `roleset`. |
+| `roleset` | Optional P/D pairing group; requires `role`. |
+
+Workers or an external controller own these registrations; the gateway only
+reads and watches them. Register each worker under a stable, unique key.
+Addresses must be reachable from the gateway. The bundled standalone Envoy uses
+`ORIGINAL_DST`, so register numeric IPv4 or IPv6 addresses when using that
+configuration; DNS names require a downstream proxy configured to resolve them.
+
+For a local etcd instance, register, update, and delete a worker:
+
+```bash
+export ETCDCTL_API=3
+export ETCDCTL_ENDPOINTS=http://127.0.0.1:2379
+
+etcdctl put /aibrix/endpoints/worker-0 \
+  '{"model":"Qwen/Qwen3.5-4B","address":"127.0.0.1:8000","engine":"vllm"}'
+
+# Updating the same key replaces its registration without restarting the gateway.
+etcdctl put /aibrix/endpoints/worker-0 \
+  '{"model":"Qwen/Qwen3.5-4B","address":"127.0.0.1:8001","engine":"vllm"}'
+
+etcdctl del /aibrix/endpoints/worker-0
+```
+
+A P/D pair uses two keys with the same model and roleset:
+
+```bash
+etcdctl put /aibrix/endpoints/prefill-0 \
+  '{"model":"Qwen/Qwen2.5-72B","address":"127.0.0.1:8100","engine":"vllm","role":"prefill","roleset":"pair-0"}'
+etcdctl put /aibrix/endpoints/decode-0 \
+  '{"model":"Qwen/Qwen2.5-72B","address":"127.0.0.1:8200","engine":"vllm","role":"decode","roleset":"pair-0"}'
+```
+
+To remove a registration automatically when its owner stops renewing it, attach
+an etcd lease:
+
+```bash
+lease_id=$(etcdctl lease grant 30 | awk '{print $2}')
+etcdctl put /aibrix/endpoints/worker-0 \
+  '{"model":"Qwen/Qwen3.5-4B","address":"127.0.0.1:8000","engine":"vllm"}' \
+  --lease="$lease_id"
+
+# Run this in the worker's registration process while it is healthy.
+etcdctl lease keep-alive "$lease_id"
+# To remove its registrations immediately, stop keep-alive and revoke the lease:
+# etcdctl lease revoke "$lease_id"
+```
+
+If renewal stops, etcd removes the key when the lease expires and the provider
+removes its route after observing the delete. A lease tracks the registration
+owner's liveness; the provider does not probe the inference endpoint. Registrations
+without leases remain until explicitly deleted.
+
+At startup the provider lists the prefix and populates the cache before
+`Watch` returns. It starts watching at the snapshot revision plus one, so changes
+between the list and watch are not lost. Disconnects are retried; a compacted
+watch revision triggers a new snapshot and reconciliation, including removal of
+registrations deleted during the outage. Until etcd is reachable again, routing
+uses the last observed registrations.
+
+An engine-only change updates the existing endpoint. Changing a model, address,
+role, or roleset removes the old routing identity and adds the new one. An invalid
+registration is excluded without interrupting other keys; if it replaces a
+previously valid value, that old route is removed. A later valid value restores
+the key. Closing the gateway stop channel stops the watch and closes the etcd
+client.
+
+Integration tests using `AIBRIX_TEST_ETCD_ENDPOINT` require a dedicated,
+disposable etcd instance: the live compaction test compacts that instance's
+history. Never point this variable at a production or shared etcd instance.
+
 ### KubernetesProvider (`kubernetes.go`)
 
 Watches Pods and ModelAdapters via K8s informers. This is the default when no `DiscoveryProvider` is set in `InitOptions`.
@@ -83,11 +200,11 @@ The handler is wired directly into K8s informer callbacks — events flow from t
               ┌──────────────┼──────────────┐
               │              │              │
     ┌─────────▼──┐  ┌───────▼────┐  ┌──────▼───────┐
-    │ Static     │  │ Kubernetes │  │ Consul/etcd  │
+    │ Static     │  │ Kubernetes │  │ Etcd         │
     │ Provider   │  │ Provider   │  │ Provider     │
     │            │  │            │  │              │
-    │ YAML file  │  │ Informers  │  │ Blocking     │
-    │ → Load()   │  │ → Watch()  │  │ query / poll │
+    │ YAML file  │  │ Informers  │  │ Snapshot     │
+    │ → Load()   │  │ → Watch()  │  │ + watch      │
     └─────┬──────┘  └─────┬──────┘  └──────┬───────┘
           │               │                │
           │  synthetic *v1.Pod objects      │
@@ -112,5 +229,5 @@ All providers produce synthetic `*v1.Pod` objects. The cache store and routing a
 
 ## Future Work
 
-- **Consul/etcd providers** — first-class support for non-K8s service discovery.
+- **Consul provider** — another backend for non-K8s service discovery.
 - **Platform-agnostic `Endpoint` type** — replace `*v1.Pod` as the internal representation to remove the K8s dependency from routing algorithms.

--- a/pkg/cache/discovery/etcd.go
+++ b/pkg/cache/discovery/etcd.go
@@ -1,0 +1,393 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/klog/v2"
+)
+
+const (
+	defaultEtcdPrefix      = "/aibrix/endpoints/"
+	defaultEtcdDialTimeout = 5 * time.Second
+	etcdRetryDelay         = time.Second
+)
+
+// EtcdConfig configures an etcd endpoint registry. Credentials and TLS are optional.
+type EtcdConfig struct {
+	Endpoints []string
+	// Prefix is the key prefix to watch. It defaults to /aibrix/endpoints/.
+	Prefix string
+	// DialTimeout also bounds each snapshot request. It defaults to five seconds.
+	DialTimeout time.Duration
+	Username    string
+	Password    string
+	TLS         *tls.Config
+}
+
+// EtcdEndpoint is the JSON value registered under each key in the discovery prefix.
+// Each key describes one backend. A registrar may attach an etcd lease to the key
+// so that an expired registration automatically removes the backend.
+type EtcdEndpoint struct {
+	Model string `json:"model"`
+	// Address must be host:port, or [IPv6]:port. Ports must be between 1 and 65535.
+	Address string `json:"address"`
+	Engine  string `json:"engine,omitempty"`
+	// Role and RoleSet must be specified together. Role is prefill or decode.
+	Role    string `json:"role,omitempty"`
+	RoleSet string `json:"roleset,omitempty"`
+}
+
+// etcdClient is the part of clientv3.Client used by discovery.
+type etcdClient interface {
+	Get(context.Context, string, ...clientv3.OpOption) (*clientv3.GetResponse, error)
+	Watch(context.Context, string, ...clientv3.OpOption) clientv3.WatchChan
+	Close() error
+}
+
+// EtcdProvider discovers backends from an etcd prefix. Watch may be called once.
+// The client is created by Watch and is closed when stopCh closes, or if initial
+// synchronization fails. After a successful initial sync, temporary outages keep
+// the last known backends until the watch can resume or reconcile a new snapshot.
+type EtcdProvider struct {
+	config    EtcdConfig
+	newClient func(clientv3.Config) (etcdClient, error)
+	mu        sync.Mutex
+	started   bool
+}
+
+// NewEtcdProvider validates configuration without opening a connection.
+func NewEtcdProvider(config EtcdConfig) (*EtcdProvider, error) {
+	if len(config.Endpoints) == 0 {
+		return nil, fmt.Errorf("etcd discovery requires at least one etcd endpoint")
+	}
+	for _, endpoint := range config.Endpoints {
+		if strings.TrimSpace(endpoint) == "" {
+			return nil, fmt.Errorf("etcd discovery endpoints must not be empty")
+		}
+	}
+	if config.Prefix == "" {
+		config.Prefix = defaultEtcdPrefix
+	}
+	if config.DialTimeout < 0 {
+		return nil, fmt.Errorf("etcd discovery dial timeout must be positive")
+	}
+	if config.DialTimeout == 0 {
+		config.DialTimeout = defaultEtcdDialTimeout
+	}
+	config.Endpoints = append([]string(nil), config.Endpoints...)
+	if config.TLS != nil {
+		config.TLS = config.TLS.Clone()
+	}
+	return &EtcdProvider{
+		config: config,
+		newClient: func(config clientv3.Config) (etcdClient, error) {
+			return clientv3.New(config)
+		},
+	}, nil
+}
+
+// Type returns the provider type identifier.
+func (p *EtcdProvider) Type() string { return "etcd" }
+
+// Watch delivers an atomic initial snapshot and then serially delivers changes.
+// Watching starts at snapshot revision + 1, including changes made during sync.
+func (p *EtcdProvider) Watch(handler EventHandler, stopCh <-chan struct{}) error {
+	if handler == nil {
+		return fmt.Errorf("etcd discovery requires an event handler")
+	}
+	p.mu.Lock()
+	if p.started {
+		p.mu.Unlock()
+		return fmt.Errorf("etcd discovery Watch may only be called once")
+	}
+	p.started = true
+	p.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	select {
+	case <-stopCh:
+		cancel()
+		return context.Canceled
+	default:
+	}
+	go func() {
+		select {
+		case <-stopCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	client, err := p.newClient(clientv3.Config{
+		Endpoints:   p.config.Endpoints,
+		DialTimeout: p.config.DialTimeout,
+		Username:    p.config.Username,
+		Password:    p.config.Password,
+		TLS:         p.config.TLS,
+		Context:     ctx,
+	})
+	if err != nil {
+		cancel()
+		return fmt.Errorf("create etcd discovery client: %w", err)
+	}
+	cleanup := func() {
+		cancel()
+		_ = client.Close()
+	}
+	pods, revision, err := p.snapshot(ctx, client)
+	if err != nil {
+		cleanup()
+		return fmt.Errorf("initial etcd discovery snapshot: %w", err)
+	}
+	// Requiring a leader prevents a watch from silently stalling on an isolated member.
+	watchCtx, stopWatch := context.WithCancel(clientv3.WithRequireLeader(ctx))
+	stream := client.Watch(watchCtx, p.config.Prefix, clientv3.WithPrefix(), clientv3.WithRev(revision+1))
+	state := make(map[string]*v1.Pod)
+	if err := reconcileEtcdPods(ctx, handler, state, pods); err != nil {
+		stopWatch()
+		cleanup()
+		return err
+	}
+	go func() {
+		defer cleanup()
+		p.run(ctx, client, handler, state, revision, stream, stopWatch)
+	}()
+	return nil
+}
+
+func (p *EtcdProvider) snapshot(ctx context.Context, client etcdClient) (map[string]*v1.Pod, int64, error) {
+	requestCtx, cancel := context.WithTimeout(ctx, p.config.DialTimeout)
+	defer cancel()
+	response, err := client.Get(requestCtx, p.config.Prefix, clientv3.WithPrefix())
+	if err != nil {
+		return nil, 0, err
+	}
+	pods := make(map[string]*v1.Pod, len(response.Kvs))
+	for _, kv := range response.Kvs {
+		if pod := registeredEtcdPod(kv); pod != nil {
+			pods[string(kv.Key)] = pod
+		}
+	}
+	return pods, response.Header.Revision, nil
+}
+
+func (p *EtcdProvider) run(ctx context.Context, client etcdClient, handler EventHandler,
+	state map[string]*v1.Pod, revision int64, stream clientv3.WatchChan, stopWatch context.CancelFunc,
+) {
+	defer func() { stopWatch() }()
+	resync := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case response, ok := <-stream:
+			if ok && response.Err() == nil && !response.Canceled {
+				nextRevision := revision
+				for _, event := range response.Events {
+					if event.Kv == nil || event.Kv.ModRevision <= revision {
+						continue
+					}
+					var pod *v1.Pod
+					if event.Type == mvccpb.PUT {
+						pod = registeredEtcdPod(event.Kv)
+					}
+					if err := replaceEtcdPod(ctx, handler, state, string(event.Kv.Key), pod); err != nil {
+						return
+					}
+					if event.Kv.ModRevision > nextRevision {
+						nextRevision = event.Kv.ModRevision
+					}
+				}
+				// A watch-created response can have a header ahead of its events.
+				// Advance only past events actually applied, after the whole batch.
+				// The client coalesces fragmented responses by default.
+				revision = nextRevision
+				continue
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			resync = response.CompactRevision > 0
+			klog.InfoS("Etcd discovery watch interrupted; reconnecting", "compacted", resync)
+		}
+
+		stopWatch()
+		for {
+			if !waitEtcdRetry(ctx) {
+				return
+			}
+			if resync {
+				pods, snapshotRevision, err := p.snapshot(ctx, client)
+				if err != nil {
+					// Values, keys, endpoints, and credentials never enter this log.
+					klog.InfoS("Etcd discovery snapshot unavailable; retrying")
+					continue
+				}
+				if err := reconcileEtcdPods(ctx, handler, state, pods); err != nil {
+					return
+				}
+				revision = snapshotRevision
+			}
+			watchCtx, cancel := context.WithCancel(clientv3.WithRequireLeader(ctx))
+			stopWatch = cancel
+			stream = client.Watch(watchCtx, p.config.Prefix, clientv3.WithPrefix(), clientv3.WithRev(revision+1))
+			break
+		}
+	}
+}
+
+func waitEtcdRetry(ctx context.Context) bool {
+	timer := time.NewTimer(etcdRetryDelay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// reconcileEtcdPods emits only actual differences, preserving unchanged pods and
+// their router statistics during full resynchronization after compaction.
+func reconcileEtcdPods(ctx context.Context, handler EventHandler, state, next map[string]*v1.Pod) error {
+	keys := make([]string, 0, len(state)+len(next))
+	for key := range state {
+		if _, exists := next[key]; !exists {
+			keys = append(keys, key)
+		}
+	}
+	for key := range next {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if err := replaceEtcdPod(ctx, handler, state, key, next[key]); err != nil {
+			return err
+		}
+	}
+	return ctx.Err()
+}
+
+func replaceEtcdPod(ctx context.Context, handler EventHandler, state map[string]*v1.Pod, key string, next *v1.Pod) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	old := state[key]
+	if reflect.DeepEqual(old, next) {
+		return nil
+	}
+	if old != nil && (next == nil || old.Name != next.Name || old.UID != next.UID) {
+		handler(WatchEvent{Type: EventDelete, Object: old.DeepCopy()})
+		delete(state, key)
+		old = nil
+	}
+	if next != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if old == nil {
+			handler(WatchEvent{Type: EventAdd, Object: next.DeepCopy()})
+		} else {
+			handler(WatchEvent{Type: EventUpdate, Object: next.DeepCopy(), OldObject: old.DeepCopy()})
+		}
+		state[key] = next
+	}
+	return nil
+}
+
+func registeredEtcdPod(kv *mvccpb.KeyValue) *v1.Pod {
+	pod, err := etcdEndpointPod(kv)
+	if err != nil {
+		// Key/value bytes can contain credentials or arbitrary input. Log only
+		// an opaque key identifier and a validation error without input values.
+		keyID := fmt.Sprintf("%x", sha256.Sum256(kv.Key))
+		klog.ErrorS(err, "Ignoring invalid etcd discovery registration", "keyHash", keyID)
+		return nil
+	}
+	return pod
+}
+
+func etcdEndpointPod(kv *mvccpb.KeyValue) (*v1.Pod, error) {
+	var endpoint EtcdEndpoint
+	if err := json.Unmarshal(kv.Value, &endpoint); err != nil {
+		return nil, fmt.Errorf("registration must be a JSON endpoint object")
+	}
+	if strings.TrimSpace(endpoint.Model) == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+	if (endpoint.Role == "") != (endpoint.RoleSet == "") {
+		return nil, fmt.Errorf("role and roleset must be specified together")
+	}
+	if endpoint.Role != "" && endpoint.Role != "prefill" && endpoint.Role != "decode" {
+		return nil, fmt.Errorf("role must be prefill or decode")
+	}
+	if endpoint.RoleSet != "" && strings.TrimSpace(endpoint.RoleSet) == "" {
+		return nil, fmt.Errorf("roleset must not be blank")
+	}
+	host, portString, err := net.SplitHostPort(endpoint.Address)
+	if err != nil || host == "" {
+		return nil, fmt.Errorf("address must be host:port or [IPv6]:port")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		host = ip.String()
+	} else {
+		host = strings.ToLower(strings.TrimSuffix(host, "."))
+		if len(validation.IsDNS1123Subdomain(host)) != 0 {
+			return nil, fmt.Errorf("address host must be an IP address or DNS name")
+		}
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil || port < 1 || port > 65535 || strings.Trim(portString, "0123456789") != "" {
+		return nil, fmt.Errorf("address port must be an integer between 1 and 65535")
+	}
+	address := net.JoinHostPort(host, strconv.Itoa(port))
+	labels := make(map[string]string)
+	if endpoint.Role != "" {
+		labels["role-name"] = endpoint.Role
+		labels["roleset-name"] = endpoint.RoleSet
+	}
+	pod, err := addressToPod(endpoint.Model, endpoint.Engine, labels, 0, address)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert registered endpoint to a pod")
+	}
+	// Include every route identity field and the key, but exclude mutable engine
+	// metadata. JSON encoding unambiguously separates fields even with NUL bytes.
+	identity, _ := json.Marshal([]string{string(kv.Key), endpoint.Model, address, endpoint.Role, endpoint.RoleSet})
+	digest := sha256.Sum256(identity)
+	pod.Name = fmt.Sprintf("etcd-%x", digest[:20])
+	pod.UID = types.UID(fmt.Sprintf("%s-%d", pod.Name, kv.CreateRevision))
+	return pod, nil
+}
+
+var _ Provider = (*EtcdProvider)(nil)

--- a/pkg/cache/discovery/etcd_integration_test.go
+++ b/pkg/cache/discovery/etcd_integration_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	v1 "k8s.io/api/core/v1"
+)
+
+// TestEtcdCompactionRecoveryIntegration requires a dedicated disposable etcd.
+// Compaction affects server-wide history, even though this test writes and deletes
+// only keys within its own UUID prefix. Never point the environment variable at
+// a production or shared server, and do not run this test in parallel with other
+// tests that depend on historical revisions.
+func TestEtcdCompactionRecoveryIntegration(t *testing.T) {
+	endpoint := os.Getenv("AIBRIX_TEST_ETCD_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("set AIBRIX_TEST_ETCD_ENDPOINT to a dedicated disposable etcd; this test compacts server-wide history")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	admin, err := clientv3.New(clientv3.Config{Endpoints: []string{endpoint}, DialTimeout: 5 * time.Second})
+	require.NoError(t, err)
+	prefix := "/aibrix/discovery-integration/" + uuid.NewString() + "/"
+	stopCh := make(chan struct{})
+	var stopOnce sync.Once
+	var wrapped *compactingEtcdClient
+	t.Cleanup(func() {
+		stopOnce.Do(func() { close(stopCh) })
+		if wrapped != nil {
+			select {
+			case <-wrapped.closed:
+			case <-time.After(5 * time.Second):
+				t.Error("provider did not close its etcd client after stop")
+			}
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cleanupCancel()
+		_, err := admin.Delete(cleanupCtx, prefix, clientv3.WithPrefix())
+		assert.NoError(t, err)
+		assert.NoError(t, admin.Close())
+	})
+	value := func(model, engine string) string {
+		data, err := json.Marshal(EtcdEndpoint{Model: model, Address: model + ":8000", Engine: engine})
+		require.NoError(t, err)
+		return string(data)
+	}
+	oldValue, stableValue, newValue := value("old", "vllm"), value("stable", "vllm"), value("new", "vllm")
+	_, err = admin.Txn(ctx).Then(clientv3.OpPut(prefix+"old", oldValue), clientv3.OpPut(prefix+"stable", stableValue)).Commit()
+	require.NoError(t, err)
+
+	provider, err := NewEtcdProvider(EtcdConfig{Endpoints: []string{endpoint}, Prefix: prefix})
+	require.NoError(t, err)
+	provider.newClient = func(config clientv3.Config) (etcdClient, error) {
+		client, err := clientv3.New(config)
+		if err != nil {
+			return nil, err
+		}
+		wrapped = &compactingEtcdClient{
+			etcdClient: client, compacted: make(chan int64, 1), closed: make(chan struct{}),
+			afterFirstSnapshot: func(requestCtx context.Context, snapshot *clientv3.GetResponse) error {
+				_, err := admin.Txn(requestCtx).Then(clientv3.OpDelete(prefix+"old"), clientv3.OpPut(prefix+"new", newValue)).Commit()
+				if err != nil {
+					return err
+				}
+				// Advance beyond snapshot+1 without changing this surviving route.
+				barrier, err := admin.Put(requestCtx, prefix+"stable", stableValue)
+				if err != nil {
+					return err
+				}
+				if barrier.Header.Revision <= snapshot.Header.Revision+1 {
+					return fmt.Errorf("compaction barrier did not advance beyond watch start revision")
+				}
+				_, err = admin.Compact(requestCtx, barrier.Header.Revision, clientv3.WithCompactPhysical())
+				return err
+			},
+		}
+		return wrapped, nil
+	}
+
+	var mu sync.Mutex
+	state := make(map[string]*v1.Pod)
+	var events []WatchEvent
+	err = provider.Watch(func(event WatchEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		pod := event.Object.(*v1.Pod)
+		model := pod.Labels[constants.ModelLabelName]
+		if event.Type == EventDelete {
+			delete(state, model)
+		} else {
+			state[model] = pod
+		}
+		events = append(events, event)
+	}, stopCh)
+	require.NoError(t, err)
+	select {
+	case revision := <-wrapped.compacted:
+		t.Logf("real etcd watch rejected compacted revision; CompactRevision=%d", revision)
+	case <-ctx.Done():
+		t.Fatal("did not observe a real compacted watch response")
+	}
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(state) == 2 && state["old"] == nil && state["new"] != nil && state["stable"] != nil
+	}, 10*time.Second, 10*time.Millisecond, "resnapshot must remove stale registration and discover replacement")
+
+	// A transaction barrier proves the recovered watch keeps processing events.
+	_, err = admin.Txn(ctx).Then(clientv3.OpPut(prefix+"new", value("new", "sglang")), clientv3.OpPut(prefix+"barrier", value("barrier", "vllm"))).Commit()
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return state["barrier"] != nil && state["new"].Labels[constants.ModelLabelEngine] == "sglang"
+	}, 10*time.Second, 10*time.Millisecond, "watch must continue after compaction recovery")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, events, 6)
+	counts := make(map[string]map[EventType]int)
+	for _, event := range events {
+		model := event.Object.(*v1.Pod).Labels[constants.ModelLabelName]
+		if counts[model] == nil {
+			counts[model] = make(map[EventType]int)
+		}
+		counts[model][event.Type]++
+	}
+	assert.Equal(t, map[EventType]int{EventAdd: 1, EventDelete: 1}, counts["old"])
+	assert.Equal(t, map[EventType]int{EventAdd: 1}, counts["stable"], "unchanged route must not be re-added or updated")
+	assert.Equal(t, map[EventType]int{EventAdd: 1, EventUpdate: 1}, counts["new"])
+	assert.Equal(t, map[EventType]int{EventAdd: 1}, counts["barrier"])
+}
+
+// compactingEtcdClient keeps all reads and watches on real etcd. Its one-time
+// hook forces history to be compacted between the provider's first Get and Watch;
+// forwarding the real watch response also verifies compaction actually occurred.
+type compactingEtcdClient struct {
+	etcdClient
+	afterFirstSnapshot func(context.Context, *clientv3.GetResponse) error
+	once               sync.Once
+	compacted          chan int64
+	closed             chan struct{}
+}
+
+func (c *compactingEtcdClient) Get(ctx context.Context, key string, options ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	response, err := c.etcdClient.Get(ctx, key, options...)
+	if err != nil {
+		return nil, err
+	}
+	c.once.Do(func() { err = c.afterFirstSnapshot(ctx, response) })
+	return response, err
+}
+
+func (c *compactingEtcdClient) Watch(ctx context.Context, key string, options ...clientv3.OpOption) clientv3.WatchChan {
+	stream := c.etcdClient.Watch(ctx, key, options...)
+	forwarded := make(chan clientv3.WatchResponse)
+	go func() {
+		defer close(forwarded)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case response, ok := <-stream:
+				if !ok {
+					return
+				}
+				if response.CompactRevision > 0 {
+					select {
+					case c.compacted <- response.CompactRevision:
+					default:
+					}
+				}
+				select {
+				case forwarded <- response:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return forwarded
+}
+
+func (c *compactingEtcdClient) Close() error {
+	err := c.etcdClient.Close()
+	close(c.closed)
+	return err
+}

--- a/pkg/cache/discovery/etcd_test.go
+++ b/pkg/cache/discovery/etcd_test.go
@@ -1,0 +1,527 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/grpc/metadata"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestEtcdEndpointPodValidation(t *testing.T) {
+	valid := EtcdEndpoint{Model: "Qwen/Qwen2.5-72B", Address: "worker:8000"}
+	for _, test := range []struct {
+		name     string
+		endpoint EtcdEndpoint
+	}{
+		{"empty model", EtcdEndpoint{Address: "worker:8000"}},
+		{"blank model", EtcdEndpoint{Model: " \t", Address: "worker:8000"}},
+		{"empty address", EtcdEndpoint{Model: "model"}},
+		{"missing port", EtcdEndpoint{Model: "model", Address: "worker"}},
+		{"empty host", EtcdEndpoint{Model: "model", Address: ":8000"}},
+		{"empty port", EtcdEndpoint{Model: "model", Address: "worker:"}},
+		{"zero port", EtcdEndpoint{Model: "model", Address: "worker:0"}},
+		{"negative port", EtcdEndpoint{Model: "model", Address: "worker:-1"}},
+		{"signed port", EtcdEndpoint{Model: "model", Address: "worker:+1"}},
+		{"large port", EtcdEndpoint{Model: "model", Address: "worker:65536"}},
+		{"named port", EtcdEndpoint{Model: "model", Address: "worker:http"}},
+		{"URL", EtcdEndpoint{Model: "model", Address: "http://worker:8000"}},
+		{"path", EtcdEndpoint{Model: "model", Address: "worker/path:8000"}},
+		{"credentials", EtcdEndpoint{Model: "model", Address: "secret@worker:8000"}},
+		{"whitespace host", EtcdEndpoint{Model: "model", Address: " worker:8000"}},
+		{"unbracketed IPv6", EtcdEndpoint{Model: "model", Address: "2001:db8::1:8000"}},
+		{"bad role", EtcdEndpoint{Model: "model", Address: "worker:8000", Role: "both", RoleSet: "group"}},
+		{"role only", EtcdEndpoint{Model: "model", Address: "worker:8000", Role: "prefill"}},
+		{"roleset only", EtcdEndpoint{Model: "model", Address: "worker:8000", RoleSet: "group"}},
+		{"blank roleset", EtcdEndpoint{Model: "model", Address: "worker:8000", Role: "decode", RoleSet: " "}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pod, err := etcdEndpointPod(etcdKV(t, "key", test.endpoint, 1, 1))
+			require.Error(t, err)
+			assert.Nil(t, pod)
+		})
+	}
+	for _, value := range []string{"", "null", "[]", "42", `{"model":"secret","address":false}`, "private-secret-value"} {
+		_, err := etcdEndpointPod(&mvccpb.KeyValue{Key: []byte("private-key"), Value: []byte(value)})
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "secret")
+	}
+	for _, address := range []string{"worker:8000", "worker.example.:08000", "127.0.0.1:1", "[2001:db8::1]:65535"} {
+		t.Run(address, func(t *testing.T) {
+			endpoint := valid
+			endpoint.Address = address
+			endpoint.Engine, endpoint.Role, endpoint.RoleSet = "vllm", "prefill", "rack-1"
+			pod, err := etcdEndpointPod(etcdKV(t, "key", endpoint, 1, 1))
+			require.NoError(t, err)
+			assert.Equal(t, endpoint.Model, pod.Labels[constants.ModelLabelName])
+			assert.Equal(t, "vllm", pod.Labels[constants.ModelLabelEngine])
+			assert.Equal(t, "prefill", pod.Labels["role-name"])
+			assert.Equal(t, "rack-1", pod.Labels["roleset-name"])
+			assert.Equal(t, standaloneNamespace, pod.Namespace)
+			assert.Equal(t, v1.PodRunning, pod.Status.Phase)
+			assert.Equal(t, v1.ConditionTrue, pod.Status.Conditions[0].Status)
+			assert.NotEmpty(t, pod.UID)
+		})
+	}
+}
+
+func TestEtcdEndpointIdentity(t *testing.T) {
+	endpoint := EtcdEndpoint{Model: "model", Address: "worker:8000", Engine: "vllm"}
+	original, err := etcdEndpointPod(etcdKV(t, "key", endpoint, 1, 2))
+	require.NoError(t, err)
+	same, err := etcdEndpointPod(etcdKV(t, "key", endpoint, 1, 20))
+	require.NoError(t, err)
+	assert.Equal(t, original, same, "ordinary PUT revisions must not change route identity")
+	endpoint.Engine = "sglang"
+	updated, err := etcdEndpointPod(etcdKV(t, "key", endpoint, 1, 21))
+	require.NoError(t, err)
+	assert.Equal(t, original.Name, updated.Name)
+	assert.Equal(t, original.UID, updated.UID)
+	recreated, err := etcdEndpointPod(etcdKV(t, "key", endpoint, 22, 22))
+	require.NoError(t, err)
+	assert.Equal(t, original.Name, recreated.Name)
+	assert.NotEqual(t, original.UID, recreated.UID)
+	for _, test := range []struct {
+		key      string
+		endpoint EtcdEndpoint
+	}{
+		{"other-key", endpoint},
+		{"key", EtcdEndpoint{Model: "other-model", Address: "worker:8000"}},
+		{"key", EtcdEndpoint{Model: "model", Address: "other-worker:8000"}},
+		{"key", EtcdEndpoint{Model: "model", Address: "worker:8001"}},
+		{"key", EtcdEndpoint{Model: "model", Address: "worker:8000", Role: "prefill", RoleSet: "a"}},
+		{"key", EtcdEndpoint{Model: "model", Address: "worker:8000", Role: "decode", RoleSet: "a"}},
+		{"key", EtcdEndpoint{Model: "model", Address: "worker:8000", Role: "decode", RoleSet: "b"}},
+	} {
+		pod, err := etcdEndpointPod(etcdKV(t, test.key, test.endpoint, 1, 2))
+		require.NoError(t, err)
+		assert.NotEqual(t, original.Name, pod.Name)
+	}
+	endpoint.Address = "WORKER.:08000"
+	canonical, err := etcdEndpointPod(etcdKV(t, "key", endpoint, 1, 22))
+	require.NoError(t, err)
+	assert.Equal(t, original.Name, canonical.Name)
+}
+
+func TestEtcdProviderConfig(t *testing.T) {
+	for _, config := range []EtcdConfig{{}, {Endpoints: []string{" "}}, {Endpoints: []string{"localhost:2379"}, DialTimeout: -1}} {
+		_, err := NewEtcdProvider(config)
+		require.Error(t, err)
+	}
+	config := EtcdConfig{Endpoints: []string{"localhost:2379"}, TLS: &tls.Config{MinVersion: tls.VersionTLS12}}
+	provider, err := NewEtcdProvider(config)
+	require.NoError(t, err)
+	assert.Equal(t, "etcd", provider.Type())
+	assert.Equal(t, defaultEtcdPrefix, provider.config.Prefix)
+	assert.Equal(t, defaultEtcdDialTimeout, provider.config.DialTimeout)
+	config.Endpoints[0] = "modified"
+	config.TLS.MinVersion = tls.VersionTLS13
+	assert.Equal(t, "localhost:2379", provider.config.Endpoints[0])
+	assert.Equal(t, uint16(tls.VersionTLS12), provider.config.TLS.MinVersion)
+	require.Error(t, provider.Watch(nil, nil))
+}
+
+func TestEtcdProviderSnapshotAndEvents(t *testing.T) {
+	client := newFakeEtcdClient()
+	provider := fakeEtcdProvider(t, client)
+	endpoint := EtcdEndpoint{Model: "model", Address: "worker:8000", Engine: "vllm"}
+	initial := etcdKV(t, "a", endpoint, 1, 10)
+	invalid := &mvccpb.KeyValue{Key: []byte("bad"), Value: []byte("invalid"), ModRevision: 10}
+	stop, events, stream := startFakeEtcdWatch(t, provider, client, 10, initial, invalid)
+	defer stop()
+	added := receiveEtcd(t, events)
+	assert.Equal(t, EventAdd, added.Type)
+	assert.Equal(t, "worker", added.Object.(*v1.Pod).Status.PodIP)
+	// A callback may mutate its objects; provider-owned state must remain intact.
+	added.Object.(*v1.Pod).Labels[constants.ModelLabelEngine] = "callback mutation"
+
+	endpoint.Engine = "sglang"
+	other := EtcdEndpoint{Model: "other", Address: "other:9000"}
+	// Both events share a transaction revision. Neither may be skipped.
+	stream <- etcdWatchResponse(11, etcdPut(etcdKV(t, "a", endpoint, 1, 11)), etcdPut(etcdKV(t, "b", other, 11, 11)))
+	updated := receiveEtcd(t, events)
+	assert.Equal(t, EventUpdate, updated.Type)
+	assert.Equal(t, "vllm", updated.OldObject.(*v1.Pod).Labels[constants.ModelLabelEngine])
+	assert.Equal(t, "sglang", updated.Object.(*v1.Pod).Labels[constants.ModelLabelEngine])
+	assert.Equal(t, EventAdd, receiveEtcd(t, events).Type)
+	// An identical value with a newer PUT revision emits no update.
+	stream <- etcdWatchResponse(12, etcdPut(etcdKV(t, "a", endpoint, 1, 12)))
+	endpoint.Model = "new-model"
+	stream <- etcdWatchResponse(13, etcdPut(etcdKV(t, "a", endpoint, 1, 13)))
+	deleted, added := receiveEtcd(t, events), receiveEtcd(t, events)
+	assert.Equal(t, EventDelete, deleted.Type)
+	assert.Equal(t, "model", deleted.Object.(*v1.Pod).Labels[constants.ModelLabelName])
+	assert.Equal(t, EventAdd, added.Type)
+	assert.Equal(t, "new-model", added.Object.(*v1.Pod).Labels[constants.ModelLabelName])
+	assert.NotEqual(t, deleted.Object.(*v1.Pod).Name, added.Object.(*v1.Pod).Name)
+	// Invalid replacement removes the old backend without blocking other keys.
+	invalid.Key, invalid.ModRevision = []byte("b"), 14
+	stream <- etcdWatchResponse(14, etcdPut(invalid))
+	deleted = receiveEtcd(t, events)
+	assert.Equal(t, EventDelete, deleted.Type)
+	assert.Equal(t, "other", deleted.Object.(*v1.Pod).Labels[constants.ModelLabelName])
+	// A lease expiration has the same DELETE event as an explicit deletion.
+	stream <- etcdWatchResponse(15, etcdDelete("a", 15))
+	assert.Equal(t, EventDelete, receiveEtcd(t, events).Type)
+	stream <- etcdWatchResponse(16, etcdDelete("a", 16), etcdPut(etcdKV(t, "marker", other, 16, 16)))
+	assert.Equal(t, EventAdd, receiveEtcd(t, events).Type)
+	assert.Empty(t, events)
+	stop()
+	receiveEtcd(t, client.closed)
+	require.Error(t, provider.Watch(func(WatchEvent) {}, nil))
+}
+
+func TestEtcdProviderChangesDuringInitialDelivery(t *testing.T) {
+	client := newFakeEtcdClient()
+	provider := fakeEtcdProvider(t, client)
+	endpoint := EtcdEndpoint{Model: "model", Address: "worker:8000", Engine: "vllm"}
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	initialEntered, releaseInitial := make(chan struct{}), make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseInitial) })
+	events, result := make(chan WatchEvent, 10), make(chan error, 1)
+	go func() {
+		result <- provider.Watch(func(event WatchEvent) {
+			if event.Type == EventAdd {
+				close(initialEntered)
+				<-releaseInitial
+			}
+			events <- event
+		}, stopCh)
+	}()
+	request := receiveEtcd(t, client.gets)
+	request.reply <- fakeEtcdGetResult{response: etcdSnapshot(10, etcdKV(t, "key", endpoint, 1, 10))}
+	watch := receiveEtcd(t, client.watches)
+	receiveEtcd(t, initialEntered)
+	// etcd changes after the snapshot, while initial callbacks are still running.
+	endpoint.Engine = "sglang"
+	watch.stream <- etcdWatchResponse(11, etcdPut(etcdKV(t, "key", endpoint, 1, 11)))
+	assert.Empty(t, events, "ongoing callbacks must not run concurrently with initial delivery")
+	assert.Empty(t, result, "Watch readiness waits for initial delivery")
+	releaseOnce.Do(func() { close(releaseInitial) })
+	require.NoError(t, receiveEtcd(t, result))
+	assert.Equal(t, EventAdd, receiveEtcd(t, events).Type)
+	updated := receiveEtcd(t, events)
+	assert.Equal(t, EventUpdate, updated.Type)
+	assert.Equal(t, "vllm", updated.OldObject.(*v1.Pod).Labels[constants.ModelLabelEngine])
+	assert.Equal(t, "sglang", updated.Object.(*v1.Pod).Labels[constants.ModelLabelEngine])
+	assert.Equal(t, int64(11), watch.op.Rev())
+}
+
+func TestEtcdProviderReconnectAndCompaction(t *testing.T) {
+	client := newFakeEtcdClient()
+	provider := fakeEtcdProvider(t, client)
+	a := EtcdEndpoint{Model: "a", Address: "a:8000"}
+	b := EtcdEndpoint{Model: "b", Address: "b:8000"}
+	c := EtcdEndpoint{Model: "c", Address: "c:8000"}
+	stop, events, stream := startFakeEtcdWatch(t, provider, client, 10,
+		etcdKV(t, "a", a, 1, 10), etcdKV(t, "b", b, 2, 10), etcdKV(t, "c", c, 3, 10))
+	defer stop()
+	for range 3 {
+		receiveEtcd(t, events)
+	}
+	// Creation header can be ahead of historical watch events. Reconnect must
+	// start at the last applied revision, not this header.
+	stream <- clientv3.WatchResponse{Header: etcdserverpb.ResponseHeader{Revision: 100}, Created: true}
+	close(stream)
+	request := receiveEtcd(t, client.watches)
+	assert.Equal(t, int64(11), request.op.Rev())
+	assertEtcdRequireLeader(t, request.ctx)
+	stream = request.stream
+	b.Engine = "vllm"
+	stream <- etcdWatchResponse(100, etcdPut(etcdKV(t, "a", a, 1, 11)), etcdPut(etcdKV(t, "b", b, 2, 11)))
+	assert.Equal(t, EventUpdate, receiveEtcd(t, events).Type)
+	close(stream)
+	request = receiveEtcd(t, client.watches)
+	assert.Equal(t, int64(12), request.op.Rev(), "header must not hide unapplied revisions")
+	stream = request.stream
+	d := EtcdEndpoint{Model: "d", Address: "d:8000"}
+	stream <- etcdWatchResponse(12, etcdPut(etcdKV(t, "b", b, 2, 11)), etcdPut(etcdKV(t, "d", d, 12, 12)))
+	assert.Equal(t, EventAdd, receiveEtcd(t, events).Type)
+	stream <- clientv3.WatchResponse{Canceled: true, CompactRevision: 50}
+	resync := receiveEtcd(t, client.gets)
+	resync.reply <- fakeEtcdGetResult{err: errors.New("temporary outage")}
+	// A failed resnapshot must preserve all last-known state and retry.
+	resync = receiveEtcd(t, client.gets)
+	assert.Empty(t, events)
+	d.Role, d.RoleSet = "decode", "group"
+	e := EtcdEndpoint{Model: "e", Address: "e:8000"}
+	resync.reply <- fakeEtcdGetResult{response: etcdSnapshot(60,
+		etcdKV(t, "a", a, 1, 58),  // Unchanged backend: no event despite PUT revision.
+		etcdKV(t, "c", c, 55, 55), // Same key/value, new registration lifetime.
+		etcdKV(t, "d", d, 12, 59), // Routing identity changed.
+		etcdKV(t, "e", e, 60, 60))}
+	for _, expected := range []struct {
+		eventType EventType
+		model     string
+	}{
+		{EventDelete, "b"}, {EventDelete, "c"}, {EventAdd, "c"},
+		{EventDelete, "d"}, {EventAdd, "d"}, {EventAdd, "e"},
+	} {
+		event := receiveEtcd(t, events)
+		assert.Equal(t, expected.eventType, event.Type)
+		assert.Equal(t, expected.model, event.Object.(*v1.Pod).Labels[constants.ModelLabelName])
+	}
+	request = receiveEtcd(t, client.watches)
+	assert.Equal(t, int64(61), request.op.Rev())
+	assertEtcdRequireLeader(t, request.ctx)
+	request.stream <- etcdWatchResponse(61, etcdDelete("e", 61))
+	assert.Equal(t, EventDelete, receiveEtcd(t, events).Type)
+	assert.Empty(t, events)
+}
+
+func TestEtcdProviderWatchLifecycle(t *testing.T) {
+	t.Run("already stopped", func(t *testing.T) {
+		provider, err := NewEtcdProvider(EtcdConfig{Endpoints: []string{"localhost:2379"}})
+		require.NoError(t, err)
+		provider.newClient = func(clientv3.Config) (etcdClient, error) {
+			t.Error("must not create a client after stop")
+			return nil, errors.New("unexpected call")
+		}
+		stop := make(chan struct{})
+		close(stop)
+		require.ErrorIs(t, provider.Watch(func(WatchEvent) { t.Error("unexpected callback") }, stop), context.Canceled)
+	})
+	t.Run("client creation error", func(t *testing.T) {
+		provider, err := NewEtcdProvider(EtcdConfig{Endpoints: []string{"localhost:2379"}})
+		require.NoError(t, err)
+		var ctx context.Context
+		provider.newClient = func(config clientv3.Config) (etcdClient, error) {
+			ctx = config.Context
+			return nil, errors.New("cannot create client")
+		}
+		require.ErrorContains(t, provider.Watch(func(WatchEvent) {}, nil), "create etcd discovery client")
+		receiveEtcd(t, ctx.Done())
+	})
+	for _, scenario := range []string{"snapshot error", "snapshot timeout", "stop during snapshot"} {
+		t.Run(scenario, func(t *testing.T) {
+			client := newFakeEtcdClient()
+			provider := fakeEtcdProvider(t, client)
+			if scenario == "snapshot timeout" {
+				provider.config.DialTimeout = 20 * time.Millisecond
+			}
+			stopCh := make(chan struct{})
+			defer func() {
+				select {
+				case <-stopCh:
+				default:
+					close(stopCh)
+				}
+			}()
+			result := make(chan error, 1)
+			go func() { result <- provider.Watch(func(WatchEvent) { t.Error("unexpected callback") }, stopCh) }()
+			request := receiveEtcd(t, client.gets)
+			switch scenario {
+			case "snapshot error":
+				request.reply <- fakeEtcdGetResult{err: errors.New("snapshot unavailable")}
+			case "stop during snapshot":
+				close(stopCh)
+			}
+			require.Error(t, receiveEtcd(t, result))
+			receiveEtcd(t, client.closed)
+			receiveEtcd(t, request.ctx.Done())
+			assert.Empty(t, client.watches)
+		})
+	}
+	t.Run("stop cancels watch", func(t *testing.T) {
+		client := newFakeEtcdClient()
+		provider := fakeEtcdProvider(t, client)
+		stop, _, _ := startFakeEtcdWatch(t, provider, client, 10)
+		stop()
+		receiveEtcd(t, client.closed)
+		receiveEtcd(t, client.lastWatchContext.Done())
+	})
+	t.Run("stop cancels resnapshot", func(t *testing.T) {
+		client := newFakeEtcdClient()
+		provider := fakeEtcdProvider(t, client)
+		stop, _, stream := startFakeEtcdWatch(t, provider, client, 10)
+		defer stop()
+		stream <- clientv3.WatchResponse{Canceled: true, CompactRevision: 20}
+		request := receiveEtcd(t, client.gets)
+		stop()
+		receiveEtcd(t, client.closed)
+		receiveEtcd(t, request.ctx.Done())
+	})
+	t.Run("stop cancels reconnect backoff", func(t *testing.T) {
+		client := newFakeEtcdClient()
+		provider := fakeEtcdProvider(t, client)
+		stop, _, stream := startFakeEtcdWatch(t, provider, client, 10)
+		close(stream)
+		stop()
+		receiveEtcd(t, client.closed)
+		assert.Empty(t, client.watches)
+	})
+}
+
+func TestEtcdProviderPassesConnectionConfig(t *testing.T) {
+	config := EtcdConfig{
+		Endpoints: []string{"https://etcd.example:2379"}, Prefix: "/custom/",
+		DialTimeout: 3 * time.Second, Username: "user", Password: "password",
+		TLS: &tls.Config{MinVersion: tls.VersionTLS12, ServerName: "etcd.example"},
+	}
+	provider, err := NewEtcdProvider(config)
+	require.NoError(t, err)
+	client := newFakeEtcdClient()
+	provider.newClient = func(actual clientv3.Config) (etcdClient, error) {
+		assert.Equal(t, config.Endpoints, actual.Endpoints)
+		assert.Equal(t, config.DialTimeout, actual.DialTimeout)
+		assert.Equal(t, config.Username, actual.Username)
+		assert.Equal(t, config.Password, actual.Password)
+		assert.Equal(t, config.TLS.ServerName, actual.TLS.ServerName)
+		return client, nil
+	}
+	stop, _, _ := startFakeEtcdWatch(t, provider, client, 1)
+	stop()
+	receiveEtcd(t, client.closed)
+}
+
+func etcdKV(t *testing.T, key string, endpoint EtcdEndpoint, createRevision, modRevision int64) *mvccpb.KeyValue {
+	t.Helper()
+	value, err := json.Marshal(endpoint)
+	require.NoError(t, err)
+	return &mvccpb.KeyValue{Key: []byte(key), Value: value, CreateRevision: createRevision, ModRevision: modRevision}
+}
+
+func etcdSnapshot(revision int64, kvs ...*mvccpb.KeyValue) *clientv3.GetResponse {
+	return &clientv3.GetResponse{Header: &etcdserverpb.ResponseHeader{Revision: revision}, Kvs: kvs}
+}
+
+func etcdPut(kv *mvccpb.KeyValue) *clientv3.Event { return &clientv3.Event{Type: mvccpb.PUT, Kv: kv} }
+func etcdDelete(key string, revision int64) *clientv3.Event {
+	return &clientv3.Event{Type: mvccpb.DELETE, Kv: &mvccpb.KeyValue{Key: []byte(key), ModRevision: revision}}
+}
+func etcdWatchResponse(revision int64, events ...*clientv3.Event) clientv3.WatchResponse {
+	return clientv3.WatchResponse{Header: etcdserverpb.ResponseHeader{Revision: revision}, Events: events}
+}
+
+type fakeEtcdGetResult struct {
+	response *clientv3.GetResponse
+	err      error
+}
+type fakeEtcdGetRequest struct {
+	ctx   context.Context
+	op    clientv3.Op
+	reply chan fakeEtcdGetResult
+}
+type fakeEtcdWatchRequest struct {
+	ctx    context.Context
+	op     clientv3.Op
+	stream chan clientv3.WatchResponse
+}
+type fakeEtcdClient struct {
+	gets             chan fakeEtcdGetRequest
+	watches          chan fakeEtcdWatchRequest
+	closed           chan struct{}
+	once             sync.Once
+	lastWatchContext context.Context
+}
+
+func newFakeEtcdClient() *fakeEtcdClient {
+	return &fakeEtcdClient{
+		gets: make(chan fakeEtcdGetRequest, 10), watches: make(chan fakeEtcdWatchRequest, 10), closed: make(chan struct{}),
+	}
+}
+func (f *fakeEtcdClient) Get(ctx context.Context, key string, options ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	request := fakeEtcdGetRequest{ctx: ctx, op: clientv3.OpGet(key, options...), reply: make(chan fakeEtcdGetResult, 1)}
+	select {
+	case f.gets <- request:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case result := <-request.reply:
+		return result.response, result.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+func (f *fakeEtcdClient) Watch(ctx context.Context, key string, options ...clientv3.OpOption) clientv3.WatchChan {
+	request := fakeEtcdWatchRequest{ctx: ctx, op: clientv3.OpGet(key, options...), stream: make(chan clientv3.WatchResponse, 10)}
+	f.lastWatchContext = ctx
+	select {
+	case f.watches <- request:
+	case <-ctx.Done():
+	}
+	return request.stream
+}
+func (f *fakeEtcdClient) Close() error { f.once.Do(func() { close(f.closed) }); return nil }
+
+func fakeEtcdProvider(t *testing.T, client *fakeEtcdClient) *EtcdProvider {
+	t.Helper()
+	provider, err := NewEtcdProvider(EtcdConfig{Endpoints: []string{"localhost:2379"}})
+	require.NoError(t, err)
+	provider.newClient = func(clientv3.Config) (etcdClient, error) { return client, nil }
+	return provider
+}
+
+func startFakeEtcdWatch(t *testing.T, provider *EtcdProvider, client *fakeEtcdClient, revision int64,
+	kvs ...*mvccpb.KeyValue,
+) (func(), chan WatchEvent, chan clientv3.WatchResponse) {
+	t.Helper()
+	stopCh := make(chan struct{})
+	var stopOnce sync.Once
+	stop := func() { stopOnce.Do(func() { close(stopCh) }) }
+	t.Cleanup(func() { stop(); receiveEtcd(t, client.closed) })
+	events := make(chan WatchEvent, 100)
+	result := make(chan error, 1)
+	go func() { result <- provider.Watch(func(event WatchEvent) { events <- event }, stopCh) }()
+	request := receiveEtcd(t, client.gets)
+	assert.Equal(t, provider.config.Prefix, string(request.op.KeyBytes()))
+	assert.Equal(t, clientv3.GetPrefixRangeEnd(provider.config.Prefix), string(request.op.RangeBytes()))
+	request.reply <- fakeEtcdGetResult{response: etcdSnapshot(revision, kvs...)}
+	watch := receiveEtcd(t, client.watches)
+	assert.Equal(t, provider.config.Prefix, string(watch.op.KeyBytes()))
+	assert.Equal(t, clientv3.GetPrefixRangeEnd(provider.config.Prefix), string(watch.op.RangeBytes()))
+	assert.Equal(t, revision+1, watch.op.Rev())
+	assertEtcdRequireLeader(t, watch.ctx)
+	require.NoError(t, receiveEtcd(t, result))
+	return stop, events, watch.stream
+}
+
+func receiveEtcd[T any](t *testing.T, channel <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-channel:
+		return value
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for %T", channel)
+		var zero T
+		return zero
+	}
+}
+
+func assertEtcdRequireLeader(t *testing.T, ctx context.Context) {
+	t.Helper()
+	md, ok := metadata.FromOutgoingContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, []string{rpctypes.MetadataHasLeader}, md.Get(rpctypes.MetadataRequireLeaderKey))
+}

--- a/pkg/cache/etcd_discovery_integration_test.go
+++ b/pkg/cache/etcd_discovery_integration_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 AIBrix Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/aibrix/pkg/cache/discovery"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	v1 "k8s.io/api/core/v1"
+)
+
+const etcdDiscoveryTestTimeout = 10 * time.Second
+
+// These tests exercise a real etcd server through discovery into the routing
+// cache. Each test owns an independent prefix and only removes its own keys.
+// Run with AIBRIX_TEST_ETCD_ENDPOINT=http://127.0.0.1:2379.
+func newEtcdDiscoveryTestClient(t *testing.T) (*clientv3.Client, string) {
+	t.Helper()
+	endpoint := os.Getenv("AIBRIX_TEST_ETCD_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("set AIBRIX_TEST_ETCD_ENDPOINT to run real-etcd discovery integration tests")
+	}
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   strings.Split(endpoint, ","),
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	prefix := "/aibrix-tests/discovery/" + uuid.NewString() + "/"
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := client.Delete(ctx, prefix, clientv3.WithPrefix())
+		require.NoError(t, err)
+	})
+	return client, prefix
+}
+
+func startEtcdDiscoveryTestCache(t *testing.T, client *clientv3.Client, prefix string) *Store {
+	t.Helper()
+	provider, err := discovery.NewEtcdProvider(discovery.EtcdConfig{
+		Endpoints:   client.Endpoints(),
+		Prefix:      prefix,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	store := NewForTest()
+	stopCh := make(chan struct{})
+	var stopOnce sync.Once
+	t.Cleanup(func() { stopOnce.Do(func() { close(stopCh) }) })
+	require.NoError(t, initDiscoveryProvider(store, provider, stopCh))
+	return store
+}
+
+func putEtcdDiscoveryTestEndpoint(
+	t *testing.T, client *clientv3.Client, key string, endpoint discovery.EtcdEndpoint,
+	opts ...clientv3.OpOption,
+) {
+	t.Helper()
+	payload, err := json.Marshal(endpoint)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = client.Put(ctx, key, string(payload), opts...)
+	require.NoError(t, err)
+}
+
+func deleteEtcdDiscoveryTestEndpoint(t *testing.T, client *clientv3.Client, key string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := client.Delete(ctx, key)
+	require.NoError(t, err)
+}
+
+func etcdDiscoveryTestPods(store *Store, model string) []*v1.Pod {
+	pods, err := store.ListPodsByModel(model)
+	if err != nil {
+		return nil
+	}
+	return pods.All()
+}
+
+func awaitEtcdDiscoveryTestPods(t *testing.T, store *Store, model string, count int) []*v1.Pod {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return len(etcdDiscoveryTestPods(store, model)) == count
+	}, etcdDiscoveryTestTimeout, 10*time.Millisecond, "model %q should have %d routing endpoints", model, count)
+	return etcdDiscoveryTestPods(store, model)
+}
+
+func TestEtcdDiscoveryRoutingCacheLifecycle(t *testing.T) {
+	client, prefix := newEtcdDiscoveryTestClient(t)
+	endpoint := discovery.EtcdEndpoint{
+		Model: "first-model", Address: "127.0.0.1:18000", Engine: "vllm",
+	}
+	putEtcdDiscoveryTestEndpoint(t, client, prefix+"worker-1", endpoint)
+	store := startEtcdDiscoveryTestCache(t, client, prefix)
+
+	// Watch returning means its initial snapshot is already routable.
+	require.ElementsMatch(t, []string{"first-model"}, store.ListModels())
+	pods := etcdDiscoveryTestPods(store, "first-model")
+	require.Len(t, pods, 1)
+	initialPod := pods[0]
+	require.Equal(t, "127.0.0.1", initialPod.Status.PodIP)
+	require.Equal(t, "18000", initialPod.Labels[constants.ModelLabelPort])
+	require.Equal(t, "vllm", initialPod.Labels[constants.ModelLabelEngine])
+	require.NotEmpty(t, initialPod.UID)
+
+	// A later key is a watch barrier: observing it proves the preceding
+	// identical PUT was consumed before checking pointer stability.
+	putEtcdDiscoveryTestEndpoint(t, client, prefix+"worker-1", endpoint)
+	putEtcdDiscoveryTestEndpoint(t, client, prefix+"barrier", discovery.EtcdEndpoint{
+		Model: "barrier-model", Address: "127.0.0.1:18999",
+	})
+	awaitEtcdDiscoveryTestPods(t, store, "barrier-model", 1)
+	require.Same(t, initialPod, etcdDiscoveryTestPods(store, "first-model")[0],
+		"an identical advertisement must not rebuild the cached pod")
+	deleteEtcdDiscoveryTestEndpoint(t, client, prefix+"barrier")
+	awaitEtcdDiscoveryTestPods(t, store, "barrier-model", 0)
+
+	// Metadata changes update the existing endpoint identity.
+	endpoint.Engine = "sglang"
+	putEtcdDiscoveryTestEndpoint(t, client, prefix+"worker-1", endpoint)
+	require.Eventually(t, func() bool {
+		current := etcdDiscoveryTestPods(store, "first-model")
+		return len(current) == 1 && current[0].Labels[constants.ModelLabelEngine] == "sglang"
+	}, etcdDiscoveryTestTimeout, 10*time.Millisecond)
+	updated := etcdDiscoveryTestPods(store, "first-model")[0]
+	require.Equal(t, initialPod.Name, updated.Name)
+	require.Equal(t, initialPod.UID, updated.UID)
+
+	putEtcdDiscoveryTestEndpoint(t, client, prefix+"worker-2", discovery.EtcdEndpoint{
+		Model: "first-model", Address: "127.0.0.1:18001",
+	})
+	awaitEtcdDiscoveryTestPods(t, store, "first-model", 2)
+
+	// Reassigning a registration must remove its old model mapping.
+	endpoint.Model = "second-model"
+	putEtcdDiscoveryTestEndpoint(t, client, prefix+"worker-1", endpoint)
+	awaitEtcdDiscoveryTestPods(t, store, "second-model", 1)
+	remaining := awaitEtcdDiscoveryTestPods(t, store, "first-model", 1)
+	require.Equal(t, "18001", remaining[0].Labels[constants.ModelLabelPort])
+	require.ElementsMatch(t, []string{"first-model", "second-model"}, store.ListModels())
+
+	// Retargeting the same key must replace the old backend address.
+	endpoint.Address = "127.0.0.2:18002"
+	putEtcdDiscoveryTestEndpoint(t, client, prefix+"worker-1", endpoint)
+	require.Eventually(t, func() bool {
+		current := etcdDiscoveryTestPods(store, "second-model")
+		return len(current) == 1 && current[0].Status.PodIP == "127.0.0.2" &&
+			current[0].Labels[constants.ModelLabelPort] == "18002"
+	}, etcdDiscoveryTestTimeout, 10*time.Millisecond)
+
+	deleteEtcdDiscoveryTestEndpoint(t, client, prefix+"worker-2")
+	awaitEtcdDiscoveryTestPods(t, store, "first-model", 0)
+	require.NotContains(t, store.ListModels(), "first-model")
+
+	// Invalid replacement data withdraws the formerly valid advertisement.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, err := client.Put(ctx, prefix+"worker-1", `{"model":"second-model","address":"127.0.0.2:invalid"}`)
+	cancel()
+	require.NoError(t, err)
+	awaitEtcdDiscoveryTestPods(t, store, "second-model", 0)
+	require.Empty(t, store.ListModels())
+
+	// A corrected registration becomes routable without a restart.
+	putEtcdDiscoveryTestEndpoint(t, client, prefix+"worker-1", endpoint)
+	awaitEtcdDiscoveryTestPods(t, store, "second-model", 1)
+	deleteEtcdDiscoveryTestEndpoint(t, client, prefix+"worker-1")
+	awaitEtcdDiscoveryTestPods(t, store, "second-model", 0)
+	require.Empty(t, store.ListModels())
+
+	// Role metadata reaches the same pod objects used by the PD router.
+	putEtcdDiscoveryTestEndpoint(t, client, prefix+"prefill", discovery.EtcdEndpoint{
+		Model: "pd-model", Address: "127.0.0.1:18100", Engine: "vllm",
+		Role: "prefill", RoleSet: "pair-a",
+	})
+	putEtcdDiscoveryTestEndpoint(t, client, prefix+"decode", discovery.EtcdEndpoint{
+		Model: "pd-model", Address: "127.0.0.1:18200", Engine: "vllm",
+		Role: "decode", RoleSet: "pair-a",
+	})
+	pdPods := awaitEtcdDiscoveryTestPods(t, store, "pd-model", 2)
+	roles := make(map[string]string)
+	for _, pod := range pdPods {
+		require.Equal(t, "pair-a", pod.Labels["roleset-name"])
+		roles[pod.Labels["role-name"]] = pod.Labels[constants.ModelLabelPort]
+	}
+	require.Equal(t, map[string]string{"prefill": "18100", "decode": "18200"}, roles)
+
+	// A new gateway cache recovers current registrations using only etcd.
+	reloaded := startEtcdDiscoveryTestCache(t, client, prefix)
+	require.ElementsMatch(t, []string{"pd-model"}, reloaded.ListModels())
+	require.Len(t, etcdDiscoveryTestPods(reloaded, "pd-model"), 2)
+}
+
+func TestEtcdDiscoveryRoutingCacheLeaseExpiry(t *testing.T) {
+	client, prefix := newEtcdDiscoveryTestClient(t)
+	store := startEtcdDiscoveryTestCache(t, client, prefix)
+	require.Empty(t, store.ListModels())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	lease, err := client.Grant(ctx, 2)
+	cancel()
+	require.NoError(t, err)
+	putEtcdDiscoveryTestEndpoint(t, client, prefix+"leased-worker", discovery.EtcdEndpoint{
+		Model: "leased-model", Address: "127.0.0.1:18300",
+	}, clientv3.WithLease(lease.ID))
+	awaitEtcdDiscoveryTestPods(t, store, "leased-model", 1)
+
+	// No revoke or explicit delete: real server TTL expiry must remove the
+	// endpoint and the now-empty model from the routing cache.
+	awaitEtcdDiscoveryTestPods(t, store, "leased-model", 0)
+	require.NotContains(t, store.ListModels(), "leased-model")
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	result, err := client.Get(ctx, prefix+"leased-worker")
+	cancel()
+	require.NoError(t, err)
+	require.Empty(t, result.Kvs)
+}

--- a/pkg/plugins/gateway/algorithms/pd/prefill/default.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -112,10 +114,9 @@ func (e *DefaultExecutor) Execute(routingCtx *types.RoutingContext, prefillPod *
 		return fmt.Errorf("failed to prepare prefill payload for request %s: %w", routingCtx.RequestID, err)
 	}
 
-	apiURL := fmt.Sprintf("http://%s:%d%s",
-		prefillPod.Status.PodIP,
-		utils.GetModelPortForPod(routingCtx.RequestID, prefillPod),
-		routingCtx.ReqPath)
+	address := net.JoinHostPort(prefillPod.Status.PodIP,
+		strconv.FormatInt(utils.GetModelPortForPod(routingCtx.RequestID, prefillPod), 10))
+	apiURL := "http://" + address + routingCtx.ReqPath
 
 	fields := []interface{}{
 		"request_id", routingCtx.RequestID,

--- a/pkg/plugins/gateway/algorithms/pd/prefill/default_test.go
+++ b/pkg/plugins/gateway/algorithms/pd/prefill/default_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefill
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/aibrix/pkg/constants"
+	"github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd"
+	"github.com/vllm-project/aibrix/pkg/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type prefillAddressTransport func(*http.Request) (*http.Response, error)
+
+func (transport prefillAddressTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	return transport(request)
+}
+
+func TestDefaultExecutorPrefillAddress(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		host string
+		url  string
+	}{
+		{"IPv4", "127.0.0.1", "http://127.0.0.1:8000/v1/chat/completions"},
+		{"DNS", "worker.example", "http://worker.example:8000/v1/chat/completions"},
+		{"IPv6", "2001:db8::1", "http://[2001:db8::1]:8000/v1/chat/completions"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var requestURL string
+			client := &http.Client{Transport: prefillAddressTransport(func(request *http.Request) (*http.Response, error) {
+				requestURL = request.URL.String()
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{}")),
+					Header:     make(http.Header),
+				}, nil
+			})}
+			tracker := pd.NewPrefillRequestTracker()
+			tracker.AddPrefillRequest("request", "prefill-worker")
+			executor := NewDefaultExecutor(client, tracker, 5)
+			routingContext := &types.RoutingContext{
+				Context:   context.Background(),
+				RequestID: "request",
+				Model:     "model",
+				ReqPath:   "/v1/chat/completions",
+				ReqBody:   []byte(`{"model":"model","messages":[]}`),
+			}
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "prefill-worker",
+					Labels: map[string]string{constants.ModelLabelPort: "8000"},
+				},
+				Status: v1.PodStatus{PodIP: test.host},
+			}
+			require.NoError(t, executor.Execute(routingContext, pod, "default", LogContext{}))
+			require.Equal(t, test.url, requestURL)
+		})
+	}
+}

--- a/pkg/types/router_context.go
+++ b/pkg/types/router_context.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -344,11 +346,11 @@ func (r *RoutingContext) targetAddress(pod *v1.Pod) string {
 		// back to the default deployment port on this warm pool pod.
 		return ""
 	}
-	return fmt.Sprintf("%v:%v", pod.Status.PodIP, utils.GetModelPortForPod(r.RequestID, pod))
+	return net.JoinHostPort(pod.Status.PodIP, strconv.FormatInt(utils.GetModelPortForPod(r.RequestID, pod), 10))
 }
 
 func (r *RoutingContext) targetAddressWithPort(podIP string, port int) string {
-	return fmt.Sprintf("%v:%v", podIP, port)
+	return net.JoinHostPort(podIP, strconv.Itoa(port))
 }
 
 // MetricModel returns the model name to emit on gateway metrics.

--- a/pkg/types/router_context_test.go
+++ b/pkg/types/router_context_test.go
@@ -18,11 +18,14 @@ package types
 import (
 	"context"
 	"fmt"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/vllm-project/aibrix/pkg/constants"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func getBlockChannel(cb func(), duration time.Duration) chan bool {
@@ -219,3 +222,48 @@ var _ = Describe("RouterContext", func() {
 		shouldNotBlock(func() { ctx.GetError() }, 100*time.Millisecond)
 	})
 })
+
+func TestTargetAddressFormatsBackendAddresses(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{name: "IPv4", host: "127.0.0.1", expected: "127.0.0.1"},
+		{name: "DNS", host: "worker.example", expected: "worker.example"},
+		{name: "IPv6", host: "2001:db8::1", expected: "[2001:db8::1]"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker",
+					Labels: map[string]string{
+						constants.ModelLabelPort: "8000",
+					},
+				},
+				Status: v1.PodStatus{PodIP: test.host},
+			}
+			ctx := NewRoutingContext(context.Background(), "random", "model", "", "request", "")
+			defer ctx.Delete()
+			ctx.SetTargetPod(pod)
+			if actual := ctx.TargetAddress(); actual != test.expected+":8000" {
+				t.Errorf("label port: got %q, want %q", actual, test.expected+":8000")
+			}
+			ctx.SetTargetPort(9000)
+			if actual := ctx.TargetAddress(); actual != test.expected+":9000" {
+				t.Errorf("explicit port: got %q, want %q", actual, test.expected+":9000")
+			}
+
+			claimPod := pod.DeepCopy()
+			claimPod.Annotations = map[string]string{
+				constants.ModelClaimPodAnnotationPrefix + "claimed": `{"model":"model","port":9100}`,
+			}
+			claimCtx := NewRoutingContext(context.Background(), "random", "model", "", "claim-request", "")
+			defer claimCtx.Delete()
+			claimCtx.SetTargetPod(claimPod)
+			if actual := claimCtx.TargetAddress(); actual != test.expected+":9100" {
+				t.Errorf("model claim port: got %q, want %q", actual, test.expected+":9100")
+			}
+		})
+	}
+}

--- a/pkg/utils/registry.go
+++ b/pkg/utils/registry.go
@@ -21,7 +21,8 @@ import (
 )
 
 // Registry is a generic hash set focus on storing values with string keys.
-// Array output is optimized by offering a cached copy.
+// Array output is optimized by offering a cached read-only snapshot.
+// Mutations invalidate the cache without modifying previously returned slices.
 type Registry[V any] struct {
 	registry map[string]V
 	values   []V  // Pods cache for quick iteration
@@ -53,21 +54,27 @@ func (reg *Registry[V]) Delete(key string) {
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
 
-	if reg.registry == nil {
-		return
-	}
+	reg.deleteLocked(key)
+}
 
-	delete(reg.registry, key)
-	// Check stale
-	if len(reg.values) != len(reg.registry) {
-		reg.values, reg.valid = reg.values[:0], false // atomic set, Reuse base array
+func (reg *Registry[V]) deleteLocked(key string) bool {
+	if _, exists := reg.registry[key]; !exists {
+		return false
 	}
+	delete(reg.registry, key)
+	reg.values, reg.valid = nil, false
+	return true
 }
 
 func (reg *CustomizedRegistry[V, A]) Delete(key string) {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+
+	if !reg.deleteLocked(key) {
+		return
+	}
 	var nilVal A
 	reg.values = nilVal
-	reg.Registry.Delete(key)
 }
 
 func (reg *Registry[V]) Load(key string) (value V, ok bool) {
@@ -82,24 +89,25 @@ func (reg *Registry[V]) Store(key string, value V) {
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
 
+	reg.storeLocked(key, value)
+}
+
+func (reg *Registry[V]) storeLocked(key string, value V) {
 	if reg.registry == nil {
 		reg.registry = make(map[string]V, 1)
 	}
 
-	_, exist := reg.registry[key]
 	reg.registry[key] = value
-	if reg.valid && !exist {
-		reg.values, reg.valid = append(reg.values, value), true // atomic set
-	} else {
-		// clear and wait regenerate
-		reg.values, reg.valid = reg.values[:0], false
-	}
+	reg.values, reg.valid = nil, false
 }
 
 func (reg *CustomizedRegistry[V, A]) Store(key string, value V) {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+
 	var nilVal A
 	reg.values = nilVal
-	reg.Registry.Store(key, value)
+	reg.storeLocked(key, value)
 }
 
 func (reg *Registry[V]) Array() (arr []V) {
@@ -107,7 +115,9 @@ func (reg *Registry[V]) Array() (arr []V) {
 		return nil
 	}
 
-	arr, valid := reg.values, reg.valid // atomic
+	reg.mu.RLock()
+	arr, valid := reg.values, reg.valid
+	reg.mu.RUnlock()
 	if valid {
 		return arr
 	}
@@ -125,7 +135,9 @@ func (reg *CustomizedRegistry[V, A]) Array() (arr A) {
 		return
 	}
 
+	reg.mu.RLock()
 	ret := reg.values
+	reg.mu.RUnlock()
 	if ret != arr { // ret != nil value
 		return ret
 	}
@@ -140,11 +152,6 @@ func (reg *CustomizedRegistry[V, A]) Array() (arr A) {
 func (reg *Registry[V]) Len() int {
 	if reg == nil {
 		return 0
-	}
-
-	arr, valid := reg.values, reg.valid // atomic
-	if valid {
-		return len(arr)
 	}
 
 	reg.mu.RLock()
@@ -163,15 +170,15 @@ func (reg *CustomizedRegistry[V, A]) Len() int {
 
 func (reg *Registry[V]) updateArrayLocked() ([]V, bool) {
 	reconstructed := false
-	if !reg.valid && reg.registry != nil {
-		if cap(reg.values) < len(reg.registry) {
-			reg.values = make([]V, 0, len(reg.registry)*2)
-		}
-		for _, pod := range reg.registry {
-			reg.values = append(reg.values, pod)
+	if !reg.valid {
+		// A previous snapshot can still be in use by a routing request.
+		// Always allocate a new backing array when rebuilding the cache.
+		reg.values = make([]V, 0, len(reg.registry))
+		for _, value := range reg.registry {
+			reg.values = append(reg.values, value)
 		}
 		reconstructed = true
-		reg.valid = true // atomic set
+		reg.valid = true
 	}
 
 	return reg.values, reconstructed

--- a/pkg/utils/registry_test.go
+++ b/pkg/utils/registry_test.go
@@ -17,6 +17,12 @@ limitations under the License.
 package utils
 
 import (
+	"runtime"
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -227,3 +233,119 @@ var _ = Describe("Registry", func() {
 		})
 	})
 })
+
+// Returned snapshots remain usable while discovery replaces or removes entries.
+func TestRegistrySnapshotStability(t *testing.T) {
+	registry := NewRegistry[string]()
+	testRegistrySnapshotStability(t, registry.Store, registry.Delete, registry.Array)
+}
+
+func TestCustomizedRegistrySnapshotStability(t *testing.T) {
+	registry := NewRegistryWithArrayProvider(func(values []string) *registryStringSnapshot {
+		return &registryStringSnapshot{values: values}
+	})
+	testRegistrySnapshotStability(t, registry.Store, registry.Delete, func() []string {
+		return registry.Array().values
+	})
+	cached := registry.Array()
+	if registry.Array() != cached {
+		t.Fatal("unchanged registry must reuse its customized snapshot")
+	}
+	registry.Delete("missing")
+	if registry.Array() != cached {
+		t.Fatal("deleting an absent key must preserve the cached snapshot")
+	}
+}
+
+type registryStringSnapshot struct {
+	values []string
+}
+
+func testRegistrySnapshotStability(t *testing.T, store func(string, string), remove func(string), array func() []string) {
+	t.Helper()
+	store("worker", "old")
+	original := array()
+	store("worker", "replacement")
+	if current := array(); !slices.Equal(current, []string{"replacement"}) {
+		t.Fatalf("replacement snapshot = %v", current)
+	}
+	if !slices.Equal(original, []string{"old"}) {
+		t.Errorf("replacing an entry changed the previous snapshot: %v", original)
+	}
+
+	store("second", "second")
+	beforeDelete := array()
+	expected := slices.Clone(beforeDelete)
+	remove("worker")
+	if current := array(); !slices.Equal(current, []string{"second"}) {
+		t.Fatalf("deletion snapshot = %v", current)
+	}
+	if !slices.Equal(beforeDelete, expected) {
+		t.Errorf("deleting an entry changed the previous snapshot: got %v, want %v", beforeDelete, expected)
+	}
+
+	beforeAdd := array()
+	store("third", "third")
+	_ = array()
+	if !slices.Equal(beforeAdd, []string{"second"}) {
+		t.Errorf("adding an entry changed the previous snapshot: %v", beforeAdd)
+	}
+}
+
+func TestRegistryConcurrentSnapshots(t *testing.T) {
+	t.Run("base", func(t *testing.T) {
+		registry := NewRegistry[string]()
+		testRegistryConcurrentSnapshots(t, registry.Store, registry.Delete, registry.Len, registry.Array)
+	})
+	t.Run("customized", func(t *testing.T) {
+		registry := NewRegistryWithArrayProvider(func(values []string) *registryStringSnapshot {
+			return &registryStringSnapshot{values: values}
+		})
+		testRegistryConcurrentSnapshots(t, registry.Store, registry.Delete, registry.Len, func() []string {
+			return registry.Array().values
+		})
+	})
+}
+
+func testRegistryConcurrentSnapshots(t *testing.T, store func(string, string), remove func(string), length func() int, array func() []string) {
+	t.Helper()
+	const iterations = 256
+	const keys = 8
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	workers.Add(4)
+	go func() {
+		defer workers.Done()
+		<-start
+		for i := range iterations {
+			key := strconv.Itoa(i % keys)
+			store(key, strconv.Itoa(i))
+			if i%3 == 0 {
+				remove(key)
+			}
+			_ = array()
+			runtime.Gosched()
+		}
+	}()
+	for range 3 {
+		go func() {
+			defer workers.Done()
+			<-start
+			for range iterations {
+				current := array()
+				expected := slices.Clone(current)
+				runtime.Gosched()
+				if !slices.Equal(current, expected) {
+					t.Errorf("published snapshot changed during concurrent updates: got %v, want %v", current, expected)
+					return
+				}
+				if n := length(); n < 0 || n > keys {
+					t.Errorf("registry length outside possible key count: %d", n)
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	workers.Wait()
+}

--- a/test/kv-event-sync-e2e.rst
+++ b/test/kv-event-sync-e2e.rst
@@ -334,7 +334,7 @@ ZMQ Build Errors
    export CGO_ENABLED=1
 
    # Build with explicit tags
-   go build -tags="zmq" -v ./cmd/plugins/main.go
+   go build -tags="zmq" -v ./cmd/plugins
 
 Kind Cluster Issues
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Description

Standalone gateways can now discover inference endpoints from etcd without restarting or editing a static endpoint list. A registration is a JSON record under a configurable prefix; updates change the routing cache, and deletion or lease expiry withdraws the route.

- Add an etcd implementation of the existing discovery Provider: initial snapshot, revision-based watch, reconnect and compaction recovery, stable endpoint identity, and prefill/decode role metadata.
- Add strict `--etcd-config` loading with username/password and verified TLS/mTLS, plus configuration and registration examples.
- Make routing-cache registry snapshots safe during concurrent discovery updates. Real-etcd race tests exposed unsynchronized cache publication and reuse of slices already returned to requests; the registry now protects publication and creates a new snapshot after mutations.
- Build the gateway as a package so the new CLI file is included, and preserve bracketed IPv6 addresses in routing targets and prefill URLs.

## Related Issues

Related: #2033. This implements the etcd provider; Consul remains future work.

## Validation

Validated on base `5c77915f74d00a4dcdd6034615f0eba47b0af66f` using Go 1.22.12 and a dedicated etcd 3.5.17 server.

- `go test -race -p=1 -count=1 ./pkg/cache/... ./pkg/plugins/gateway/... ./pkg/types ./pkg/utils ./cmd/plugins`: 16 tested packages passed.
- `make lint-all`: license check and full golangci-lint passed.
- Real-etcd race integration: compaction recovery, routing-cache lifecycle, and natural lease expiry passed.
- Rebuilt the gateway with `CGO_ENABLED=0 go build -tags=nozmq ./cmd/plugins`.
- A real ext_proc gRPC client verified registration, address updates, invalid-update withdrawal, repair, deletion, and lease expiry through the gateway.
- A separate etcd server requiring client certificates verified gateway registration discovery and deletion watch over mTLS.

The blackbox validation covers ext_proc decisions, not Envoy forwarding or GPU inference. Multi-node etcd failure injection and throughput benchmarking were not run. During etcd outages, the provider retains the last known routes until discovery recovers, as documented.
