### PR TITLE
[Bug] Reject non-positive durations in LoadEnvDuration

### DIFF
--- a/pkg/plugins/gateway/ENV_VARS.md
+++ b/pkg/plugins/gateway/ENV_VARS.md
@@ -2,6 +2,8 @@
 
 This document covers all environment variables used in the `pkg/plugins/gateway` package and its sub-packages.
 
+Variables of type `duration` are parsed with Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration), so they need a unit: `30s`, `5m`, `1h30m`. A bare number such as `30`, or a zero or negative duration such as `0s` or `-1s`, is rejected with a warning and the default is used instead.
+
 ---
 
 ## General Gateway

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -152,11 +152,14 @@ func LoadEnvBool(key string, defaultValue bool) bool {
 }
 
 // LoadEnvDuration loads a duration environment variable or returns a default value if not set.
+// Like LoadEnvInt and LoadEnvFloat, it rejects non-positive values. The result is used as a
+// period, TTL or timeout, where zero or a negative value does not mean "off": it either makes
+// a time.After-based loop spin without waiting or silently skips work gated on a positive period.
 func LoadEnvDuration(key string, defaultValue time.Duration) time.Duration {
 	value := os.Getenv(key)
 	if value != "" {
 		duration, err := time.ParseDuration(value)
-		if err != nil {
+		if err != nil || duration <= 0 {
 			klog.Warningf("invalid %s: %s, falling back to default: %v", key, value, defaultValue)
 		} else {
 			klog.Infof("set %s: %v", key, duration)

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pkoukk/tiktoken-go"
 	tiktoken_loader "github.com/pkoukk/tiktoken-go-loader"
@@ -101,4 +102,34 @@ func TestShuffle(t *testing.T) {
 		}
 		wg.Wait()
 	})
+}
+
+func TestLoadEnvDuration(t *testing.T) {
+	const key = "AIBRIX_TEST_LOAD_ENV_DURATION"
+	const def = 10 * time.Second
+
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{name: "unset uses default", value: "", want: def},
+		{name: "seconds", value: "45s", want: 45 * time.Second},
+		{name: "compound duration", value: "1m30s", want: 90 * time.Second},
+		{name: "sub-second", value: "250ms", want: 250 * time.Millisecond},
+		{name: "unparsable uses default", value: "soon", want: def},
+		{name: "missing unit uses default", value: "30", want: def},
+		// time.ParseDuration accepts a bare "0" without a unit, so it has to be
+		// rejected by the positivity check rather than by the parser.
+		{name: "bare zero uses default", value: "0", want: def},
+		{name: "zero uses default", value: "0s", want: def},
+		{name: "negative uses default", value: "-1s", want: def},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(key, tt.value)
+			assert.Equal(t, tt.want, LoadEnvDuration(key, def))
+		})
+	}
 }


### PR DESCRIPTION
## Pull Request Description

`LoadEnvInt` and `LoadEnvFloat` fall back to the default for zero and negative values, but `LoadEnvDuration` only checked for parse errors. So `0s`, `-1s` and a bare `0` (which `time.ParseDuration` accepts without a unit) were returned as-is. All four callers use the value as a period, TTL or timeout:

- `AIBRIX_STATESYNC_SYNC_PERIOD`: `syncLoop` waits on `time.After` with a non-positive interval, so each gateway replica syncs against Redis back to back. Against miniredis this was 3,868 commands in 500ms with `0s` and 3,972 with `-1s`, versus 0 after this change.
- `AIBRIX_TOKENIZER_HEALTH_CHECK_PERIOD`: fails the `> 0` guard in `NewTokenizerPool`, so the health checker and stale tokenizer cleanup never start.
- `AIBRIX_TOKENIZER_TTL`: every cleanup pass evicts every tokenizer.
- `AIBRIX_TOKENIZER_REQUEST_TIMEOUT`: `validateRemoteConfig` replaces a non-positive value with its own 30s default rather than the documented 5s.

## Changes

- `LoadEnvDuration` rejects `duration <= 0` with the same warning and fallback as `LoadEnvInt` / `LoadEnvFloat`.
- Table-driven `TestLoadEnvDuration`, including bare `0`, `0s` and `-1s`.
- `ENV_VARS.md` documents the expected format for `duration` variables.

Behavior change: `AIBRIX_TOKENIZER_REQUEST_TIMEOUT=0s` now resolves to 5s instead of 30s.

## Tests

- `go test ./pkg/utils/... ./pkg/plugins/gateway/...` passes.
- With the `util.go` change reverted, the bare `0`, `0s` and `-1s` cases fail.

## Related Issues

Follow-up to #2694.
