### PR TITLE
[Docs] Add repository agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,129 @@
+# AIBrix
+
+AIBrix is a Kubernetes-native platform for building scalable GenAI inference
+infrastructure. This repository contains Go controllers, gateway plugins,
+custom resources, deployment manifests, tests, and Python runtime components.
+This file gives coding agents the repository-specific context and safety rules
+needed to make focused changes.
+
+## Scope and repository layout
+
+| Path | Role |
+|------|------|
+| `api/` | Kubernetes API types and CRD definitions |
+| `pkg/controller/` | Kubernetes controllers and reconciliation logic |
+| `pkg/plugins/` | Gateway plugins and request processing |
+| `pkg/` | Shared Go libraries, clients, caches, metrics, and utilities |
+| `cmd/` | Go binary entrypoints |
+| `config/` | Kustomize configuration, CRDs, RBAC, and deployment manifests |
+| `test/integration/` | Ginkgo-based integration tests |
+| `test/e2e/` | Kind and cluster-level end-to-end tests |
+| `hack/` | Code generation, verification, and CI scripts |
+| `python/aibrix/` | Python runtime, downloader, batch, metadata, and optimizer |
+| `python/aibrix_kvcache/` | Python distributed KV-cache components |
+| `apps/` | Application services and the console |
+| `docs/` | Project documentation and generated documentation assets |
+| `samples/` | Example deployments and feature samples |
+
+Rules in a deeper `AGENTS.md` take precedence for files under that directory.
+The Python runtime has additional guidance in
+[`python/aibrix/AGENTS.md`](python/aibrix/AGENTS.md).
+
+## Working rules
+
+- State the intended scope and success criteria before making a non-trivial
+  change.
+- Read the closest existing implementation and its tests before introducing a
+  new pattern.
+- Keep changes focused. Do not combine unrelated refactors, formatting, or
+  generated output with a feature or bug fix.
+- Verify behavior from code and tests rather than inferring it from filenames.
+- Preserve unrelated user changes in the working tree.
+- Do not push branches, rewrite history, modify remote GitHub state, or send
+  external messages without explicit authorization for that action.
+- Ask before upgrading dependencies or changing `.github/` workflow policy.
+
+## API and compatibility surfaces
+
+Treat the following as compatibility surfaces:
+
+- Kubernetes API types, CRD schemas, JSON/YAML tags, defaults, validation,
+  list semantics, subresources, and printer columns.
+- Public HTTP endpoints, request and response fields, headers, status codes,
+  and gateway plugin contracts.
+- CLI flags, configuration keys, environment variables, labels, and
+  annotations used by deployment or controller logic.
+
+Do not rename, remove, or repurpose an existing field or key without an
+explicit migration and compatibility plan. Preserve pointer and `omitempty`
+choices when absent, zero, and explicit values have different meanings.
+Keep status fields observational; status transitions must remain consistent
+with every controller that writes or consumes them.
+
+Keep API types declarative. Admission behavior belongs in webhooks,
+reconciliation policy belongs in controllers, and transport compatibility
+belongs in the relevant API or gateway layer.
+
+## Build and verification
+
+Run commands from the repository root. Start with the narrowest relevant check
+and run broader checks for changes that cross package or language boundaries.
+
+| Command | Purpose |
+|---------|---------|
+| `make fmt` | Format Go code |
+| `make vet` | Run `go vet ./...` |
+| `make generate` | Regenerate Go and Kubernetes generated artifacts |
+| `make manifests` | Regenerate webhook, RBAC, and CRD manifests |
+| `make verify` | Verify generated code and CRD synchronization |
+| `make lint` | Run Go linting |
+| `make lint-all` | Run license and Go lint checks |
+| `make test` | Run Go unit tests, excluding integration and E2E packages |
+| `make test-race-condition` | Run Go unit tests with the race detector |
+| `make test-integration` | Run integration tests |
+| `make python-ci` | Run Python Ruff, mypy, and tests for `python/aibrix` |
+| `make test-e2e` | Run Kind-based end-to-end tests |
+
+For a Go package, a focused check such as `go test ./pkg/<package>/...` is
+appropriate while iterating. For cluster-level behavior, use the existing
+helpers and test organization under `test/e2e/`; do not replace polling with
+arbitrary sleeps.
+
+When API types, controller-gen markers, or CRDs change, run the applicable
+generation and verification targets and include the resulting generated files
+in the change. Do not hand-edit generated files unless the generator explicitly
+requires it.
+
+## Coding conventions
+
+- Follow existing Go package structure and standard Go style; use `gofmt` or
+  `make fmt`.
+- Put reusable implementation in `pkg/`; keep `cmd/` entrypoints thin.
+- Use table-driven tests where they match the surrounding package style.
+- Add or update tests for behavior changes, including failure and compatibility
+  cases when applicable.
+- Comments should explain non-obvious reasons or invariants, not restate code.
+- Preserve existing logging, error handling, retry, timeout, and context
+  propagation patterns unless the change specifically addresses them.
+- For Python changes, follow the more specific rules in
+  [`python/aibrix/AGENTS.md`](python/aibrix/AGENTS.md) and run checks from that
+  subtree as documented there.
+
+## Pull requests and documentation
+
+- Keep a PR focused on one issue or coherent behavior change.
+- Use the repository [PR template](.github/PULL_REQUEST_TEMPLATE.md), link the
+  relevant issue, and describe the tests actually run.
+- Update user or developer documentation when behavior, configuration, API,
+  deployment, or CLI usage changes.
+- Large design changes should be discussed before implementation and recorded
+  in the appropriate documentation area.
+- Review every generated or AI-assisted change yourself; do not submit code
+  that you cannot explain and verify.
+
+## Further reading
+
+- [Contributing guide](CONTRIBUTING.md)
+- [Development guide](development/README.md)
+- [Test guide](test/README.md)
+- [Project documentation](docs/README.md)

--- a/docs/source/designs/aibrix-stormservice.rst
+++ b/docs/source/designs/aibrix-stormservice.rst
@@ -314,6 +314,339 @@ See the complete `topology policy samples`_ in the AIBrix repository.
 .. _topology policy samples: https://github.com/vllm-project/aibrix/tree/main/samples/orchestration/topology-policy
 
 
+Gang Scheduling Strategies
+--------------------------
+
+StormService supports PodGroup-based gang scheduling through
+``spec.template.spec.schedulingStrategy``. This is the StormService entry point
+for configuring all Pods in each generated RoleSet as one gang-scheduled group.
+
+Gang scheduling is useful for PD-disaggregated serving and other multi-role
+inference workloads where starting only part of the service replica is not
+useful. For example, a Prefill/Decode replica may need enough Prefill Pods and
+enough Decode Pods to be admitted together before it can serve traffic.
+
+``schedulingStrategy`` currently accepts one of the following scheduler-specific
+strategies:
+
+.. list-table:: Gang scheduling strategies
+   :header-rows: 1
+   :widths: 20 35 45
+
+   * - Strategy field
+     - PodGroup API
+     - Main fields
+   * - ``volcanoSchedulingStrategy``
+     - Volcano ``PodGroup``
+     - ``minMember``, ``minTaskMember``, ``queue``,
+       ``priorityClassName``, ``minResources``
+   * - ``godelSchedulingStrategy``
+     - Godel ``PodGroup``
+     - ``minMember``, ``priorityClassName``,
+       ``scheduleTimeoutSeconds``, ``application``, ``affinity``
+   * - ``coschedulingSchedulingStrategy``
+     - Kubernetes scheduler-plugins ``PodGroup``
+     - ``minMember``, ``minResources``, ``scheduleTimeoutSeconds``
+
+When the scheduling strategy is set on the StormService template, the
+StormService controller copies it to each managed RoleSet. The RoleSet
+controller creates one scheduler-specific ``PodGroup`` for the RoleSet and
+attaches generated Pods or PodSets to that PodGroup. For Volcano, the
+controller also marks each role with the Volcano task name
+``volcano.sh/task-spec=<role name>``. ``minTaskMember`` keys therefore match
+StormService role names.
+
+The rest of this section focuses on Volcano because it supports both
+group-level ``minMember`` and role-level ``minTaskMember`` from the
+StormService entry point.
+
+For single-Pod role replicas, the RoleSet can create Pods directly. For
+multi-node inference, set ``podGroupSize > 1`` on a role. Each role replica then
+becomes one PodSet, and the PodSet creates the multiple Pods that form that
+replica. A RoleSet-level scheduling strategy still creates one PodGroup for the
+whole RoleSet, so Volcano admits the Prefill and Decode PodSets together.
+
+.. mermaid::
+
+   graph TD
+       SS["StormService<br/>replicas: 1<br/>template.spec.schedulingStrategy"]
+       RS["RoleSet replica 0<br/>copied schedulingStrategy"]
+       PG["Volcano PodGroup<br/>RoleSet-level gang<br/>minMember: 6"]
+
+       RP["Role: prefill<br/>replicas: 2<br/>podGroupSize: 2"]
+       RD["Role: decode<br/>replicas: 3<br/>podGroupSize: 2"]
+
+       PSP["2 prefill PodSets<br/>4 Pods<br/>task: prefill"]
+       PSD["3 decode PodSets<br/>6 Pods<br/>task: decode"]
+
+       PP["prefill Pods<br/>schedulerName: volcano"]
+       PD["decode Pods<br/>schedulerName: volcano"]
+
+       MT["minTaskMember<br/>prefill: 4<br/>decode: 2"]
+
+       SS --> RS
+       RS --> RP
+       RS --> RD
+       RP --> PSP
+       RD --> PSD
+       PSP --> PP
+       PSD --> PD
+
+       RS -. creates .-> PG
+       PG -. admits together .-> PSP
+       PG -. admits together .-> PSD
+       MT -. role task gates .-> PG
+
+Group-level ``minMember``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``minMember`` is the minimum total number of Pods that must be schedulable for
+the Volcano PodGroup. If fewer than ``minMember`` Pods can be admitted, Volcano
+keeps the gang pending instead of starting only a partial RoleSet.
+
+The following multi-node shape shows how ``minMember`` applies when role
+replicas are expanded into PodSets. The YAML after the diagram uses the same
+shape: two Prefill replicas and three Decode replicas, each with
+``podGroupSize: 2``.
+
+.. code-block:: text
+
+   minMember gates the whole RoleSet PodGroup.
+
+   +-----------------------------------------------------------+
+   | StormService: sglang-pd                                   |
+   | replicas: 1                                               |
+   +-----------------------------------------------------------+
+   | RoleSet-0                                                 |
+   |   Volcano PodGroup: RoleSet-0                             |
+   |   minMember: 6                                            |
+   |                                                           |
+   |   role: prefill, replicas: 2, podGroupSize: 2             |
+   |     +---------------------+                               |
+   |     | PodSet prefill-0    |                               |
+   |     |  Pod prefill-0-0    |                               |
+   |     |  Pod prefill-0-1    |                               |
+   |     +---------------------+                               |
+   |     +---------------------+                               |
+   |     | PodSet prefill-1    |                               |
+   |     |  Pod prefill-1-0    |                               |
+   |     |  Pod prefill-1-1    |                               |
+   |     +---------------------+                               |
+   |                                                           |
+   |   role: decode, replicas: 3, podGroupSize: 2              |
+   |     +---------------------+                               |
+   |     | PodSet decode-0     |                               |
+   |     |  Pod decode-0-0     |                               |
+   |     |  Pod decode-0-1     |                               |
+   |     +---------------------+                               |
+   |     +---------------------+                               |
+   |     | PodSet decode-1     |                               |
+   |     |  Pod decode-1-0     |                               |
+   |     |  Pod decode-1-1     |                               |
+   |     +---------------------+                               |
+   |     +---------------------+                               |
+   |     | PodSet decode-2     |                               |
+   |     |  Pod decode-2-0     |                               |
+   |     |  Pod decode-2-1     |                               |
+   |     +---------------------+                               |
+   +-----------------------------------------------------------+
+
+   Volcano may admit this RoleSet when any 6 of the 10 Pods from the PodSets
+   can be scheduled together. minMember does not require a specific
+   prefill/decode mix.
+
+.. code-block:: yaml
+
+   apiVersion: orchestration.aibrix.ai/v1alpha1
+   kind: StormService
+   metadata:
+     name: sglang-pd
+   spec:
+     replicas: 1
+     selector:
+       matchLabels:
+         app: sglang-pd
+     template:
+       metadata:
+         labels:
+           app: sglang-pd
+       spec:
+         schedulingStrategy:
+           volcanoSchedulingStrategy:
+             minMember: 6
+             queue: default
+         roles:
+           - name: prefill
+             replicas: 2
+             podGroupSize: 2
+             template:
+               spec:
+                 schedulerName: volcano
+                 containers:
+                   - name: prefill
+                     image: example/sglang:latest
+           - name: decode
+             replicas: 3
+             podGroupSize: 2
+             template:
+               spec:
+                 schedulerName: volcano
+                 containers:
+                   - name: decode
+                     image: example/sglang:latest
+
+Role-level ``minTaskMember``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``minTaskMember`` adds per-task minimums inside the same Volcano PodGroup. In a
+StormService-created RoleSet, each role becomes a Volcano task, so the map keys
+are role names such as ``prefill`` and ``decode``.
+
+The following multi-node shape shows how ``minTaskMember`` applies to the Pods
+inside each role's PodSet. The YAML after the diagram keeps the same
+multi-node shape and requires all Pods from the two Prefill PodSets and at
+least one Decode PodSet worth of Pods before the PodGroup is considered ready
+for task-level admission.
+
+.. code-block:: text
+
+   minTaskMember gates Pods by Volcano task, which AIBrix derives from the
+   StormService role name.
+
+   +-----------------------------------------------------------+
+   | StormService: sglang-pd                                   |
+   | replicas: 1                                               |
+   +-----------------------------------------------------------+
+   | RoleSet-0                                                 |
+   |   Volcano PodGroup: RoleSet-0                             |
+   |   minMember: 6                                            |
+   |   minTaskMember: prefill=4, decode=2                      |
+   |                                                           |
+   |   role: prefill, replicas: 2, podGroupSize: 2             |
+   |   volcano.sh/task-spec=prefill                            |
+   |     +---------------------+                               |
+   |     | PodSet prefill-0    |                               |
+   |     |  Pod prefill-0-0    |                               |
+   |     |  Pod prefill-0-1    |                               |
+   |     +---------------------+                               |
+   |     +---------------------+                               |
+   |     | PodSet prefill-1    |                               |
+   |     |  Pod prefill-1-0    |                               |
+   |     |  Pod prefill-1-1    |                               |
+   |     +---------------------+                               |
+   |                                                           |
+   |   role: decode, replicas: 3, podGroupSize: 2              |
+   |   volcano.sh/task-spec=decode                             |
+   |     +---------------------+                               |
+   |     | PodSet decode-0     |                               |
+   |     |  Pod decode-0-0     |                               |
+   |     |  Pod decode-0-1     |                               |
+   |     +---------------------+                               |
+   |     +---------------------+                               |
+   |     | PodSet decode-1     |                               |
+   |     |  Pod decode-1-0     |                               |
+   |     |  Pod decode-1-1     |                               |
+   |     +---------------------+                               |
+   |     +---------------------+                               |
+   |     | PodSet decode-2     |                               |
+   |     |  Pod decode-2-0     |                               |
+   |     |  Pod decode-2-1     |                               |
+   |     +---------------------+                               |
+   +-----------------------------------------------------------+
+
+   Volcano must satisfy both the total PodGroup gate and the per-task gates:
+   at least 6 Pods total, including 4 prefill Pods and 2 decode Pods from the
+   PodSets.
+
+.. code-block:: yaml
+
+   apiVersion: orchestration.aibrix.ai/v1alpha1
+   kind: StormService
+   metadata:
+     name: sglang-pd
+   spec:
+     replicas: 1
+     selector:
+       matchLabels:
+         app: sglang-pd
+     template:
+       metadata:
+         labels:
+           app: sglang-pd
+       spec:
+         schedulingStrategy:
+           volcanoSchedulingStrategy:
+             minMember: 6
+             minTaskMember:
+               prefill: 4
+               decode: 2
+             queue: default
+         roles:
+           - name: prefill
+             replicas: 2
+             podGroupSize: 2
+             template:
+               spec:
+                 schedulerName: volcano
+                 containers:
+                   - name: prefill
+                     image: example/sglang:latest
+           - name: decode
+             replicas: 3
+             podGroupSize: 2
+             template:
+               spec:
+                 schedulerName: volcano
+                 containers:
+                   - name: decode
+                     image: example/sglang:latest
+
+``minTaskMember`` counts Pods, not logical role replicas. If a role uses
+``podGroupSize`` greater than 1 for multi-pod replicas, translate replica
+minimums into Pod counts yourself. For example, if each Prefill replica has two
+Pods and the desired minimum is two Prefill replicas, set
+``minTaskMember.prefill`` to ``4``.
+
+RoleSet-level and per-role scheduling
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set ``spec.template.spec.schedulingStrategy`` on StormService when the whole
+generated RoleSet should share one PodGroup. This is the common setting for
+PD-disaggregated serving, because Prefill and Decode Pods are admitted as one
+service replica.
+
+Set ``spec.template.spec.roles[].schedulingStrategy`` only when a specific role
+needs its own scheduling strategy. For roles that use ``podGroupSize > 1``, the
+controller creates PodSet resources for the role, and a role-level scheduling
+strategy applies to those PodSets instead of the whole RoleSet. Do not set
+``spec.template.spec.schedulingStrategy`` together with any
+``spec.template.spec.roles[].schedulingStrategy`` entry; RoleSet-level and
+role-level scheduling strategies are mutually exclusive.
+
+Scheduler and limitations
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set each Pod template's ``schedulerName`` to the scheduler that should consume
+the selected PodGroup. The Volcano examples set ``schedulerName: volcano``
+explicitly so the scheduling intent is visible in the StormService manifest.
+AIBrix also defaults generated Pods and PodSet Pods to the Volcano scheduler
+when it attaches them to a Volcano PodGroup, but keeping the field explicit
+makes the configuration easier to review and debug. For Godel or
+Coscheduling, use the scheduler name installed in your cluster.
+
+``minTaskMember`` is not the same as Volcano ``subGroupPolicy``. AIBrix exposes
+Volcano ``minTaskMember`` as a simple per-task Pod-count minimum; it does not
+expose ``subGroupPolicy`` through the StormService API. If a workload needs
+subgroup semantics beyond per-role Pod counts, that behavior is outside the
+current StormService API.
+
+When using ``minTaskMember``, keep ``minMember`` greater than or equal to the
+sum of all ``minTaskMember`` values. If ``minMember`` is lower than that sum,
+the StormService and RoleSet webhooks reject the object as invalid because
+Volcano would otherwise ignore ``minTaskMember``. If validation is bypassed,
+AIBrix reports the same issue through the ``GangSchedulingError`` condition.
+
+
 Historical-Node Replacement Scheduling
 --------------------------------------
 


### PR DESCRIPTION
## Summary

- Add root-level AGENTS.md for repository-wide coding-agent guidance.
- Document repository layout, API compatibility surfaces, generated artifacts, verification commands, and PR expectations.
- Preserve python/aibrix/AGENTS.md as the more specific guidance for that subtree.

## Test Plan

- [x] git diff --check
- [x] Confirmed the commit contains only AGENTS.md

No code behavior changed.