### PR TITLE
[Docs] Fix api-key sample path in the LoRA guide

### DIFF
--- a/docs/source/features/lora-dynamic-loading.rst
+++ b/docs/source/features/lora-dynamic-loading.rst
@@ -599,7 +599,7 @@ User may pass in the argument ``--api-key`` or environment variable ``VLLM_API_K
 
     vllm serve --api-key sk-kFJ12nKsFakefVmGpj3QzX65s4RbN2xJqWzPYCjYu7wT3BFake
 
-We already have an example and you can ``kubectl apply -f samples/adapter/adapter-with-key.yaml``.
+We already have an example and you can ``kubectl apply -f samples/adapter/base-api-key.yaml``.
 
 
 In that case, lora model adapter can not query the vLLM server correctly, showing ``{"error":"Unauthorized"}`` error. You need to update ``additionalConfig`` field to pass in the API key.


### PR DESCRIPTION
## Pull Request Description

The "Model api-key Authentication" section of the LoRA dynamic loading guide tells users to run:

```bash
kubectl apply -f samples/adapter/adapter-with-key.yaml
```

That file does not exist. It is not a stale path left behind by a rename either — `samples/adapter/adapter-with-key.yaml` has never existed in this repository, so anyone following the guide hits `error: the path "samples/adapter/adapter-with-key.yaml" does not exist`.

The manifest the paragraph is describing is `samples/adapter/base-api-key.yaml`:

- the paragraph directly follows the `vllm serve --api-key sk-kFJ12nKsFake...` snippet, and `base-api-key.yaml` is the base model Deployment started with that exact same key;
- the adapter side of the same example, `adapter-api-key.yaml`, is already pulled into the page via `literalinclude` two paragraphs further down, so this line is about deploying the base model, not the adapter.

This PR points the command at `samples/adapter/base-api-key.yaml`.

I also checked every other `literalinclude`/`figure`/`image` directive and every repo-relative path referenced from `docs/`; this was the only broken one.

## Related Issues

None — found while reading the docs.
