### PR TITLE
[Bug] Stop scaling AIBRIX_TOKENIZER_* durations by time.Second twice

### DIFF
--- a/pkg/plugins/gateway/algorithms/prefix_cache.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache.go
@@ -225,6 +225,27 @@ func newTokenizer() tokenizer.Tokenizer {
 	return tokenizer.NewCharacterTokenizer()
 }
 
+// loadTokenizerPoolConfigFromEnv builds the remote tokenizer pool configuration
+// from the AIBRIX_TOKENIZER_* environment variables.
+//
+// The duration defaults are time.Duration values on purpose: utils.LoadEnvDuration
+// parses the environment value with time.ParseDuration and already returns a
+// time.Duration, so scaling its result by time.Second again would multiply any
+// user-supplied value by 1e9. Only KV Event Sync constants are defined in
+// pkg/constants, the rest are read by name here.
+func loadTokenizerPoolConfigFromEnv() TokenizerPoolConfig {
+	return TokenizerPoolConfig{
+		EnableVLLMRemote:     true, // We're using it, so enable it
+		EndpointTemplate:     utils.LoadEnv("AIBRIX_VLLM_TOKENIZER_ENDPOINT_TEMPLATE", "http://%s:8000"),
+		HealthCheckPeriod:    utils.LoadEnvDuration("AIBRIX_TOKENIZER_HEALTH_CHECK_PERIOD", 30*time.Second),
+		TokenizerTTL:         utils.LoadEnvDuration("AIBRIX_TOKENIZER_TTL", 300*time.Second),
+		MaxTokenizersPerPool: utils.LoadEnvInt("AIBRIX_MAX_TOKENIZERS_PER_POOL", 100),
+		DefaultTokenizer:     nil, // Set by the caller
+		Timeout:              utils.LoadEnvDuration("AIBRIX_TOKENIZER_REQUEST_TIMEOUT", 5*time.Second),
+		ModelServiceMap:      make(map[string]string),
+	}
+}
+
 func NewPrefixCacheRouter() (types.Router, error) {
 	// Initialize prefix cache metrics if enabled
 	if err := initializePrefixCacheMetrics(); err != nil {
@@ -266,17 +287,7 @@ func NewPrefixCacheRouter() (types.Router, error) {
 	// Configure TokenizerPool if remote tokenizer is needed
 	if useRemoteTokenizer {
 		// Load pool configuration from environment
-		// Only KV Event Sync constants are defined in pkg/constants
-		poolConfig := TokenizerPoolConfig{
-			EnableVLLMRemote:     true, // We're using it, so enable it
-			EndpointTemplate:     utils.LoadEnv("AIBRIX_VLLM_TOKENIZER_ENDPOINT_TEMPLATE", "http://%s:8000"),
-			HealthCheckPeriod:    utils.LoadEnvDuration("AIBRIX_TOKENIZER_HEALTH_CHECK_PERIOD", 30) * time.Second,
-			TokenizerTTL:         utils.LoadEnvDuration("AIBRIX_TOKENIZER_TTL", 300) * time.Second,
-			MaxTokenizersPerPool: utils.LoadEnvInt("AIBRIX_MAX_TOKENIZERS_PER_POOL", 100),
-			DefaultTokenizer:     nil, // Will be set below
-			Timeout:              utils.LoadEnvDuration("AIBRIX_TOKENIZER_REQUEST_TIMEOUT", 5) * time.Second,
-			ModelServiceMap:      make(map[string]string),
-		}
+		poolConfig := loadTokenizerPoolConfigFromEnv()
 
 		// Create default tokenizer based on configured type
 		var defaultTokenizer = newTokenizer()

--- a/pkg/plugins/gateway/algorithms/tokenizer_pool_test.go
+++ b/pkg/plugins/gateway/algorithms/tokenizer_pool_test.go
@@ -739,3 +739,99 @@ func BenchmarkTimeNowOptimization(b *testing.B) {
 		}
 	})
 }
+
+// TestLoadTokenizerPoolConfigFromEnv covers the AIBRIX_TOKENIZER_* durations.
+//
+// utils.LoadEnvDuration already returns a time.Duration, so the values it hands
+// back must not be scaled by time.Second again. Doing so overflows int64 for any
+// realistic setting (30s becomes a negative duration, which silently disables the
+// health checker in NewTokenizerPool), while still producing the correct value on
+// the default path - so only a case that sets the variables explicitly catches it.
+func TestLoadTokenizerPoolConfigFromEnv(t *testing.T) {
+	const (
+		healthCheckEnv = "AIBRIX_TOKENIZER_HEALTH_CHECK_PERIOD"
+		ttlEnv         = "AIBRIX_TOKENIZER_TTL"
+		timeoutEnv     = "AIBRIX_TOKENIZER_REQUEST_TIMEOUT"
+	)
+
+	tests := []struct {
+		name            string
+		healthCheck     string
+		ttl             string
+		timeout         string
+		wantHealthCheck time.Duration
+		wantTTL         time.Duration
+		wantTimeout     time.Duration
+	}{
+		{
+			name:            "unset falls back to defaults",
+			wantHealthCheck: 30 * time.Second,
+			wantTTL:         300 * time.Second,
+			wantTimeout:     5 * time.Second,
+		},
+		{
+			name:            "documented defaults set explicitly",
+			healthCheck:     "30s",
+			ttl:             "300s",
+			timeout:         "5s",
+			wantHealthCheck: 30 * time.Second,
+			wantTTL:         300 * time.Second,
+			wantTimeout:     5 * time.Second,
+		},
+		{
+			name:            "custom durations are honored",
+			healthCheck:     "45s",
+			ttl:             "10m",
+			timeout:         "2500ms",
+			wantHealthCheck: 45 * time.Second,
+			wantTTL:         10 * time.Minute,
+			wantTimeout:     2500 * time.Millisecond,
+		},
+		{
+			name:            "unparsable values fall back to defaults",
+			healthCheck:     "not-a-duration",
+			ttl:             "300", // missing unit, rejected by time.ParseDuration
+			timeout:         "-",
+			wantHealthCheck: 30 * time.Second,
+			wantTTL:         300 * time.Second,
+			wantTimeout:     5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Always set all three so the case is independent of the ambient
+			// environment; an empty value is treated as unset by LoadEnvDuration.
+			t.Setenv(healthCheckEnv, tt.healthCheck)
+			t.Setenv(ttlEnv, tt.ttl)
+			t.Setenv(timeoutEnv, tt.timeout)
+
+			cfg := loadTokenizerPoolConfigFromEnv()
+
+			assert.Equal(t, tt.wantHealthCheck, cfg.HealthCheckPeriod, "HealthCheckPeriod")
+			assert.Equal(t, tt.wantTTL, cfg.TokenizerTTL, "TokenizerTTL")
+			assert.Equal(t, tt.wantTimeout, cfg.Timeout, "Timeout")
+
+			// NewTokenizerPool only starts the health checker (which is also what
+			// evicts stale tokenizers) when HealthCheckPeriod is positive.
+			assert.Positive(t, cfg.HealthCheckPeriod, "HealthCheckPeriod must stay positive")
+			assert.Positive(t, cfg.TokenizerTTL, "TokenizerTTL must stay positive")
+			assert.Positive(t, cfg.Timeout, "Timeout must stay positive")
+		})
+	}
+}
+
+// TestLoadTokenizerPoolConfigFromEnvNonDurationDefaults pins the remaining
+// defaults documented in pkg/plugins/gateway/ENV_VARS.md.
+func TestLoadTokenizerPoolConfigFromEnvNonDurationDefaults(t *testing.T) {
+	t.Setenv("AIBRIX_VLLM_TOKENIZER_ENDPOINT_TEMPLATE", "")
+	t.Setenv("AIBRIX_MAX_TOKENIZERS_PER_POOL", "")
+
+	cfg := loadTokenizerPoolConfigFromEnv()
+
+	assert.True(t, cfg.EnableVLLMRemote)
+	assert.Equal(t, "http://%s:8000", cfg.EndpointTemplate)
+	assert.Equal(t, 100, cfg.MaxTokenizersPerPool)
+	assert.Nil(t, cfg.DefaultTokenizer)
+	assert.NotNil(t, cfg.ModelServiceMap)
+}


### PR DESCRIPTION
## Pull Request Description

`utils.LoadEnvDuration` parses the environment value with `time.ParseDuration` and returns a `time.Duration`. Three tokenizer pool settings in `pkg/plugins/gateway/algorithms/prefix_cache.go` multiplied that result by `time.Second` a second time:

```go
HealthCheckPeriod:    utils.LoadEnvDuration("AIBRIX_TOKENIZER_HEALTH_CHECK_PERIOD", 30) * time.Second,
TokenizerTTL:         utils.LoadEnvDuration("AIBRIX_TOKENIZER_TTL", 300) * time.Second,
Timeout:              utils.LoadEnvDuration("AIBRIX_TOKENIZER_REQUEST_TIMEOUT", 5) * time.Second,
```

### Why it has gone unnoticed

On the default path the two mistakes cancel out. The defaults are passed as bare integers, so `30` is a 30ns duration and scaling it by `time.Second` lands back on exactly the 30s that `ENV_VARS.md` documents. Everything looks right as long as nobody sets the variables.

Setting them is what breaks, because by then the value has already been parsed into nanoseconds:

| env value | parsed | after `* time.Second` |
|---|---|---|
| `AIBRIX_TOKENIZER_HEALTH_CHECK_PERIOD=30s` | 3e10 ns | overflows int64, wraps to **≈ −218 years** |
| `AIBRIX_TOKENIZER_TTL=300s` | 3e11 ns | ≈ 154 years |
| `AIBRIX_TOKENIZER_REQUEST_TIMEOUT=5s` | 5e9 ns | ≈ 158 years |

### Impact

A negative `HealthCheckPeriod` fails the `if config.HealthCheckPeriod > 0` guard in `NewTokenizerPool` (`tokenizer_pool.go`), so `startHealthChecker()` is never called. That goroutine is also the only caller of `cleanupStaleTokenizers()`, so with health checking off:

- unhealthy remote tokenizers are never evicted and keep serving,
- nothing is ever removed by TTL either, so the pool grows to `MaxTokenizersPerPool` (100) and every model after that silently falls back to the default tokenizer.

The inflated `TokenizerTTL` disables TTL eviction on its own, and the inflated `Timeout` is handed to `RemoteTokenizerConfig`, which effectively removes the timeout on remote tokenizer requests.

None of this is visible in the logs: `LoadEnvDuration` logs the parsed value *before* the extra multiplication, so the operator sees `set AIBRIX_TOKENIZER_HEALTH_CHECK_PERIOD: 30s` while the pool is running with a negative period.

`pkg/plugins/gateway/statesync/redissync.go` already calls `LoadEnvDuration` the correct way (`defaultSyncPeriod = 10 * time.Second`), so this is isolated to these three lines.

## Changes

- Pass the defaults as `time.Duration` values and drop the extra `* time.Second`.
- Move the pool config construction into `loadTokenizerPoolConfigFromEnv()` so it can be exercised without standing up a router and a cache. No behaviour change beyond the fix.
- Add table-driven tests in `tokenizer_pool_test.go` covering the unset path, the documented defaults set **explicitly** (the case that reproduces the overflow), custom durations, and unparsable values. The existing tests only exercised the default path, which is why CI stayed green.

Without the fix, the "documented defaults set explicitly" case fails with a negative `HealthCheckPeriod`.

## Related Issues

None — found while auditing `ENV_VARS.md` against the code.

## Verification

Reverting only the three defaults back to the bare integers, with the new tests in place:

```
--- FAIL: TestLoadTokenizerPoolConfigFromEnv/documented_defaults_set_explicitly
    HealthCheckPeriod: expected 30s,  actual -1914857h49m7.419103232s
    TokenizerTTL:      expected 5m0s, actual  1347804h7m0.647174144s
    Timeout:           expected 5s,   actual  1388888h53m20s
```

`unset falls back to defaults` keeps passing in that run, which is what kept CI green.

With the fix, `go test ./pkg/plugins/gateway/...` is green:

```
ok  github.com/vllm-project/aibrix/pkg/plugins/gateway              0.244s
ok  github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms   6.816s
ok  github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms/pd 0.154s
...
ok  github.com/vllm-project/aibrix/pkg/plugins/gateway/statesync    0.130s
```
