### PR TITLE
fix(telemetry): propagate PD routing traces

### DIFF
--- a/cmd/plugins/main.go
+++ b/cmd/plugins/main.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/filters"
 	_ "go.uber.org/automaxprocs"
 	"google.golang.org/grpc"
 	"k8s.io/client-go/kubernetes"
@@ -200,7 +201,13 @@ func main() {
 		if err != nil || telApp == nil {
 			klog.Fatalf("Failed to initialize OpenTelemetry: %v", err)
 		}
-		opts = append(opts, grpc.StatsHandler(otelgrpc.NewServerHandler()))
+		opts = append(opts, grpc.StatsHandler(
+			otelgrpc.NewServerHandler(
+				otelgrpc.WithFilter(
+					filters.Not(filters.HealthCheck()),
+				),
+			),
+		))
 	}
 
 	grpcMaxMessageSize := utils.LoadEnvInt(envGRPCMaxMessageSizeBytes, defaultGRPCMaxMessageSizeBytes)

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/tidwall/sjson v1.2.5
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.28.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0
@@ -84,6 +85,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lSh
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
@@ -336,6 +338,8 @@ github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0 h1:9G6E0TXzGFVfTnawRzrPl83iHOAV7L8NJiR8RSGYV1g=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0/go.mod h1:azvtTADFQJA8mX80jIH/akaE7h+dbm/sVuaHqN13w74=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 h1:4K4tsIXefpVJtvA/8srF4V4y0akAoPHkIslgAkjixJA=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0/go.mod h1:jjdQuTGVsXV4vSs+CJ2qYDeDPf9yIJV23qlIzBm73Vg=
 go.opentelemetry.io/otel v1.28.0 h1:/SqNcYk+idO0CxKEUOtKQClMK/MimZihKYMruSMViUo=
 go.opentelemetry.io/otel v1.28.0/go.mod h1:q68ijF8Fc8CnMHKyzqL6akLO46ePnjkgfIMIjUIX9z4=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 h1:3Q/xZUyC1BBkualc9ROb4G8qkH90LXEIICcs5zv1OYY=

--- a/pkg/plugins/gateway/algorithms/pd_disaggregation.go
+++ b/pkg/plugins/gateway/algorithms/pd_disaggregation.go
@@ -39,6 +39,7 @@ import (
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
 	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -295,15 +296,17 @@ func NewPDRouter() (types.Router, error) {
 	}
 	klog.InfoS("pd_router decode score policy", "policy", decodePol.Name(), "describe", decodePol.Describe())
 
-	// Create a shared HTTP client with connection pooling
+	// Create a shared HTTP client with connection pooling. otelhttp creates the
+	// prefill client span and injects its trace context into the outbound request.
+	transport := &http.Transport{
+		// TODO: tune settings later
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     90 * time.Second,
+	}
 	httpClient := &http.Client{
-		Timeout: time.Duration(prefillRequestTimeout) * time.Second,
-		Transport: &http.Transport{
-			// TODO: tune settings later
-			MaxIdleConns:        100,
-			MaxIdleConnsPerHost: 10,
-			IdleConnTimeout:     90 * time.Second,
-		},
+		Timeout:   time.Duration(prefillRequestTimeout) * time.Second,
+		Transport: otelhttp.NewTransport(transport),
 	}
 
 	r := &pdRouter{

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -549,7 +549,7 @@ func (s *Server) sendProcessingResponse(srv extProcPb.ExternalProcessor_ProcessS
 
 func (s *Server) selectTargetPod(ctx context.Context, routeCtx *types.RoutingContext, pods types.PodList, externalFilterExpr string) (string, error) {
 	var span trace.Span
-	_, span = tracer.Start(ctx, "process.select_target_pod")
+	ctx, span = tracer.Start(ctx, "process.select_target_pod")
 	defer span.End()
 
 	if pods.Len() == 0 {
@@ -608,6 +608,11 @@ func (s *Server) selectTargetPod(ctx context.Context, routeCtx *types.RoutingCon
 		return routeCtx.TargetAddress(), nil
 	}
 	utils.CryptoShuffle(readyPods)
+	// PD issues an additional HTTP request while routing. Pass the current span
+	// to that request without changing Context semantics for other routers.
+	if routeCtx.Algorithm == routing.RouterPD {
+		routeCtx.Context = ctx
+	}
 	return router.Route(routeCtx, &utils.PodArray{Pods: readyPods})
 }
 

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -610,7 +610,7 @@ func (s *Server) selectTargetPod(ctx context.Context, routeCtx *types.RoutingCon
 	utils.CryptoShuffle(readyPods)
 	// PD issues an additional HTTP request while routing. Pass the current span
 	// to that request without changing Context semantics for other routers.
-	if routeCtx.Algorithm == routing.RouterPD {
+	if isExclusive && resolvedExclusive == string(routing.RouterPD) {
 		routeCtx.Context = ctx
 	}
 	return router.Route(routeCtx, &utils.PodArray{Pods: readyPods})


### PR DESCRIPTION
- Filter gRPC health checks from plugin server telemetry in cmd/plugins to avoid noisy spans from routine probes
- Wrap the PD prefill HTTP client transport with otelhttp so outbound requests create spans and carry trace context
- Preserve the select_target_pod span context for PD routing in gateway so prefill requests attach to the active routing trace

## Pull Request Description

This PR connects prefill requests in PD-disaggregated inference to the gateway's existing OpenTelemetry trace.

Previously, the gateway's secondary HTTP request to the prefill pod was sent without HTTP client instrumentation, so the prefill service could start a disconnected trace. The PD prefill client now uses `otelhttp.NewTransport`, which automatically creates an HTTP client span, injects the configured propagation headers, and records HTTP status and transport errors.

<img width="582" height="611" alt="image" src="https://github.com/user-attachments/assets/e112a6b2-30b7-427b-a80a-ea22ba4e7f8f" />


The routing span context is passed to `RoutingContext` only for the PD router, keeping the context semantics of all other routing algorithms unchanged. This also works for asynchronous SGLang prefill requests because their detached context retains tracing values while allowing the prefill handshake to continue after the original request context is cancelled.

The resulting trace hierarchy is:

```text
ext_proc server span
└── process.handle_request_body
    └── process.select_target_pod
        └── HTTP POST (prefill client)
            └── llm_request.prefill
original_destination_cluster
└── llm_request.decode
```

This PR also filters gRPC health-check RPCs from server instrumentation to reduce high-frequency, low-value trace noise.

### Changes

- Wrap the shared PD prefill HTTP transport with OpenTelemetry HTTP instrumentation.
- Propagate the active routing span only through the PD routing path.
- Support both synchronous and asynchronous prefill requests without manual span lifecycle management.
- Exclude gRPC health-check calls from gateway server tracing.
- Add the version-aligned `otelhttp` dependency.

### Compatibility and risk

- No public API or configuration changes.
- Non-PD routing algorithms retain their existing context behavior.
- Existing HTTP connection-pooling and timeout settings are preserved.
- When OpenTelemetry is not configured, the instrumentation uses the global no-op provider.

## Related Issues

N/A

## Testing

- [x] Ran `gofmt` on the modified Go files.
- [x] Ran `git diff --check`.
- [x] Run targeted gateway and PD router tests in an environment
- [x] Validate an end-to-end PD trace with OpenTelemetry enabled, covering both synchronous prefill and asynchronous SGLang prefill.

- vllm (please ignore the wrong tag in trace)

<img width="2550" height="1233" alt="image_1789005660190" src="https://github.com/user-attachments/assets/55e432b9-f63f-4b3c-b0cb-a2134fb9db78" />


- sglang
<img width="2550" height="1233" alt="image_1789010196055" src="https://github.com/user-attachments/assets/1d132bb0-302b-40ce-b3d3-9e3edf553bab" />
