### PR TITLE
[Docs] Add Simplified Chinese catalogs and a navbar language switcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ dist/
 
 # Sphinx documentation
 docs/build/
+docs/source/locale/**/*.mo
 !**/*.template.rst
 
 # benchmark logs, result and figs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,14 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+html-zh:
+	@$(SPHINXBUILD) -b html -D language=zh_CN "$(SOURCEDIR)" "$(BUILDDIR)/zh-cn" $(SPHINXOPTS) $(O)
+
+update-po:
+	@$(SPHINXBUILD) -M gettext "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	sphinx-intl update -p "$(BUILDDIR)/gettext" -d "$(SOURCEDIR)/locale" -l zh_CN
+
+.PHONY: help html-zh update-po Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,15 @@ make html
 ```
 
 Now the html paged should be generated at "docs/build/html/index.html". You can open this html page with your web browser as our project front page.
+
+Chinese catalogs are under `source/locale/zh_CN`. After English RST changes:
+
+```
+make update-po
+```
+
+Preview Chinese HTML at `docs/build/zh-cn`:
+
+```
+make html-zh
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ pip install -r requirements-docs.txt
 make html
 ```
 
-Now the html paged should be generated at "docs/build/html/index.html". You can open this html page with your web browser as our project front page.
+Now the html pages should be generated at "docs/build/html/index.html". You can open this html page with your web browser as our project front page.
 
 Chinese catalogs are under `source/locale/zh_CN`. After English RST changes:
 
@@ -26,3 +26,15 @@ Preview Chinese HTML at `docs/build/zh-cn`:
 ```
 make html-zh
 ```
+
+To exercise the English / 中文 navbar switcher locally, serve the `docs/build` directory over HTTP (opening `file://` pages also works after the switcher fix, but an HTTP server matches Read the Docs more closely):
+
+```
+python -m http.server -d build 8000
+```
+
+Then open `http://127.0.0.1:8000/html/` and `http://127.0.0.1:8000/zh-cn/`.
+
+### Read the Docs Chinese project
+
+Hosted Chinese pages need a separate Read the Docs project (same repo, language **Chinese Simplified**) linked from the main project's **Translations** settings. After that project builds successfully, set `AIBRIX_DOCS_SHOW_ZH=1` in the main project's RTD environment variables so the navbar offers 中文 on English pages.

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -7,3 +7,5 @@ sphinxemoji==0.3.1
 sphinx-autodoc-typehints==2.4.1
 sphinx_design==0.6.1
 sphinxcontrib-mermaid==1.0.0
+jieba==0.42.1
+sphinx-intl==2.3.2

--- a/docs/source/_static/language-switcher.css
+++ b/docs/source/_static/language-switcher.css
@@ -1,0 +1,11 @@
+.aibrix-lang-switcher {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.75rem;
+}
+
+.aibrix-lang-switcher select {
+  font-size: 0.9rem;
+  line-height: 1.4;
+  padding: 0.15rem 0.35rem;
+}

--- a/docs/source/_static/language-switcher.js
+++ b/docs/source/_static/language-switcher.js
@@ -6,8 +6,18 @@
     return "html";
   }
 
+  // Prefer RTD language prefixes and Sphinx local build dirs so we do not
+  // rewrite unrelated path segments that happen to contain "html" or "en".
   function rewritePath(path, slugs, target) {
     var dest = target === "en" ? englishSegment(path) : target;
+    var rtdMatch = path.match(/^\/([^/]+)\//);
+    if (rtdMatch && slugs.indexOf(rtdMatch[1]) !== -1) {
+      return path.replace(/^\/[^/]+\//, "/" + dest + "/");
+    }
+    var localMatch = path.match(/\/build\/([^/]+)\//);
+    if (localMatch && slugs.indexOf(localMatch[1]) !== -1) {
+      return path.replace(/\/build\/[^/]+\//, "/build/" + dest + "/");
+    }
     var re = new RegExp("/(" + slugs.join("|") + ")/");
     if (re.test(path)) {
       return path.replace(re, "/" + dest + "/");
@@ -16,6 +26,14 @@
       return path.replace(/^\//, "/" + dest + "/");
     }
     return path;
+  }
+
+  function switchUrl(loc, path) {
+    // file:// pages report origin as the string "null"; preserve the scheme.
+    if (loc.protocol === "file:") {
+      return "file://" + path + loc.search + loc.hash;
+    }
+    return loc.origin + path + loc.search + loc.hash;
   }
 
   function init() {
@@ -33,7 +51,7 @@
       select.addEventListener("change", function () {
         var loc = window.location;
         loc.assign(
-          loc.origin + rewritePath(loc.pathname, slugs, select.value) + loc.search + loc.hash
+          switchUrl(loc, rewritePath(loc.pathname, slugs, select.value))
         );
       });
     });

--- a/docs/source/_static/language-switcher.js
+++ b/docs/source/_static/language-switcher.js
@@ -1,0 +1,47 @@
+(function () {
+  function englishSegment(path) {
+    if (/readthedocs/.test(window.location.host) || /\/en\//.test(path)) {
+      return "en";
+    }
+    return "html";
+  }
+
+  function rewritePath(path, slugs, target) {
+    var dest = target === "en" ? englishSegment(path) : target;
+    var re = new RegExp("/(" + slugs.join("|") + ")/");
+    if (re.test(path)) {
+      return path.replace(re, "/" + dest + "/");
+    }
+    if (dest !== "en" && dest !== "html") {
+      return path.replace(/^\//, "/" + dest + "/");
+    }
+    return path;
+  }
+
+  function init() {
+    var selects = document.querySelectorAll(".aibrix-lang-switcher select");
+    if (!selects.length) {
+      return;
+    }
+
+    var slugs = Array.prototype.map.call(selects[0].options, function (option) {
+      return option.value;
+    });
+    slugs.push("html");
+
+    Array.prototype.forEach.call(selects, function (select) {
+      select.addEventListener("change", function () {
+        var loc = window.location;
+        loc.assign(
+          loc.origin + rewritePath(loc.pathname, slugs, select.value) + loc.search + loc.hash
+        );
+      });
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/docs/source/_templates/language-switcher.html
+++ b/docs/source/_templates/language-switcher.html
@@ -1,0 +1,7 @@
+<label class="aibrix-lang-switcher">
+  <select aria-label="Language">
+    {% for lang in docs_languages %}
+      <option value="{{ lang.slug }}"{% if lang.id == docs_language %} selected{% endif %}>{{ lang.label }}</option>
+    {% endfor %}
+  </select>
+</label>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,19 @@ extensions = [
 ]
 
 templates_path = ['_templates']
-exclude_patterns = []
+exclude_patterns = ['locale']
+
+# -- Internationalization ----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/advanced/intl.html
+locale_dirs = ['locale/']
+gettext_compact = False
+
+html_context = {
+    'docs_languages': [
+        {'id': 'en', 'slug': 'en', 'label': 'English'},
+        {'id': 'zh_CN', 'slug': 'zh-cn', 'label': '中文'},
+    ],
+}
 
 # Exclude the prompt "$" when copying code
 copybutton_prompt_text = r"\$ "
@@ -44,6 +56,8 @@ html_title = project
 html_theme = 'sphinx_book_theme'
 html_logo = 'assets/logos/aibrix-logo.jpeg'
 html_static_path = ['_static']
+html_css_files = ['language-switcher.css']
+html_js_files = ['language-switcher.js']
 html_theme_options = {
     # repository level setting
     'repository_url': 'https://github.com/vllm-project/aibrix',
@@ -65,6 +79,7 @@ html_theme_options = {
     ],
     'navigation_depth': 3,
     'primary_sidebar_end': [],
+    'navbar_end': ['language-switcher', 'theme-switcher', 'navbar-icon-links'],
 
     # article
 
@@ -80,3 +95,13 @@ intersphinx_mapping = {
     "pillow": ("https://pillow.readthedocs.io/en/stable", None),
     "psutil": ("https://psutil.readthedocs.io/en/stable", None),
 }
+
+
+def setup(app):
+    def on_config(app, config):
+        zh = (config.language or '').replace('-', '_').lower() in ('zh_cn', 'zh')
+        config.language = 'zh_CN' if zh else 'en'
+        config.html_search_language = 'zh' if zh else 'en'
+        config.html_context['docs_language'] = config.language
+
+    app.connect('config-inited', on_config)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,6 +3,8 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
@@ -37,11 +39,40 @@ exclude_patterns = ['locale']
 locale_dirs = ['locale/']
 gettext_compact = False
 
+_EN_LANGUAGE = {'id': 'en', 'slug': 'en', 'label': 'English'}
+_ZH_LANGUAGE = {'id': 'zh_CN', 'slug': 'zh-cn', 'label': '中文'}
+
+
+def _is_zh_language(language):
+    return (language or '').replace('-', '_').lower() in ('zh_cn', 'zh')
+
+
+def _env_flag(name):
+    return os.environ.get(name, '').strip().lower() in ('1', 'true', 'yes')
+
+
+def _docs_languages(language):
+    """Languages shown in the navbar switcher.
+
+    Chinese is always available for local builds. On Read the Docs English
+    builds it stays hidden until a zh-CN translation project is linked and
+    ``AIBRIX_DOCS_SHOW_ZH=1`` is set on the main project, so the switcher does
+    not send users to missing ``/zh-cn/`` pages.
+    """
+    languages = [_EN_LANGUAGE]
+    on_rtd = os.environ.get('READTHEDOCS') == 'True'
+    show_zh = (
+        not on_rtd
+        or _is_zh_language(language)
+        or _env_flag('AIBRIX_DOCS_SHOW_ZH')
+    )
+    if show_zh:
+        languages.append(_ZH_LANGUAGE)
+    return languages
+
+
 html_context = {
-    'docs_languages': [
-        {'id': 'en', 'slug': 'en', 'label': 'English'},
-        {'id': 'zh_CN', 'slug': 'zh-cn', 'label': '中文'},
-    ],
+    'docs_languages': _docs_languages(None),
 }
 
 # Exclude the prompt "$" when copying code
@@ -99,9 +130,13 @@ intersphinx_mapping = {
 
 def setup(app):
     def on_config(app, config):
-        zh = (config.language or '').replace('-', '_').lower() in ('zh_cn', 'zh')
-        config.language = 'zh_CN' if zh else 'en'
-        config.html_search_language = 'zh' if zh else 'en'
+        if _is_zh_language(config.language):
+            config.language = 'zh_CN'
+            config.html_search_language = 'zh'
+        elif not config.language:
+            config.language = 'en'
+            config.html_search_language = 'en'
         config.html_context['docs_language'] = config.language
+        config.html_context['docs_languages'] = _docs_languages(config.language)
 
     app.connect('config-inited', on_config)

--- a/docs/source/locale/zh_CN/LC_MESSAGES/community/community.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/community/community.po
@@ -1,0 +1,311 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/community/community.rst:5
+msgid "Community"
+msgstr "社区"
+
+#: ../../source/community/community.rst:8
+msgid "AIBrix Slack Channels"
+msgstr "AIBrix Slack 频道"
+
+#: ../../source/community/community.rst:10
+msgid ""
+"We use the vLLM Slack `#AIBrix <https://vllm-"
+"dev.slack.com/archives/C08EQ883CSV>`_ for informal discussions among "
+"users and contributors. Join the channels to start conversations and get "
+"support from the community."
+msgstr ""
+"我们使用 vLLM Slack `#AIBrix <https://vllm-"
+"dev.slack.com/archives/C08EQ883CSV>`_ 供用户和贡献者进行非正式讨论。"
+"加入频道即可发起交流，并从社区获得支持。"
+
+#: ../../source/community/community.rst:15
+msgid "AiBrix Mailing List"
+msgstr "AIBrix 邮件列表"
+
+#: ../../source/community/community.rst:17
+msgid ""
+"The official AIBrix mailing list is hosted on Google Groups at "
+"`maintainers@aibrix.ai <maintainers@aibrix.ai>`_."
+msgstr ""
+"官方 AIBrix 邮件列表托管在 Google Groups，地址为 `maintainers@aibrix.ai <maintainers@aibrix.ai>`_ "
+"。"
+
+#: ../../source/community/community.rst:21
+msgid "Becoming a Maintainer"
+msgstr "成为维护者"
+
+#: ../../source/community/community.rst:23
+msgid ""
+"We appreciate contributors who consistently help improve AIBrix. If "
+"you’ve been actively contributing, consider becoming a **Maintainer** — a"
+" role with broader responsibilities and deeper involvement in the "
+"project."
+msgstr ""
+"我们感谢持续帮助改进 AIBrix 的贡献者。如果你一直在积极贡献，可以考虑成为 **维护者** —"
+" 该角色承担更广的职责，并更深入地参与项目。"
+
+#: ../../source/community/community.rst:26
+msgid "What is a Maintainer?"
+msgstr "什么是维护者？"
+
+#: ../../source/community/community.rst:28
+msgid ""
+"Maintainers play a key role in keeping AIBrix healthy and growing. They "
+"help with:"
+msgstr "维护者在保持 AIBrix 健康发展和持续成长方面起着关键作用。他们协助："
+
+#: ../../source/community/community.rst:30
+msgid "Reviewing and merging Pull Requests"
+msgstr "审查并合并 Pull Request"
+
+#: ../../source/community/community.rst:31
+msgid "Triaging issues and managing labels"
+msgstr "分流 issue 并管理标签"
+
+#: ../../source/community/community.rst:32
+msgid "Shaping the project roadmap and priorities"
+msgstr "规划项目路线图与优先级"
+
+#: ../../source/community/community.rst:33
+msgid "Supporting new contributors and community members"
+msgstr "支持新贡献者和社区成员"
+
+#: ../../source/community/community.rst:34
+msgid "Ensuring code quality and consistency across the codebase"
+msgstr "确保代码库的代码质量与一致性"
+
+#: ../../source/community/community.rst:37
+msgid "Promotion Criteria"
+msgstr "晋升标准"
+
+#: ../../source/community/community.rst:39
+msgid ""
+"We promote contributors to maintainers based on merit and sustained "
+"contribution. Here's what we look for:"
+msgstr "我们基于贡献质量与持续性将贡献者晋升为维护者。我们关注以下几点："
+
+#: ../../source/community/community.rst:41
+msgid ""
+"**Consistent Contributions**: You’ve submitted several high-quality PRs "
+"(code or docs) that have been merged."
+msgstr "**持续贡献** ：你已提交并合并了若干高质量 PR（代码或文档）。"
+
+#: ../../source/community/community.rst:42
+msgid ""
+"**Helpful Reviews**: You’ve reviewed and commented constructively on "
+"other contributors' PRs."
+msgstr "**有帮助的审查** ：你对其他贡献者的 PR 进行过审查并给出建设性意见。"
+
+#: ../../source/community/community.rst:43
+msgid ""
+"**Community Engagement**: You actively participate in GitHub issues, "
+"Slack discussions, or RFC reviews."
+msgstr "**社区参与** ：你积极参与 GitHub issue、Slack 讨论或 RFC 评审。"
+
+#: ../../source/community/community.rst:44
+msgid ""
+"**Responsibility and Ownership**: You demonstrate initiative in "
+"identifying problems and proposing improvements."
+msgstr "**责任感与主人翁意识** ：你主动发现问题并提出改进。"
+
+#: ../../source/community/community.rst:46
+msgid ""
+"There is no strict rule on the number of contributions — we evaluate "
+"holistically."
+msgstr "对贡献数量没有硬性规定 — 我们进行综合评估。"
+
+#: ../../source/community/community.rst:49
+msgid "How to Become a Maintainer"
+msgstr "如何成为维护者"
+
+#: ../../source/community/community.rst:51
+msgid ""
+"If you meet the above criteria and are interested in taking on the "
+"maintainer role:"
+msgstr "如果你满足上述条件，并有意承担维护者职责："
+
+#: ../../source/community/community.rst:53
+msgid "Let us know! You can:"
+msgstr "请告知我们！你可以："
+
+#: ../../source/community/community.rst:55
+msgid "Open a GitHub discussion or issue to express interest."
+msgstr "开启 GitHub discussion 或 issue 表达意向。"
+
+#: ../../source/community/community.rst:56
+msgid ""
+"Reach out to existing maintainers in Slack `#AIBrix <https://vllm-"
+"dev.slack.com/archives/C08EQ883CSV>`_ or by `maintainers@aibrix.ai "
+"<maintainers@aibrix.ai>`_ ."
+msgstr ""
+"在 Slack `#AIBrix <https://vllm-"
+"dev.slack.com/archives/C08EQ883CSV>`_ 联系现有维护者，或发送邮件至 "
+"`maintainers@aibrix.ai <maintainers@aibrix.ai>`_ 。"
+
+#: ../../source/community/community.rst:58
+msgid ""
+"We'll initiate a lightweight evaluation based on your recent "
+"contributions, engagement, and readiness to take on responsibilities."
+msgstr "我们将根据你近期的贡献、参与度以及承担责任的准备情况，进行一次轻量评估。"
+
+#: ../../source/community/community.rst:60
+msgid "Once approved, we'll:"
+msgstr "获批后，我们将："
+
+#: ../../source/community/community.rst:62
+msgid "Grant you write access to the repository."
+msgstr "授予你仓库写权限。"
+
+#: ../../source/community/community.rst:63
+msgid "Add you to the `@aibrix-maintainers` team."
+msgstr "将你加入 `@aibrix-maintainers` 团队。"
+
+#: ../../source/community/community.rst:64
+msgid "Invite you to internal roadmap discussions if applicable."
+msgstr "在适用情况下邀请你参加内部路线图讨论。"
+
+#: ../../source/community/community.rst:66
+msgid ""
+"Open source is a marathon, not a sprint. If you ever need to step back "
+"temporarily or permanently:"
+msgstr "开源是一场马拉松，而不是冲刺。如果你需要暂时或永久退出："
+
+#: ../../source/community/community.rst:68
+msgid "Just let us know — no hard feelings."
+msgstr "只需告知我们 — 完全没有关系。"
+
+#: ../../source/community/community.rst:69
+msgid "You can always return when you're ready."
+msgstr "准备好后随时可以回来。"
+
+#: ../../source/community/community.rst:71
+msgid "Thank you for helping us grow AIBrix together!"
+msgstr "感谢你与我们一起推动 AIBrix 成长！"
+
+#: ../../source/community/community.rst:75
+msgid "Maintainers & Areas of Focus"
+msgstr "维护者与关注领域"
+
+#: ../../source/community/community.rst:77
+msgid ""
+"For technical support or collaborative development, feel free to @mention"
+" the corresponding maintainers:"
+msgstr "如需技术支持或协作开发，欢迎 @mention 对应维护者："
+
+#: ../../source/community/community.rst:80
+msgid "Maintainers"
+msgstr "维护者"
+
+#: ../../source/community/community.rst:80
+#: ../../source/community/community.rst:102
+msgid "Focus Areas"
+msgstr "关注领域"
+
+#: ../../source/community/community.rst:82
+msgid "`@Jeffwan <https://github.com/Jeffwan>`_"
+msgstr "`@Jeffwan <https://github.com/Jeffwan>`_"
+
+#: ../../source/community/community.rst:82
+msgid "Overall architecture and orchestration"
+msgstr "整体架构与编排"
+
+#: ../../source/community/community.rst:84
+msgid "`@varungup90 <https://github.com/varungup90>`_"
+msgstr "`@varungup90 <https://github.com/varungup90>`_"
+
+#: ../../source/community/community.rst:84
+msgid "Gateway architecture and routing algorithms"
+msgstr "网关架构与路由算法"
+
+#: ../../source/community/community.rst:86
+msgid "`@DwyaneShi <https://github.com/DwyaneShi>`_"
+msgstr "`@DwyaneShi <https://github.com/DwyaneShi>`_"
+
+#: ../../source/community/community.rst:86
+msgid "KVCache Offloading, Disaggregation"
+msgstr "KVCache Offloading、Disaggregation"
+
+#: ../../source/community/community.rst:88
+msgid "`@zhangjyr <https://github.com/zhangjyr>`_"
+msgstr "`@zhangjyr <https://github.com/zhangjyr>`_"
+
+#: ../../source/community/community.rst:88
+msgid "Heterogenous and routing"
+msgstr "异构与路由"
+
+#: ../../source/community/community.rst:90
+msgid "`@happyandslow <https://github.com/happyandslow>`_"
+msgstr "`@happyandslow <https://github.com/happyandslow>`_"
+
+#: ../../source/community/community.rst:90
+msgid "Benchmark and research collaboration"
+msgstr "基准测试与研究合作"
+
+#: ../../source/community/community.rst:92
+msgid "`@nwangfw <https://github.com/nwangfw>`_"
+msgstr "`@nwangfw <https://github.com/nwangfw>`_"
+
+#: ../../source/community/community.rst:92
+msgid "Autoscaling"
+msgstr "Autoscaling"
+
+#: ../../source/community/community.rst:94
+msgid "`@xunzhuo <https://github.com/xunzhuo>`_"
+msgstr "`@xunzhuo <https://github.com/xunzhuo>`_"
+
+#: ../../source/community/community.rst:94
+msgid "Gateway architecture and routing performance"
+msgstr "网关架构与路由性能"
+
+#: ../../source/community/community.rst:96
+msgid "`@googs1025 <https://github.com/googs1025>`_"
+msgstr "`@googs1025 <https://github.com/googs1025>`_"
+
+#: ../../source/community/community.rst:96
+msgid "Control Plane Features and Stability"
+msgstr "控制面功能与稳定性"
+
+#: ../../source/community/community.rst:99
+msgid ""
+"Emeritus Maintainers will also participate in design reviews, feel free "
+"to @mention them if needed."
+msgstr "荣誉维护者也会参与设计评审，如有需要可随时 @mention 他们。"
+
+#: ../../source/community/community.rst:102
+msgid "Emeritus Maintainers"
+msgstr "荣誉维护者"
+
+#: ../../source/community/community.rst:104
+msgid "`@brosoul <https://github.com/brosoul>`_"
+msgstr "`@brosoul <https://github.com/brosoul>`_"
+
+#: ../../source/community/community.rst:104
+msgid "AI runtime and model loading acceleration"
+msgstr "AI Runtime 与模型加载加速"
+
+#: ../../source/community/community.rst:106
+msgid "`@kr11 <https://github.com/kr11>`_"
+msgstr "`@kr11 <https://github.com/kr11>`_"
+
+#: ../../source/community/community.rst:106
+msgid "Autoscaling algorithms"
+msgstr "自动扩缩容算法"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/community/contribution.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/community/contribution.po
@@ -1,0 +1,239 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/community/contribution.rst:5
+msgid "Contribution"
+msgstr "贡献指南"
+
+#: ../../source/community/contribution.rst:7
+msgid ""
+"This document serves as the definitive guide for contributing to the "
+"codebase. We welcome your patches and contributions to the project and "
+"appreciate your support."
+msgstr ""
+"本文档是向代码库贡献的权威指南。我们欢迎你提交补丁并为项目做贡献，感谢你的支持。"
+
+#: ../../source/community/contribution.rst:9
+msgid "To ensure a smooth process, please follow a few simple guidelines."
+msgstr "为确保流程顺畅，请遵循以下简单规范。"
+
+#: ../../source/community/contribution.rst:13
+msgid "Getting Started"
+msgstr "入门"
+
+#: ../../source/community/contribution.rst:15
+msgid ""
+"Please make sure to read and observe our `Code of Conduct "
+"<https://github.com/vllm-project/aibrix/blob/main/CODE_OF_CONDUCT.md>`_."
+msgstr ""
+"请务必阅读并遵守我们的 `行为准则 <https://github.com/vllm-project/aibrix/blob/main/CODE_OF_CONDUCT.md>`_ "
+"。"
+
+#: ../../source/community/contribution.rst:19
+msgid "Make your first contribution"
+msgstr "完成你的第一次贡献"
+
+#: ../../source/community/contribution.rst:22
+msgid "Find something to start with"
+msgstr "找一个切入点"
+
+#: ../../source/community/contribution.rst:24
+msgid ""
+"Help is always welcome! For example, documentation can always use "
+"improvement. There’s always code that can be clarified and variables or "
+"functions that can be renamed or commented. There’s always a need for "
+"more test coverage. You get the idea - if you ever see something you "
+"think should be fixed, you should own it. Here is how you get started."
+msgstr ""
+"我们始终欢迎帮助！例如，文档总有改进空间。代码可以写得更清晰，变量或函数可以重命名或补充注释。"
+"测试覆盖也始终需要加强。如果你看到应该修复的问题，就把它当作自己的任务。下面介绍如何开始。"
+
+#: ../../source/community/contribution.rst:30
+msgid "Good Start issues"
+msgstr "适合入门的 issue"
+
+#: ../../source/community/contribution.rst:32
+msgid "To find AIBrix issues that make good entry points:"
+msgstr "要查找适合入门的 AIBrix issue："
+
+#: ../../source/community/contribution.rst:34
+#, python-format
+msgid ""
+"Start with issues labeled `good first issue <https://github.com/vllm-"
+"project/aibrix/labels/good%20first%20issue>`_."
+msgstr ""
+"从标记为 `good first issue <https://github.com/vllm-"
+"project/aibrix/labels/good%20first%20issue>`_ 的 issue 开始。"
+
+#: ../../source/community/contribution.rst:35
+msgid ""
+"For issues that require deeper knowledge of one or more technical "
+"aspects, look at issues labeled `help wanted <https://github.com/vllm-"
+"project/aibrix/labels/help%20wanted>`_."
+msgstr ""
+"对于需要更深入了解一项或多项技术细节的 issue，请查看标记为 `help wanted <https://github.com/vllm-"
+"project/aibrix/labels/help%20wanted>`_ 的 issue。"
+
+#: ../../source/community/contribution.rst:38
+msgid "Joining the community"
+msgstr "加入社区"
+
+#: ../../source/community/contribution.rst:40
+msgid "Follow these instructions if you want to:"
+msgstr "如果你希望以下事项，请按说明操作："
+
+#: ../../source/community/contribution.rst:43
+msgid "Become an official member of the AIBrix GitHub Org"
+msgstr "成为 AIBrix GitHub Org 的正式成员"
+
+#: ../../source/community/contribution.rst:45
+msgid ""
+"Before requesting to join the AIBrix GitHub Org, we kindly ask that you "
+"make a few initial contributions to demonstrate your intent to continue "
+"contributing to AIBrix."
+msgstr ""
+"在申请加入 AIBrix GitHub Org 之前，请先完成若干初始贡献，以表明你打算持续为 AIBrix 做贡献。"
+
+#: ../../source/community/contribution.rst:47
+msgid "There are a number of ways to contribute to AIBrix:"
+msgstr "为 AIBrix 做贡献的方式有很多："
+
+#: ../../source/community/contribution.rst:49
+msgid "Submit PRs (codes or docs)"
+msgstr "提交 PR（代码或文档）"
+
+#: ../../source/community/contribution.rst:50
+msgid "File issues reporting bugs or providing feedback"
+msgstr "提交 issue 报告缺陷或提供反馈"
+
+#: ../../source/community/contribution.rst:51
+msgid "Answer questions on Slack or GitHub issues"
+msgstr "在 Slack 或 GitHub issue 中回答问题"
+
+#: ../../source/community/contribution.rst:53
+msgid ""
+"When you are ready to join, please send an issue asking adding yourself "
+"as a member in the issue."
+msgstr "准备加入时，请提交 issue，在其中申请将自己添加为成员。"
+
+#: ../../source/community/contribution.rst:57
+msgid "PR process"
+msgstr "PR 流程"
+
+#: ../../source/community/contribution.rst:60
+msgid "Enrich your PR information"
+msgstr "完善 PR 信息"
+
+#: ../../source/community/contribution.rst:62
+msgid ""
+"**Provide Clear Descriptions**: Ensure your PR includes a concise yet "
+"informative description. Summarize the problem being solved, the approach"
+" taken, and any notable changes or additions to the codebase. This helps "
+"reviewers quickly understand the purpose of the PR."
+msgstr ""
+"**提供清晰描述** ：确保 PR 包含简洁且信息充分的说明。概括要解决的问题、采取的方案，以及代码库中的重要变更或新增内容。这有助于审查者快速理解 "
+"PR 目的。"
+
+#: ../../source/community/contribution.rst:64
+msgid ""
+"**Reference Related Issues**: Link to any related issues, discussion "
+"threads, or feature requests in the description. Use keywords like Fixes "
+"#IssueNumber to automatically close an issue when the PR is merged."
+msgstr ""
+"**关联相关 issue** ：在描述中链接相关 issue、讨论线程或功能请求。使用 Fixes #IssueNumber 等关键字，以便 PR "
+"合并时自动关闭对应 issue。"
+
+#: ../../source/community/contribution.rst:66
+msgid ""
+"**Include Context for Major Changes**: If the PR involves significant "
+"changes or refactors, include a brief rationale for why these changes are"
+" necessary and how they improve the project."
+msgstr "**为重大变更提供背景** ：如果 PR 包含重大变更或重构，请简要说明为何需要这些变更，以及它们如何改进项目。"
+
+#: ../../source/community/contribution.rst:68
+msgid ""
+"**Document New Features**: If the PR introduces a new feature, ensure "
+"that documentation (e.g., README updates, code comments) is included or "
+"planned as part of the PR."
+msgstr "**为新功能补充文档** ：如果 PR 引入新功能，请确保文档（例如 README 更新、代码注释）已包含在 PR 中，或已纳入计划。"
+
+#: ../../source/community/contribution.rst:70
+msgid ""
+"**Provide Test Coverage**: If applicable, describe the tests you've added"
+" to cover the changes in the PR. This helps reviewers assess if the code "
+"is robust and if potential edge cases are handled."
+msgstr "**提供测试覆盖** ：如适用，请说明你为覆盖本次变更所添加的测试。这有助于审查者评估代码是否稳健，以及潜在边界情况是否得到处理。"
+
+#: ../../source/community/contribution.rst:72
+msgid ""
+"**Use Clear Commit Messages**: Each commit message should be clear and "
+"focused on one change or improvement. Commit titles should describe the "
+"change in 50 characters or less, and more details can be added in the "
+"commit body."
+msgstr ""
+"**使用清晰的提交说明** ：每条 commit message 应清晰，并聚焦于一项变更或改进。提交标题应在 50 个字符以内描述变更，更多细节可写在提交正文中。"
+
+#: ../../source/community/contribution.rst:76
+msgid "Code Review"
+msgstr "代码审查"
+
+#: ../../source/community/contribution.rst:78
+msgid ""
+"**Be Open to Feedback**: Reviewers may suggest improvements, point out "
+"bugs, or ask for clarifications. Be open to suggestions, even if you "
+"don’t agree initially. Use this as an opportunity to strengthen your "
+"code."
+msgstr "**开放接受反馈** ：审查者可能会建议改进、指出缺陷或请求澄清。即使最初不完全同意，也请开放对待建议。把这当作强化代码的机会。"
+
+#: ../../source/community/contribution.rst:80
+msgid ""
+"**Respond Promptly**: Acknowledge feedback with comments explaining how "
+"you’ll address the concerns or why a change may not be necessary. Keeping"
+" communication clear and respectful helps maintain a productive review "
+"process."
+msgstr "**及时回复** ：用评论确认反馈，说明你将如何处理相关问题，或为何不必修改。保持沟通清晰、尊重，有助于维持高效的审查过程。"
+
+#: ../../source/community/contribution.rst:82
+msgid ""
+"**Update Your PR Gradually**: Apply changes based on reviewer feedback as"
+" soon as possible. Avoid force-pushing updates unless necessary, as this "
+"can disrupt the review flow and history tracking."
+msgstr "**逐步更新 PR** ：尽快根据审查意见修改。除非必要，避免 force-push，以免打断审查流程和历史追踪。"
+
+#: ../../source/community/contribution.rst:84
+msgid ""
+"**Clarify Unclear Feedback**: If you’re unsure about a comment, don’t "
+"hesitate to ask for clarification before making changes. Miscommunication"
+" can lead to unnecessary rework."
+msgstr "**澄清不清楚的反馈** ：如果对某条评论不确定，请在修改前先询问。误解会导致不必要的返工。"
+
+#: ../../source/community/contribution.rst:86
+msgid ""
+"**Use Suggestions Appropriately**: If the reviewer uses GitHub’s "
+"suggestion feature, accept or modify the suggestions as needed, while "
+"ensuring the PR remains aligned with the original goal."
+msgstr "**合理使用建议** ：如果审查者使用了 GitHub 的 suggestion 功能，请按需接受或调整建议，同时确保 PR 仍与原目标一致。"
+
+#: ../../source/community/contribution.rst:88
+msgid ""
+"**Summarize Major Revisions**: If the PR undergoes significant revisions "
+"after the initial review, summarize the new changes to give reviewers a "
+"clearer understanding of what’s been updated."
+msgstr "**总结重大修订** ：如果首次审查后 PR 发生了显著修改，请总结新变更，便于审查者理解更新内容。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/community/research.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/community/research.po
@@ -1,0 +1,150 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/community/research.rst:5
+msgid "Research Collaboration"
+msgstr "研究合作"
+
+#: ../../source/community/research.rst:7
+msgid ""
+"At AIBrix, we strongly support system-level research and are committed to"
+" fostering collaboration with researchers and academics in the AI "
+"infrastructure domain. Our platform provides a unique opportunity to "
+"bridge the gap between theoretical research and real-world production "
+"challenges. If you're a PhD student or researcher looking to explore "
+"innovative ideas in AI systems, we'd love to support your work."
+msgstr ""
+"AIBrix 大力支持系统级研究，并致力于与 AI 基础设施领域的研究人员和学者开展合作。"
+"我们的平台为弥合理论研究与真实生产挑战之间的差距提供了独特机会。"
+"如果你是博士生或研究人员，希望探索 AI 系统方面的创新想法，我们很乐意支持你的工作。"
+
+#: ../../source/community/research.rst:12
+msgid "Opportunities for Research"
+msgstr "研究机会"
+
+#: ../../source/community/research.rst:14
+msgid ""
+"**Unresolved Production Challenges**: The AI production environment "
+"presents numerous unresolved problems, from efficient resource allocation"
+" to scalable inference architectures. We can provide case studies and "
+"real-world scenarios for researchers interested in exploring and solving "
+"these challenges."
+msgstr ""
+"**尚未解决的生产挑战** ：AI 生产环境存在大量未解决问题，从高效资源分配到可扩展推理架构。我们可以为有意探索并解决这些挑战的研究者提供案例研究与真实场景。"
+
+#: ../../source/community/research.rst:16
+#, python-format
+msgid ""
+"**Research Paper Implementation**: Some research ideas have been "
+"integrated into AIBrix, making it a practical landing ground for cutting-"
+"edge innovations. We regularly publish `Help Wanted <https://github.com"
+"/vllm-"
+"project/aibrix/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22>`_"
+" issues on our GitHub, highlighting open research opportunities—feel free"
+" to take a look and contribute!"
+msgstr ""
+"**研究论文落地** ：部分研究想法已集成到 AIBrix 中，使其成为前沿创新的实际落地平台。我们会定期在 GitHub 上发布 `Help "
+"Wanted <https://github.com/vllm-project/aibrix/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22>`_ "
+"issue，标出开放的研究机会——欢迎查看并参与贡献！"
+
+#: ../../source/community/research.rst:18
+msgid ""
+"**AIBrix as a Research Testbed**: Our system is designed to serve as a "
+"research testbed for system-level problems in AI infrastructure. Whether "
+"it's testing new scheduling algorithms, optimizing inference latency, or "
+"improving resource efficiency, we provide hands-on support to help set up"
+" experiments and validate hypotheses."
+msgstr ""
+"**将 AIBrix 作为研究试验台** ：我们的系统设计为 AI 基础设施系统级问题的研究试验台。无论是测试新的调度算法、优化推理延迟，还是提升资源效率，我们都会提供实践支持，帮助搭建实验并验证假设。"
+
+#: ../../source/community/research.rst:21
+msgid "Acknowledgments"
+msgstr "致谢"
+
+#: ../../source/community/research.rst:23
+msgid ""
+"Many of our innovative ideas have been inspired by academic research, "
+"including works such as Preble, Melange, QLM, and MoonCake. Integrating "
+"cutting-edge research into a production-grade system has been an "
+"enriching journey, enabling us to transform theoretical concepts into "
+"real-world applications. These contributions have significantly "
+"influenced our work, and we sincerely appreciate the researchers behind "
+"them—thank you!"
+msgstr ""
+"我们的许多创新想法受到学术研究启发，包括 Preble、Melange、QLM 和 MoonCake 等工作。"
+"将前沿研究集成到生产级系统是一段充实的历程，使我们能够把理论概念转化为实际应用。"
+"这些贡献深刻影响了我们的工作，我们衷心感谢背后的研究者——谢谢你们！"
+
+#: ../../source/community/research.rst:25
+msgid ""
+"We also extend our gratitude to the vLLM community for their support in "
+"making AIBrix the control plane for vLLM, further strengthening our "
+"mission to build scalable and efficient AI infrastructure."
+msgstr ""
+"我们也感谢 vLLM 社区的支持，使 AIBrix 成为 vLLM 的控制面，进一步强化我们构建可扩展、高效 AI 基础设施的使命。"
+
+#: ../../source/community/research.rst:28
+msgid "Get Involved"
+msgstr "参与进来"
+
+#: ../../source/community/research.rst:30
+msgid ""
+"At AIBrix, we actively welcome research collaborations across a wide "
+"range of topics, from cloud infrastructure cost optimizations to engine "
+"and system co-design innovations. AIBrix offers a robust experimentation "
+"platform featuring:"
+msgstr ""
+"AIBrix 积极欢迎广泛主题的研究合作，从云基础设施成本优化到引擎与系统协同设计创新。"
+"AIBrix 提供稳健的实验平台，涵盖："
+
+#: ../../source/community/research.rst:32
+msgid "Request Routing Strategies"
+msgstr "请求路由策略"
+
+#: ../../source/community/research.rst:33
+msgid "LLM Specific Autoscaling"
+msgstr "面向 LLM 的自动扩缩容"
+
+#: ../../source/community/research.rst:34
+msgid "Disaggregated KV Cache Pool"
+msgstr "分离式 KV Cache 池"
+
+#: ../../source/community/research.rst:35
+msgid "Serverless & Engine Resource Elasticity"
+msgstr "Serverless 与引擎资源弹性"
+
+#: ../../source/community/research.rst:36
+msgid "Large scale inference system tracing and simulation"
+msgstr "大规模推理系统追踪与仿真"
+
+#: ../../source/community/research.rst:38
+msgid ""
+"Whether you're a researcher, an academic, or an engineer working on GenAI"
+" system optimization strategies, we invite you to collaborate with us and"
+" contribute to the future of scalable AI infrastructure."
+msgstr ""
+"无论你是研究者、学者，还是从事 GenAI 系统优化策略的工程师，我们都邀请你与我们合作，"
+"共同推动可扩展 AI 基础设施的未来。"
+
+#: ../../source/community/research.rst:40
+msgid ""
+"For inquiries or collaboration opportunities, feel free to reach out to "
+"us by cutting Github issues or through the Slack Channel."
+msgstr "如有咨询或合作意向，欢迎通过提交 GitHub issue 或 Slack 频道联系我们。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/designs/aibrix-autoscaler.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/designs/aibrix-autoscaler.po
@@ -1,0 +1,352 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/designs/aibrix-autoscaler.rst:5
+msgid "AIBrix Autoscaler"
+msgstr "AIBrix Autoscaler"
+
+#: ../../source/designs/aibrix-autoscaler.rst:8
+msgid "Overview"
+msgstr "概述"
+
+#: ../../source/designs/aibrix-autoscaler.rst:10
+msgid ""
+"AIBrix provides a comprehensive autoscaling framework tailored for large "
+"language model (LLM) serving on Kubernetes (K8s). It supports multiple "
+"scaling paradigms, integrating native Kubernetes components with "
+"enhancements specifically designed for LLM workloads. This enables users "
+"to flexibly choose the most appropriate autoscaler for their workload "
+"patterns and cost-performance objectives."
+msgstr ""
+"AIBrix 提供面向 Kubernetes（K8s）上大语言模型（LLM）推理服务的自动扩缩容框架。"
+"它支持多种扩缩容范式，将原生 Kubernetes 组件与针对 LLM 工作负载的增强能力结合，"
+"便于按负载模式和成本性能目标选择合适的扩缩容器。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:15
+msgid "Supported Autoscaling Mechanisms"
+msgstr "支持的自动扩缩容机制"
+
+#: ../../source/designs/aibrix-autoscaler.rst:17
+msgid ""
+"AIBrix currently implements **two distinct categories of autoscaling "
+"mechanisms**, each suited to different needs:"
+msgstr "AIBrix 当前实现了 **两类自动扩缩容机制** ，分别适用于不同需求："
+
+#: ../../source/designs/aibrix-autoscaler.rst:19
+msgid "**Metrics-based Autoscaling**"
+msgstr "**基于指标的自动扩缩容**"
+
+#: ../../source/designs/aibrix-autoscaler.rst:21
+msgid ""
+"This family relies on runtime metrics (like CPU/GPU utilization, "
+"concurrent requests, or token throughput) to make scaling decisions. It "
+"reacts immediately to observed changes in system load."
+msgstr ""
+"该类机制依赖运行时指标（如 CPU/GPU 利用率、并发请求数或 token 吞吐）做扩缩容决策，"
+"对观测到的系统负载变化立即响应。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:24
+msgid ""
+"**HPA (Horizontal Pod Autoscaler)** The standard Kubernetes HPA scales "
+"pod replicas based on CPU, memory, or custom metrics. Best suited for "
+"generic workloads with stable utilization patterns."
+msgstr ""
+"**HPA（Horizontal Pod Autoscaler）** 标准 Kubernetes HPA 基于 CPU、内存或自定义指标扩缩 Pod 副本。"
+"最适合利用率模式稳定的通用工作负载。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:28
+msgid ""
+"**KPA (Knative Pod Autoscaler)** Uses a dual-window approach (stable + "
+"panic) to enable rapid scale-up on sudden traffic spikes. AIBrix enhances"
+" this by fetching metrics internally instead of relying solely on "
+"Prometheus scraping."
+msgstr ""
+"**KPA（Knative Pod Autoscaler）** 采用双窗口（stable + panic）在突发流量时快速扩容。"
+"AIBrix 在此基础上改为内部拉取指标，而不只依赖 Prometheus 抓取。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:32
+msgid ""
+"**APA (Advanced Pod Autoscaler)** AIBrix’s own scaler designed "
+"specifically for LLM workloads. Adds fluctuation tolerance to reduce "
+"oscillations and is evolving to incorporate profiling-informed scaling."
+msgstr ""
+"**APA（Advanced Pod Autoscaler）** AIBrix 面向 LLM 工作负载的原生扩缩容器。"
+"增加波动容忍以减少振荡，并逐步引入基于性能剖析的扩缩容。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:36
+msgid "**Optimizer-based Autoscaling**"
+msgstr "**基于优化器的自动扩缩容**"
+
+#: ../../source/designs/aibrix-autoscaler.rst:38
+msgid ""
+"This is a fundamentally different approach that does *not* depend on "
+"online metric thresholds. Instead, it leverages **offline profiling "
+"data** and **optimization solvers** to proactively determine optimal "
+"resource allocation. It includes (1) LLM Request Monitoring and (2) GPU "
+"Optimizer. The following figure shows the overall architecture. First, "
+"the LLM Request Monitoring component is responsible for monitoring past "
+"inference requests and their request patterns. Second, the GPU Optimizer "
+"component is responsible for calculating the optimal GPU number "
+"recommendation based on the request patterns and sending the "
+"recommendation to the K8s KPA."
+msgstr ""
+"这是一种本质不同的方法，*不*依赖在线指标阈值。"
+"它利用 **离线剖析数据** 和 **优化求解器** 主动确定最优资源分配。"
+"包含 (1) LLM 请求监控和 (2) GPU Optimizer。下图给出整体架构。"
+"首先，LLM 请求监控组件负责观测历史推理请求及其模式。"
+"其次，GPU Optimizer 基于请求模式计算最优 GPU 数量建议，并将建议发送给 K8s KPA。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:42
+msgid "optimizer-based-podautoscaler"
+msgstr "optimizer-based-podautoscaler"
+
+#: ../../source/designs/aibrix-autoscaler.rst:47
+msgid "This method is particularly suited for:"
+msgstr "该方法尤其适合："
+
+#: ../../source/designs/aibrix-autoscaler.rst:49
+msgid "Scheduled or tidal workloads with known patterns."
+msgstr "具有已知模式的定时或潮汐型工作负载。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:50
+msgid ""
+"Heterogeneous GPU setups where optimal cost-performance balancing is "
+"required."
+msgstr "需要在成本与性能之间取得最优平衡的异构 GPU 环境。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:51
+msgid ""
+"SLO-driven environments that benefit from planning resources before the "
+"load actually arrives."
+msgstr "需要在负载到达前规划资源的 SLO 驱动环境。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:55
+msgid "Type"
+msgstr "类型"
+
+#: ../../source/designs/aibrix-autoscaler.rst:55
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/designs/aibrix-autoscaler.rst:55
+msgid "Best suited for"
+msgstr "最适用场景"
+
+#: ../../source/designs/aibrix-autoscaler.rst:57
+msgid "HPA"
+msgstr "HPA"
+
+#: ../../source/designs/aibrix-autoscaler.rst:57
+msgid "Standard Kubernetes HPA scaling pods based on CPU/memory/custom metrics."
+msgstr "标准 Kubernetes HPA，基于 CPU/内存/自定义指标扩缩 Pod。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:57
+msgid "Generic workloads with steady utilization."
+msgstr "利用率稳定的通用工作负载。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:60
+msgid "KPA"
+msgstr "KPA"
+
+#: ../../source/designs/aibrix-autoscaler.rst:60
+msgid "Knative-style scaler with stable & panic windows"
+msgstr "带 stable 与 panic 窗口的 Knative 风格扩缩容器"
+
+#: ../../source/designs/aibrix-autoscaler.rst:60
+msgid "Burst-prone, unpredictable traffic patterns."
+msgstr "易突发、不可预测的流量模式。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:62
+msgid "APA"
+msgstr "APA"
+
+#: ../../source/designs/aibrix-autoscaler.rst:62
+msgid ""
+"AIBrix’s native scaler for LLM, with tolerance buffers to minimize "
+"thrashing."
+msgstr "AIBrix 面向 LLM 的原生扩缩容器，带容忍缓冲以减少抖动。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:62
+msgid "LLM workloads requiring stability, fine-grained optimizations."
+msgstr "需要稳定性与细粒度优化的 LLM 工作负载。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:65
+msgid "Optimizer-based"
+msgstr "基于优化器"
+
+#: ../../source/designs/aibrix-autoscaler.rst:65
+msgid ""
+"Plans scaling using offline profiling + solver, without relying on live "
+"metric thresholds."
+msgstr "利用离线剖析与求解器规划扩缩容，不依赖实时指标阈值。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:65
+msgid ""
+"Scheduled workloads, multi-GPU cost/SLO optimization, proactive scaling "
+"needs."
+msgstr "定时工作负载、多 GPU 成本/SLO 优化、需要主动扩缩容的场景。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:70
+msgid "Example Scenarios"
+msgstr "示例场景"
+
+#: ../../source/designs/aibrix-autoscaler.rst:72
+msgid "**HPA**: Scaling a demonstration deployment purely on CPU utilization."
+msgstr "**HPA** ：仅基于 CPU 利用率扩缩演示部署。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:73
+msgid ""
+"**KPA**: Handling short-term spikes for a ``vllm``-backed Llama2-7b model"
+" with aggressive panic scaling."
+msgstr "**KPA** ：对 ``vllm`` 后端的 Llama2-7b 模型使用激进 panic 扩容，应对短时流量尖峰。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:74
+msgid ""
+"**APA**: Applying fluctuation tolerance to reduce scale oscillations for "
+"latency-sensitive LLM services."
+msgstr "**APA** ：对延迟敏感的 LLM 服务应用波动容忍，减少扩缩振荡。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:75
+msgid ""
+"**Optimizer-based**: Using offline profiling results plus an optimization"
+" model to proactively scale GPUs ahead of a large scheduled campaign, "
+"minimizing costs while safeguarding SLOs."
+msgstr "**基于优化器** ：结合离线剖析结果与优化模型，在大规模定时活动前主动扩容 GPU，在保障 SLO 的同时降低成本。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:78
+msgid "Scaling Approaches"
+msgstr "扩缩容方法"
+
+#: ../../source/designs/aibrix-autoscaler.rst:80
+msgid "These autoscaling mechanisms broadly cover two methodologies:"
+msgstr "上述自动扩缩容机制大致覆盖两种方法论："
+
+#: ../../source/designs/aibrix-autoscaler.rst:82
+msgid ""
+"**Reactive Autoscaling** Observes current system metrics and reacts by "
+"scaling resources up or down immediately. This includes all metrics-based"
+" approaches: HPA, KPA, APA."
+msgstr ""
+"**反应式自动扩缩容** 观测当前系统指标并立即扩容或缩容。"
+"包括所有基于指标的方法：HPA、KPA、APA。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:86
+msgid ""
+"**Proactive Autoscaling** Makes decisions based on forecasts or offline-"
+"derived optimal plans, scaling ahead of time rather than waiting for "
+"metrics to cross thresholds. This is embodied by AIBrix’s optimizer-based"
+" approach, which uses workload profiles, cost models, and solvers to plan"
+" the best scaling actions."
+msgstr ""
+"**主动式自动扩缩容** 基于预测或离线得出的最优计划做决策，提前扩缩容，而不是等待指标越过阈值。"
+"AIBrix 基于优化器的方法即属于此类，它使用工作负载画像、成本模型和求解器来规划最佳扩缩容动作。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:93
+msgid "Metrics"
+msgstr "指标"
+
+#: ../../source/designs/aibrix-autoscaler.rst:95
+msgid ""
+"The AIBrix autoscaling framework integrates tightly with the serving "
+"layer, directly consuming metrics exposed by engines like ``vllm``."
+msgstr ""
+"AIBrix 自动扩缩容框架与服务层紧密集成，直接消费 ``vllm`` 等引擎暴露的指标。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:98
+msgid ""
+"Examples of metrics the autoscaler can consume. These are AIBrix's "
+"engine-neutral names, which the controller maps to the engine's own "
+"metric (for vLLM, ``num_requests_waiting`` becomes "
+"``vllm:num_requests_waiting``):"
+msgstr ""
+"自动扩缩容器可消费的指标示例。这些是 AIBrix 的引擎无关名称，控制器会映射到各引擎自身的指标（对 vLLM，``num_requests_waiting`` "
+"会映射为 ``vllm:num_requests_waiting`` ）："
+
+#: ../../source/designs/aibrix-autoscaler.rst:102
+msgid "``num_requests_running`` / ``num_requests_waiting``"
+msgstr "``num_requests_running`` / ``num_requests_waiting``"
+
+#: ../../source/designs/aibrix-autoscaler.rst:103
+msgid "``gpu_cache_usage_perc``"
+msgstr "``gpu_cache_usage_perc``"
+
+#: ../../source/designs/aibrix-autoscaler.rst:104
+msgid "``time_to_first_token_seconds``"
+msgstr "``time_to_first_token_seconds``"
+
+#: ../../source/designs/aibrix-autoscaler.rst:105
+msgid "``e2e_request_latency_seconds``"
+msgstr "``e2e_request_latency_seconds``"
+
+#: ../../source/designs/aibrix-autoscaler.rst:106
+msgid ""
+"``vllm:deployment_replicas`` (produced by the GPU optimizer rather than "
+"the engine)"
+msgstr "``vllm:deployment_replicas`` （由 GPU Optimizer 产生，而非引擎）"
+
+#: ../../source/designs/aibrix-autoscaler.rst:108
+msgid ""
+"For the full list, including what each name maps to for SGLang, xLLM and "
+"TRT-LLM, see the metric table in :doc:`../features/multi-engine`, and the"
+" `vLLM Metrics Documentation "
+"<https://docs.vllm.ai/en/stable/serving/metrics.html>`_."
+msgstr ""
+"完整列表（含各名称在 SGLang、xLLM 和 TRT-LLM 上的映射）见 :doc:`../features/multi-engine` "
+"中的指标表，以及 `vLLM Metrics Documentation <https://docs.vllm.ai/en/stable/serving/metrics.html>`_ "
+"。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:112
+msgid "Extending or Selecting Autoscalers"
+msgstr "扩展或选择扩缩容器"
+
+#: ../../source/designs/aibrix-autoscaler.rst:114
+msgid ""
+"AIBrix lets you declaratively select your desired autoscaler type in "
+"deployment specifications. This makes it easy to experiment with "
+"different strategies or integrate new autoscaling plugins as your "
+"infrastructure evolves."
+msgstr ""
+"AIBrix 允许在部署规格中以声明方式选择所需的扩缩容器类型。"
+"便于试验不同策略，或随基础设施演进接入新的自动扩缩容插件。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:117
+msgid "Future improvements include:"
+msgstr "后续改进包括："
+
+#: ../../source/designs/aibrix-autoscaler.rst:119
+msgid ""
+"Adding integer linear programming (ILP) based scheduling to enable even "
+"more advanced optimizer-driven planning."
+msgstr "加入基于整数线性规划（ILP）的调度，以支持更高级的优化器驱动规划。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:120
+msgid ""
+"Combining proactive (optimizer-based) and reactive (metrics-based) "
+"mechanisms into hybrid autoscalers for maximum robustness and efficiency."
+msgstr ""
+"将主动（基于优化器）与反应式（基于指标）机制结合为混合扩缩容器，以兼顾稳健性与效率。"
+
+#: ../../source/designs/aibrix-autoscaler.rst:125
+msgid ":doc:`../features/autoscaling/autoscaling`"
+msgstr ":doc:`../features/autoscaling/autoscaling`"
+
+#: ../../source/designs/aibrix-autoscaler.rst:126
+msgid "Configuring PodAutoscaler with HPA, KPA, and APA strategies."
+msgstr "使用 HPA、KPA 和 APA 策略配置 PodAutoscaler。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/designs/aibrix-engine-runtime.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/designs/aibrix-engine-runtime.po
@@ -1,0 +1,110 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:5
+msgid "AIBrix Engine Runtime"
+msgstr "AIBrix Engine Runtime"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:7
+msgid ""
+"AI Engine Runtime is a Unified Management Layer for Inference Containers."
+" It is a versatile sidecar enabling metric standardization, model "
+"downloading, and local model management. The AI Runtime hides various "
+"implementation details on the inference engine side, providing a "
+"universal method to guide model download and management, as well as "
+"expose inference monitoring metrics."
+msgstr ""
+"AI Engine Runtime 是推理容器的统一管理层。"
+"它是一个多功能 sidecar，用于指标标准化、模型下载和本地模型管理。"
+"AI Runtime 屏蔽推理引擎侧的实现细节，提供统一方式来指导模型下载与管理，并暴露推理监控指标。"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:10
+msgid ""
+"Currently, this component is mainly designed for the lora model "
+"deployment and multi-engine support. You do not necessarily need to "
+"install the runtime for most of the cases. As we expand the support for "
+"more inference engines and enrich the features for cold start management "
+"etc, the runtime will be more useful."
+msgstr ""
+"当前该组件主要用于 LoRA 模型部署和多引擎支持。大多数场景不必安装 runtime。"
+"随着对更多推理引擎的支持以及冷启动管理等能力的完善，runtime 会更加有用。"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:14
+msgid "Introduction"
+msgstr "简介"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:16
+msgid ""
+"AI Engine Runtime serves as an essential bridge between the AIBrix "
+"Control Plane and inference engine pods, enabling model management, "
+"engine configuration, observability, and vendor-agnostic engine support."
+msgstr ""
+"AI Engine Runtime 是 AIBrix 控制面与推理引擎 Pod 之间的桥梁，"
+"用于模型管理、引擎配置、可观测性以及与厂商无关的引擎支持。"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:18
+msgid ""
+"**API for Control Plane Integration**: It ensures seamless communication "
+"between the control plane and inference pods. This allows components like"
+" the LoRA adapter controller, autoscaler, and cold start manager to "
+"interact dynamically with inference containers, managing resources in a "
+"cloud-native way."
+msgstr ""
+"**控制面集成 API** ：确保控制面与推理 Pod 之间的通信。LoRA 适配器控制器、自动扩缩容器和冷启动管理器等组件可以通过云原生方式动态管理推理容器资源。"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:19
+msgid ""
+"**Abstracting Vendor-Specific Inference Engines**: AI Engine Runtime is "
+"designed to work with diverse inference engines, including most popular "
+"ones. However, the engine api are all different. Instead of tightly "
+"coupling with any specific engine, AIRuntime abstracts key operations "
+"like model loading/unloading, adapter configuration, and performance "
+"monitoring, allowing new inference backends to be integrated with minimal"
+" friction."
+msgstr ""
+"**抽象厂商特定的推理引擎** ：AI Engine Runtime 面向多种推理引擎（含主流引擎）设计。各引擎 API 并不相同。AIRuntime "
+"不与特定引擎紧耦合，而是抽象模型加载/卸载、适配器配置和性能监控等关键操作，使新的推理后端可以低成本接入。"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:20
+msgid ""
+"**Observability**: It provides a unified interface for monitoring across "
+"different inference engines, allowing for consistent performance tracking"
+" and troubleshooting."
+msgstr "**可观测性** ：为不同推理引擎提供统一监控接口，便于一致地跟踪性能并排查问题。"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:23
+msgid ""
+"This runtime is different from Istio sidecar. Data plane traffic won't go"
+" through this runtime, it just provide some management capabilities for "
+"control plane interaction."
+msgstr ""
+"该 runtime 不同于 Istio sidecar。数据面流量不会经过它，它只为控制面交互提供管理能力。"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:25
+msgid "ai-engine-runtime-overview"
+msgstr "ai-engine-runtime-overview"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:32
+msgid ":doc:`../features/runtime`"
+msgstr ":doc:`../features/runtime`"
+
+#: ../../source/designs/aibrix-engine-runtime.rst:33
+msgid "Using the AI Runtime sidecar."
+msgstr "使用 AI Runtime sidecar。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/designs/aibrix-kvcache-offloading-framework.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/designs/aibrix-kvcache-offloading-framework.po
@@ -1,0 +1,895 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:5
+msgid "AIBrix KVCache Offloading Framework"
+msgstr "AIBrix KVCache Offloading Framework"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:7
+msgid ""
+"The rising demand for large language models has intensified the need for "
+"efficient memory management and caching to optimize inference performance"
+" and reduce costs. In multi-round use cases like chatbots and agent-based"
+" systems, overlapping token sequences lead to redundant computations "
+"during the prefill phase, wasting resources and limiting throughput."
+msgstr ""
+"大语言模型需求上升，使高效内存管理与缓存对优化推理性能、降低成本更加关键。"
+"在聊天机器人和智能体等多轮场景中，重叠的 token 序列会在 prefill 阶段造成重复计算，浪费资源并限制吞吐。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:9
+msgid ""
+"Many inference engines, such as `vLLM <https://github.com/vllm-"
+"project/vllm>`_, use built-in KV caching to mitigate this issue, "
+"leveraging idle HBM and DRAM. However, single-node KV caches face key "
+"limitations: constrained memory capacity, engine-specific storage that "
+"prevents sharing across instances, and difficulty supporting scenarios "
+"like KV migration and prefill-decode disaggregation."
+msgstr ""
+"许多推理引擎（如 `vLLM <https://github.com/vllm-project/vllm>`_ ）使用内置 KV 缓存缓解该问题，利用空闲 "
+"HBM 和 DRAM。但单节点 KV 缓存有明显限制：内存容量受限、存储与引擎绑定导致实例间无法共享，以及难以支持 KV 迁移和 Prefill/Decode "
+"分离等场景。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:11
+msgid ""
+"With AIBrix v0.3.0, we introduce a **production-ready KVCache Offloading "
+"Framework**, which enables efficient memory tiering and low-overhead "
+"cross-engine reuse. By default, the framework leverages **L1 DRAM-based "
+"caching**, which already provides significant performance improvements by"
+" offloading GPU memory pressure without incurring high latency. For "
+"scenarios requiring **multi-node sharing or larger-scale reuse**, AIBrix "
+"allows users to optionally enable **L2 remote caching**, unlocking the "
+"benefits of a distributed KV cache layer."
+msgstr ""
+"AIBrix v0.3.0 引入了 **可用于生产的 KVCache Offloading Framework** ，支持高效内存分层和低开销跨引擎复用。默认使用 "
+"**基于 DRAM 的 L1Cache** ，通过卸载 GPU 内存压力即可显著提升性能，且不会引入高延迟。若需要 **多节点共享或更大规模复用** "
+"，可选择启用 **L2 远程缓存** ，使用分布式 KVCache 层。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:13
+msgid "aibrix-kvcache-offloading-arch-overview"
+msgstr "aibrix-kvcache-offloading-arch-overview"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:18
+msgid "**Figure 1. AIBrix KVCache Offloading Framework**"
+msgstr "**图 1. AIBrix KVCache Offloading Framework**"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:20
+msgid ""
+"As shown in Figure 1, on the data plane, it integrates tightly with "
+"inference engines (e.g., vLLM) via *AIBrix Offloading Connector*, which "
+"employs optimized CUDA kernels to significantly accelerate data movement "
+"between GPU and CPU. For memory scalability, its multi-tiered cache "
+"manager dynamically balances workloads across storage layers, alleviating"
+" GPU memory capacity limits while minimizing latency penalties. The "
+"framework supports pluggable eviction policies (e.g., LRU, `S3FIFO "
+"<https://blog.jasony.me/system/cache/2023/08/01/s3fifo>`_) and diverse "
+"backend storage options (e.g., `InfiniStore "
+"<https://github.com/bytedance/InfiniStore>`_), enabling selective KV "
+"cache offloading to reduce network and PCIe contention. Crucially, its "
+"cache placement module can coordinate with the centralized distributed KV"
+" cache cluster manager to maximize global KV cache utilization. This "
+"enables cross-engine KV reuse and ensures cluster-wide resource "
+"efficiency, transforming isolated KV cache instances into a scalable, "
+"shared KV cache infrastructure."
+msgstr ""
+"如图 1 所示，数据面通过 *AIBrix Offloading Connector* 与推理引擎（如 vLLM）紧密集成，该连接器使用优化的 "
+"CUDA kernel 加速 GPU 与 CPU 之间的数据搬运。为扩展内存，多层缓存管理器在各存储层之间动态均衡负载，缓解 GPU 内存容量限制，同时尽量降低延迟代价。框架支持可插拔淘汰策略（如 "
+"LRU、`S3FIFO <https://blog.jasony.me/system/cache/2023/08/01/s3fifo>`_ ）以及多种后端存储（如 "
+"`InfiniStore <https://github.com/bytedance/InfiniStore>`_ ），可选择性卸载 KVCache，以减少网络和 "
+"PCIe 争用。更关键的是，缓存放置模块可与集中式分布式 KVCache 集群管理器协同，最大化全局 KVCache 利用率。这支持跨引擎 KV "
+"复用，并保证集群范围的资源效率，将孤立的 KVCache 实例转变为可扩展的共享 KVCache 基础设施。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:23
+msgid "L1 Engine DRAM Cache Management"
+msgstr "L1 引擎 DRAM 缓存管理"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:25
+msgid ""
+"The growing demands of modern models and increasing context lengths in "
+"LLM inference have led to KV caches consuming progressively more GPU "
+"memory, pushing against the hardware limits of even the most advanced "
+"GPUs. Recent systems like `Dynamo <https://github.com/ai-"
+"dynamo/dynamo>`_, `LMCache <https://github.com/LMCache/LMCache>`_, and "
+"`MoonCake <https://github.com/kvcache-ai/Mooncake>`_ have developed "
+"solutions that offload KV cache to external memory hierarchies, spanning "
+"from CPU memory to SSDs. :ref:`kvcache-offloading` supports the "
+"offloading of KV cache to CPU memory as well by only enabling its DRAM-"
+"backed ``L1Cache``. While this approach does not enable KV cache sharing "
+"across multiple engines, it eliminates the complexity of distributed KV "
+"cache setup and configuration. More importantly, by leveraging the "
+"significantly larger capacity of CPU memory, this method delivers "
+"substantial performance gains —- making it an ideal solution for use "
+"cases that prioritize scalable KV cache capacity over cross-engine KV "
+"reuse."
+msgstr ""
+"现代模型规模与 LLM 推理上下文长度不断增加，使 KVCache 占用越来越多 GPU 内存，即使最先进的 GPU 也接近硬件上限。近期系统如 "
+"`Dynamo <https://github.com/ai-dynamo/dynamo>`_ 、`LMCache <https://github.com/LMCache/LMCache>`_ "
+"和 `MoonCake <https://github.com/kvcache-ai/Mooncake>`_ 已将 KVCache 卸载到从 CPU "
+"内存到 SSD 的外部存储层次。:ref:`kvcache-offloading` 也可以仅启用基于 DRAM 的 ``L1Cache`` ，将 "
+"KVCache 卸载到 CPU 内存。该方式不支持跨引擎共享 KVCache，但省去了分布式 KVCache 的部署与配置复杂度。更重要的是，借助 "
+"CPU 内存显著更大的容量，该方法能带来明显性能收益——适合优先扩展 KVCache 容量、而非跨引擎 KV 复用的场景。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:29
+msgid "L2 Distributed KVCache and Cross-Engine KV Reuse"
+msgstr "L2 分布式 KVCache 与跨引擎 KV 复用"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:31
+msgid ""
+"The growing demand for large language models has significantly increased "
+"the need for expansive KV cache capacity. While CPU memory offloading "
+"effectively addresses moderate scaling needs, production environments "
+"handling massive-scale, dynamic workloads require even greater "
+"scalability -- particularly when memory needs exceed single-node "
+"capacities. To address this, AIBrix enables distributed KV cache services"
+" as its ``L2Cache`` backends, which can scale horizontally across "
+"multiple nodes to meet capacity demands."
+msgstr ""
+"大语言模型需求增长显著提高了对更大 KVCache 容量的要求。"
+"CPU 内存卸载能满足中等规模扩展，但处理超大规模、动态负载的生产环境需要更强扩展性——"
+"尤其当内存需求超过单节点容量时。"
+"为此，AIBrix 将分布式 KVCache 服务作为 ``L2Cache`` 后端，可跨多个节点水平扩展以满足容量需求。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:33
+msgid ""
+"In the meantime, as LLM deployments scale across multiple engines in the "
+"cluster, the redundancy of KV caches across engines introduces "
+"substantial inefficiencies. Repeated computations of common prompt "
+"prefixes waste GPU cycles and HBM bandwidth. AIBrix solves this challenge"
+" by enabling efficient **cross-engine KV reuse** through a high-"
+"performance, shared distributed KV cache, optimizing resource utilization"
+" at scale."
+msgstr ""
+"同时，当集群中多个引擎部署 LLM 时，引擎间 KVCache 冗余会带来显著低效。重复计算公共 prompt 前缀会浪费 GPU 周期和 HBM "
+"带宽。AIBrix 通过高性能、共享的分布式 KVCache 实现高效 **跨引擎 KV 复用** ，在规模化场景下优化资源利用率。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:35
+msgid "aibrix-infinistore-arch-overview"
+msgstr "aibrix-infinistore-arch-overview"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:42
+msgid "Adding New KVCache Backends"
+msgstr "添加新的 KVCache 后端"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:44
+msgid ""
+"New KVCache backends can be easily added by implementing the "
+"``Connector`` interface:"
+msgstr "实现 ``Connector`` 接口即可添加新的 KVCache 后端："
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:229
+msgid ""
+"Please refer to the `existing connectors <https://github.com/vllm-"
+"project/aibrix/tree/main/python/aibrix_kvcache/aibrix_kvcache/l2/connectors>`_"
+" for more details."
+msgstr ""
+"更多细节请参考 `existing connectors <https://github.com/vllm-project/aibrix/tree/main/python/aibrix_kvcache/aibrix_kvcache/l2/connectors>`_ "
+"。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:234
+msgid "Environment Variables Reference"
+msgstr "环境变量参考"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:236
+msgid ""
+"This section describes all available environment variables for AIBrix "
+"KVCache Offloading Framework."
+msgstr "本节说明 AIBrix KVCache Offloading Framework 的全部可用环境变量。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:239
+msgid "Core Configuration"
+msgstr "核心配置"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:245
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:286
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:315
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:353
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:379
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:408
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:431
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:454
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:470
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:492
+msgid "Variable"
+msgstr "变量"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:246
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:287
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:316
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:354
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:380
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:409
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:432
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:455
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:471
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:493
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:247
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:288
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:317
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:355
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:381
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:410
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:433
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:456
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:472
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:494
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:248
+msgid "AIBRIX_KV_CACHE_OL_CHUNK_SIZE"
+msgstr "AIBRIX_KV_CACHE_OL_CHUNK_SIZE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:249
+msgid "\"512\""
+msgstr "\"512\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:250
+msgid "Chunk size for operations."
+msgstr "操作的 chunk 大小。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:251
+msgid "AIBRIX_KV_CACHE_OL_BLOCK_SIZE"
+msgstr "AIBRIX_KV_CACHE_OL_BLOCK_SIZE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:252
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:255
+msgid "\"-1\""
+msgstr "\"-1\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:253
+msgid ""
+"Number of tokens in a kvcache block (the finest IO granularity). Defaults"
+" to -1, which means to use engine's block size."
+msgstr "一个 KVCache block 中的 token 数（最细 IO 粒度）。默认 -1，表示使用引擎的 block size。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:254
+msgid "AIBRIX_KV_CACHE_OL_MAX_SEQ_LEN"
+msgstr "AIBRIX_KV_CACHE_OL_MAX_SEQ_LEN"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:256
+msgid ""
+"Maximum sequence length. Defaults to -1, which means no limit. If set, "
+"tokens beyond this length will be ignored."
+msgstr "最大序列长度。默认 -1 表示不限制。若设置，超出该长度的 token 会被忽略。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:257
+msgid "AIBRIX_KV_CACHE_OL_TIME_MEASUREMENT_ENABLED"
+msgstr "AIBRIX_KV_CACHE_OL_TIME_MEASUREMENT_ENABLED"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:258
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:261
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:290
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:302
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:392
+msgid "\"1\""
+msgstr "\"1\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:259
+msgid "Enable time measurement."
+msgstr "启用时间测量。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:260
+msgid "AIBRIX_KV_CACHE_OL_BREAKDOWN_MEASUREMENT_ENABLED"
+msgstr "AIBRIX_KV_CACHE_OL_BREAKDOWN_MEASUREMENT_ENABLED"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:262
+msgid "Enable breakdown measurement."
+msgstr "启用分项测量。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:263
+msgid "AIBRIX_KV_CACHE_OL_DOUBLE_GET_THRESHOLD"
+msgstr "AIBRIX_KV_CACHE_OL_DOUBLE_GET_THRESHOLD"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:264
+msgid "\"4,0.1\""
+msgstr "\"4,0.1\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:265
+msgid ""
+"Controls when to issue a second get request to L2 cache. First value is "
+"minimum missing blocks, second is ratio threshold."
+msgstr "控制何时向 L2Cache 发起第二次 get。第一个值是最少缺失 block 数，第二个值是比例阈值。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:266
+msgid "AIBRIX_KV_CACHE_OL_TOKEN_VALIDATION_ENABLED"
+msgstr "AIBRIX_KV_CACHE_OL_TOKEN_VALIDATION_ENABLED"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:267
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:273
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:337
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:441
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:474
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:477
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:480
+msgid "\"0\""
+msgstr "\"0\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:268
+msgid ""
+"Whether to validate tokens in L2 cache. Disabling uses tighter memory "
+"layout."
+msgstr "是否校验 L2Cache 中的 token。关闭后使用更紧凑的内存布局。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:269
+msgid "AIBRIX_KV_CACHE_OL_TRANSPORT_RDMA_ADDR_RANGE"
+msgstr "AIBRIX_KV_CACHE_OL_TRANSPORT_RDMA_ADDR_RANGE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:270
+msgid "\"::/0\""
+msgstr "\"::/0\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:271
+msgid ""
+"Valid GID range (CIDR format). Similar to NVSHMEM_IB_ADDR_RANGE for "
+"NVSHMEM."
+msgstr "有效 GID 范围（CIDR 格式）。类似于 NVSHMEM 的 NVSHMEM_IB_ADDR_RANGE。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:272
+msgid "AIBRIX_KV_CACHE_OL_PROFILING_ENABLED"
+msgstr "AIBRIX_KV_CACHE_OL_PROFILING_ENABLED"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:274
+msgid "Enable profiling."
+msgstr "启用性能剖析。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:275
+msgid "AIBRIX_KV_CACHE_OL_PROFILING_SERVER_ADDRESS"
+msgstr "AIBRIX_KV_CACHE_OL_PROFILING_SERVER_ADDRESS"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:276
+msgid "\"http://0.0.0.0:4040\""
+msgstr "\"http://0.0.0.0:4040\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:277
+msgid ""
+"Profiling server address. Profiling server is responsible for collecting "
+"profiling data and displaying it in a web UI."
+msgstr "性能剖析服务器地址。该服务器负责收集剖析数据并在 Web UI 中展示。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:280
+msgid "L1 Cache Configuration"
+msgstr "L1Cache 配置"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:289
+msgid "AIBRIX_KV_CACHE_OL_L1_CACHE_ENABLED"
+msgstr "AIBRIX_KV_CACHE_OL_L1_CACHE_ENABLED"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:291
+msgid "Enable L1 cache."
+msgstr "启用 L1Cache。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:292
+msgid "AIBRIX_KV_CACHE_OL_L1_CACHE_EVICTION_POLICY"
+msgstr "AIBRIX_KV_CACHE_OL_L1_CACHE_EVICTION_POLICY"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:293
+msgid "\"S3FIFO\""
+msgstr "\"S3FIFO\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:294
+msgid "Eviction policy for L1 cache (\"S3FIFO\", \"LRU\", or \"FIFO\")"
+msgstr "L1Cache 淘汰策略（\"S3FIFO\"、\"LRU\" 或 \"FIFO\"）"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:295
+msgid "AIBRIX_KV_CACHE_OL_L1_CACHE_CAPACITY_GB"
+msgstr "AIBRIX_KV_CACHE_OL_L1_CACHE_CAPACITY_GB"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:296
+msgid "\"10\""
+msgstr "\"10\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:297
+msgid "L1 cache capacity in GB."
+msgstr "L1Cache 容量，单位 GB。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:298
+msgid "AIBRIX_KV_CACHE_OL_DEVICE"
+msgstr "AIBRIX_KV_CACHE_OL_DEVICE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:299
+msgid "\"cpu\""
+msgstr "\"cpu\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:300
+msgid "Device to use for cache operations (\"cpu\" or \"cuda\")"
+msgstr "缓存操作使用的设备（\"cpu\" 或 \"cuda\"）"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:301
+msgid "AIBRIX_KV_CACHE_OL_S3FIFO_SMALL_TO_MAIN_PROMO_THRESHOLD"
+msgstr "AIBRIX_KV_CACHE_OL_S3FIFO_SMALL_TO_MAIN_PROMO_THRESHOLD"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:303
+msgid "S3FIFO eviction policy: promotion threshold from small to main queue."
+msgstr "S3FIFO 淘汰策略：从 small 队列晋升到 main 队列的阈值。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:304
+msgid "AIBRIX_KV_CACHE_OL_S3FIFO_SMALL_FIFO_CAPACITY_RATIO"
+msgstr "AIBRIX_KV_CACHE_OL_S3FIFO_SMALL_FIFO_CAPACITY_RATIO"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:305
+msgid "0.3"
+msgstr "0.3"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:306
+msgid "S3FIFO eviction policy: capacity ratio for small FIFO."
+msgstr "S3FIFO 淘汰策略：small FIFO 的容量比例。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:309
+msgid "L2 Cache Configuration"
+msgstr "L2Cache 配置"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:318
+msgid "AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND"
+msgstr "AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:319
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:357
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:363
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:366
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:398
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:444
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:458
+msgid "\"\""
+msgstr "\"\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:320
+msgid "Backend for L2 cache."
+msgstr "L2Cache 后端。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:321
+msgid "AIBRIX_KV_CACHE_OL_L2_CACHE_NAMESPACE"
+msgstr "AIBRIX_KV_CACHE_OL_L2_CACHE_NAMESPACE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:322
+msgid "\"aibrix\""
+msgstr "\"aibrix\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:323
+msgid "Namespace for L2 cache."
+msgstr "L2Cache 命名空间。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:324
+msgid "AIBRIX_KV_CACHE_OL_L2_CACHE_OP_BATCH"
+msgstr "AIBRIX_KV_CACHE_OL_L2_CACHE_OP_BATCH"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:325
+msgid "\"32\""
+msgstr "\"32\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:326
+msgid "Operation batch size."
+msgstr "操作批大小。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:327
+msgid "AIBRIX_KV_CACHE_OL_L2_CACHE_PER_TOKEN_TIMEOUT_MS"
+msgstr "AIBRIX_KV_CACHE_OL_L2_CACHE_PER_TOKEN_TIMEOUT_MS"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:328
+msgid "\"20\""
+msgstr "\"20\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:329
+msgid "Per-token timeout in milliseconds."
+msgstr "每 token 超时时间，单位毫秒。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:330
+msgid "AIBRIX_KV_CACHE_OL_L2_CACHE_KEY_BUILDER"
+msgstr "AIBRIX_KV_CACHE_OL_L2_CACHE_KEY_BUILDER"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:331
+msgid "\"ROLLING_HASH\""
+msgstr "\"ROLLING_HASH\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:332
+msgid "Key builder for L2 cache (\"RAW\", \"ROLLING_HASH\", or \"SIMPLE_HASH\")"
+msgstr "L2Cache 的 key 构建器（\"RAW\"、\"ROLLING_HASH\" 或 \"SIMPLE_HASH\"）"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:333
+msgid "AIBRIX_KV_CACHE_OL_L2_CACHE_INGESTION_TYPE"
+msgstr "AIBRIX_KV_CACHE_OL_L2_CACHE_INGESTION_TYPE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:334
+msgid "\"HOT\""
+msgstr "\"HOT\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:335
+msgid "Ingestion type (\"ALL\", \"HOT\", or \"EVICTED\")."
+msgstr "写入类型（\"ALL\"、\"HOT\" 或 \"EVICTED\"）。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:336
+msgid "AIBRIX_KV_CACHE_OL_L2_CACHE_INGESTION_MAX_INFLIGHT_TOKENS"
+msgstr "AIBRIX_KV_CACHE_OL_L2_CACHE_INGESTION_MAX_INFLIGHT_TOKENS"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:338
+msgid "Max inflight writes (0 for synchronous)."
+msgstr "最大进行中写操作数（0 表示同步）。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:339
+msgid "AIBRIX_KV_CACHE_OL_L2_CACHE_NUM_ASYNC_WORKERS"
+msgstr "AIBRIX_KV_CACHE_OL_L2_CACHE_NUM_ASYNC_WORKERS"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:340
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:514
+msgid "\"8\""
+msgstr "\"8\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:341
+msgid "Number of async workers."
+msgstr "异步 worker 数量。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:342
+msgid "AIBRIX_KV_CACHE_OL_L2_CACHE_PLACEMENT_POLICY"
+msgstr "AIBRIX_KV_CACHE_OL_L2_CACHE_PLACEMENT_POLICY"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:343
+msgid "\"SIMPLE\""
+msgstr "\"SIMPLE\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:344
+msgid "Placement policy (only applicable if using meta service)."
+msgstr "放置策略（仅在使用 meta service 时适用）。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:347
+msgid "Meta Service Configuration"
+msgstr "Meta Service 配置"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:356
+msgid "AIBRIX_KV_CACHE_OL_META_SERVICE_BACKEND"
+msgstr "AIBRIX_KV_CACHE_OL_META_SERVICE_BACKEND"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:358
+msgid ""
+"Backend for meta service. If meta service backend is not set, L2 cache "
+"backend will use direct mode to access the given cache server. Otherwise,"
+" we will get membership information from meta service and construct the "
+"L2 cache cluster."
+msgstr ""
+"meta service 后端。未设置时，L2Cache 后端以 direct 模式访问给定缓存服务器；"
+"否则从 meta service 获取成员信息并构建 L2Cache 集群。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:359
+msgid "AIBRIX_KV_CACHE_OL_META_SERVICE_REFRESH_INTERVAL_S"
+msgstr "AIBRIX_KV_CACHE_OL_META_SERVICE_REFRESH_INTERVAL_S"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:360
+msgid "\"30\""
+msgstr "\"30\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:361
+msgid "Refresh interval in seconds."
+msgstr "刷新间隔，单位秒。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:362
+msgid "AIBRIX_KV_CACHE_OL_META_SERVICE_URL"
+msgstr "AIBRIX_KV_CACHE_OL_META_SERVICE_URL"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:364
+msgid "URL for meta service."
+msgstr "meta service 的 URL。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:365
+msgid "AIBRIX_KV_CACHE_OL_META_SERVICE_CLUSTER_META_KEY"
+msgstr "AIBRIX_KV_CACHE_OL_META_SERVICE_CLUSTER_META_KEY"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:367
+msgid "Cluster meta key."
+msgstr "集群 meta key。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:370
+msgid "Connector Configurations"
+msgstr "连接器配置"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:373
+msgid "InfiniStore Connector Configuration"
+msgstr "InfiniStore 连接器配置"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:382
+msgid "AIBRIX_KV_CACHE_OL_INFINISTORE_HOST_ADDR"
+msgstr "AIBRIX_KV_CACHE_OL_INFINISTORE_HOST_ADDR"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:383
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:412
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:418
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:435
+msgid "\"127.0.0.1\""
+msgstr "\"127.0.0.1\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:384
+msgid "Host address."
+msgstr "主机地址。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:385
+msgid "AIBRIX_KV_CACHE_OL_INFINISTORE_SERVICE_PORT"
+msgstr "AIBRIX_KV_CACHE_OL_INFINISTORE_SERVICE_PORT"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:386
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:421
+msgid "\"12345\""
+msgstr "\"12345\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:387
+msgid "Service port."
+msgstr "服务端口。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:388
+msgid "AIBRIX_KV_CACHE_OL_INFINISTORE_CONNECTION_TYPE"
+msgstr "AIBRIX_KV_CACHE_OL_INFINISTORE_CONNECTION_TYPE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:389
+msgid "\"RDMA\""
+msgstr "\"RDMA\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:390
+msgid "Connection type."
+msgstr "连接类型。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:391
+msgid "AIBRIX_KV_CACHE_OL_INFINISTORE_IB_PORT"
+msgstr "AIBRIX_KV_CACHE_OL_INFINISTORE_IB_PORT"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:393
+msgid "IB port."
+msgstr "IB 端口。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:394
+msgid "AIBRIX_KV_CACHE_OL_INFINISTORE_LINK_TYPE"
+msgstr "AIBRIX_KV_CACHE_OL_INFINISTORE_LINK_TYPE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:395
+msgid "\"Ethernet\""
+msgstr "\"Ethernet\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:396
+msgid "Link type."
+msgstr "链路类型。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:397
+msgid "AIBRIX_KV_CACHE_OL_INFINISTORE_VISIBLE_DEV_LIST"
+msgstr "AIBRIX_KV_CACHE_OL_INFINISTORE_VISIBLE_DEV_LIST"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:399
+msgid ""
+"Visible device list. Since 0.2.42, InfiniStore supports RDMA GID index in"
+" client config, users can specify the GID index of each device in this "
+"format: \"mlx5_0:gid0,mlx5_1:gid1,mlx5_2:gid2\""
+msgstr ""
+"可见设备列表。自 0.2.42 起，InfiniStore 在客户端配置中支持 RDMA GID 索引，"
+"可用如下格式为每个设备指定 GID 索引：\"mlx5_0:gid0,mlx5_1:gid1,mlx5_2:gid2\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:402
+msgid "HPKV Connector Configuration"
+msgstr "HPKV 连接器配置"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:411
+msgid "AIBRIX_KV_CACHE_OL_HPKV_REMOTE_ADDR"
+msgstr "AIBRIX_KV_CACHE_OL_HPKV_REMOTE_ADDR"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:413
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:436
+msgid "Remote address."
+msgstr "远端地址。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:414
+msgid "AIBRIX_KV_CACHE_OL_HPKV_REMOTE_PORT"
+msgstr "AIBRIX_KV_CACHE_OL_HPKV_REMOTE_PORT"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:415
+msgid "\"12346\""
+msgstr "\"12346\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:416
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:439
+msgid "Remote port."
+msgstr "远端端口。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:417
+msgid "AIBRIX_KV_CACHE_OL_HPKV_LOCAL_ADDR"
+msgstr "AIBRIX_KV_CACHE_OL_HPKV_LOCAL_ADDR"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:419
+msgid "Local address."
+msgstr "本地地址。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:420
+msgid "AIBRIX_KV_CACHE_OL_HPKV_LOCAL_PORT"
+msgstr "AIBRIX_KV_CACHE_OL_HPKV_LOCAL_PORT"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:422
+msgid "Local port."
+msgstr "本地端口。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:425
+msgid "PrisKV Connector Configuration"
+msgstr "PrisKV 连接器配置"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:434
+msgid "AIBRIX_KV_CACHE_OL_PRISKV_REMOTE_ADDR"
+msgstr "AIBRIX_KV_CACHE_OL_PRISKV_REMOTE_ADDR"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:437
+msgid "AIBRIX_KV_CACHE_OL_PRISKV_REMOTE_PORT"
+msgstr "AIBRIX_KV_CACHE_OL_PRISKV_REMOTE_PORT"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:438
+msgid "\"6379\""
+msgstr "\"6379\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:440
+msgid "AIBRIX_KV_CACHE_OL_PRISKV_USE_MPUT_MGET"
+msgstr "AIBRIX_KV_CACHE_OL_PRISKV_USE_MPUT_MGET"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:442
+msgid "Enable MPUT/MGET."
+msgstr "启用 MPUT/MGET。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:443
+msgid "AIBRIX_KV_CACHE_OL_PRISKV_PASSWORD"
+msgstr "AIBRIX_KV_CACHE_OL_PRISKV_PASSWORD"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:445
+msgid "Password."
+msgstr "密码。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:448
+msgid "EIC Connector Configuration"
+msgstr "EIC 连接器配置"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:457
+msgid "AIBRIX_KV_CACHE_OL_EIC_CONFIG_FILE"
+msgstr "AIBRIX_KV_CACHE_OL_EIC_CONFIG_FILE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:459
+msgid "EIC config file."
+msgstr "EIC 配置文件。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:462
+msgid "Mock Connector Configuration"
+msgstr "Mock 连接器配置"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:464
+msgid "Mock connector is used for testing and profiling purposes."
+msgstr "Mock 连接器用于测试和性能剖析。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:473
+msgid "AIBRIX_KV_CACHE_OL_MOCK_USE_RDMA"
+msgstr "AIBRIX_KV_CACHE_OL_MOCK_USE_RDMA"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:475
+msgid "Use RDMA in mock connector."
+msgstr "在 mock 连接器中使用 RDMA。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:476
+msgid "AIBRIX_KV_CACHE_OL_MOCK_USE_MPUT_MGET"
+msgstr "AIBRIX_KV_CACHE_OL_MOCK_USE_MPUT_MGET"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:478
+msgid "Use MPUT/MGET in mock connector."
+msgstr "在 mock 连接器中使用 MPUT/MGET。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:479
+msgid "AIBRIX_KV_CACHE_OL_MOCK_USE_NOOP"
+msgstr "AIBRIX_KV_CACHE_OL_MOCK_USE_NOOP"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:481
+msgid "Use NOOP for all operations. Useful for profiling the framework overhead."
+msgstr "所有操作使用 NOOP。用于剖析框架开销。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:484
+msgid "RocksDB Connector Configuration"
+msgstr "RocksDB 连接器配置"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:486
+msgid "RocksDB connector is used for testing purposes."
+msgstr "RocksDB 连接器用于测试。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:495
+msgid "AIBRIX_KV_CACHE_OL_ROCKSDB_ROOT"
+msgstr "AIBRIX_KV_CACHE_OL_ROCKSDB_ROOT"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:496
+msgid "\"~/.kv_cache_ol/rocksdb\""
+msgstr "\"~/.kv_cache_ol/rocksdb\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:497
+msgid "Root directory for RocksDB."
+msgstr "RocksDB 根目录。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:498
+msgid "AIBRIX_KV_CACHE_OL_ROCKSDB_TTL_S"
+msgstr "AIBRIX_KV_CACHE_OL_ROCKSDB_TTL_S"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:499
+msgid "\"600\""
+msgstr "\"600\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:500
+msgid "TTL in seconds."
+msgstr "TTL，单位秒。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:501
+msgid "AIBRIX_KV_CACHE_OL_ROCKSDB_WRITE_BUFFER_SIZE"
+msgstr "AIBRIX_KV_CACHE_OL_ROCKSDB_WRITE_BUFFER_SIZE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:502
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:505
+msgid "\"67108864\""
+msgstr "\"67108864\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:503
+msgid "Write buffer size. Default 64MB."
+msgstr "写缓冲区大小。默认 64MB。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:504
+msgid "AIBRIX_KV_CACHE_OL_ROCKSDB_TARGET_FILE_SIZE_BASE"
+msgstr "AIBRIX_KV_CACHE_OL_ROCKSDB_TARGET_FILE_SIZE_BASE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:506
+msgid "Target file size base. Default 64MB."
+msgstr "目标文件大小基数。默认 64MB。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:507
+msgid "AIBRIX_KV_CACHE_OL_ROCKSDB_MAX_WRITE_BUFFER_NUMBER"
+msgstr "AIBRIX_KV_CACHE_OL_ROCKSDB_MAX_WRITE_BUFFER_NUMBER"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:508
+msgid "\"3\""
+msgstr "\"3\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:509
+msgid "Max write buffers."
+msgstr "最大写缓冲区数量。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:510
+msgid "AIBRIX_KV_CACHE_OL_ROCKSDB_MAX_TOTAL_WAL_SIZE"
+msgstr "AIBRIX_KV_CACHE_OL_ROCKSDB_MAX_TOTAL_WAL_SIZE"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:511
+msgid "\"134217728\""
+msgstr "\"134217728\""
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:512
+msgid "Max total WAL size. Default 128MB."
+msgstr "WAL 总大小上限。默认 128MB。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:513
+msgid "AIBRIX_KV_CACHE_OL_ROCKSDB_MAX_BACKGROUND_JOBS"
+msgstr "AIBRIX_KV_CACHE_OL_ROCKSDB_MAX_BACKGROUND_JOBS"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:515
+msgid "Max background jobs."
+msgstr "最大后台任务数。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:519
+msgid ":doc:`../features/kvcache-offloading`"
+msgstr ":doc:`../features/kvcache-offloading`"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:520
+msgid "Deploying and configuring distributed KV cache."
+msgstr "部署并配置分布式 KVCache。"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:521
+msgid ":doc:`../features/kv-event-sync`"
+msgstr ":doc:`../features/kv-event-sync`"
+
+#: ../../source/designs/aibrix-kvcache-offloading-framework.rst:522
+msgid "Synchronizing KV cache events with the gateway."
+msgstr "与网关同步 KVCache 事件。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/designs/aibrix-router.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/designs/aibrix-router.po
@@ -1,0 +1,407 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/designs/aibrix-router.rst:5
+msgid "AIBrix Router"
+msgstr "AIBrix Router"
+
+#: ../../source/designs/aibrix-router.rst:8
+msgid "Overview"
+msgstr "概述"
+
+#: ../../source/designs/aibrix-router.rst:10
+msgid ""
+"The AIBrix Router is a pluggable, intelligent traffic management "
+"component embedded in the AIBrix LLM serving stack. It is designed as an "
+"Envoy Gateway extension via external processing hooks, serving as the "
+"single entry point for all LLM inference requests."
+msgstr ""
+"AIBrix Router 是嵌入 AIBrix LLM 服务栈的可插拔智能流量管理组件。"
+"它通过外部处理钩子作为 Envoy Gateway 扩展，是所有 LLM 推理请求的统一入口。"
+
+#: ../../source/designs/aibrix-router.rst:12
+msgid ""
+"This gateway abstracts away the underlying complexity of managing "
+"multiple models, LoRA adapters, heterogeneous GPU backends, and diverse "
+"scaling strategies."
+msgstr ""
+"该网关屏蔽了管理多模型、LoRA 适配器、异构 GPU 后端以及多种扩缩容策略的底层复杂性。"
+
+#: ../../source/designs/aibrix-router.rst:14
+msgid "gateway-design"
+msgstr "gateway-design"
+
+#: ../../source/designs/aibrix-router.rst:20
+msgid "Core Principle"
+msgstr "核心原则"
+
+#: ../../source/designs/aibrix-router.rst:22
+msgid ""
+"The router maintains a high-frequency local cache of pod metrics via "
+"periodic pulls and subscriptions. This allows it to apply sophisticated "
+"multi-objective routing logic without blocking on live queries to pods, "
+"keeping latency low on the hot path and enabling scaling to thousands of "
+"QPS."
+msgstr ""
+"路由器通过周期性拉取和订阅，维护 Pod 指标的高频本地缓存。"
+"因此可以在不阻塞实时查询 Pod 的情况下应用多目标路由逻辑，"
+"保持热路径低延迟，并支持扩展到数千 QPS。"
+
+#: ../../source/designs/aibrix-router.rst:24
+msgid ""
+"The active routing strategy can be set per-request via the ``routing-"
+"strategy`` HTTP header, or globally via the ``ROUTING_ALGORITHM`` "
+"environment variable, or through a model config profile annotation."
+msgstr ""
+"可通过 ``routing-strategy`` HTTP 请求头按请求设置路由策略，"
+"也可通过 ``ROUTING_ALGORITHM`` 环境变量全局设置，或通过模型配置 profile 注解设置。"
+
+#: ../../source/designs/aibrix-router.rst:27
+msgid "Detailed Sequence Flow"
+msgstr "详细时序流程"
+
+#: ../../source/designs/aibrix-router.rst:61
+msgid "Supported Routing Strategies"
+msgstr "支持的路由策略"
+
+#: ../../source/designs/aibrix-router.rst:63
+msgid ""
+"AIBrix ships with a set of built-in algorithms, each optimized for "
+"different workload patterns."
+msgstr "AIBrix 内置一组算法，分别针对不同工作负载模式优化。"
+
+#: ../../source/designs/aibrix-router.rst:65
+msgid "**General load balancing**"
+msgstr "**通用负载均衡**"
+
+#: ../../source/designs/aibrix-router.rst:67
+msgid ""
+"``random``: routes to a randomly selected pod. Useful as a baseline or "
+"when pods are homogeneous and load is uniform."
+msgstr "``random`` ：路由到随机选中的 Pod。适合作为基线，或 Pod 同质且负载均匀时使用。"
+
+#: ../../source/designs/aibrix-router.rst:68
+msgid "``least-request``: routes to the pod with the fewest in-flight requests."
+msgstr "``least-request`` ：路由到进行中请求数最少的 Pod。"
+
+#: ../../source/designs/aibrix-router.rst:69
+msgid ""
+"``least-busy-time``: routes to the pod with the least cumulative busy "
+"processing time."
+msgstr "``least-busy-time`` ：路由到累计忙处理时间最少的 Pod。"
+
+#: ../../source/designs/aibrix-router.rst:70
+msgid ""
+"``least-latency``: routes to the pod with the lowest average processing "
+"latency."
+msgstr "``least-latency`` ：路由到平均处理延迟最低的 Pod。"
+
+#: ../../source/designs/aibrix-router.rst:71
+msgid ""
+"``least-kv-cache``: routes to the pod with the smallest current KV cache "
+"occupancy (least VRAM used)."
+msgstr "``least-kv-cache`` ：路由到当前 KVCache 占用最小（显存使用最少）的 Pod。"
+
+#: ../../source/designs/aibrix-router.rst:72
+msgid ""
+"``least-gpu-cache``: routes to the pod with the lowest GPU cache "
+"utilization."
+msgstr "``least-gpu-cache`` ：路由到 GPU cache 利用率最低的 Pod。"
+
+#: ../../source/designs/aibrix-router.rst:73
+msgid ""
+"``least-utilization``: routes to the pod with the lowest overall "
+"utilization score."
+msgstr "``least-utilization`` ：路由到综合利用率分数最低的 Pod。"
+
+#: ../../source/designs/aibrix-router.rst:74
+msgid ""
+"``load-balance``: capacity-aware weighted least-request routing. Scores "
+"each pod as ``running_requests / drain_rate`` (pending time), where "
+"``drain_rate`` is the observed request completion rate. Selects the pod "
+"with the lowest pending time, breaking ties using least combined GPU+CPU "
+"KV-cache usage (falling back to a random pick if cache metrics are "
+"unavailable for the tied pods) — the same secondary-signal pattern "
+"``prefix-cache`` uses to break ties in prefix-match percentage via "
+"request count. Falls back to uniform capacity when drain-rate metrics are"
+" unavailable. Its load-imbalance gate, which restricts candidates to the "
+"least-loaded pods when load is severely skewed, is applied centrally by "
+"the gateway ahead of whichever strategy actually routes each request — "
+"not just when ``load-balance`` itself is selected (see "
+"``pkg/plugins/gateway/ENV_VARS.md``)."
+msgstr ""
+"``load-balance`` ：感知容量的加权最少请求路由。按 ``running_requests / drain_rate`` （待处理时间）为每个 "
+"Pod 打分，其中 ``drain_rate`` 是观测到的请求完成速率。选择待处理时间最低的 Pod；并列时用 GPU+CPU KVCache "
+"合计占用最低者打破平局（若并列 Pod 缺少缓存指标则随机选择）——与 ``prefix-cache`` 用请求数打破前缀匹配百分比平局的次级信号模式相同。当 "
+"drain-rate 指标不可用时回退到均匀容量。其负载不均衡门控会在负载严重倾斜时把候选限制为负载最低的 Pod；该门控由网关在实际路由策略之前统一应用，而不仅在选择 "
+"``load-balance`` 时生效（见 ``pkg/plugins/gateway/ENV_VARS.md`` ）。"
+
+#: ../../source/designs/aibrix-router.rst:75
+msgid ""
+"``throughput``: routes to the pod that has processed the fewest total "
+"weighted tokens, favoring underloaded pods."
+msgstr "``throughput`` ：路由到已处理加权 token 总数最少的 Pod，偏向负载较低的 Pod。"
+
+#: ../../source/designs/aibrix-router.rst:76
+msgid ""
+"``power-of-two``: applies the power-of-two choices algorithm — samples "
+"two pods and selects the better one."
+msgstr "``power-of-two`` ：应用 power-of-two choices 算法——抽样两个 Pod 并选择更优者。"
+
+#: ../../source/designs/aibrix-router.rst:78
+msgid "**KV-cache aware**"
+msgstr "**感知 KVCache**"
+
+#: ../../source/designs/aibrix-router.rst:80
+msgid ""
+"``prefix-cache``: routes to a pod that already has a KV cache matching "
+"the request's prompt prefix; the best prefix-matched pod within a stddev "
+"load threshold is selected. Purely about prefix caching — it does not "
+"itself gate on cluster-wide load imbalance (the gateway applies that gate"
+" centrally ahead of it; see ``load-balance`` above). Supports standard "
+"mode (local hash table) and KV sync mode (real-time distributed index, "
+"enabled via ``AIBRIX_PREFIX_CACHE_KV_EVENT_SYNC_ENABLED=true``)."
+msgstr ""
+"``prefix-cache`` ：路由到已有与请求 prompt 前缀匹配的 KVCache 的 Pod；在标准差负载阈值内选择前缀匹配最好的 "
+"Pod。仅关注前缀缓存——自身不对集群范围负载不均衡做门控（网关会在其之前统一应用该门控；见上文 ``load-balance`` ）。支持标准模式（本地哈希表）和 "
+"KV sync 模式（实时分布式索引，通过 ``AIBRIX_PREFIX_CACHE_KV_EVENT_SYNC_ENABLED=true`` "
+"启用）。"
+
+#: ../../source/designs/aibrix-router.rst:81
+msgid ""
+"``prefix-cache-preble``: routes considering both prefix cache hits and "
+"pod load. Based on `Preble: Efficient Distributed Prompt Scheduling for "
+"LLM Serving <https://arxiv.org/abs/2407.00023>`_."
+msgstr ""
+"``prefix-cache-preble`` ：同时考虑前缀缓存命中与 Pod 负载进行路由。基于 `Preble: Efficient Distributed "
+"Prompt Scheduling for LLM Serving <https://arxiv.org/abs/2407.00023>`_ 。"
+
+#: ../../source/designs/aibrix-router.rst:83
+msgid "**Fairness**"
+msgstr "**公平性**"
+
+#: ../../source/designs/aibrix-router.rst:85
+msgid ""
+"``vtc-basic``: routes using a hybrid score that balances per-user token "
+"fairness and pod utilization. A simplified variant of the Virtual Token "
+"Counter (VTC) algorithm. See `VTC-artifact <https://github.com/Ying1123"
+"/VTC-artifact>`_ for background."
+msgstr ""
+"``vtc-basic`` ：使用兼顾每用户 token 公平性与 Pod 利用率的混合分数进行路由。是 Virtual Token Counter（VTC）算法的简化变体。背景见 "
+"`VTC-artifact <https://github.com/Ying1123/VTC-artifact>`_ 。"
+
+#: ../../source/designs/aibrix-router.rst:87
+msgid "**SLO-aware**"
+msgstr "**感知 SLO**"
+
+#: ../../source/designs/aibrix-router.rst:89
+msgid "``slo``: routes with awareness of per-request service-level objectives."
+msgstr "``slo`` ：感知每请求服务等级目标进行路由。"
+
+#: ../../source/designs/aibrix-router.rst:90
+msgid ""
+"``slo-pack-load``: SLO-aware routing that packs load onto fewer pods to "
+"improve efficiency."
+msgstr "``slo-pack-load`` ：感知 SLO 的路由，将负载集中到更少 Pod 以提升效率。"
+
+#: ../../source/designs/aibrix-router.rst:91
+msgid ""
+"``slo-least-load``: SLO-aware routing that spreads load to the least "
+"loaded pod."
+msgstr "``slo-least-load`` ：感知 SLO 的路由，将负载分散到负载最低的 Pod。"
+
+#: ../../source/designs/aibrix-router.rst:92
+msgid ""
+"``slo-least-load-pulling``: variant of ``slo-least-load`` that pulls "
+"metrics directly rather than relying on the cached snapshot."
+msgstr "``slo-least-load-pulling`` ：``slo-least-load`` 的变体，直接拉取指标而不依赖缓存快照。"
+
+#: ../../source/designs/aibrix-router.rst:94
+msgid "**Specialized**"
+msgstr "**专用策略**"
+
+#: ../../source/designs/aibrix-router.rst:96
+msgid ""
+"``pd``: prefill-decode disaggregation routing. Splits processing between "
+"dedicated prefill pods and decode pods for optimized end-to-end latency."
+msgstr "``pd`` ：Prefill/Decode 分离路由。将处理拆分到专用 prefill Pod 和 decode Pod，以优化端到端延迟。"
+
+#: ../../source/designs/aibrix-router.rst:97
+msgid ""
+"``session-affinity``: sticky session routing. Encodes the target pod's "
+"address (``IP:Port``) as a base64 value in the ``x-session-id`` response "
+"header. Subsequent requests carrying that header are routed to the same "
+"pod. Falls back to a random ready pod and issues a new session ID if the "
+"original pod is unavailable."
+msgstr ""
+"``session-affinity`` ：会话粘滞路由。将目标 Pod 地址（``IP:Port`` ）编码为 base64，写入 ``x-session-id`` "
+"响应头。后续携带该头的请求会路由到同一 Pod。若原 Pod 不可用，则回退到随机就绪 Pod 并签发新的 session ID。"
+
+#: ../../source/designs/aibrix-router.rst:99
+msgid "**Auto-blended capacity awareness**"
+msgstr "**自动混合的容量感知**"
+
+#: ../../source/designs/aibrix-router.rst:101
+msgid ""
+"Every strategy above, except the exclusive ones (``pd``, "
+"``slo``/``slo-*``) and an explicit standalone ``load-balance`` selection,"
+" silently gets ``load-balance``'s capacity-aware scoring blended in "
+"behind the scenes — and ``least-request`` too, when the selected strategy"
+" doesn't already route by request count, to keep multi-port/data-parallel"
+" pod routing working under the blend. The caller never sees this: "
+"``ctx.Algorithm``, response headers, and ``Validate()`` all still reflect"
+" exactly the strategy that was requested. This keeps any single strategy "
+"from steering traffic at an already-hot pod even outside the load-"
+"imbalance gate described above. Set "
+"``AIBRIX_ROUTING_AUTO_BLEND_LOAD_BALANCE_WEIGHT=0`` to disable it (see "
+"``pkg/plugins/gateway/ENV_VARS.md``)."
+msgstr ""
+"除独占策略（``pd`` 、``slo``/``slo-*`` ）以及显式单独选择 ``load-balance`` 外，上述每种策略都会在后台静默混入 "
+"``load-balance`` 的容量感知打分；当所选策略本身不按请求数路由时，还会混入 ``least-request`` ，以保证混合后多端口/数据并行 "
+"Pod 路由仍可用。调用方看不到这一层：``ctx.Algorithm`` 、响应头和 ``Validate()`` 仍反映所请求的策略。这样即使在上文负载不均衡门控之外，单一策略也不会把流量导向已经过热的 "
+"Pod。设置 ``AIBRIX_ROUTING_AUTO_BLEND_LOAD_BALANCE_WEIGHT=0`` 可关闭该行为（见 ``pkg/plugins/gateway/ENV_VARS.md`` "
+"）。"
+
+#: ../../source/designs/aibrix-router.rst:113
+msgid "How to Extend Routing Algorithms"
+msgstr "如何扩展路由算法"
+
+#: ../../source/designs/aibrix-router.rst:115
+msgid ""
+"The routing framework is designed to be highly pluggable. All routing "
+"logic is expressed through the ``Router`` interface:"
+msgstr "路由框架高度可插拔。所有路由逻辑都通过 ``Router`` 接口表达："
+
+#: ../../source/designs/aibrix-router.rst:126
+msgid "**Parameters**"
+msgstr "**参数**"
+
+#: ../../source/designs/aibrix-router.rst:128
+msgid ""
+"``ctx *RoutingContext``: Per-request context carrying routing inputs. Key"
+" fields include:"
+msgstr "``ctx *RoutingContext`` ：携带路由输入的每请求上下文。关键字段包括："
+
+#: ../../source/designs/aibrix-router.rst:130
+msgid "``Algorithm`` — the active routing strategy name."
+msgstr "``Algorithm`` — 当前路由策略名称。"
+
+#: ../../source/designs/aibrix-router.rst:131
+msgid "``Model`` — the model name extracted from the request body."
+msgstr "``Model`` — 从请求体提取的模型名称。"
+
+#: ../../source/designs/aibrix-router.rst:132
+msgid "``Message`` — the raw prompt text (available for token-level decisions)."
+msgstr "``Message`` — 原始 prompt 文本（可用于 token 级决策）。"
+
+#: ../../source/designs/aibrix-router.rst:133
+msgid ""
+"``User`` — the optional user identifier (used by fairness-based "
+"algorithms)."
+msgstr "``User`` — 可选用户标识（公平性算法使用）。"
+
+#: ../../source/designs/aibrix-router.rst:134
+msgid "``ReqHeaders`` — a copy of the incoming HTTP request headers."
+msgstr "``ReqHeaders`` — 入站 HTTP 请求头的副本。"
+
+#: ../../source/designs/aibrix-router.rst:135
+msgid ""
+"``ConfigProfile`` — resolved model config profile (strategy override, RPS"
+" limit, etc.), or ``nil`` if not set."
+msgstr "``ConfigProfile`` — 解析后的模型配置 profile（策略覆盖、RPS 限制等）；未设置时为 ``nil`` 。"
+
+#: ../../source/designs/aibrix-router.rst:137
+msgid ""
+"``readyPodList PodList``: Pre-filtered list of pods that are healthy and "
+"eligible for routing. Guaranteed non-empty."
+msgstr "``readyPodList PodList`` ：已预过滤、健康且可路由的 Pod 列表。保证非空。"
+
+#: ../../source/designs/aibrix-router.rst:139
+msgid "**Return value**"
+msgstr "**返回值**"
+
+#: ../../source/designs/aibrix-router.rst:141
+msgid ""
+"The IP address of the selected pod (e.g. ``\"10.0.0.5:8080\"``), or a "
+"non-nil error if selection fails."
+msgstr "所选 Pod 的 IP 地址（例如 ``\"10.0.0.5:8080\"`` ）；选择失败时返回非 nil 错误。"
+
+#: ../../source/designs/aibrix-router.rst:143
+msgid "**Steps to add a new algorithm**"
+msgstr "**添加新算法的步骤**"
+
+#: ../../source/designs/aibrix-router.rst:145
+msgid ""
+"Implement the ``Router`` interface in a new ``*.go`` file under "
+"``pkg/plugins/gateway/algorithms/``."
+msgstr ""
+"在 ``pkg/plugins/gateway/algorithms/`` 下新建 ``*.go`` 文件并实现 ``Router`` 接口。"
+
+#: ../../source/designs/aibrix-router.rst:146
+msgid "Declare a typed constant for the strategy name:"
+msgstr "为策略名称声明类型化常量："
+
+#: ../../source/designs/aibrix-router.rst:152
+msgid ""
+"Register the constructor in an ``init()`` function so it is picked up at "
+"startup:"
+msgstr "在 ``init()`` 函数中注册构造函数，以便启动时加载："
+
+#: ../../source/designs/aibrix-router.rst:160
+msgid ""
+"Specify it per-request via the ``routing-strategy`` HTTP header, or set "
+"``ROUTING_ALGORITHM=my-strategy`` to use it as the default."
+msgstr ""
+"通过 ``routing-strategy`` HTTP 请求头按请求指定，或设置 "
+"``ROUTING_ALGORITHM=my-strategy`` 作为默认策略。"
+
+#: ../../source/designs/aibrix-router.rst:162
+msgid ""
+"Additional router interfaces in ``pkg/types/router.go`` support optional "
+"capabilities:"
+msgstr "``pkg/types/router.go`` 中还有额外路由器接口，用于可选能力："
+
+#: ../../source/designs/aibrix-router.rst:164
+msgid ""
+"``QueueRouter`` — for routers that maintain an internal queue and expose "
+"queue length."
+msgstr "``QueueRouter`` — 维护内部队列并暴露队列长度的路由器。"
+
+#: ../../source/designs/aibrix-router.rst:165
+msgid ""
+"``FallbackRouter`` — enables chaining by delegating to a secondary router"
+" when the primary cannot make a decision."
+msgstr "``FallbackRouter`` — 主路由器无法决策时委托给次级路由器，以支持链式回退。"
+
+#: ../../source/designs/aibrix-router.rst:169
+msgid ":doc:`../features/gateway-plugins`"
+msgstr ":doc:`../features/gateway-plugins`"
+
+#: ../../source/designs/aibrix-router.rst:170
+msgid "Configuring the gateway and choosing a routing strategy."
+msgstr "配置网关并选择路由策略。"
+
+#: ../../source/designs/aibrix-router.rst:171
+msgid ":doc:`../production/gateway`"
+msgstr ":doc:`../production/gateway`"
+
+#: ../../source/designs/aibrix-router.rst:172
+msgid "Production gateway deployment."
+msgstr "生产环境网关部署。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/designs/aibrix-stormservice.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/designs/aibrix-stormservice.po
@@ -1,0 +1,1371 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/designs/aibrix-stormservice.rst:5
+msgid "AIBrix StormService"
+msgstr "AIBrix StormService"
+
+#: ../../source/designs/aibrix-stormservice.rst:7
+msgid ""
+"**StormService** is a specialized component designed to manage and "
+"orchestrate the lifecycle of inference containers in Prefill/Decode "
+"disaggregated architectures. Additionally, it can be utilized to oversee "
+"various deployment modes, such as Tensor Parallelism (TP), Pipeline "
+"Parallelism (PP), and even single GPU model deployments."
+msgstr ""
+"**StormService** 用于在 Prefill/Decode 分离架构中管理并编排推理容器生命周期。"
+"也可用于监督多种部署模式，例如张量并行（TP）、流水线并行（PP），以及单 GPU 模型部署。"
+
+#: ../../source/designs/aibrix-stormservice.rst:10
+msgid "Three-layer Architecture"
+msgstr "三层架构"
+
+#: ../../source/designs/aibrix-stormservice.rst:12
+msgid ""
+"StormService is implemented using several Custom Resource Definitions "
+"(CRDs) following a three-layer architecture. An illustration of this "
+"architecture is shown below:"
+msgstr "StormService 通过多个自定义资源定义（CRD）实现三层架构。示意图如下："
+
+#: ../../source/designs/aibrix-stormservice.rst:14
+msgid "AIBrix StormService Architecture"
+msgstr "AIBrix StormService 架构"
+
+#: ../../source/designs/aibrix-stormservice.rst:19
+msgid ""
+"**StormService**: This is the top-level CRD that wraps the entire "
+"service. It defines the specification of a service unit and tracks its "
+"status, including the number of replicas (i.e., RoleSet), a unified "
+"template for RoleSets, update strategy, and other configurations. For the"
+" detailed definition, see the `stormservice_types.go`_ file."
+msgstr ""
+"**StormService** ：封装整个服务的顶层 CRD。它定义服务单元规格并跟踪状态，包括副本数（即 RoleSet）、统一的 RoleSet "
+"模板、更新策略及其他配置。详细定义见 `stormservice_types.go`_ 。"
+
+#: ../../source/designs/aibrix-stormservice.rst:23
+msgid ""
+"**RoleSet**: A RoleSet represents a collection of roles, where each role "
+"can serve a specific function (e.g., Prefill or Decode). For more "
+"information, see the `roleset_types.go`_ file."
+msgstr ""
+"**RoleSet** ：一组角色的集合，每个角色可承担特定功能（如 Prefill 或 Decode）。更多信息见 `roleset_types.go`_ "
+"。"
+
+#: ../../source/designs/aibrix-stormservice.rst:27
+msgid ""
+"**Pods**: Each role within a RoleSet contains multiple Pods, which are "
+"the actual containers executing the inference tasks."
+msgstr "**Pods** ：RoleSet 中每个角色包含多个 Pod，即实际执行推理任务的容器。"
+
+#: ../../source/designs/aibrix-stormservice.rst:29
+msgid ""
+"Following this layered design, updates to the spec propagate from the "
+"StormService to its RoleSets, and then to the individual roles. The "
+"reconciler at the StormService level synchronizes the status of RoleSets "
+"with the StormService spec (primarily the `Replicas` field), while the "
+"reconciler at the RoleSet level synchronizes the status of individual "
+"roles with the RoleSet spec."
+msgstr ""
+"按该分层设计，spec 更新从 StormService 传播到其 RoleSet，再传播到各个角色。"
+"StormService 层的 reconciler 将 RoleSet 状态与 StormService spec 同步（主要是 `Replicas` 字段），"
+"RoleSet 层的 reconciler 将各角色状态与 RoleSet spec 同步。"
+
+#: ../../source/designs/aibrix-stormservice.rst:31
+msgid ""
+"StormService supports two operational modes at its level: **Rolling "
+"Update** and **Inplace Update**. At the RoleSet level, three update modes"
+" are supported: **Parallel**, **Sequential**, and **Interleaved**. These "
+"are explained in detail below."
+msgstr ""
+"StormService 层支持两种运行模式：**滚动更新（Rolling Update）** 和 **原地更新（Inplace Update）** "
+"。RoleSet 层支持三种更新模式：**Parallel** 、**Sequential** 和 **Interleaved** 。下文详细说明。"
+
+#: ../../source/designs/aibrix-stormservice.rst:35
+msgid "Deployment Mode"
+msgstr "部署模式"
+
+#: ../../source/designs/aibrix-stormservice.rst:37
+msgid ""
+"Stormservice supports two deployment modes: **Replica Mode** and **Pooled"
+" Mode**."
+msgstr "StormService 支持两种部署模式：**Replica Mode** 和 **Pooled Mode** 。"
+
+#: ../../source/designs/aibrix-stormservice.rst:40
+msgid ""
+"These two modes are mutually exclusive. The mode is declared through the "
+"`stormservice.spec.mode` field, which accepts `Replica` or `Pooled`."
+msgstr "这两种模式互斥。通过 `stormservice.spec.mode` 声明，取值为 `Replica` 或 `Pooled` 。"
+
+#: ../../source/designs/aibrix-stormservice.rst:41
+msgid ""
+"`spec.mode` is optional and is not defaulted. When it is omitted the mode"
+" is inferred for backward compatibility from "
+"`stormservice.spec.replicas`: replica mode when `replicas > 1`, otherwise"
+" pooled mode."
+msgstr ""
+"`spec.mode` 可选且无默认值。省略时为保持向后兼容，根据 `stormservice.spec.replicas` 推断："
+"`replicas > 1` 为 replica mode，否则为 pooled mode。"
+
+#: ../../source/designs/aibrix-stormservice.rst:42
+msgid ""
+"When `spec.mode` is set to `Pooled`, `spec.replicas` must stay at `1`; "
+"roles are scaled through `spec.template.spec.roles[].replicas`."
+msgstr ""
+"当 `spec.mode` 为 `Pooled` 时，`spec.replicas` 必须为 `1` ；角色通过 `spec.template.spec.roles[].replicas` "
+"扩缩。"
+
+#: ../../source/designs/aibrix-stormservice.rst:43
+msgid ""
+"A declared `spec.mode` drives the update path: `Replica` uses the rolling"
+" update path and `Pooled` uses the in-place update path, even when "
+"`spec.updateStrategy.type` holds the (possibly CRD-defaulted) "
+"`RollingUpdate` value. Declaring `mode: Replica` together with "
+"`updateStrategy.type: InPlaceUpdate` is rejected by the webhook. When "
+"`spec.mode` is omitted, `spec.updateStrategy.type` keeps selecting the "
+"update path as before."
+msgstr ""
+"已声明的 `spec.mode` 决定更新路径：`Replica` 走滚动更新，`Pooled` 走原地更新，即使 `spec.updateStrategy.type` "
+"为（可能由 CRD 默认的）`RollingUpdate` 。同时声明 `mode: Replica` 与 `updateStrategy.type: "
+"InPlaceUpdate` 会被 webhook 拒绝。省略 `spec.mode` 时，仍由 `spec.updateStrategy.type` "
+"选择更新路径。"
+
+#: ../../source/designs/aibrix-stormservice.rst:44
+msgid ""
+"A declared `spec.mode` is also the source of truth for PodAutoscaler "
+"role-level scaling. The `autoscaling.aibrix.ai/storm-service-mode` "
+"annotation is deprecated and only honored when the target StormService "
+"does not declare `spec.mode`."
+msgstr ""
+"已声明的 `spec.mode` 也是 PodAutoscaler 角色级扩缩容的权威来源。"
+"`autoscaling.aibrix.ai/storm-service-mode` 注解已弃用，仅在目标 StormService 未声明 `spec.mode` 时生效。"
+
+#: ../../source/designs/aibrix-stormservice.rst:48
+msgid "Replica Mode"
+msgstr "Replica Mode"
+
+#: ../../source/designs/aibrix-stormservice.rst:50
+msgid ""
+"**Replica Mode** treats each `RoleSet` as an independent replica of the "
+"service. If you already know P/D ratio, you can directly configure the "
+"RoleSet and replicate it."
+msgstr ""
+"**Replica Mode** 将每个 `RoleSet` 视为服务的独立副本。"
+"若已确定 P/D 比例，可直接配置 RoleSet 并复制。"
+
+#: ../../source/designs/aibrix-stormservice.rst:52
+#: ../../source/designs/aibrix-stormservice.rst:63
+msgid "**Characteristics**"
+msgstr "**特点**"
+
+#: ../../source/designs/aibrix-stormservice.rst:54
+msgid ""
+"**Independent Replicas**: Each `RoleSet` operates independently, and "
+"changes to one `RoleSet` do not directly affect others."
+msgstr "**独立副本** ：每个 `RoleSet` 独立运行，对一个 `RoleSet` 的变更不会直接影响其他副本。"
+
+#: ../../source/designs/aibrix-stormservice.rst:55
+msgid ""
+"**Scaling at RoleSet Level**: Scaling operations are performed by adding "
+"or removing entire `RoleSet` instances."
+msgstr "**RoleSet 级扩缩** ：通过增加或删除整个 `RoleSet` 实例进行扩缩。"
+
+#: ../../source/designs/aibrix-stormservice.rst:59
+msgid "Pooled Mode"
+msgstr "Pooled Mode"
+
+#: ../../source/designs/aibrix-stormservice.rst:61
+msgid ""
+"**Pooled Mode** views each role within a `RoleSet` as part of a shared "
+"pool. In this mode, each role is supposed to be independently scalable. "
+"It is designed to handle scenarios where different roles have different "
+"scaling needs."
+msgstr ""
+"**Pooled Mode** 将 `RoleSet` 中每个角色视为共享池的一部分。该模式下各角色应可独立扩缩，"
+"用于不同角色有不同扩缩需求的场景。"
+
+#: ../../source/designs/aibrix-stormservice.rst:65
+msgid "**Resource Pool**: Prefill or Decode instance form a shared pool."
+msgstr "**资源池** ：Prefill 或 Decode 实例组成共享池。"
+
+#: ../../source/designs/aibrix-stormservice.rst:66
+msgid ""
+"**Independent Role Scaling**: Each role can be scaled independently based"
+" on its specific load and requirements."
+msgstr "**角色独立扩缩** ：每个角色可按其负载与需求独立扩缩。"
+
+#: ../../source/designs/aibrix-stormservice.rst:70
+msgid "Drain Before Controller-Managed Deletion"
+msgstr "控制器删除前的 Drain"
+
+#: ../../source/designs/aibrix-stormservice.rst:72
+msgid ""
+"RoleSet can mark Pods as draining before controller-managed deletion. "
+"This is useful for scale-in and recreate rollouts where the gateway "
+"should stop sending new requests to a Pod before the Pod is deleted."
+msgstr ""
+"RoleSet 可在控制器管理的删除前将 Pod 标记为 draining。"
+"适用于缩容与重建滚动：网关应在 Pod 删除前停止向其发送新请求。"
+
+#: ../../source/designs/aibrix-stormservice.rst:76
+msgid ""
+"Configure drain per role through ``spec.template.spec.roles[].drain`` on "
+"a StormService, or ``spec.roles[].drain`` when managing a RoleSet "
+"directly:"
+msgstr ""
+"通过 StormService 的 ``spec.template.spec.roles[].drain`` 按角色配置 drain；直接管理 "
+"RoleSet 时使用 ``spec.roles[].drain`` ："
+
+#: ../../source/designs/aibrix-stormservice.rst:90
+msgid ""
+"``timeoutSeconds`` is optional and must be non-negative. When it is "
+"omitted or set to ``0``, the controller keeps the previous behavior and "
+"deletes selected Pods immediately."
+msgstr ""
+"``timeoutSeconds`` 可选且必须非负。省略或设为 ``0`` 时，控制器保持原有行为，立即删除所选 Pod。"
+
+#: ../../source/designs/aibrix-stormservice.rst:94
+msgid ""
+"When ``timeoutSeconds`` is greater than ``0``, the RoleSet controller "
+"handles a selected Pod in two phases:"
+msgstr "当 ``timeoutSeconds`` 大于 ``0`` 时，RoleSet 控制器分两阶段处理所选 Pod："
+
+#: ../../source/designs/aibrix-stormservice.rst:97
+msgid ""
+"Patch the Pod with drain annotations and requeue until the timeout "
+"expires."
+msgstr "为 Pod 打上 drain 注解，并重新入队直到超时。"
+
+#: ../../source/designs/aibrix-stormservice.rst:98
+msgid "Delete the Pod after the configured timeout has elapsed."
+msgstr "超时后删除该 Pod。"
+
+#: ../../source/designs/aibrix-stormservice.rst:100
+msgid "The controller writes the following annotations:"
+msgstr "控制器写入以下注解："
+
+#: ../../source/designs/aibrix-stormservice.rst:102
+msgid "Drain annotations"
+msgstr "Drain 注解"
+
+#: ../../source/designs/aibrix-stormservice.rst:106
+msgid "Annotation"
+msgstr "注解"
+
+#: ../../source/designs/aibrix-stormservice.rst:107
+msgid "Purpose"
+msgstr "用途"
+
+#: ../../source/designs/aibrix-stormservice.rst:108
+msgid "``aibrix.ai/draining=true``"
+msgstr "``aibrix.ai/draining=true``"
+
+#: ../../source/designs/aibrix-stormservice.rst:109
+msgid ""
+"Marks the Pod as draining. Gateway ready-pod filtering excludes Pods with"
+" this value."
+msgstr "将 Pod 标记为 draining。网关就绪 Pod 过滤会排除带该值的 Pod。"
+
+#: ../../source/designs/aibrix-stormservice.rst:111
+msgid "``aibrix.ai/drain-start-time``"
+msgstr "``aibrix.ai/drain-start-time``"
+
+#: ../../source/designs/aibrix-stormservice.rst:112
+msgid "RFC3339 UTC timestamp used by the controller to calculate timeout expiry."
+msgstr "RFC3339 UTC 时间戳，控制器用其计算超时到期。"
+
+#: ../../source/designs/aibrix-stormservice.rst:114
+msgid "``aibrix.ai/drain-reason``"
+msgstr "``aibrix.ai/drain-reason``"
+
+#: ../../source/designs/aibrix-stormservice.rst:115
+msgid "Diagnostic reason, such as ``scale-in`` or ``rollout``."
+msgstr "诊断原因，例如 ``scale-in`` 或 ``rollout`` 。"
+
+#: ../../source/designs/aibrix-stormservice.rst:116
+msgid "``aibrix.ai/drain-target-action=delete``"
+msgstr "``aibrix.ai/drain-target-action=delete``"
+
+#: ../../source/designs/aibrix-stormservice.rst:117
+msgid ""
+"Confirms the controller intends to delete this Pod after drain. If this "
+"value is missing or unexpected, the controller resets the drain state "
+"instead of deleting immediately."
+msgstr ""
+"确认控制器打算在 drain 后删除该 Pod。若该值缺失或异常，控制器会重置 drain 状态，而不是立即删除。"
+
+#: ../../source/designs/aibrix-stormservice.rst:121
+msgid ""
+"The controller emits ``PodDrainStarted`` when drain begins, "
+"``PodDrainCompleted`` when the Pod is deleted after the timeout, and "
+"``PodDrainStateInvalid`` when it repairs malformed drain state. It does "
+"not emit an event while simply waiting for the timeout; waiting is logged"
+" at verbose level only."
+msgstr ""
+"drain 开始时控制器发出 ``PodDrainStarted`` ，超时后删除 Pod 时发出 ``PodDrainCompleted`` "
+"，修复异常 drain 状态时发出 ``PodDrainStateInvalid`` 。仅等待超时不会发事件；等待只在 verbose 级别记录日志。"
+
+#: ../../source/designs/aibrix-stormservice.rst:127
+msgid ""
+"For roles using ``podGroupSize > 1``, the RoleSet controller propagates "
+"the role drain configuration to the internal PodSet so grouped Pods "
+"follow the same drain-before-delete behavior."
+msgstr ""
+"对使用 ``podGroupSize > 1`` 的角色，RoleSet 控制器将角色 drain 配置传播到内部 PodSet，"
+"使成组 Pod 遵循相同的删除前 drain 行为。"
+
+#: ../../source/designs/aibrix-stormservice.rst:133
+msgid "Topology Policy"
+msgstr "拓扑策略"
+
+#: ../../source/designs/aibrix-stormservice.rst:135
+msgid ""
+"StormService supports ``spec.template.spec.topologyPolicy`` to request "
+"Pod co-location through Kubernetes pod affinity. The same field is "
+"available on ``RoleSet.spec.topologyPolicy`` when managing RoleSets "
+"directly."
+msgstr ""
+"StormService 支持 ``spec.template.spec.topologyPolicy`` ，通过 Kubernetes pod "
+"affinity 请求 Pod 共置。直接管理 RoleSet 时，同一字段位于 ``RoleSet.spec.topologyPolicy`` "
+"。"
+
+#: ../../source/designs/aibrix-stormservice.rst:139
+msgid ""
+"This is useful when roles have topology-sensitive data paths, such as "
+"keeping Prefill and Decode Pods in the same host or zone to reduce cross-"
+"domain traffic. The controller injects the generated affinity into "
+"directly managed Pods and into PodSet templates for roles that use "
+"``podGroupSize > 1``."
+msgstr ""
+"适用于角色有拓扑敏感数据路径的场景，例如将 Prefill 与 Decode Pod 放在同一主机或可用区，以减少跨域流量。"
+"控制器将生成的 affinity 注入直接管理的 Pod，以及对 ``podGroupSize > 1`` 的角色注入 PodSet 模板。"
+
+#: ../../source/designs/aibrix-stormservice.rst:144
+msgid ""
+"Assume a StormService has two RoleSets, and each RoleSet has two roles: "
+"``prefill`` and ``decode``."
+msgstr "假设一个 StormService 有两个 RoleSet，每个 RoleSet 有两个角色：``prefill`` 和 ``decode`` 。"
+
+#: ../../source/designs/aibrix-stormservice.rst:197
+msgid "``scope`` controls which Pods the injected affinity matches:"
+msgstr "``scope`` 控制注入的 affinity 匹配哪些 Pod："
+
+#: ../../source/designs/aibrix-stormservice.rst:199
+msgid "Topology policy scope"
+msgstr "拓扑策略作用域"
+
+#: ../../source/designs/aibrix-stormservice.rst:203
+msgid "Scope"
+msgstr "作用域"
+
+#: ../../source/designs/aibrix-stormservice.rst:204
+msgid "Co-location behavior"
+msgstr "共置行为"
+
+#: ../../source/designs/aibrix-stormservice.rst:205
+msgid "Common use case"
+msgstr "常见用例"
+
+#: ../../source/designs/aibrix-stormservice.rst:206
+msgid "``StormService``"
+msgstr "``StormService``"
+
+#: ../../source/designs/aibrix-stormservice.rst:207
+msgid "All Pods in the StormService share the same topology value."
+msgstr "StormService 中所有 Pod 共享同一拓扑值。"
+
+#: ../../source/designs/aibrix-stormservice.rst:208
+msgid "Keep a small service replica inside one host or zone."
+msgstr "将小型服务副本保持在同一主机或可用区。"
+
+#: ../../source/designs/aibrix-stormservice.rst:209
+msgid "``RoleSet``"
+msgstr "``RoleSet``"
+
+#: ../../source/designs/aibrix-stormservice.rst:210
+msgid ""
+"All Pods in each RoleSet share a topology value. Different RoleSets may "
+"land in different topology domains."
+msgstr "每个 RoleSet 内的所有 Pod 共享同一拓扑值。不同 RoleSet 可落在不同拓扑域。"
+
+#: ../../source/designs/aibrix-stormservice.rst:212
+msgid "Keep each Prefill/Decode replica pair together."
+msgstr "将每对 Prefill/Decode 副本放在一起。"
+
+#: ../../source/designs/aibrix-stormservice.rst:213
+msgid "``Role``"
+msgstr "``Role``"
+
+#: ../../source/designs/aibrix-stormservice.rst:214
+msgid "Pods with the same role share a topology value across RoleSets."
+msgstr "相同角色的 Pod 跨 RoleSet 共享同一拓扑值。"
+
+#: ../../source/designs/aibrix-stormservice.rst:215
+msgid "Keep role-specific pools, such as all Prefill Pods, together."
+msgstr "将角色专用池（如所有 Prefill Pod）放在一起。"
+
+#: ../../source/designs/aibrix-stormservice.rst:217
+msgid ""
+"``key`` selects the Kubernetes node label used as the topology domain. "
+"Common values are ``kubernetes.io/hostname`` for node-level co-location "
+"and ``topology.kubernetes.io/zone`` for zone-level co-location."
+msgstr ""
+"``key`` 选择用作拓扑域的 Kubernetes 节点标签。"
+"常见值：``kubernetes.io/hostname`` 表示节点级共置，``topology.kubernetes.io/zone`` 表示可用区级共置。"
+
+#: ../../source/designs/aibrix-stormservice.rst:221
+msgid ""
+"You can also use an internal resource-pool label as the topology key. For"
+" example, label nodes by business pool:"
+msgstr "也可使用内部资源池标签作为拓扑 key。例如按业务池给节点打标签："
+
+#: ../../source/designs/aibrix-stormservice.rst:230
+msgid "Then use that label key in the topology policy:"
+msgstr "然后在拓扑策略中使用该标签 key："
+
+#: ../../source/designs/aibrix-stormservice.rst:242
+msgid ""
+"With this policy, Pods inside each RoleSet prefer to schedule into the "
+"same business resource pool, such as ``latency-pool`` or ``throughput-"
+"pool``."
+msgstr ""
+"使用该策略时，每个 RoleSet 内的 Pod 优先调度到同一业务资源池，例如 ``latency-pool`` 或 ``throughput-pool`` "
+"。"
+
+#: ../../source/designs/aibrix-stormservice.rst:245
+msgid "``mode`` selects scheduling strength:"
+msgstr "``mode`` 选择调度强度："
+
+#: ../../source/designs/aibrix-stormservice.rst:247
+msgid ""
+"``Preferred`` adds a strong pod affinity preference and is the default. "
+"Pods can still schedule in another topology domain when the preferred "
+"domain does not have enough resources."
+msgstr ""
+"``Preferred`` 添加较强的 pod affinity 偏好，且为默认值。"
+"首选拓扑域资源不足时，Pod 仍可调度到其他拓扑域。"
+
+#: ../../source/designs/aibrix-stormservice.rst:250
+msgid ""
+"``Required`` adds hard pod affinity. Pods can remain ``Pending`` when no "
+"node in the selected topology domain can satisfy the request."
+msgstr "``Required`` 添加硬性 pod affinity。所选拓扑域中没有节点能满足请求时，Pod 会保持 ``Pending`` 。"
+
+#: ../../source/designs/aibrix-stormservice.rst:254
+msgid "Example"
+msgstr "示例"
+
+#: ../../source/designs/aibrix-stormservice.rst:256
+msgid ""
+"The following policy prefers to place all Pods inside each RoleSet "
+"replica on the same node:"
+msgstr "以下策略优先将每个 RoleSet 副本内的所有 Pod 放到同一节点："
+
+#: ../../source/designs/aibrix-stormservice.rst:294
+msgid ""
+"Before using a custom topology key, label the nodes with that key. For "
+"example:"
+msgstr "使用自定义拓扑 key 前，先用该 key 给节点打标签。例如："
+
+#: ../../source/designs/aibrix-stormservice.rst:301
+msgid "Apply one of the topology policy samples and inspect Pod placement:"
+msgstr "应用某个拓扑策略示例并检查 Pod 放置："
+
+#: ../../source/designs/aibrix-stormservice.rst:308
+msgid ""
+"Topology policy updates affect only newly created or replaced Pods "
+"because Kubernetes Pod affinity is immutable after Pod creation. Existing"
+" Pods and PodSet templates pick up the new affinity after replacement or "
+"recreation."
+msgstr ""
+"拓扑策略更新只影响新创建或被替换的 Pod，因为 Kubernetes Pod affinity 在创建后不可变。"
+"现有 Pod 和 PodSet 模板在替换或重建后才会采用新的 affinity。"
+
+#: ../../source/designs/aibrix-stormservice.rst:312
+msgid "See the complete `topology policy samples`_ in the AIBrix repository."
+msgstr "完整示例见 AIBrix 仓库中的 `topology policy samples`_ 。"
+
+#: ../../source/designs/aibrix-stormservice.rst:318
+msgid "Gang Scheduling Strategies"
+msgstr "Gang 调度策略"
+
+#: ../../source/designs/aibrix-stormservice.rst:320
+msgid ""
+"StormService supports PodGroup-based gang scheduling through "
+"``spec.template.spec.schedulingStrategy``. This is the StormService entry"
+" point for configuring all Pods in each generated RoleSet as one gang-"
+"scheduled group."
+msgstr ""
+"StormService 通过 ``spec.template.spec.schedulingStrategy`` 支持基于 PodGroup 的 gang 调度。"
+"这是将每个生成的 RoleSet 中所有 Pod 配置为一个 gang 调度组的 StormService 入口。"
+
+#: ../../source/designs/aibrix-stormservice.rst:324
+msgid ""
+"Gang scheduling is useful for PD-disaggregated serving and other multi-"
+"role inference workloads where starting only part of the service replica "
+"is not useful. For example, a Prefill/Decode replica may need enough "
+"Prefill Pods and enough Decode Pods to be admitted together before it can"
+" serve traffic."
+msgstr ""
+"Gang 调度适用于 PD 分离服务及其他多角色推理负载：只启动服务副本的一部分没有意义。"
+"例如，Prefill/Decode 副本可能需要足够的 Prefill Pod 和 Decode Pod 一起被准入后才能对外服务。"
+
+#: ../../source/designs/aibrix-stormservice.rst:329
+msgid ""
+"``schedulingStrategy`` currently accepts one of the following scheduler-"
+"specific strategies:"
+msgstr "``schedulingStrategy`` 当前可接受以下调度器特定策略之一："
+
+#: ../../source/designs/aibrix-stormservice.rst:332
+msgid "Gang scheduling strategies"
+msgstr "Gang 调度策略"
+
+#: ../../source/designs/aibrix-stormservice.rst:336
+msgid "Strategy field"
+msgstr "策略字段"
+
+#: ../../source/designs/aibrix-stormservice.rst:337
+msgid "PodGroup API"
+msgstr "PodGroup API"
+
+#: ../../source/designs/aibrix-stormservice.rst:338
+msgid "Main fields"
+msgstr "主要字段"
+
+#: ../../source/designs/aibrix-stormservice.rst:339
+msgid "``volcanoSchedulingStrategy``"
+msgstr "``volcanoSchedulingStrategy``"
+
+#: ../../source/designs/aibrix-stormservice.rst:340
+msgid "Volcano ``PodGroup``"
+msgstr "Volcano ``PodGroup``"
+
+#: ../../source/designs/aibrix-stormservice.rst:341
+msgid ""
+"``minMember``, ``minTaskMember``, ``queue``, ``priorityClassName``, "
+"``minResources``"
+msgstr ""
+"``minMember`` 、``minTaskMember`` 、``queue`` 、``priorityClassName`` 、``minResources``"
+
+#: ../../source/designs/aibrix-stormservice.rst:343
+msgid "``godelSchedulingStrategy``"
+msgstr "``godelSchedulingStrategy``"
+
+#: ../../source/designs/aibrix-stormservice.rst:344
+msgid "Godel ``PodGroup``"
+msgstr "Godel ``PodGroup``"
+
+#: ../../source/designs/aibrix-stormservice.rst:345
+msgid ""
+"``minMember``, ``priorityClassName``, ``scheduleTimeoutSeconds``, "
+"``application``, ``affinity``"
+msgstr ""
+"``minMember`` 、``priorityClassName`` 、``scheduleTimeoutSeconds`` 、``application`` "
+"、``affinity``"
+
+#: ../../source/designs/aibrix-stormservice.rst:347
+msgid "``coschedulingSchedulingStrategy``"
+msgstr "``coschedulingSchedulingStrategy``"
+
+#: ../../source/designs/aibrix-stormservice.rst:348
+msgid "Kubernetes scheduler-plugins ``PodGroup``"
+msgstr "Kubernetes scheduler-plugins ``PodGroup``"
+
+#: ../../source/designs/aibrix-stormservice.rst:349
+msgid "``minMember``, ``minResources``, ``scheduleTimeoutSeconds``"
+msgstr "``minMember`` 、``minResources`` 、``scheduleTimeoutSeconds``"
+
+#: ../../source/designs/aibrix-stormservice.rst:351
+msgid ""
+"When the scheduling strategy is set on the StormService template, the "
+"StormService controller copies it to each managed RoleSet. The RoleSet "
+"controller creates one scheduler-specific ``PodGroup`` for the RoleSet "
+"and attaches generated Pods or PodSets to that PodGroup. For Volcano, the"
+" controller also marks each role with the Volcano task name ``volcano.sh"
+"/task-spec=<role name>``. ``minTaskMember`` keys therefore match "
+"StormService role names."
+msgstr ""
+"调度策略设置在 StormService 模板上时，StormService 控制器会将其复制到每个托管 RoleSet。RoleSet 控制器为该 "
+"RoleSet 创建一个调度器特定的 ``PodGroup`` ，并将生成的 Pod 或 PodSet 挂到该 PodGroup。对 Volcano，控制器还会用 "
+"Volcano 任务名 ``volcano.sh/task-spec=<role name>`` 标记每个角色。因此 ``minTaskMember`` "
+"的 key 与 StormService 角色名一致。"
+
+#: ../../source/designs/aibrix-stormservice.rst:359
+msgid ""
+"The rest of this section focuses on Volcano because it supports both "
+"group-level ``minMember`` and role-level ``minTaskMember`` from the "
+"StormService entry point."
+msgstr ""
+"本节其余部分聚焦 Volcano，因为它从 StormService 入口同时支持组级 ``minMember`` 和角色级 ``minTaskMember`` "
+"。"
+
+#: ../../source/designs/aibrix-stormservice.rst:363
+msgid ""
+"For single-Pod role replicas, the RoleSet can create Pods directly. For "
+"multi-node inference, set ``podGroupSize > 1`` on a role. Each role "
+"replica then becomes one PodSet, and the PodSet creates the multiple Pods"
+" that form that replica. A RoleSet-level scheduling strategy still "
+"creates one PodGroup for the whole RoleSet, so Volcano admits the Prefill"
+" and Decode PodSets together."
+msgstr ""
+"对单 Pod 角色副本，RoleSet 可直接创建 Pod。对多节点推理，在角色上设置 ``podGroupSize > 1`` 。每个角色副本随后成为一个 "
+"PodSet，由 PodSet 创建组成该副本的多个 Pod。RoleSet 级调度策略仍为整个 RoleSet 创建一个 PodGroup，因此 "
+"Volcano 会一起准入 Prefill 和 Decode PodSet。"
+
+#: ../../source/designs/aibrix-stormservice.rst:401
+msgid "Group-level ``minMember``"
+msgstr "组级 ``minMember``"
+
+#: ../../source/designs/aibrix-stormservice.rst:403
+msgid ""
+"``minMember`` is the minimum total number of Pods that must be "
+"schedulable for the Volcano PodGroup. If fewer than ``minMember`` Pods "
+"can be admitted, Volcano keeps the gang pending instead of starting only "
+"a partial RoleSet."
+msgstr ""
+"``minMember`` 是 Volcano PodGroup 必须可调度的最少 Pod 总数。若可准入的 Pod 少于 ``minMember`` "
+"，Volcano 会让 gang 保持 pending，而不是只启动部分 RoleSet。"
+
+#: ../../source/designs/aibrix-stormservice.rst:407
+msgid ""
+"The following multi-node shape shows how ``minMember`` applies when role "
+"replicas are expanded into PodSets. The YAML after the diagram uses the "
+"same shape: two Prefill replicas and three Decode replicas, each with "
+"``podGroupSize: 2``."
+msgstr ""
+"以下多节点形态说明角色副本展开为 PodSet 时 ``minMember`` 如何生效。图后 YAML 使用同一形态：两个 Prefill 副本和三个 "
+"Decode 副本，每个 ``podGroupSize: 2`` 。"
+
+#: ../../source/designs/aibrix-stormservice.rst:499
+msgid "Role-level ``minTaskMember``"
+msgstr "角色级 ``minTaskMember``"
+
+#: ../../source/designs/aibrix-stormservice.rst:501
+msgid ""
+"``minTaskMember`` adds per-task minimums inside the same Volcano "
+"PodGroup. In a StormService-created RoleSet, each role becomes a Volcano "
+"task, so the map keys are role names such as ``prefill`` and ``decode``."
+msgstr ""
+"``minTaskMember`` 在同一 Volcano PodGroup 内增加每任务最小值。在 StormService 创建的 RoleSet "
+"中，每个角色成为一个 Volcano 任务，因此 map key 为角色名，如 ``prefill`` 和 ``decode`` 。"
+
+#: ../../source/designs/aibrix-stormservice.rst:505
+msgid ""
+"The following multi-node shape shows how ``minTaskMember`` applies to the"
+" Pods inside each role's PodSet. The YAML after the diagram keeps the "
+"same multi-node shape and requires all Pods from the two Prefill PodSets "
+"and at least one Decode PodSet worth of Pods before the PodGroup is "
+"considered ready for task-level admission."
+msgstr ""
+"以下多节点形态说明 ``minTaskMember`` 如何作用于每个角色 PodSet 内的 Pod。"
+"图后 YAML 保持同一多节点形态：任务级准入要求两个 Prefill PodSet 的全部 Pod，以及至少一个 Decode PodSet 的 Pod。"
+
+#: ../../source/designs/aibrix-stormservice.rst:604
+msgid ""
+"``minTaskMember`` counts Pods, not logical role replicas. If a role uses "
+"``podGroupSize`` greater than 1 for multi-pod replicas, translate replica"
+" minimums into Pod counts yourself. For example, if each Prefill replica "
+"has two Pods and the desired minimum is two Prefill replicas, set "
+"``minTaskMember.prefill`` to ``4``."
+msgstr ""
+"``minTaskMember`` 统计的是 Pod 数，不是逻辑角色副本数。若角色使用大于 1 的 ``podGroupSize`` 做多 Pod "
+"副本，需自行将副本最小值换算为 Pod 数。例如每个 Prefill 副本有两个 Pod，最少需要两个 Prefill 副本时，将 ``minTaskMember.prefill`` "
+"设为 ``4`` 。"
+
+#: ../../source/designs/aibrix-stormservice.rst:611
+msgid "RoleSet-level and per-role scheduling"
+msgstr "RoleSet 级与按角色调度"
+
+#: ../../source/designs/aibrix-stormservice.rst:613
+msgid ""
+"Set ``spec.template.spec.schedulingStrategy`` on StormService when the "
+"whole generated RoleSet should share one PodGroup. This is the common "
+"setting for PD-disaggregated serving, because Prefill and Decode Pods are"
+" admitted as one service replica."
+msgstr ""
+"当整个生成的 RoleSet 应共享一个 PodGroup 时，在 StormService 上设置 ``spec.template.spec.schedulingStrategy`` "
+"。这是 PD 分离服务的常见设置，因为 Prefill 和 Decode Pod 作为同一服务副本被准入。"
+
+#: ../../source/designs/aibrix-stormservice.rst:618
+msgid ""
+"Set ``spec.template.spec.roles[].schedulingStrategy`` only when a "
+"specific role needs its own scheduling strategy. For roles that use "
+"``podGroupSize > 1``, the controller creates PodSet resources for the "
+"role, and a role-level scheduling strategy applies to those PodSets "
+"instead of the whole RoleSet. Do not set "
+"``spec.template.spec.schedulingStrategy`` together with any "
+"``spec.template.spec.roles[].schedulingStrategy`` entry; RoleSet-level "
+"and role-level scheduling strategies are mutually exclusive."
+msgstr ""
+"仅当特定角色需要自己的调度策略时，设置 ``spec.template.spec.roles[].schedulingStrategy`` 。对使用 "
+"``podGroupSize > 1`` 的角色，控制器会为该角色创建 PodSet 资源，角色级调度策略作用于这些 PodSet 而非整个 RoleSet。不要同时设置 "
+"``spec.template.spec.schedulingStrategy`` 与任何 ``spec.template.spec.roles[].schedulingStrategy`` "
+"；RoleSet 级与角色级调度策略互斥。"
+
+#: ../../source/designs/aibrix-stormservice.rst:627
+msgid "Scheduler and limitations"
+msgstr "调度器与限制"
+
+#: ../../source/designs/aibrix-stormservice.rst:629
+msgid ""
+"Set each Pod template's ``schedulerName`` to the scheduler that should "
+"consume the selected PodGroup. The Volcano examples set ``schedulerName: "
+"volcano`` explicitly so the scheduling intent is visible in the "
+"StormService manifest. AIBrix also defaults generated Pods and PodSet "
+"Pods to the Volcano scheduler when it attaches them to a Volcano "
+"PodGroup, but keeping the field explicit makes the configuration easier "
+"to review and debug. For Godel or Coscheduling, use the scheduler name "
+"installed in your cluster."
+msgstr ""
+"将每个 Pod 模板的 ``schedulerName`` 设为应消费所选 PodGroup 的调度器。Volcano 示例显式设置 ``schedulerName: "
+"volcano`` ，以便在 StormService 清单中看到调度意图。当把生成的 Pod 和 PodSet Pod 挂到 Volcano "
+"PodGroup 时，AIBrix 也会默认使用 Volcano 调度器，但显式写出该字段更便于审查和调试。对 Godel 或 Coscheduling，使用集群中已安装的调度器名称。"
+
+#: ../../source/designs/aibrix-stormservice.rst:637
+msgid ""
+"``minTaskMember`` is not the same as Volcano ``subGroupPolicy``. AIBrix "
+"exposes Volcano ``minTaskMember`` as a simple per-task Pod-count minimum;"
+" it does not expose ``subGroupPolicy`` through the StormService API. If a"
+" workload needs subgroup semantics beyond per-role Pod counts, that "
+"behavior is outside the current StormService API."
+msgstr ""
+"``minTaskMember`` 与 Volcano ``subGroupPolicy`` 不同。AIBrix 将 Volcano ``minTaskMember`` "
+"暴露为简单的每任务 Pod 数下限；不通过 StormService API 暴露 ``subGroupPolicy`` 。若工作负载需要超出按角色 "
+"Pod 计数的子组语义，该行为不在当前 StormService API 范围内。"
+
+#: ../../source/designs/aibrix-stormservice.rst:643
+msgid ""
+"When using ``minTaskMember``, keep ``minMember`` greater than or equal to"
+" the sum of all ``minTaskMember`` values. If ``minMember`` is lower than "
+"that sum, the StormService and RoleSet webhooks reject the object as "
+"invalid because Volcano would otherwise ignore ``minTaskMember``. If "
+"validation is bypassed, AIBrix reports the same issue through the "
+"``GangSchedulingError`` condition."
+msgstr ""
+"使用 ``minTaskMember`` 时，``minMember`` 必须大于或等于所有 ``minTaskMember`` 值之和。若 ``minMember`` "
+"小于该和，StormService 和 RoleSet webhook 会拒绝该对象，因为否则 Volcano 会忽略 ``minTaskMember`` "
+"。若绕过校验，AIBrix 会通过 ``GangSchedulingError`` 条件报告同一问题。"
+
+#: ../../source/designs/aibrix-stormservice.rst:651
+msgid "Historical-Node Replacement Scheduling"
+msgstr "历史节点替换调度"
+
+#: ../../source/designs/aibrix-stormservice.rst:653
+msgid ""
+"RoleSet historical-node scheduling lets replacement Pods prefer nodes "
+"that previously ran the same role workload. It is useful for inference "
+"workloads where node locality can preserve useful warm state, such as "
+"downloaded model files, runtime caches, or KV cache artifacts."
+msgstr ""
+"RoleSet 历史节点调度让替换 Pod 优先选择曾运行同一角色负载的节点。"
+"适用于节点局部性可保留有用热状态的推理负载，例如已下载的模型文件、运行时缓存或 KVCache 产物。"
+
+#: ../../source/designs/aibrix-stormservice.rst:658
+msgid ""
+"Enable the policy on a role with "
+"``spec.roles[].updateStrategy.replacementScheduling.historicalNode``. The"
+" same field can be used through "
+"``StormService.spec.template.spec.roles[]`` because StormService "
+"templates carry RoleSet role specs."
+msgstr ""
+"通过 ``spec.roles[].updateStrategy.replacementScheduling.historicalNode`` 在角色上启用该策略。"
+"同一字段也可通过 ``StormService.spec.template.spec.roles[]`` 使用，因为 StormService 模板携带 RoleSet 角色规格。"
+
+#: ../../source/designs/aibrix-stormservice.rst:673
+msgid ""
+"``mode: Preferred`` injects a preferred ``kubernetes.io/hostname`` node "
+"affinity into replacement Pods. The preference is soft: Kubernetes can "
+"still place the Pod on another node when the historical node is "
+"unavailable or lacks capacity."
+msgstr ""
+"``mode: Preferred`` 向替换 Pod 注入首选 ``kubernetes.io/hostname`` 节点亲和性。"
+"该偏好是软约束：历史节点不可用或容量不足时，Kubernetes 仍可将 Pod 放到其他节点。"
+
+#: ../../source/designs/aibrix-stormservice.rst:678
+msgid ""
+"The controller records historical node bindings in the RoleSet annotation"
+" ``orchestration.aibrix.ai/historical-node-bindings``. Because the "
+"history is persisted on the RoleSet, replacement scheduling can continue "
+"to use remembered nodes after the controller restarts."
+msgstr ""
+"控制器将历史节点绑定记录在 RoleSet 注解 ``orchestration.aibrix.ai/historical-node-bindings`` 中。"
+"历史持久化在 RoleSet 上，因此控制器重启后替换调度仍可使用记住的节点。"
+
+#: ../../source/designs/aibrix-stormservice.rst:683
+msgid ""
+"Stateful and stateless roles use different history scopes because they "
+"have different identity semantics:"
+msgstr "有状态与无状态角色使用不同的历史作用域，因为身份语义不同："
+
+#: ../../source/designs/aibrix-stormservice.rst:690
+msgid "Role type"
+msgstr "角色类型"
+
+#: ../../source/designs/aibrix-stormservice.rst:691
+msgid "History scope"
+msgstr "历史作用域"
+
+#: ../../source/designs/aibrix-stormservice.rst:692
+msgid "Reason"
+msgstr "原因"
+
+#: ../../source/designs/aibrix-stormservice.rst:693
+msgid "Stateful"
+msgstr "有状态"
+
+#: ../../source/designs/aibrix-stormservice.rst:694
+msgid "Replica slot, for example ``worker/0 -> node-a``"
+msgstr "副本槽位，例如 ``worker/0 -> node-a``"
+
+#: ../../source/designs/aibrix-stormservice.rst:695
+msgid ""
+"A stateful slot remains the same logical replica after its Pod is deleted"
+" and recreated, so the controller can safely bind history to the slot."
+msgstr "有状态槽位在 Pod 删除并重建后仍是同一逻辑副本，因此控制器可安全将历史绑定到该槽位。"
+
+#: ../../source/designs/aibrix-stormservice.rst:698
+msgid "Stateless"
+msgstr "无状态"
+
+#: ../../source/designs/aibrix-stormservice.rst:699
+msgid "Role-level recent-node list, for example ``worker -> [node-a, node-b]``"
+msgstr "角色级近期节点列表，例如 ``worker -> [node-a, node-b]``"
+
+#: ../../source/designs/aibrix-stormservice.rst:700
+msgid ""
+"Stateless Pods do not have stable per-replica identity, so a replacement "
+"Pod cannot safely inherit one exact old Pod's slot binding."
+msgstr "无状态 Pod 没有稳定的每副本身份，因此替换 Pod 不能安全继承某个旧 Pod 的槽位绑定。"
+
+#: ../../source/designs/aibrix-stormservice.rst:703
+msgid ""
+"For stateless roles, the controller injects the remembered node list as "
+"one preferred affinity term. The Kubernetes scheduler chooses among those"
+" nodes with normal scheduling scoring; the RoleSet controller does not "
+"choose one node from the list, and multiple replacement Pods can still "
+"land on the same historical node when that node is the scheduler's best "
+"fit."
+msgstr ""
+"对无状态角色，控制器将记住的节点列表注入为一个首选亲和性项。"
+"Kubernetes 调度器按正常调度打分在这些节点中选择；RoleSet 控制器不会从列表中指定单个节点。"
+"当某历史节点是调度器的最佳匹配时，多个替换 Pod 仍可能落到同一节点。"
+
+#: ../../source/designs/aibrix-stormservice.rst:709
+msgid ""
+"The policy applies when the RoleSet controller creates replacement Pods "
+"during recreate-style rollouts. For stateful roles, empty-slot creation "
+"can also reuse an existing slot binding. Stateless scale-up is not "
+"replacement and does not use historical-node affinity because the new Pod"
+" adds capacity instead of replacing a remembered logical replica."
+msgstr ""
+"该策略在 RoleSet 控制器于重建式滚动中创建替换 Pod 时生效。"
+"对有状态角色，空槽创建也可复用已有槽位绑定。"
+"无状态扩容不是替换，不使用历史节点亲和性，因为新 Pod 是增加容量，而不是替换被记住的逻辑副本。"
+
+#: ../../source/designs/aibrix-stormservice.rst:715
+msgid ""
+"Historical-node scheduling only adds preferred node affinity. The "
+"controller skips injection when the Pod template already defines required"
+" node affinity, when the RoleSet has a required topology policy using "
+"``kubernetes.io/hostname``, or when the role uses ``podGroupSize`` "
+"greater than 1. When injection is skipped, the controller logs the "
+"reason."
+msgstr ""
+"历史节点调度只添加首选节点亲和性。以下情况控制器跳过注入："
+"Pod 模板已定义 required 节点亲和性、RoleSet 有使用 ``kubernetes.io/hostname`` 的 required 拓扑策略、"
+"或角色的 ``podGroupSize`` 大于 1。跳过时控制器会记录原因。"
+
+#: ../../source/designs/aibrix-stormservice.rst:721
+msgid ""
+"See ``samples/orchestration/stormservice-historical-node-"
+"scheduling.yaml`` for stateful and stateless examples with inline "
+"comments."
+msgstr ""
+"有状态与无状态示例（含行内注释）见 ``samples/orchestration/stormservice-historical-node-scheduling.yaml`` "
+"。"
+
+#: ../../source/designs/aibrix-stormservice.rst:727
+msgid "Update Strategy"
+msgstr "更新策略"
+
+#: ../../source/designs/aibrix-stormservice.rst:729
+msgid ""
+"StormService supports multiple strategies to update the managed RoleSets."
+" These strategies are designed to handle different operational modes and "
+"ensure service availability during the update process. Below is a "
+"detailed explanation of each strategy:"
+msgstr ""
+"StormService 支持多种策略来更新所管理的 RoleSet。"
+"这些策略面向不同运行模式，并在更新过程中保证服务可用性。下文详细说明每种策略："
+
+#: ../../source/designs/aibrix-stormservice.rst:732
+msgid "Rolling Update"
+msgstr "滚动更新"
+
+#: ../../source/designs/aibrix-stormservice.rst:734
+msgid ""
+"**Designed for replica mode**, the rolling update strategy gradually "
+"replaces old RoleSets with new ones. This approach ensures that the "
+"service remains available throughout the update process by respecting the"
+" `MaxUnavailable` and `MaxSurge` settings."
+msgstr ""
+"**面向 replica mode** ，滚动更新策略逐步用新 RoleSet 替换旧 RoleSet。通过遵守 `MaxUnavailable` "
+"和 `MaxSurge` 设置，保证更新过程中服务可用。"
+
+#: ../../source/designs/aibrix-stormservice.rst:736
+#: ../../source/designs/aibrix-stormservice.rst:775
+msgid "**How it Works**"
+msgstr "**工作方式**"
+
+#: ../../source/designs/aibrix-stormservice.rst:738
+msgid ""
+"**Initial State**: At the start, all RoleSets are running the old "
+"revision."
+msgstr "**初始状态** ：开始时所有 RoleSet 运行旧 revision。"
+
+#: ../../source/designs/aibrix-stormservice.rst:739
+msgid ""
+"**Create New RoleSets**: The controller creates new RoleSets with the "
+"updated revision, ensuring that the total number of RoleSets (old + new) "
+"does not exceed the sum of the desired replicas and `MaxSurge`."
+msgstr ""
+"**创建新 RoleSet** ：控制器用更新后的 revision 创建新 RoleSet，确保 RoleSet 总数（旧 + 新）不超过期望副本数与 "
+"`MaxSurge` 之和。"
+
+#: ../../source/designs/aibrix-stormservice.rst:740
+msgid ""
+"**Delete Old RoleSets**: Once the new RoleSets are ready, the controller "
+"starts deleting old RoleSets. It ensures that the number of unavailable "
+"RoleSets does not exceed `MaxUnavailable` at any time."
+msgstr ""
+"**删除旧 RoleSet** ：新 RoleSet 就绪后，控制器开始删除旧 RoleSet。任何时刻不可用 RoleSet 数都不超过 `MaxUnavailable` "
+"。"
+
+#: ../../source/designs/aibrix-stormservice.rst:741
+msgid ""
+"**Repeat**: Steps 2 and 3 are repeated until all old RoleSets are "
+"replaced by new ones."
+msgstr "**重复** ：重复步骤 2 和 3，直到所有旧 RoleSet 被新 RoleSet 替换。"
+
+#: ../../source/designs/aibrix-stormservice.rst:743
+msgid "**Configuration Parameters**"
+msgstr "**配置参数**"
+
+#: ../../source/designs/aibrix-stormservice.rst:745
+msgid ""
+"**MaxUnavailable**: This parameter defines the maximum number of RoleSets"
+" that can be unavailable during the update process. It ensures that a "
+"minimum number of RoleSets are always available to serve requests."
+msgstr "**MaxUnavailable** ：更新过程中最多允许多少 RoleSet 不可用。保证始终有最少数量的 RoleSet 可服务请求。"
+
+#: ../../source/designs/aibrix-stormservice.rst:746
+msgid ""
+"**MaxSurge**: This parameter defines the maximum number of RoleSets that "
+"can be created above the desired number of replicas during the update "
+"process. It allows the controller to create additional RoleSets "
+"temporarily to speed up the update."
+msgstr "**MaxSurge** ：更新过程中允许超出期望副本数额外创建的 RoleSet 上限。控制器可临时创建额外 RoleSet 以加快更新。"
+
+#: ../../source/designs/aibrix-stormservice.rst:748
+msgid "**Example**"
+msgstr "**示例**"
+
+#: ../../source/designs/aibrix-stormservice.rst:750
+msgid ""
+"Suppose we have a `StormService` with 3 replicas, `MaxUnavailable` set to"
+" 1, and `MaxSurge` set to 1. The rolling update process might look like "
+"this:"
+msgstr ""
+"假设 `StormService` 有 3 个副本，`MaxUnavailable` 为 1，`MaxSurge` 为 1。滚动更新过程可能如下："
+
+#: ../../source/designs/aibrix-stormservice.rst:768
+msgid "InPlace Update"
+msgstr "原地更新"
+
+#: ../../source/designs/aibrix-stormservice.rst:770
+msgid ""
+"**Designed for pooled mode**, the StormService ``InPlaceUpdate`` strategy"
+" updates the existing RoleSets instead of deleting and recreating them. "
+"This is an outer update layer: preserving a RoleSet does not, by itself, "
+"preserve the Pods owned by that RoleSet."
+msgstr ""
+"**面向 pooled mode** ，StormService ``InPlaceUpdate`` 策略更新现有 RoleSet，而不是删除后重建。这是外层更新：保留 "
+"RoleSet 本身并不等于保留该 RoleSet 拥有的 Pod。"
+
+#: ../../source/designs/aibrix-stormservice.rst:777
+msgid ""
+"The StormService controller identifies RoleSets that do not use the "
+"latest StormService revision."
+msgstr "StormService 控制器识别未使用最新 StormService revision 的 RoleSet。"
+
+#: ../../source/designs/aibrix-stormservice.rst:779
+msgid ""
+"With ``StormService.spec.updateStrategy.type: InPlaceUpdate``, the "
+"controller updates those RoleSet objects in place."
+msgstr ""
+"当 ``StormService.spec.updateStrategy.type: InPlaceUpdate`` 时，控制器原地更新这些 RoleSet 对象。"
+
+#: ../../source/designs/aibrix-stormservice.rst:781
+msgid ""
+"Each RoleSet then updates its roles. The role-level strategy determines "
+"whether Pods are patched or replaced."
+msgstr "随后每个 RoleSet 更新其角色。角色级策略决定对 Pod 做 patch 还是替换。"
+
+#: ../../source/designs/aibrix-stormservice.rst:784
+msgid "**Advantages**"
+msgstr "**优点**"
+
+#: ../../source/designs/aibrix-stormservice.rst:786
+msgid ""
+"**Stable RoleSets**: No replacement RoleSets are created during the "
+"update."
+msgstr "**RoleSet 稳定** ：更新期间不创建替换 RoleSet。"
+
+#: ../../source/designs/aibrix-stormservice.rst:787
+msgid ""
+"**Fast propagation**: The latest template is applied directly to the "
+"existing RoleSets."
+msgstr "**传播快** ：最新模板直接应用到现有 RoleSet。"
+
+#: ../../source/designs/aibrix-stormservice.rst:789
+msgid ""
+"**No extra RoleSet capacity**: The outer update does not require surge "
+"RoleSets."
+msgstr "**无需额外 RoleSet 容量** ：外层更新不需要 surge RoleSet。"
+
+#: ../../source/designs/aibrix-stormservice.rst:802
+msgid "StormService and role update strategies"
+msgstr "StormService 与角色更新策略"
+
+#: ../../source/designs/aibrix-stormservice.rst:804
+msgid ""
+"StormService and role in-place strategies operate at different layers. To"
+" update a Pod image through a StormService while preserving the Pod name "
+"and UID, configure both layers."
+msgstr ""
+"StormService 与角色原地策略作用于不同层。"
+"要通过 StormService 更新 Pod 镜像并保留 Pod 名称和 UID，需同时配置这两层。"
+
+#: ../../source/designs/aibrix-stormservice.rst:808
+msgid "Update strategy comparison"
+msgstr "更新策略对比"
+
+#: ../../source/designs/aibrix-stormservice.rst:812
+msgid "Strategy"
+msgstr "策略"
+
+#: ../../source/designs/aibrix-stormservice.rst:813
+msgid "Target"
+msgstr "作用对象"
+
+#: ../../source/designs/aibrix-stormservice.rst:814
+msgid "Identity behavior"
+msgstr "身份行为"
+
+#: ../../source/designs/aibrix-stormservice.rst:815
+msgid "Configuration path"
+msgstr "配置路径"
+
+#: ../../source/designs/aibrix-stormservice.rst:816
+msgid "StormService ``InPlaceUpdate``"
+msgstr "StormService ``InPlaceUpdate``"
+
+#: ../../source/designs/aibrix-stormservice.rst:817
+msgid "RoleSet"
+msgstr "RoleSet"
+
+#: ../../source/designs/aibrix-stormservice.rst:818
+msgid "Preserves RoleSet identity; does not guarantee Pod identity"
+msgstr "保留 RoleSet 身份；不保证 Pod 身份"
+
+#: ../../source/designs/aibrix-stormservice.rst:819
+msgid "``StormService.spec.updateStrategy.type``"
+msgstr "``StormService.spec.updateStrategy.type``"
+
+#: ../../source/designs/aibrix-stormservice.rst:820
+msgid "Role ``InPlaceIfPossible``"
+msgstr "角色 ``InPlaceIfPossible``"
+
+#: ../../source/designs/aibrix-stormservice.rst:821
+#: ../../source/designs/aibrix-stormservice.rst:826
+msgid "Pod"
+msgstr "Pod"
+
+#: ../../source/designs/aibrix-stormservice.rst:822
+msgid "Preserves Pod name and UID for eligible image-only updates"
+msgstr "对符合条件的仅镜像更新保留 Pod 名称和 UID"
+
+#: ../../source/designs/aibrix-stormservice.rst:823
+#: ../../source/designs/aibrix-stormservice.rst:828
+msgid ""
+"``RoleSet.spec.roles[].updateStrategy.type`` or "
+"``StormService.spec.template.spec.roles[].updateStrategy.type``"
+msgstr ""
+"``RoleSet.spec.roles[].updateStrategy.type`` 或 "
+"``StormService.spec.template.spec.roles[].updateStrategy.type``"
+
+#: ../../source/designs/aibrix-stormservice.rst:825
+msgid "Role ``Recreate``"
+msgstr "角色 ``Recreate``"
+
+#: ../../source/designs/aibrix-stormservice.rst:827
+msgid "Replaces Pods during a role update; this is the default"
+msgstr "角色更新时替换 Pod；这是默认行为"
+
+#: ../../source/designs/aibrix-stormservice.rst:831
+msgid ""
+"For a StormService-managed rollout, configure the outer strategy on the "
+"StormService and the Pod strategy on each role:"
+msgstr "对 StormService 管理的滚动，在 StormService 上配置外层策略，在每个角色上配置 Pod 策略："
+
+#: ../../source/designs/aibrix-stormservice.rst:846
+msgid ""
+"When managing a RoleSet directly, only the role-level strategy is "
+"required:"
+msgstr "直接管理 RoleSet 时，只需角色级策略："
+
+#: ../../source/designs/aibrix-stormservice.rst:856
+msgid ""
+"See the complete `StormService sample`_ and `RoleSet sample`_ in the "
+"AIBrix repository."
+msgstr "完整示例见 AIBrix 仓库中的 `StormService sample`_ 和 `RoleSet sample`_ 。"
+
+#: ../../source/designs/aibrix-stormservice.rst:863
+msgid "Pod in-place update eligibility"
+msgstr "Pod 原地更新适用条件"
+
+#: ../../source/designs/aibrix-stormservice.rst:865
+msgid ""
+"``InPlaceIfPossible`` updates existing Pods only when container images "
+"are the only fields changed in the Pod template. The controller patches "
+"the requested images, waits for the runtime container image IDs and "
+"readiness to reflect the new images, and then completes the role "
+"revision. ``maxUnavailable`` limits how many role Pods can be unavailable"
+" while the images restart; ``maxSurge`` still controls any replacement "
+"Pods required by a fallback."
+msgstr ""
+"``InPlaceIfPossible`` 仅在 Pod 模板中只有容器镜像字段变更时更新现有 Pod。"
+"控制器 patch 请求的镜像，等待运行时容器镜像 ID 与就绪状态反映新镜像，然后完成角色 revision。"
+"镜像重启期间 ``maxUnavailable`` 限制不可用的角色 Pod 数量；``maxSurge`` 仍控制回退时所需的替换 Pod。"
+
+#: ../../source/designs/aibrix-stormservice.rst:872
+msgid ""
+"Changes to commands, arguments, environment variables, resources, "
+"volumes, or other Pod template fields are not eligible. The controller "
+"emits a normal ``InPlaceFallback`` event and recreates the affected Pods "
+"instead of blocking the rollout. Roles with ``podGroupSize > 1`` are "
+"managed through PodSet and also fall back to recreation. Omitting the "
+"role strategy selects the default ``Recreate`` behavior."
+msgstr ""
+"变更 command、参数、环境变量、资源、卷或其他 Pod 模板字段则不适用。"
+"控制器发出普通 ``InPlaceFallback`` 事件并重建受影响 Pod，而不是阻塞滚动。"
+"``podGroupSize > 1`` 的角色通过 PodSet 管理，同样回退到重建。"
+"省略角色策略则选择默认 ``Recreate`` 行为。"
+
+#: ../../source/designs/aibrix-stormservice.rst:880
+msgid "Trigger and observe an image update"
+msgstr "触发并观察镜像更新"
+
+#: ../../source/designs/aibrix-stormservice.rst:882
+msgid "Apply the StormService sample and record the original Pod UID:"
+msgstr "应用 StormService 示例并记录原始 Pod UID："
+
+#: ../../source/designs/aibrix-stormservice.rst:891
+msgid "Patch only the image field to trigger an eligible in-place update:"
+msgstr "仅 patch 镜像字段以触发符合条件的原地更新："
+
+#: ../../source/designs/aibrix-stormservice.rst:900
+msgid ""
+"Watch the image and compare the UID with the value recorded before the "
+"update:"
+msgstr "观察镜像，并将 UID 与更新前记录的值比较："
+
+#: ../../source/designs/aibrix-stormservice.rst:907
+msgid ""
+"While an update is in progress, the controller can set the Pod readiness "
+"condition ``stormservice.orchestration.aibrix.ai/in-place-update-ready`` "
+"and the annotation ``stormservice.orchestration.aibrix.ai/in-place-"
+"update-pending-reason``. Inspect them with ``kubectl describe pod <pod-"
+"name>``. If the controller falls back to recreation, inspect the reason "
+"on the RoleSet event:"
+msgstr ""
+"更新进行中时，控制器可设置 Pod 就绪条件 ``stormservice.orchestration.aibrix.ai/in-place-update-ready`` "
+"和注解 ``stormservice.orchestration.aibrix.ai/in-place-update-pending-reason`` "
+"。用 ``kubectl describe pod <pod-name>`` 查看。若控制器回退到重建，在 RoleSet 事件中查看原因："
+
+#: ../../source/designs/aibrix-stormservice.rst:920
+msgid "Rolling Strategy"
+msgstr "滚动策略"
+
+#: ../../source/designs/aibrix-stormservice.rst:922
+msgid ""
+"StormService supports multiple rolling strategies to update roles within "
+"RoleSets. These strategies offer different ways to manage updates while "
+"maintaining service stability."
+msgstr ""
+"StormService 支持多种滚动策略来更新 RoleSet 内的角色。"
+"这些策略以不同方式管理更新，同时保持服务稳定。"
+
+#: ../../source/designs/aibrix-stormservice.rst:924
+msgid "**Sequential**: Roles are updated one at a time, in sequence."
+msgstr "**Sequential** ：按顺序一次更新一个角色。"
+
+#: ../../source/designs/aibrix-stormservice.rst:926
+msgid "**Parallel**: All roles are updated simultaneously."
+msgstr "**Parallel** ：所有角色同时更新。"
+
+#: ../../source/designs/aibrix-stormservice.rst:928
+msgid ""
+"**Interleaved**: Roles are updated in an interleaved manner.  This "
+"strategy partitions the update process for every Role into distinct "
+"steps. Each update step is coordinated across all roles to progress "
+"synchronously. In each operational cycle, the controller determines a "
+"global progress state based on the least-advanced role. It instructs "
+"roles that have not reached the current step to proceed with their "
+"updates, while skipping those that have."
+msgstr ""
+"**Interleaved** ：以交错方式更新角色。该策略将每个角色的更新过程划分为若干步骤。每个更新步骤在所有角色间协同，同步推进。每个操作周期中，控制器根据进度最慢的角色确定全局进度状态，指示尚未到达当前步骤的角色继续更新，并跳过已经到达的角色。"
+
+#: ../../source/designs/aibrix-stormservice.rst:931
+msgid "Stateful vs Stateless"
+msgstr "有状态与无状态"
+
+#: ../../source/designs/aibrix-stormservice.rst:933
+msgid ""
+"This is determined by the `Stateful` field in both StormService and "
+"RoleSet specs. It defines whether the RoleSet uses a `StatefulRoleSyncer`"
+" or a `StatelessRoleSyncer`, which leads to different behaviors."
+msgstr ""
+"由 StormService 和 RoleSet spec 中的 `Stateful` 字段决定。它定义 RoleSet 使用 `StatefulRoleSyncer` "
+"还是 `StatelessRoleSyncer` ，从而产生不同行为。"
+
+#: ../../source/designs/aibrix-stormservice.rst:935
+msgid ""
+"**Stateful**: `StatefulRoleSyncer` treats each Pod as a unique, non-"
+"interchangeable entity, assigning a stable and unique index to each Pod. "
+"There are exactly *n* slots for *n* replicas, and updates are performed "
+"slot-by-slot in a controlled manner."
+msgstr ""
+"**有状态** ：`StatefulRoleSyncer` 将每个 Pod 视为唯一、不可互换的实体，为每个 Pod 分配稳定唯一的索引。*n* "
+"个副本对应恰好 *n* 个槽位，更新按槽位受控进行。"
+
+#: ../../source/designs/aibrix-stormservice.rst:937
+msgid ""
+"**Stateless**: `StatelessRoleSyncer` treats all Pods as identical "
+"replicas. Any Pod can be replaced without affecting the overall "
+"application. Pods are managed as a collective pool, and scaling actions "
+"simply add or randomly remove Pods. Updates are performed at the pool "
+"level rather than targeting specific Pods."
+msgstr ""
+"**无状态** ：`StatelessRoleSyncer` 将所有 Pod 视为相同副本。替换任一 Pod 不影响整体应用。Pod 作为集合池管理，扩缩只是增加或随机移除 "
+"Pod。更新在池级别进行，而不是针对特定 Pod。"
+
+#: ../../source/designs/aibrix-stormservice.rst:940
+msgid "Autoscaling"
+msgstr "自动扩缩容"
+
+#: ../../source/designs/aibrix-stormservice.rst:942
+msgid ""
+"**Replica Mode**: StormService enables the `/scale` subresource on its "
+"CRD. The scale unit is `RoleSet`. It involves extending the StormService "
+"status with a dynamic label selector and implementing the controller "
+"logic to ensure this selector is correctly populated, thereby allowing "
+"external autoscalers to manage StormService replicas effectively."
+msgstr ""
+"**Replica Mode** ：StormService 在其 CRD 上启用 `/scale` 子资源。扩缩单元是 `RoleSet` 。需要在 "
+"StormService status 中扩展动态标签选择器，并由控制器逻辑正确填充该选择器，以便外部自动扩缩容器有效管理 StormService "
+"副本。"
+
+#: ../../source/designs/aibrix-stormservice.rst:943
+msgid ""
+"**Pooled Mode**: In pooled mode, each role in the RoleSet is supposed to "
+"be independently scalable."
+msgstr "**Pooled Mode** ：在 pooled mode 中，RoleSet 内每个角色应可独立扩缩。"
+
+#: ../../source/designs/aibrix-stormservice.rst:946
+msgid ""
+"Pooled mode autoscaling (independent scaling of each role) is not yet "
+"supported. See Issue `#1260 <https://github.com/vllm-"
+"project/aibrix/issues/1260>`_ for more details. As an alternative, you "
+"can adjust replicas of each role in the RoleSet spec."
+msgstr ""
+"Pooled mode 自动扩缩容（各角色独立扩缩）尚未支持。详见 Issue `#1260 <https://github.com/vllm-project/aibrix/issues/1260>`_ "
+"。作为替代，可在 RoleSet spec 中调整各角色的 replicas。"
+
+#: ../../source/designs/aibrix-stormservice.rst:951
+msgid "ControllerRevision"
+msgstr "ControllerRevision"
+
+#: ../../source/designs/aibrix-stormservice.rst:953
+msgid ""
+"In the Kubernetes ecosystem, `ControllerRevision` is a crucial resource "
+"object used to record the version information of controllers (such as "
+"Deployments, StatefulSets, etc.). In the AIBrix project, the "
+"`ControllerRevision` mechanism is employed to track the version changes "
+"of `StormService`, providing strong support for version management, "
+"rollback operations, and system state traceability."
+msgstr ""
+"在 Kubernetes 生态中，`ControllerRevision` 是记录控制器（如 Deployment、StatefulSet 等）版本信息的关键资源。"
+"AIBrix 使用 `ControllerRevision` 机制跟踪 `StormService` 的版本变更，为版本管理、回滚和系统状态追溯提供支持。"
+
+#: ../../source/designs/aibrix-stormservice.rst:955
+msgid ""
+"**Version Recording**: `ControllerRevision` stores the configuration "
+"information of a specific version of `StormService`, primarily the `spec`"
+" section. Whenever the configuration of `StormService` changes, the "
+"system creates a new `ControllerRevision` object and stores the changed "
+"configuration in a serialized form within this object. In this way, the "
+"system can clearly record the configuration states of `StormService` at "
+"different time points."
+msgstr ""
+"**版本记录** ：`ControllerRevision` 存储特定版本 `StormService` 的配置信息，主要是 `spec` 部分。每当 "
+"`StormService` 配置变更，系统会创建新的 `ControllerRevision` 对象，并以序列化形式保存变更后的配置。这样系统可以清晰记录 "
+"`StormService` 在不同时间点的配置状态。"
+
+#: ../../source/designs/aibrix-stormservice.rst:956
+msgid ""
+"**Version Rollback**: When it is necessary to restore `StormService` to a"
+" previous configuration state, a rollback operation can be performed "
+"based on the historical configuration information saved in "
+"`ControllerRevision`. By specifying the version number of the target "
+"`ControllerRevision`, the system can restore the configuration of "
+"`StormService` to the state corresponding to that version."
+msgstr ""
+"**版本回滚** ：需要将 `StormService` 恢复到先前配置状态时，可基于 `ControllerRevision` 中保存的历史配置执行回滚。指定目标 "
+"`ControllerRevision` 的版本号后，系统可将 `StormService` 配置恢复到该版本对应状态。"
+
+#: ../../source/designs/aibrix-stormservice.rst:957
+msgid ""
+"**Historical Traceability**: `ControllerRevision` provides system "
+"operation and development personnel with the ability to trace historical "
+"configurations. By viewing different versions of `ControllerRevision` "
+"objects, one can understand the change history of the `StormService` "
+"configuration, which is helpful for issue troubleshooting and system "
+"auditing."
+msgstr ""
+"**历史追溯** ：`ControllerRevision` 为运维和开发人员提供追溯历史配置的能力。查看不同版本的 `ControllerRevision` "
+"对象，可了解 `StormService` 配置变更历史，有助于问题排查和系统审计。"
+
+#: ../../source/designs/aibrix-stormservice.rst:968
+msgid ":doc:`../features/pd-disaggregation`"
+msgstr ":doc:`../features/pd-disaggregation`"
+
+#: ../../source/designs/aibrix-stormservice.rst:969
+msgid "Prefill/decode disaggregation built on StormService."
+msgstr "基于 StormService 的 Prefill/Decode 分离。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/designs/architecture.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/designs/architecture.po
@@ -1,0 +1,127 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/designs/architecture.rst:5
+msgid "AIBrix Architecture"
+msgstr "AIBrix 架构"
+
+#: ../../source/designs/architecture.rst:7
+msgid ""
+"An overview of AIBrix’s architecture. This guide introduces the AIBrix "
+"ecosystem and explains how its components integrate into the LLM "
+"inference lifecycle."
+msgstr ""
+"本文概述 AIBrix 架构，介绍 AIBrix 生态系统，并说明各组件如何融入 LLM "
+"推理生命周期。"
+
+#: ../../source/designs/architecture.rst:9
+msgid ""
+"The following diagram gives an overview of the AIBrix Ecosystem and how "
+"it relates to the wider Kubernetes and LLM landscapes."
+msgstr ""
+"下图概览 AIBrix 生态系统，以及它与更广泛的 Kubernetes 和 LLM 生态之间的关系。"
+
+#: ../../source/designs/architecture.rst:11
+msgid "aibrix-architecture-v1"
+msgstr "aibrix-architecture-v1"
+
+#: ../../source/designs/architecture.rst:16
+msgid ""
+"AIBrix contains both :strong:`control plane` components and :strong:`data"
+" plane` components. The components of the control plane manage the "
+"registration of model metadata, autoscaling, model adapter registration, "
+"and enforce various types of policies. Data plane components provide "
+"configurable components for dispatching, scheduling, and serving "
+"inference requests, enabling flexible and high-performance model "
+"execution."
+msgstr ""
+"AIBrix 同时包含 :strong:`控制面` 组件和 :strong:`数据面` "
+"组件。控制面负责模型元数据注册、自动扩缩容、模型适配器注册，并执行各类策略。"
+"数据面提供可配置的分发、调度与推理请求服务组件，以支持灵活、高性能的模型执行。"
+
+#: ../../source/designs/architecture.rst:19
+msgid "AIBrix Control Plane"
+msgstr "AIBrix 控制面"
+
+#: ../../source/designs/architecture.rst:21
+msgid "AIBrix currently provides several control plane components."
+msgstr "AIBrix 当前提供以下控制面组件。"
+
+#: ../../source/designs/architecture.rst:23
+msgid ""
+":strong:`Model Adapter (Lora) controller`: enables multi-LoRA-per-pod "
+"deployments, significantly improving scalability and resource efficiency."
+msgstr ":strong:`Model Adapter (LoRA) 控制器` ：支持单个 Pod 部署多个 LoRA，显著提升可扩展性与资源利用率。"
+
+#: ../../source/designs/architecture.rst:24
+msgid ""
+":strong:`RayClusterFleet`: orchestrates multi-node inference, ensuring "
+"optimal performance across distributed environments."
+msgstr ":strong:`RayClusterFleet` ：编排多节点推理，确保分布式环境下的性能。"
+
+#: ../../source/designs/architecture.rst:25
+msgid ""
+":strong:`LLM-Specific Autoscale`: enables real-time, second-level "
+"scaling, leveraging KV cache utilization and inference-aware metrics to "
+"dynamically optimize resource allocation"
+msgstr ":strong:`LLM 专用自动扩缩容` ：基于 KVCache 利用率与推理相关指标，实现秒级实时扩缩容，动态优化资源分配"
+
+#: ../../source/designs/architecture.rst:26
+msgid ""
+":strong:`GPU Optimizer`: a profiler based optimizer which optimizes "
+"heterogeneous serving, dynamically adjusting allocations to maximize "
+"cost-efficiency while maintaining service guarantee"
+msgstr ":strong:`GPU Optimizer` ：基于性能剖析的优化器，面向异构推理服务动态调整资源分配，在满足服务保障的同时提升成本效率"
+
+#: ../../source/designs/architecture.rst:27
+msgid ""
+":strong:`AI Engine Runtime`: a lightweight sidecar that offloads "
+"management tasks, enforces policies, and abstracts engine interactions."
+msgstr ":strong:`AI Engine Runtime` ：轻量 sidecar，卸载管理任务、执行策略，并抽象与推理引擎的交互。"
+
+#: ../../source/designs/architecture.rst:28
+msgid ""
+":strong:`Accelerator Diagnose Tools`: provides automated failure "
+"detection and mock-up testing to improve fault resilience."
+msgstr ":strong:`加速器诊断工具` ：提供自动化故障检测与模拟测试，提升故障韧性。"
+
+#: ../../source/designs/architecture.rst:32
+msgid "AIBrix Data Plane"
+msgstr "AIBrix 数据面"
+
+#: ../../source/designs/architecture.rst:34
+msgid "AIBrix currently provides several data plane components:"
+msgstr "AIBrix 当前提供以下数据面组件："
+
+#: ../../source/designs/architecture.rst:36
+msgid ""
+":strong:`Request Router`: serves as the central request dispatcher, "
+"enforcing fairness policies, rate control (TPM/RPM), and workload "
+"isolation."
+msgstr ":strong:`请求路由器` ：作为中心请求分发器，执行公平性策略、速率控制（TPM/RPM）以及工作负载隔离。"
+
+#: ../../source/designs/architecture.rst:37
+msgid ""
+":strong:`Distributed KV Cache Runtime`: provides scalable, low-latency "
+"cache access across nodes. By enabling KV cache reuse, it reduces "
+"redundant computation and improves token generation efficiency."
+msgstr ""
+":strong:`分布式 KVCache 运行时` ：在节点间提供可扩展、低延迟的缓存访问。通过复用 KVCache，减少重复计算并提升 token "
+"生成效率。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/development/development.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/development/development.po
@@ -1,0 +1,330 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/development/development.rst:5
+msgid "Development"
+msgstr "开发"
+
+#: ../../source/development/development.rst:8
+msgid "Source Code Development"
+msgstr "源码开发"
+
+#: ../../source/development/development.rst:11
+msgid "Build from Source"
+msgstr "从源码构建"
+
+#: ../../source/development/development.rst:13
+msgid "Build all binaries:"
+msgstr "构建全部二进制："
+
+#: ../../source/development/development.rst:19
+msgid "Build specific components:"
+msgstr "构建指定组件："
+
+#: ../../source/development/development.rst:33
+msgid "Code Generation"
+msgstr "代码生成"
+
+#: ../../source/development/development.rst:35
+msgid "After modifying APIs or custom resources:"
+msgstr "修改 API 或自定义资源后："
+
+#: ../../source/development/development.rst:46
+msgid "Code Quality"
+msgstr "代码质量"
+
+#: ../../source/development/development.rst:48
+msgid "Run linter to check code style and catch issues:"
+msgstr "运行 linter 检查代码风格并发现问题："
+
+#: ../../source/development/development.rst:59
+msgid "Testing Framework"
+msgstr "测试框架"
+
+#: ../../source/development/development.rst:61
+msgid ""
+"AIBrix includes a comprehensive testing suite with unit tests, "
+"integration tests, and end-to-end tests."
+msgstr "AIBrix 提供完整测试套件，包括单元测试、集成测试和端到端测试。"
+
+#: ../../source/development/development.rst:64
+msgid "Development Workflow"
+msgstr "开发工作流"
+
+#: ../../source/development/development.rst:66
+msgid "**Write tests first** - Add unit/integration tests for new features"
+msgstr "**先写测试** - 为新功能添加单元/集成测试"
+
+#: ../../source/development/development.rst:67
+msgid "**Run locally** - Use ``make test`` and ``make test-integration``"
+msgstr "**本地运行** - 使用 ``make test`` 和 ``make test-integration``"
+
+#: ../../source/development/development.rst:68
+msgid "**E2E validation** - Run ``make test-e2e`` before submitting changes"
+msgstr "**E2E 验证** - 提交变更前运行 ``make test-e2e``"
+
+#: ../../source/development/development.rst:71
+msgid "Unit Tests"
+msgstr "单元测试"
+
+#: ../../source/development/development.rst:73
+msgid "Unit tests are located alongside source code (``*_test.go`` files):"
+msgstr "单元测试与源码放在一起（``*_test.go`` 文件）："
+
+#: ../../source/development/development.rst:84
+msgid "Integration Tests"
+msgstr "集成测试"
+
+#: ../../source/development/development.rst:86
+msgid "Integration tests use Ginkgo framework to test component interactions:"
+msgstr "集成测试使用 Ginkgo 框架验证组件交互："
+
+#: ../../source/development/development.rst:99
+msgid "End-to-End Tests"
+msgstr "端到端测试"
+
+#: ../../source/development/development.rst:101
+msgid ""
+"E2E tests validate complete AIBrix functionality against a running "
+"Kubernetes cluster."
+msgstr "E2E 测试在运行中的 Kubernetes 集群上验证完整的 AIBrix 功能。"
+
+#: ../../source/development/development.rst:103
+msgid "**Development Environment (Local Testing):**"
+msgstr "**开发环境（本地测试）：**"
+
+#: ../../source/development/development.rst:105
+msgid "For local development where cluster and AIBrix are already running:"
+msgstr "适用于集群和 AIBrix 已在运行的本地开发："
+
+#: ../../source/development/development.rst:107
+msgid "Prerequisites for Development Mode:"
+msgstr "开发模式前置条件："
+
+#: ../../source/development/development.rst:109
+msgid "Kubernetes cluster is running and accessible"
+msgstr "Kubernetes 集群正在运行且可访问"
+
+#: ../../source/development/development.rst:110
+msgid "AIBrix is deployed and healthy"
+msgstr "AIBrix 已部署且健康"
+
+#: ../../source/development/development.rst:122
+msgid "**CI Environment (Automated Testing):**"
+msgstr "**CI 环境（自动化测试）：**"
+
+#: ../../source/development/development.rst:124
+msgid "For CI pipelines that need full cluster setup and teardown:"
+msgstr "适用于需要完整集群创建与清理的 CI 流水线："
+
+#: ../../source/development/development.rst:134
+msgid ""
+"Environment Variables: - ``KIND_E2E=true`` - Creates Kind cluster with "
+"proper configuration - ``INSTALL_AIBRIX=true`` - Builds images, installs "
+"dependencies, and deploys AIBrix - ``SKIP_KUBECTL_INSTALL=true`` - Skip "
+"kubectl installation (default: true) - ``SKIP_KIND_INSTALL=true`` - Skip "
+"Kind installation (default: true)"
+msgstr ""
+"环境变量： - ``KIND_E2E=true`` - 创建配置正确的 Kind 集群 - ``INSTALL_AIBRIX=true`` - 构建镜像、安装"
+"依赖并部署 AIBrix - ``SKIP_KUBECTL_INSTALL=true`` - 跳过 "
+"kubectl 安装（默认：true） - ``SKIP_KIND_INSTALL=true`` - 跳过 "
+"Kind 安装（默认：true）"
+
+#: ../../source/development/development.rst:141
+msgid "Container Images and Deployment"
+msgstr "容器镜像与部署"
+
+#: ../../source/development/development.rst:144
+msgid "Building Container Images"
+msgstr "构建容器镜像"
+
+#: ../../source/development/development.rst:146
+msgid ""
+"We encourage contributors to build and test AIBrix on local dev "
+"environment for most cases. If you use Macbook, `Docker for Desktop "
+"<https://www.docker.com/products/docker-desktop/>`_ is the most "
+"convenient tool to use."
+msgstr ""
+"多数情况下，我们鼓励贡献者在本地开发环境构建并测试 AIBrix。如果使用 Macbook，`Docker for Desktop "
+"<https://www.docker.com/products/docker-desktop/>`_ 是最方便的工具。"
+
+#: ../../source/development/development.rst:149
+msgid "Build ``nightly`` docker images:"
+msgstr "构建 ``nightly`` Docker 镜像："
+
+#: ../../source/development/development.rst:159
+msgid "Quick Deployment to Dev Environment"
+msgstr "快速部署到开发环境"
+
+#: ../../source/development/development.rst:161
+msgid ""
+"Run following command to quickly deploy the latest code changes to your "
+"dev kubernetes environment:"
+msgstr "运行以下命令，将最新代码变更快速部署到开发用 Kubernetes 环境："
+
+#: ../../source/development/development.rst:168
+msgid "If you want to clean up everything and reinstall the latest code:"
+msgstr "如果要清理全部内容并重新安装最新代码："
+
+#: ../../source/development/development.rst:176
+msgid "Complete Development Setup with Kind"
+msgstr "使用 Kind 完成完整开发环境搭建"
+
+#: ../../source/development/development.rst:178
+msgid "For a complete local development environment with monitoring:"
+msgstr "如需带监控的完整本地开发环境："
+
+#: ../../source/development/development.rst:195
+msgid "Manual Testing with CPU-only vLLM"
+msgstr "使用仅 CPU 的 vLLM 进行手动测试"
+
+#: ../../source/development/development.rst:197
+msgid ""
+"This section explains how to manually test AIBrix with vLLM in a local "
+"Kubernetes cluster using CPU-only environments (e.g., for macOS or Linux "
+"dev)."
+msgstr ""
+"本节说明如何在仅 CPU 环境（例如 macOS 或 Linux 开发机）的本地 Kubernetes 集群中，"
+"使用 vLLM 手动测试 AIBrix。"
+
+#: ../../source/development/development.rst:200
+msgid "Setup Local Environment"
+msgstr "搭建本地环境"
+
+#: ../../source/development/development.rst:202
+msgid "Download model locally using Hugging Face CLI:"
+msgstr "使用 Hugging Face CLI 在本地下载模型："
+
+#: ../../source/development/development.rst:208
+msgid ""
+"Start local cluster with kind (edit ``kind-config.yaml`` to mount your "
+"model cache):"
+msgstr "使用 kind 启动本地集群（编辑 ``kind-config.yaml`` 以挂载模型缓存）："
+
+#: ../../source/development/development.rst:214
+msgid "Build and load images:"
+msgstr "构建并加载镜像："
+
+#: ../../source/development/development.rst:221
+msgid "Load CPU environment image for your platform:"
+msgstr "为你的平台加载 CPU 环境镜像："
+
+#: ../../source/development/development.rst:223
+#: ../../source/development/development.rst:242
+msgid "**For macOS:**"
+msgstr "**macOS：**"
+
+#: ../../source/development/development.rst:230
+#: ../../source/development/development.rst:248
+msgid "**For Linux:**"
+msgstr "**Linux：**"
+
+#: ../../source/development/development.rst:238
+msgid "Deploy and Test vLLM Model"
+msgstr "部署并测试 vLLM 模型"
+
+#: ../../source/development/development.rst:240
+msgid "Deploy vLLM model in kind cluster:"
+msgstr "在 kind 集群中部署 vLLM 模型："
+
+#: ../../source/development/development.rst:254
+msgid "Access model endpoint:"
+msgstr "访问模型端点："
+
+#: ../../source/development/development.rst:260
+msgid "Query locally:"
+msgstr "在本地查询："
+
+#: ../../source/development/development.rst:275
+msgid "Practical Notes"
+msgstr "实用说明"
+
+#: ../../source/development/development.rst:277
+msgid ""
+"``vllm-cpu-env`` is ideal for development and debugging. Inference "
+"latency will be high due to CPU-only backend."
+msgstr "``vllm-cpu-env`` 适合开发和调试。由于仅使用 CPU 后端，推理延迟会较高。"
+
+#: ../../source/development/development.rst:278
+msgid ""
+"Be sure to mount your Hugging Face model cache directory, or the "
+"container will re-download it online."
+msgstr "请务必挂载 Hugging Face 模型缓存目录，否则容器会在线重新下载。"
+
+#: ../../source/development/development.rst:279
+msgid "Confirm both ``runtime`` and ``env`` images are loaded into kind."
+msgstr "确认 ``runtime`` 和 ``env`` 镜像都已加载到 kind。"
+
+#: ../../source/development/development.rst:280
+msgid "Use ``kubectl logs`` or ``kubectl exec`` to debug model pod issues."
+msgstr "使用 ``kubectl logs`` 或 ``kubectl exec`` 调试模型 Pod 问题。"
+
+#: ../../source/development/development.rst:283
+msgid "Debugging"
+msgstr "调试"
+
+#: ../../source/development/development.rst:286
+msgid "Debugging Gateway IPs"
+msgstr "调试网关 IP"
+
+#: ../../source/development/development.rst:297
+msgid ""
+"Please also follow `debugging guidelines "
+"<https://aibrix.readthedocs.io/latest/features/gateway-plugins.html"
+"#debugging-guidelines>`_."
+msgstr ""
+"也请遵循 `调试指南 <https://aibrix.readthedocs.io/latest/features/gateway-plugins.html#debugging-guidelines>`_ "
+"。"
+
+#: ../../source/development/development.rst:300
+msgid "Mocked CPU App"
+msgstr "模拟 CPU 应用"
+
+#: ../../source/development/development.rst:302
+msgid ""
+"In order to run the control plane and data plane e2e in development "
+"environments, we build a mocked app to mock a model server. Now, it "
+"supports basic model inference, metrics and lora feature. Feel free to "
+"enrich the features. Check ``development`` folder for more details."
+msgstr ""
+"为了在开发环境中运行控制面和数据面的端到端流程，我们构建了一个模拟应用来模拟模型服务。"
+"目前支持基础模型推理、指标和 LoRA 功能。欢迎扩充功能。更多细节见 ``development`` 目录。"
+
+#: ../../source/development/development.rst:306
+msgid "GPU Testing Environment"
+msgstr "GPU 测试环境"
+
+#: ../../source/development/development.rst:308
+msgid ""
+"If you need to test the model in real GPU environment, we highly "
+"recommend `Lambda Labs <https://lambdalabs.com/>`_ platform to install "
+"and test kind based deployment."
+msgstr ""
+"如果需要在真实 GPU 环境中测试模型，我们强烈建议使用 `Lambda Labs <https://lambdalabs.com/>`_ "
+"平台安装并测试基于 kind 的部署。"
+
+#: ../../source/development/development.rst:311
+msgid ""
+"Kind itself doesn't support GPU yet. In order to use the kind version "
+"with GPU support, feel free to checkout `nvkind "
+"<https://github.com/klueska/nvkind>`_."
+msgstr ""
+"Kind 本身尚不支持 GPU。如需带 GPU 支持的 kind 版本，可查看 `nvkind <https://github.com/klueska/nvkind>`_ "
+"。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/development/release.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/development/release.po
@@ -1,0 +1,229 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/development/release.rst:5
+msgid "Release"
+msgstr "发布"
+
+#: ../../source/development/release.rst:8
+msgid "This document is for release team only. Feel free to skip it."
+msgstr "本文档仅面向发布团队。如不相关可跳过。"
+
+#: ../../source/development/release.rst:10
+msgid ""
+"This process outlines the steps required to create and publish a release "
+"for AIBrix Github project. Follow these steps to ensure a smooth and "
+"consistent release cycle."
+msgstr ""
+"本流程说明为 AIBrix GitHub 项目创建并发布版本所需的步骤。请按这些步骤操作，以确保发布周期顺畅一致。"
+
+#: ../../source/development/release.rst:14
+msgid "Prepare the code"
+msgstr "准备代码"
+
+#: ../../source/development/release.rst:17
+msgid "Option 1 RC version release"
+msgstr "方案 1：RC 版本发布"
+
+#: ../../source/development/release.rst:19
+msgid ""
+"For RC release like ``v0.4.0-rc.2``, there's no need to checkout a new "
+"branch, Let's cut the tag & release directly against ``main`` branch."
+msgstr ""
+"对于 ``v0.4.0-rc.2`` 这类 RC 发布，无需检出新分支，直接在 ``main`` 分支打 tag 并发布即可。"
+
+#: ../../source/development/release.rst:24
+msgid "Option 2 minor version release"
+msgstr "方案 2：次版本发布"
+
+#: ../../source/development/release.rst:26
+msgid ""
+"For new minor version release like ``v0.3.0``, please checkout a new "
+"branch named ``release-0.3``."
+msgstr "对于 ``v0.3.0`` 这类新的次版本发布，请检出名为 ``release-0.3`` 的新分支。"
+
+#: ../../source/development/release.rst:35
+msgid ""
+"Here we assume ``origin`` points to upstream, if it doesn't, other "
+"remotes like ``upstream`` should be right remote to push to."
+msgstr ""
+"这里假设 ``origin`` 指向上游仓库；如果不是，应推送到 ``upstream`` 等正确的远程。"
+
+#: ../../source/development/release.rst:38
+msgid "Option 3: patch version release"
+msgstr "方案 3：补丁版本发布"
+
+#: ../../source/development/release.rst:40
+msgid ""
+"Bug fixes should be merged on ``main`` first. Then cherry-pick the bugfix"
+" to target release branch like ``release-0.3``. However, the fix may not "
+"able to be cherry-picked to ``release-0.3`` due to conflicts. If that's "
+"the case, cut PR to release branch directly. For patch version like "
+"``v0.3.1``, please reuse the release branch ``release-0.3``, it should be"
+" created earlier from the minor version release. for patch release, we do"
+" not rebase ``main`` because it will introduce new features. All fixes "
+"have to be cherry-picked or cut PR against ``release-0.3`` directly."
+msgstr ""
+"缺陷修复应先合并到 ``main`` 。然后将修复 cherry-pick 到目标发布分支，例如 ``release-0.3`` 。不过，由于冲突，修复可能无法 "
+"cherry-pick 到 ``release-0.3`` 。此时请直接向发布分支提交 PR。对于 ``v0.3.1`` 这类补丁版本，请复用发布分支 "
+"``release-0.3`` ，该分支应在次版本发布时已创建。补丁发布不要 rebase ``main`` ，因为会引入新功能。所有修复必须 "
+"cherry-pick，或直接针对 ``release-0.3`` 提交 PR。"
+
+#: ../../source/development/release.rst:46
+msgid "Performance Regression Testing against RC release"
+msgstr "针对 RC 发布的性能回归测试"
+
+#: ../../source/development/release.rst:48
+msgid ""
+"The ``test/regression/`` directory contains benchmark configurations for "
+"release testing:"
+msgstr "``test/regression/`` 目录包含用于发布测试的基准配置："
+
+#: ../../source/development/release.rst:50
+msgid "**v0.2.1/**: performance benchmark baseline"
+msgstr "**v0.2.1/** ：性能基准基线"
+
+#: ../../source/development/release.rst:51
+msgid "**v0.3.0/**: KV cache variants"
+msgstr "**v0.3.0/** ：KV cache 变体"
+
+#: ../../source/development/release.rst:52
+msgid "**v0.4.0/**: Helm-based templates for SGLang/VLLM testing"
+msgstr "**v0.4.0/** ：用于 SGLang/VLLM 测试的 Helm 模板"
+
+#: ../../source/development/release.rst:54
+msgid ""
+"Before each release, run performance benchmarks using configurations in "
+"``test/regression/vX.Y.Z/``."
+msgstr "每次发布前，使用 ``test/regression/vX.Y.Z/`` 中的配置运行性能基准测试。"
+
+#: ../../source/development/release.rst:57
+msgid ""
+"It's recommended to build specific test cases for each release since the "
+"focus is different. It's also important to keep the test cases up-to-date"
+" with the latest release so we can also use previous tests cases against "
+"new versions."
+msgstr ""
+"建议为每次发布构建专门的测试用例，因为关注点不同。同时要让测试用例与最新发布保持同步，"
+"以便也能用先前的测试用例验证新版本。"
+
+#: ../../source/development/release.rst:61
+msgid "Release new version"
+msgstr "发布新版本"
+
+#: ../../source/development/release.rst:63
+msgid ""
+"Make sure the manifest images tags and updated and python version is "
+"updated. A sample PR is `Cut v0.4.0-rc.2 release <https://github.com"
+"/vllm-project/aibrix/pull/1373>`_. Merge the PR."
+msgstr ""
+"确保清单中的镜像标签已更新，且 Python 版本已更新。示例 PR 见 `Cut v0.4.0-rc.2 release <https://github.com/vllm-project/aibrix/pull/1373>`_ "
+"。合并该 PR。"
+
+#: ../../source/development/release.rst:67
+msgid ""
+"container image actually is not built yet, we preserve the tag name and "
+"it would be built later once the tag is created."
+msgstr "容器镜像此时尚未构建，我们先保留标签名，待 tag 创建后再构建。"
+
+#: ../../source/development/release.rst:71
+msgid "Create the tag and push to remote"
+msgstr "创建 tag 并推送到远程"
+
+#: ../../source/development/release.rst:73
+msgid "for rc release:"
+msgstr "RC 发布："
+
+#: ../../source/development/release.rst:87
+msgid "for official release:"
+msgstr "正式发布："
+
+#: ../../source/development/release.rst:102
+msgid "Monitor the release pipeline"
+msgstr "监控发布流水线"
+
+#: ../../source/development/release.rst:104
+msgid ""
+"After pushing the tag, the release pipeline (e.g., CI/CD workflows) "
+"should automatically begin. This may include: - Running tests and "
+"validations - Building manifest artifacts - Building container image and "
+"push to the registry - Building python library and upload to PyPI"
+msgstr ""
+"推送 tag 后，发布流水线（例如 CI/CD 工作流）应自动开始。可能包括： - 运行测试与校验 - 构建清单产物 - 构建容器镜像并"
+"推送到仓库 - 构建 Python 库并上传到 PyPI"
+
+#: ../../source/development/release.rst:110
+msgid "Monitor the pipeline's progress to ensure it completes successfully"
+msgstr "监控流水线进度，确保其成功完成"
+
+#: ../../source/development/release.rst:112
+#: ../../source/development/release.rst:117
+#: ../../source/development/release.rst:130
+msgid "draft-release"
+msgstr "draft-release"
+
+#: ../../source/development/release.rst:123
+msgid "Publish the release on Github"
+msgstr "在 GitHub 上发布版本"
+
+#: ../../source/development/release.rst:125
+msgid ""
+"Release pipeline will cut a draft pre-release in `Github Releases "
+"<https://github.com/vllm-project/aibrix/releases>`_. Go to the "
+"\"Releases\" section in the repository, select the draft release "
+"corresponding to the tag you created. Include release notes summarizing "
+"the changes (new features, bug fixes, breaking changes, etc.). Optionally"
+" attach binaries, documentation, or other assets. In the end, let's "
+"publish the release."
+msgstr ""
+"发布流水线会在 `Github Releases "
+"<https://github.com/vllm-project/aibrix/releases>`_ 中生成草稿预发布。"
+"进入仓库的 \"Releases\" 部分，选择与所创建 tag 对应的草稿发布。"
+"填写发布说明，概括变更（新功能、缺陷修复、破坏性变更等）。可选附加二进制、文档或其他资源。"
+"最后发布该版本。"
+
+#: ../../source/development/release.rst:136
+msgid "Sync images to Volcano Engine Container Registry"
+msgstr "将镜像同步到火山引擎容器镜像服务"
+
+#: ../../source/development/release.rst:138
+msgid ""
+"Currently, release pipeline only push images to dockerhub. In order to "
+"use them in VKE, we need to retag the images and push to VKE Container "
+"Registry."
+msgstr ""
+"目前发布流水线只将镜像推送到 Docker Hub。要在 VKE 中使用，需要重新打标签并推送到 VKE 容器镜像服务。"
+
+#: ../../source/development/release.rst:142
+msgid ""
+"It requires you to use a machine that have both VKE and Dockerhub access."
+" Do not forget to get the temporary credential and login the registry "
+"service before pushing."
+msgstr ""
+"需要使用同时具备 VKE 和 Docker Hub 访问权限的机器。"
+"推送前不要忘记获取临时凭证并登录镜像仓库服务。"
+
+#: ../../source/development/release.rst:152
+msgid "Update released tags in main branch docs"
+msgstr "在 main 分支文档中更新已发布标签"
+
+#: ../../source/development/release.rst:154
+msgid "A sample PR is `here <https://github.com/vllm-project/aibrix/pull/378>`_."
+msgstr "示例 PR 见 `此处 <https://github.com/vllm-project/aibrix/pull/378>`_ 。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/autoscaling/autoscaling.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/autoscaling/autoscaling.po
@@ -1,0 +1,334 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/autoscaling/autoscaling.rst:3
+msgid "Autoscaling"
+msgstr "自动扩缩容"
+
+#: ../../source/features/autoscaling/autoscaling.rst:5
+msgid ""
+"Autoscaling is crucial for deploying Large Language Model (LLM) services "
+"on Kubernetes (K8s), as timely scaling up handles peaks in request "
+"traffic, and scaling down conserves resources when demand wanes."
+msgstr ""
+"在 Kubernetes（K8s）上部署大语言模型（LLM）服务时，自动扩缩容至关重要："
+"及时扩容可应对请求流量高峰，需求回落时缩容可节省资源。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:7
+msgid ""
+"AIBrix ships one custom resource for this, ``PodAutoscaler`` in the "
+"``autoscaling.aibrix.ai/v1alpha1`` API group, and several algorithms "
+"behind it. This page explains how the pieces fit together and which page "
+"to read next. The two child pages hold the full configuration and "
+"examples."
+msgstr ""
+"AIBrix 为此提供一个自定义资源：``autoscaling.aibrix.ai/v1alpha1`` API 组中的 ``PodAutoscaler`` "
+"，以及其后的多种算法。本页说明各部分如何协作以及接下来应阅读哪一页。完整配置与示例见两个子页面。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:18
+msgid "How it works"
+msgstr "工作原理"
+
+#: ../../source/features/autoscaling/autoscaling.rst:29
+msgid ""
+"You create a ``PodAutoscaler`` that points at a workload through "
+"``scaleTargetRef``. The target can be a ``Deployment``, a "
+"``StormService`` (optionally one role of it, through "
+"``subTargetSelector.roleName``), or a ``RayClusterFleet``."
+msgstr ""
+"创建 ``PodAutoscaler`` ，通过 ``scaleTargetRef`` 指向工作负载。目标可以是 ``Deployment`` "
+"、``StormService`` （可通过 ``subTargetSelector.roleName`` 指定其中一个角色），或 ``RayClusterFleet`` "
+"。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:32
+msgid ""
+"The controller collects the metric named in ``metricsSources``. With "
+"``metricSourceType: pod`` it scrapes every pod of the target at the given"
+" ``port`` and ``path``. With ``metricSourceType: external`` it reads a "
+"single HTTP endpoint instead, which is how the GPU optimizer hands its "
+"recommendation to the autoscaler."
+msgstr ""
+"控制器采集 ``metricsSources`` 中指定的指标。``metricSourceType: pod`` 时，"
+"会在给定的 ``port`` 和 ``path`` 上抓取目标的每个 pod。"
+"``metricSourceType: external`` 时则读取单个 HTTP 端点，这是 GPU optimizer "
+"向自动扩缩容器传递建议的方式。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:36
+msgid ""
+"The algorithm selected by ``scalingStrategy`` (``HPA``, ``KPA`` or "
+"``APA``) turns the observed value and ``targetValue`` into a desired "
+"replica count, using ``observeWindowSeconds`` and, for KPA, "
+"``panicWindowSeconds`` as its windows."
+msgstr ""
+"``scalingStrategy`` 所选算法（``HPA`` 、``KPA`` 或 ``APA`` ）将观测值和 ``targetValue`` "
+"转换为期望副本数，使用 ``observeWindowSeconds`` 作为窗口；对 KPA 还会使用 ``panicWindowSeconds`` "
+"。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:39
+msgid ""
+"The result is clamped to ``minReplicas`` and ``maxReplicas``, or to the "
+"bounds of a matching entry in ``schedules`` when one is active, and "
+"written to the target."
+msgstr ""
+"结果会被限制在 ``minReplicas`` 和 ``maxReplicas`` 范围内；若有匹配且生效的 "
+"``schedules`` 条目，则使用该条目的边界，然后写入目标。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:43
+msgid "Choosing a strategy"
+msgstr "选择策略"
+
+#: ../../source/features/autoscaling/autoscaling.rst:49
+msgid "Strategy"
+msgstr "策略"
+
+#: ../../source/features/autoscaling/autoscaling.rst:50
+msgid "How it decides"
+msgstr "决策方式"
+
+#: ../../source/features/autoscaling/autoscaling.rst:51
+msgid "Use it when"
+msgstr "适用场景"
+
+#: ../../source/features/autoscaling/autoscaling.rst:52
+msgid "``HPA``"
+msgstr "``HPA``"
+
+#: ../../source/features/autoscaling/autoscaling.rst:53
+msgid ""
+"Same algorithm as the Kubernetes HorizontalPodAutoscaler, applied to the "
+"metric you choose."
+msgstr "与 Kubernetes HorizontalPodAutoscaler 相同的算法，作用于你选择的指标。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:55
+msgid "Traffic is steady and you want the most familiar behaviour."
+msgstr "流量平稳，且希望使用最熟悉的行为。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:56
+msgid "``KPA``"
+msgstr "``KPA``"
+
+#: ../../source/features/autoscaling/autoscaling.rst:57
+msgid ""
+"Knative-style: a long stable window plus a short panic window that scales"
+" up fast when the panic window crosses the threshold. Metrics are fetched"
+" by AIBrix directly rather than through Prometheus, which shortens "
+"reaction time."
+msgstr ""
+"Knative 风格：较长的稳定窗口加上较短的 panic 窗口；当 panic 窗口越过阈值时快速扩容。"
+"指标由 AIBrix 直接获取，而非通过 Prometheus，从而缩短反应时间。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:60
+msgid "Bursty or unpredictable traffic where scale-up latency matters most."
+msgstr "突发或不可预测的流量，扩容延迟最为关键。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:61
+msgid "``APA``"
+msgstr "``APA``"
+
+#: ../../source/features/autoscaling/autoscaling.rst:62
+msgid ""
+"AIBrix's own algorithm. Like HPA but with a fluctuation tolerance that "
+"must be exceeded before any scaling happens, which suppresses "
+"oscillation."
+msgstr ""
+"AIBrix 自有算法。类似 HPA，但带有波动容差，必须超过该容差才会扩缩容，从而抑制振荡。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:64
+msgid "Latency-sensitive services that must not thrash between replica counts."
+msgstr "对延迟敏感、且不能在副本数之间频繁抖动的服务。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:65
+msgid "Optimizer-based"
+msgstr "基于优化器"
+
+#: ../../source/features/autoscaling/autoscaling.rst:66
+msgid ""
+"Not a ``scalingStrategy`` value. The GPU optimizer computes the replica "
+"count from offline benchmark profiles and an SLO, then exposes it as a "
+"metric that a ``KPA`` PodAutoscaler consumes through an ``external`` "
+"metric source."
+msgstr ""
+"不是 ``scalingStrategy`` 的取值。GPU optimizer 根据离线基准配置文件和 SLO 计算副本数，"
+"然后将其作为指标暴露；``KPA`` PodAutoscaler 通过 ``external`` 指标源消费该指标。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:69
+msgid ""
+"You have benchmark data per GPU type, an explicit latency SLO, or a mix "
+"of GPU types to balance for cost. See :doc:`optimizer-based-autoscaling` "
+"and :doc:`../heterogeneous-gpu`."
+msgstr ""
+"你有按 GPU 类型划分的基准数据、明确的延迟 SLO，或需要在多种 GPU 类型之间做成本均衡。参见 :doc:`optimizer-based-autoscaling` "
+"和 :doc:`../heterogeneous-gpu` 。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:74
+msgid "Metric sources"
+msgstr "指标源"
+
+#: ../../source/features/autoscaling/autoscaling.rst:76
+msgid ""
+"``metricSourceType`` accepts ``pod``, ``external``, ``resource`` and "
+"``custom``. ``domain`` is a deprecated alias of ``external`` kept for "
+"manifests written before the rename. The two the documentation and "
+"samples use are:"
+msgstr ""
+"``metricSourceType`` 接受 ``pod`` 、``external`` 、``resource`` 和 ``custom`` "
+"。``domain`` 是 ``external`` 的已弃用别名，保留用于重命名前编写的清单。文档和示例使用的两种是："
+
+#: ../../source/features/autoscaling/autoscaling.rst:80
+msgid ""
+"``pod``: scrape each target pod. Validation requires ``port``, ``path`` "
+"and ``protocolType``, but only ``port`` shapes the request: the "
+"controller always scrapes plain HTTP at the path implied by the pod's "
+"``model.aibrix.ai/engine`` label (``/metrics``, or "
+"``/prometheus/metrics`` for ``trtllm``), and ``path`` does not override "
+"it. Set ``targetMetric`` to one of AIBrix's engine-neutral metric names, "
+"such as ``num_requests_waiting`` or ``gpu_cache_usage_perc``. AIBrix "
+"translates the name to what the pod's engine actually exports "
+"(``vllm:num_requests_waiting`` for vLLM, ``sglang:num_queue_reqs`` for "
+"SGLang), so do not use the raw engine names here."
+msgstr ""
+"``pod`` ：抓取每个目标 pod。校验要求 ``port`` 、``path`` 和 ``protocolType`` ，但只有 ``port`` "
+"影响请求形态：控制器始终以普通 HTTP 抓取由 pod 的 ``model.aibrix.ai/engine`` 标签所隐含的路径（``/metrics`` "
+"，对 ``trtllm`` 则为 ``/prometheus/metrics`` ），``path`` 不会覆盖它。将 ``targetMetric`` "
+"设为 AIBrix 的引擎无关指标名之一，例如 ``num_requests_waiting`` 或 ``gpu_cache_usage_perc`` "
+"。AIBrix 会将该名称转换为 pod 引擎实际导出的名称（vLLM 为 ``vllm:num_requests_waiting`` ，SGLang "
+"为 ``sglang:num_queue_reqs`` ），因此不要在此处使用引擎原始名称。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:88
+msgid ""
+"``external``: read one HTTP endpoint instead of the pods. ``endpoint`` is"
+" the host and port, and ``path`` and ``protocolType`` are required "
+"alongside it. The fetcher requests ``<protocolType>://<endpoint>/<path>``"
+" and reads ``targetMetric`` from the response by its literal Prometheus "
+"name, with no registry translation. This is the shape the GPU optimizer "
+"sample uses; see :doc:`optimizer-based-autoscaling`. If ``endpoint`` is "
+"left empty, the controller queries the Kubernetes ``external.metrics`` "
+"API for ``targetMetric`` instead."
+msgstr ""
+"``external`` ：读取一个 HTTP 端点而非 pod。``endpoint`` 是主机和端口，同时必须提供 ``path`` 和 ``protocolType`` "
+"。抓取器请求 ``<protocolType>://<endpoint>/<path>`` ，并按字面 Prometheus 名称从响应中读取 "
+"``targetMetric`` ，不做注册表转换。这是 GPU optimizer 示例使用的形态；参见 :doc:`optimizer-based-autoscaling` "
+"。若 ``endpoint`` 留空，控制器改为向 Kubernetes ``external.metrics`` API 查询 ``targetMetric`` "
+"。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:95
+msgid ""
+"For the engine-neutral names and what each engine exports for them, see "
+"the table in :doc:`../multi-engine`."
+msgstr "引擎无关名称以及各引擎对应导出的指标，见 :doc:`../multi-engine` 中的表格。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:99
+msgid "PodAutoscaler spec at a glance"
+msgstr "PodAutoscaler spec 一览"
+
+#: ../../source/features/autoscaling/autoscaling.rst:105
+msgid "Field"
+msgstr "字段"
+
+#: ../../source/features/autoscaling/autoscaling.rst:106
+msgid "Meaning"
+msgstr "含义"
+
+#: ../../source/features/autoscaling/autoscaling.rst:107
+msgid "``scaleTargetRef``"
+msgstr "``scaleTargetRef``"
+
+#: ../../source/features/autoscaling/autoscaling.rst:108
+msgid ""
+"``apiVersion``, ``kind`` and ``name`` of the workload to scale. The name "
+"must match the workload exactly."
+msgstr "要扩缩容的工作负载的 ``apiVersion`` 、``kind`` 和 ``name`` 。名称必须与工作负载完全一致。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:110
+msgid "``subTargetSelector.roleName``"
+msgstr "``subTargetSelector.roleName``"
+
+#: ../../source/features/autoscaling/autoscaling.rst:111
+msgid "When the target is a ``StormService``, scale only this role."
+msgstr "当目标是 ``StormService`` 时，只扩缩容该角色。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:112
+msgid "``scalingStrategy``"
+msgstr "``scalingStrategy``"
+
+#: ../../source/features/autoscaling/autoscaling.rst:113
+msgid "``HPA``, ``KPA`` or ``APA``."
+msgstr "``HPA`` 、``KPA`` 或 ``APA`` 。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:114
+msgid "``minReplicas`` / ``maxReplicas``"
+msgstr "``minReplicas`` / ``maxReplicas``"
+
+#: ../../source/features/autoscaling/autoscaling.rst:115
+msgid "Hard bounds on the result. ``maxReplicas`` is required."
+msgstr "结果的硬性边界。``maxReplicas`` 为必填。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:116
+msgid "``metricsSources[]``"
+msgstr "``metricsSources[]``"
+
+#: ../../source/features/autoscaling/autoscaling.rst:117
+msgid ""
+"One or more of ``metricSourceType``, ``protocolType``, ``endpoint``, "
+"``path``, ``port``, ``targetMetric``, ``targetValue``. Several sources "
+"can be combined; see *Multi-Metric Based Autoscaling* in :doc:`metric-"
+"based-autoscaling`."
+msgstr ""
+"一项或多项 ``metricSourceType`` 、``protocolType`` 、``endpoint`` 、``path`` 、``port`` "
+"、``targetMetric`` 、``targetValue`` 。可以组合多个源；参见 :doc:`metric-based-autoscaling` "
+"中的 *基于多指标的自动扩缩容*。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:120
+msgid "``observeWindowSeconds`` / ``panicWindowSeconds``"
+msgstr "``observeWindowSeconds`` / ``panicWindowSeconds``"
+
+#: ../../source/features/autoscaling/autoscaling.rst:121
+msgid "Metric windows. ``panicWindowSeconds`` only applies to ``KPA``."
+msgstr "指标窗口。``panicWindowSeconds`` 仅适用于 ``KPA`` 。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:122
+msgid "``schedules[]``"
+msgstr "``schedules[]``"
+
+#: ../../source/features/autoscaling/autoscaling.rst:123
+msgid ""
+"Time-boxed overrides of ``minReplicas`` and ``maxReplicas`` with "
+"``name``, ``timezone``, ``daysOfWeek``, ``startTime`` and ``endTime``."
+msgstr ""
+"带时间范围的 ``minReplicas`` 和 ``maxReplicas`` 覆盖，包含 ``name`` 、``timezone`` 、``daysOfWeek`` "
+"、``startTime`` 和 ``endTime`` 。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:126
+msgid ""
+"Algorithm tunables that are not part of the spec, such as KPA's scale-"
+"down delay or APA's tolerance, are set through annotations on the "
+"``PodAutoscaler``. The full annotation list and worked YAML examples for "
+"every strategy live in :doc:`metric-based-autoscaling`."
+msgstr ""
+"不属于 spec 的算法调参（例如 KPA 的缩容延迟或 APA 的容差）通过 ``PodAutoscaler`` 上的注解设置。完整注解列表以及各策略的 "
+"YAML 示例见 :doc:`metric-based-autoscaling` 。"
+
+#: ../../source/features/autoscaling/autoscaling.rst:132
+msgid ":doc:`../../designs/aibrix-autoscaler`"
+msgstr ":doc:`../../designs/aibrix-autoscaler`"
+
+#: ../../source/features/autoscaling/autoscaling.rst:133
+msgid "Internal design of the AIBrix autoscaler."
+msgstr "AIBrix 自动扩缩容器的内部设计。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/autoscaling/metric-based-autoscaling.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/autoscaling/metric-based-autoscaling.po
@@ -1,0 +1,863 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:5
+msgid "Metric-based Autoscaling"
+msgstr "基于指标的自动扩缩容"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:8
+msgid ""
+"AIBrix Autoscaler includes various metric-based autoscaling components, "
+"allowing users to conveniently select the appropriate scaler. These "
+"options include the Knative-based Kubernetes Pod Autoscaler (KPA), the "
+"native Kubernetes Horizontal Pod Autoscaler (HPA), and AIBrix’s custom "
+"Advanced Pod Autoscaler (APA) tailored for LLM-serving."
+msgstr ""
+"AIBrix Autoscaler 包含多种基于指标的自动扩缩容组件，便于用户选择合适的扩缩容器。"
+"选项包括基于 Knative 的 Kubernetes Pod Autoscaler（KPA）、原生 Kubernetes "
+"Horizontal Pod Autoscaler（HPA），以及面向 LLM 推理服务定制的 AIBrix Advanced "
+"Pod Autoscaler（APA）。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:10
+msgid ""
+"In the following sections, we will demonstrate how users can create "
+"various types of autoscalers within AIBrix."
+msgstr "以下各节演示如何在 AIBrix 中创建各类自动扩缩容器。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:14
+msgid "Supported Autoscaling Mechanism"
+msgstr "支持的自动扩缩容机制"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:16
+msgid ""
+"HPA: it is same as vanilla K8s HPA. HPA, the native Kubernetes "
+"autoscaler, is utilized when users deploy a specification with AIBrix "
+"that calls for an HPA. This setup scales the replicas of a demo "
+"deployment based on CPU utilization."
+msgstr ""
+"HPA：与原生 K8s HPA 相同。当用户通过 AIBrix 部署需要 HPA 的规范时，会使用该原生 "
+"Kubernetes 自动扩缩容器。此配置根据 CPU 利用率扩缩 demo deployment 的副本数。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:17
+msgid ""
+"KPA: it is from Knative. KPA has panic mode which scales up more quickly "
+"based on short term history. More rapid scaling is possible. The KPA, "
+"inspired by Knative, maintains two time windows: a longer ``stable "
+"window`` and a shorter ``panic window``. It rapidly scales up resources "
+"in response to sudden spikes in traffic based on the panic window "
+"measurements. Unlike other solutions that might rely on Prometheus for "
+"gathering deployment metrics, AIBrix fetches and maintains metrics "
+"internally, enabling faster response times. Example of a KPA scaling "
+"operation using a mocked vllm-based Llama2-7b deployment"
+msgstr ""
+"KPA：来自 Knative。KPA 具有 panic 模式，可根据短期历史更快扩容，从而实现更迅速的扩缩。受 Knative 启发，KPA 维护两个时间窗口：较长的 "
+"``stable window`` 和较短的 ``panic window`` 。它根据 panic 窗口的测量值，在流量突然升高时快速扩容。与依赖 "
+"Prometheus 采集 deployment 指标的方案不同，AIBrix 在内部获取并维护指标，从而加快响应。下面是使用模拟的基于 vLLM "
+"的 Llama2-7b deployment 的 KPA 扩缩示例。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:18
+msgid ""
+"APA: similar as HPA but it has fluctuation parameter which acts as "
+"minimum buffer before triggering scaling up and down to prevent "
+"oscillation."
+msgstr "APA：类似 HPA，但带有波动参数，作为触发扩缩前的最小缓冲，以防止振荡。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:20
+msgid ""
+"While HPA and KPA are widely used, they are not specifically designed and"
+" optimized for LLM serving, which has distinct optimization points. "
+"AIBrix's custom APA (AIBrix Pod Autoscaler) solution will gradually "
+"introduce features such as:"
+msgstr ""
+"HPA 和 KPA 虽被广泛使用，但并非专为 LLM 推理服务设计与优化，而 LLM 服务有其独特的优化点。"
+"AIBrix 定制的 APA（AIBrix Pod Autoscaler）将逐步引入如下能力："
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:22
+msgid ""
+"Selecting appropriate LLM-specific metrics for scaling based on AI "
+"Runtime metrics standardization."
+msgstr "基于 AI Runtime 指标标准化，选择合适的 LLM 专用扩缩指标。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:23
+msgid "Proactive scaling algorithm rather than a reactive one. (WIP)"
+msgstr "主动扩缩算法，而非被动响应。（开发中）"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:24
+msgid "Profiling & SLO driven autoscaling solution. (Testing Phase)"
+msgstr "基于画像与 SLO 驱动的自动扩缩方案。（测试阶段）"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:28
+msgid "Metrics"
+msgstr "指标"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:30
+msgid ""
+"AiBrix supports all the vllm metrics. Please refer to "
+"https://docs.vllm.ai/en/stable/design/metrics.html"
+msgstr ""
+"AIBrix 支持全部 vLLM 指标。请参见 "
+"https://docs.vllm.ai/en/stable/design/metrics.html"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:33
+msgid "How to deploy autoscaling policy"
+msgstr "如何部署自动扩缩策略"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:35
+msgid ""
+"It is simply applying PodAutoscaler yaml file. One important thing you "
+"should note is that the deployment name and the name in `scaleTargetRef` "
+"in PodAutoscaler must be same. That's how AiBrix PodAutoscaler refers to "
+"the right deployment."
+msgstr ""
+"只需应用 PodAutoscaler yaml 文件。需要注意：deployment 名称必须与 PodAutoscaler 中 "
+"`scaleTargetRef` 的名称相同。AIBrix PodAutoscaler 据此关联到正确的 deployment。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:39
+msgid "All the sample files can be found in the following directory."
+msgstr "所有示例文件位于以下目录。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:46
+msgid "Example HPA yaml config"
+msgstr "HPA yaml 配置示例"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:52
+msgid "Example KPA yaml config"
+msgstr "KPA yaml 配置示例"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:59
+msgid "Configurable metric windows"
+msgstr "可配置的指标窗口"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:61
+msgid ""
+"``PodAutoscaler`` supports optional metric window fields under ``spec``. "
+"These fields control how much recent metric history the autoscaler keeps "
+"for scaling decisions."
+msgstr ""
+"``PodAutoscaler`` 在 ``spec`` 下支持可选的指标窗口字段。"
+"这些字段控制自动扩缩容器为扩缩决策保留多少近期指标历史。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:69
+msgid "Field"
+msgstr "字段"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:70
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:238
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:71
+msgid "Valid range"
+msgstr "有效范围"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:72
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:240
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:73
+msgid "``observeWindowSeconds``"
+msgstr "``observeWindowSeconds``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:74
+msgid "``180``"
+msgstr "``180``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:75
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:81
+msgid "``1`` to ``3600``"
+msgstr "``1`` 到 ``3600``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:76
+msgid ""
+"Stable metric window used for regular scaling recommendations. Increase "
+"it to smooth noisy metrics; decrease it to make the autoscaler react "
+"faster to recent load changes."
+msgstr ""
+"用于常规扩缩建议的稳定指标窗口。增大可平滑噪声指标；减小可使自动扩缩容器对近期负载变化反应更快。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:79
+msgid "``panicWindowSeconds``"
+msgstr "``panicWindowSeconds``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:80
+msgid "``60``"
+msgstr "``60``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:82
+msgid ""
+"Short metric window used by KPA panic-mode decisions. It must be less "
+"than or equal to ``observeWindowSeconds``."
+msgstr "KPA panic 模式决策使用的短指标窗口。必须小于或等于 ``observeWindowSeconds`` 。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:85
+msgid ""
+"If either field is omitted, AIBrix uses the default value above. "
+"Validation rejects non-positive values, values greater than ``3600``, and"
+" configurations where ``panicWindowSeconds`` is greater than "
+"``observeWindowSeconds``. This comparison uses defaults for omitted "
+"fields, so setting ``observeWindowSeconds`` below ``60`` also requires "
+"setting ``panicWindowSeconds`` to the same or a smaller value."
+msgstr ""
+"若省略任一字段，AIBrix 使用上述默认值。校验会拒绝非正值、大于 ``3600`` 的值，以及 "
+"``panicWindowSeconds`` 大于 ``observeWindowSeconds`` 的配置。"
+"比较时对省略字段使用默认值，因此将 ``observeWindowSeconds`` 设为小于 ``60`` 时，"
+"也必须将 ``panicWindowSeconds`` 设为相同或更小的值。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:92
+msgid ""
+"Example KPA policy with a 10-minute stable window and a 1-minute panic "
+"window:"
+msgstr "稳定窗口 10 分钟、panic 窗口 1 分钟的 KPA 策略示例："
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:120
+msgid "Scheduled replica bounds"
+msgstr "定时副本边界"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:122
+msgid ""
+"``PodAutoscaler`` supports optional scheduled replica bounds under "
+"``spec.schedules``. Each entry defines a recurring daily wall-clock "
+"window with ``startTime`` and ``endTime`` in strict zero-padded ``HH:MM``"
+" format. The start time is inclusive and the end time is exclusive. While"
+" active, a schedule overrides the base ``spec.minReplicas`` and/or "
+"``spec.maxReplicas``."
+msgstr ""
+"``PodAutoscaler`` 在 ``spec.schedules`` 下支持可选的定时副本边界。每条记录定义一个按日重复的墙上时钟窗口，``startTime`` "
+"和 ``endTime`` 必须为严格补零的 ``HH:MM`` 格式。开始时间包含，结束时间不包含。生效期间，该计划会覆盖基础的 ``spec.minReplicas`` "
+"和/或 ``spec.maxReplicas`` 。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:128
+msgid ""
+"If ``timezone`` is omitted, schedules are evaluated in UTC. When set, "
+"``timezone`` must be a valid IANA timezone such as "
+"``America/Los_Angeles``. If ``daysOfWeek`` is omitted, the schedule "
+"applies every day. When set, ``daysOfWeek`` accepts English three-letter "
+"weekday names such as ``Mon`` through ``Sun``."
+msgstr ""
+"若省略 ``timezone`` ，计划按 UTC 求值。若设置，``timezone`` 必须是有效的 IANA 时区，例如 ``America/Los_Angeles`` "
+"。若省略 ``daysOfWeek`` ，计划每天生效。若设置，``daysOfWeek`` 接受英文三字母星期名，如 ``Mon`` 到 ``Sun`` "
+"。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:134
+msgid ""
+"Scheduled entries may set either ``minReplicas``, ``maxReplicas``, or "
+"both. A partial override inherits the missing bound from the base "
+"PodAutoscaler spec. Validation rejects entries that do not set either "
+"bound, produce an effective minimum greater than the effective maximum, "
+"use invalid timezones or invalid time formats, span midnight, or overlap "
+"with another scheduled bounds entry. Overlapping windows are rejected "
+"instead of relying on implicit priority."
+msgstr ""
+"定时条目可设置 ``minReplicas`` 、``maxReplicas`` 或两者。部分覆盖会从基础 PodAutoscaler spec "
+"继承缺失的边界。校验会拒绝未设置任一边界、有效最小值大于有效最大值、使用无效时区或时间格式、跨越午夜，或与另一条定时边界重叠的条目。重叠窗口会被拒绝，而不是依赖隐式优先级。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:141
+msgid ""
+"HPA, KPA, and APA all use the effective scheduled bounds. For HPA "
+"strategy, AIBrix writes the effective bounds to the generated Kubernetes "
+"``HorizontalPodAutoscaler``. If the effective minimum is ``0``, the "
+"generated HPA omits ``spec.minReplicas`` to preserve the existing "
+"Kubernetes HPA compatibility behavior."
+msgstr ""
+"HPA、KPA 和 APA 都使用生效的定时边界。对 HPA 策略，AIBrix 将生效边界写入生成的 Kubernetes ``HorizontalPodAutoscaler`` "
+"。若生效最小值为 ``0`` ，生成的 HPA 会省略 ``spec.minReplicas`` ，以保持现有 Kubernetes HPA 兼容行为。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:147
+msgid "Example APA policy with weekday business-hour bounds:"
+msgstr "工作日营业时间边界的 APA 策略示例："
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:154
+msgid "Example APA yaml config"
+msgstr "APA yaml 配置示例"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:161
+msgid "Using Kubernetes external metrics"
+msgstr "使用 Kubernetes 外部指标"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:163
+msgid ""
+"Besides scraping a metrics endpoint directly, a ``PodAutoscaler`` can "
+"read its target metric from the Kubernetes ``external.metrics.k8s.io`` "
+"API. This lets you scale on any metric published by an external metrics "
+"adapter, such as Prometheus Adapter or an adapter of your own, without "
+"AiBrix having to reach the workload's metrics port itself."
+msgstr ""
+"除直接抓取指标端点外，``PodAutoscaler`` 也可从 Kubernetes ``external.metrics.k8s.io`` "
+"API 读取目标指标。这样可以基于外部指标适配器（如 Prometheus Adapter 或自建适配器）"
+"发布的任意指标扩缩，而无需 AIBrix 自行访问工作负载的指标端口。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:169
+msgid ""
+"This is useful when the signal you want to scale on does not live on the "
+"pod, for example a queue depth held in a broker, or a metric already "
+"aggregated by an existing monitoring stack."
+msgstr ""
+"当扩缩所依据的信号不在 pod 上时很有用，例如保存在 broker 中的队列深度，"
+"或已由现有监控栈聚合的指标。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:174
+msgid "Selecting the external metrics API"
+msgstr "选择外部指标 API"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:176
+msgid ""
+"A metric source uses the Kubernetes external metrics API when "
+"``metricSourceType`` is ``external`` and ``endpoint`` is left unset. "
+"Setting ``endpoint`` switches the same source type back to scraping that "
+"HTTP endpoint, in which case ``protocolType``, ``endpoint`` and ``path`` "
+"are all required."
+msgstr ""
+"当 ``metricSourceType`` 为 ``external`` 且未设置 ``endpoint`` 时，指标源使用 Kubernetes "
+"外部指标 API。设置 ``endpoint`` 会将同一源类型切回抓取该 HTTP 端点，此时 ``protocolType`` 、``endpoint`` "
+"和 ``path`` 均为必填。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:181
+msgid "So for the external metrics API, specify only the metric and its target:"
+msgstr "因此对外部指标 API，只需指定指标及其目标值："
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:190
+msgid ""
+"Omitting ``endpoint``, ``path`` and ``protocolType`` is deliberate here, "
+"not an incomplete example."
+msgstr "此处省略 ``endpoint`` 、``path`` 和 ``protocolType`` 是有意为之，并非示例不完整。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:194
+msgid "Requirements"
+msgstr "要求"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:196
+msgid ""
+"An external metrics adapter must be installed and serving the "
+"``external.metrics.k8s.io`` API group in the cluster."
+msgstr "必须安装外部指标适配器，并在集群中提供 ``external.metrics.k8s.io`` API 组。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:198
+msgid ""
+"The adapter must expose the metric named in ``targetMetric``, in the same"
+" namespace as the target workload."
+msgstr "适配器必须在目标工作负载所在命名空间中暴露 ``targetMetric`` 所指定的指标。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:200
+msgid ""
+"The AiBrix controller needs ``get`` and ``list`` on "
+"``external.metrics.k8s.io``. The shipped RBAC already grants this."
+msgstr ""
+"AIBrix 控制器需要对 ``external.metrics.k8s.io`` 的 ``get`` 和 ``list`` 权限。"
+"随附的 RBAC 已授予这些权限。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:203
+msgid ""
+"If the external metrics client cannot be constructed at controller "
+"startup, the controller logs a warning and continues with external "
+"metrics unavailable, so check the controller logs if a ``PodAutoscaler`` "
+"using this mode never scales."
+msgstr ""
+"若控制器启动时无法构建外部指标客户端，控制器会记录警告并继续运行，但外部指标不可用。"
+"因此若使用此模式的 ``PodAutoscaler`` 始终不扩缩，请检查控制器日志。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:208
+msgid "Example external metrics KPA config"
+msgstr "外部指标 KPA 配置示例"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:214
+msgid "Example external metrics APA config"
+msgstr "外部指标 APA 配置示例"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:221
+msgid "Supported PodAutoscaler annotations"
+msgstr "支持的 PodAutoscaler 注解"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:223
+msgid ""
+"Metric-based autoscalers can be tuned with annotations on the "
+"``PodAutoscaler`` object. The controller currently recognizes the generic"
+" ``autoscaling.aibrix.ai/`` annotation keys listed below. Annotation "
+"values are strings in Kubernetes metadata, so quote numeric and duration "
+"values in YAML when needed."
+msgstr ""
+"基于指标的自动扩缩容器可通过 ``PodAutoscaler`` 对象上的注解调参。"
+"控制器当前识别下列通用 ``autoscaling.aibrix.ai/`` 注解键。"
+"注解值在 Kubernetes metadata 中为字符串，因此在 YAML 中必要时请为数值和时长加引号。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:229
+msgid ""
+"Durations are parsed with Go duration syntax such as ``30s`` or ``5m``. "
+"Floating-point values are parsed as decimal numbers such as ``0.1`` or "
+"``2.0``."
+msgstr "时长按 Go duration 语法解析，例如 ``30s`` 或 ``5m`` 。浮点值按十进制数解析，例如 ``0.1`` 或 ``2.0`` 。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:236
+msgid "Annotation"
+msgstr "注解"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:237
+msgid "Value type"
+msgstr "值类型"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:239
+msgid "Strategy use"
+msgstr "适用策略"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:241
+msgid "``autoscaling.aibrix.ai/max-scale-up-rate``"
+msgstr "``autoscaling.aibrix.ai/max-scale-up-rate``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:242
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:247
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:252
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:257
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:262
+msgid "float"
+msgstr "float"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:243
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:248
+msgid "``2``"
+msgstr "``2``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:244
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:249
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:269
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:274
+msgid "HPA, KPA, APA"
+msgstr "HPA、KPA、APA"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:245
+msgid ""
+"Limits how quickly replicas can increase in one scaling decision. For "
+"example, ``2.0`` allows the recommendation to grow up to 2x the current "
+"replica count."
+msgstr ""
+"限制单次扩缩决策中副本可增加的速度。例如 ``2.0`` 允许建议值最多增长到当前副本数的 2 倍。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:246
+msgid "``autoscaling.aibrix.ai/max-scale-down-rate``"
+msgstr "``autoscaling.aibrix.ai/max-scale-down-rate``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:250
+msgid ""
+"Limits how quickly replicas can decrease in one scaling decision. For "
+"example, ``2.0`` prevents scaling below roughly half of the current "
+"replica count in one decision."
+msgstr ""
+"限制单次扩缩决策中副本可减少的速度。例如 ``2.0`` 可防止一次决策缩到大约当前副本数的一半以下。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:251
+msgid "``autoscaling.aibrix.ai/scale-up-tolerance``"
+msgstr "``autoscaling.aibrix.ai/scale-up-tolerance``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:253
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:258
+msgid "``0.1``"
+msgstr "``0.1``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:254
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:259
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:279
+msgid "KPA, APA"
+msgstr "KPA、APA"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:255
+msgid ""
+"Avoids scale-up for small metric fluctuations. A value of ``0.1`` means "
+"the metric must exceed the target by more than 10% before scaling up."
+msgstr ""
+"避免因指标小幅波动而扩容。值为 ``0.1`` 表示指标必须超过目标 10% 以上才会扩容。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:256
+msgid "``autoscaling.aibrix.ai/scale-down-tolerance``"
+msgstr "``autoscaling.aibrix.ai/scale-down-tolerance``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:260
+msgid ""
+"Avoids scale-down for small metric fluctuations. A value of ``0.1`` means"
+" the metric must fall below the target by more than 10% before scaling "
+"down."
+msgstr ""
+"避免因指标小幅波动而缩容。值为 ``0.1`` 表示指标必须低于目标 10% 以上才会缩容。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:261
+msgid "``autoscaling.aibrix.ai/panic-threshold``"
+msgstr "``autoscaling.aibrix.ai/panic-threshold``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:263
+msgid "``2.0``"
+msgstr "``2.0``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:264
+msgid "KPA"
+msgstr "KPA"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:265
+msgid ""
+"Sets the threshold for entering KPA panic mode when short-window demand "
+"is high relative to stable-window demand."
+msgstr "设置进入 KPA panic 模式的阈值：短窗口需求相对稳定窗口需求较高时触发。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:266
+msgid "``autoscaling.aibrix.ai/scale-up-cooldown-window``"
+msgstr "``autoscaling.aibrix.ai/scale-up-cooldown-window``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:267
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:272
+msgid "duration"
+msgstr "duration"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:268
+msgid "``0s``"
+msgstr "``0s``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:270
+msgid "Stabilization window for scale-up recommendations."
+msgstr "扩容建议的稳定窗口。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:271
+msgid "``autoscaling.aibrix.ai/scale-down-cooldown-window``"
+msgstr "``autoscaling.aibrix.ai/scale-down-cooldown-window``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:273
+msgid "``300s``"
+msgstr "``300s``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:275
+msgid ""
+"Stabilization window for scale-down recommendations. The default is 5 "
+"minutes."
+msgstr "缩容建议的稳定窗口。默认为 5 分钟。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:276
+msgid "``autoscaling.aibrix.ai/scale-to-zero``"
+msgstr "``autoscaling.aibrix.ai/scale-to-zero``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:277
+msgid "bool"
+msgstr "bool"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:278
+msgid "``false``"
+msgstr "``false``"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:280
+msgid ""
+"Enables the scaling context's scale-to-zero flag. The final replica count"
+" is still bounded by ``spec.minReplicas``."
+msgstr "启用扩缩上下文的缩到零标志。最终副本数仍受 ``spec.minReplicas`` 约束。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:282
+msgid "Example:"
+msgstr "示例："
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:304
+msgid "StormService Role-Level Autoscaling"
+msgstr "StormService 角色级自动扩缩容"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:306
+msgid ""
+"For StormService in pooled mode (``spec.mode: Pooled``), different roles "
+"(e.g., prefill and decode) can be autoscaled independently. This enables "
+"fine-grained control where each role scales based on its specific "
+"metrics."
+msgstr ""
+"对 pooled 模式（``spec.mode: Pooled`` ）的 StormService，不同角色（例如 prefill 和 decode）可独立自动扩缩。这样可精细控制，使每个角色基于其特定指标扩缩。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:308
+msgid ""
+"Use the ``subTargetSelector`` field to target a specific role within a "
+"StormService, and declare ``spec.mode`` on the StormService (``Pooled`` "
+"to scale the targeted role, ``Replica`` to scale ``spec.replicas``). The "
+"autoscaler reads ``spec.mode`` to route role-level scaling; "
+"``replicas=1`` alone cannot distinguish the two modes. The PodAutoscaler "
+"annotation ``autoscaling.aibrix.ai/storm-service-mode`` is deprecated and"
+" only honored as a compatibility fallback when the target StormService "
+"does not declare ``spec.mode``."
+msgstr ""
+"使用 ``subTargetSelector`` 字段指向 StormService 中的特定角色，并在 StormService 上声明 ``spec.mode`` "
+"（``Pooled`` 扩缩目标角色，``Replica`` 扩缩 ``spec.replicas`` ）。自动扩缩容器读取 ``spec.mode`` "
+"以路由角色级扩缩；仅凭 ``replicas=1`` 无法区分两种模式。PodAutoscaler 注解 ``autoscaling.aibrix.ai/storm-service-mode`` "
+"已弃用，仅在目标 StormService 未声明 ``spec.mode`` 时作为兼容回退生效。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:310
+msgid "**Key features:**"
+msgstr "**主要特性：**"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:312
+msgid ""
+"Each role has its own PodAutoscaler with independent metrics and scaling "
+"policies"
+msgstr "每个角色有独立的 PodAutoscaler，以及独立的指标和扩缩策略"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:313
+msgid "Works with StormService in pooled mode (``replicas=1``)"
+msgstr "适用于 pooled 模式（``replicas=1`` ）的 StormService"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:314
+msgid "Supports different scaling strategies (HPA, KPA, APA) per role"
+msgstr "每个角色可使用不同扩缩策略（HPA、KPA、APA）"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:315
+msgid "Allows different min/max replicas and scaling behaviors per role"
+msgstr "每个角色可使用不同的最小/最大副本数和扩缩行为"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:317
+msgid "**Complete example:**"
+msgstr "**完整示例：**"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:322
+msgid "**When to use:**"
+msgstr "**适用场景：**"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:324
+msgid ""
+"**Pooled mode**: StormService with ``replicas=1`` where roles need "
+"independent scaling"
+msgstr "**Pooled 模式** ：``replicas=1`` 的 StormService，各角色需要独立扩缩"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:325
+msgid ""
+"**Different workload patterns**: Prefill and decode have different "
+"resource needs and traffic patterns"
+msgstr "**不同工作负载模式** ：Prefill 和 decode 的资源需求和流量模式不同"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:326
+msgid ""
+"**Independent metrics**: Each role has its own metrics (e.g., queue "
+"length, batch utilization)"
+msgstr "**独立指标** ：每个角色有各自的指标（例如队列长度、batch 利用率）"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:329
+msgid "Multi-Metric Based Autoscaling"
+msgstr "基于多指标的自动扩缩容"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:331
+msgid ""
+"AIBrix supports multi-metric autoscaling, allowing users to define "
+"multiple scaling metrics within a single PodAutoscaler resource. This is "
+"especially useful for LLM-serving workloads where a single metric (e.g., "
+"GPU cache usage) may not fully capture system pressure—combining it with "
+"queue-based metrics (e.g., number of waiting requests) enables more "
+"robust and responsive scaling decisions."
+msgstr ""
+"AIBrix 支持多指标自动扩缩容，允许在单个 PodAutoscaler 资源中定义多个扩缩指标。"
+"这对 LLM 推理工作负载尤其有用：单一指标（例如 GPU cache 使用率）可能无法充分反映系统压力——"
+"将其与基于队列的指标（例如等待请求数）结合，可做出更稳健、更灵敏的扩缩决策。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:335
+msgid "How It Works"
+msgstr "工作原理"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:337
+msgid ""
+"When multiple metrics are specified under ``spec.metricsSources``, the "
+"autoscaler evaluates all metrics independently."
+msgstr "当 ``spec.metricsSources`` 下指定多个指标时，自动扩缩容器会独立评估所有指标。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:338
+msgid ""
+"The final desired replica count is determined by the metric that demands "
+"the highest number of replicas (i.e., the \"max\" strategy)."
+msgstr "最终期望副本数由要求副本数最多的指标决定（即 \"max\" 策略）。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:341
+msgid "Configuration Example"
+msgstr "配置示例"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:343
+msgid ""
+"The following PodAutoscaler uses two metrics simultaneously with APA "
+"strategy:"
+msgstr "以下 PodAutoscaler 使用 APA 策略同时采用两个指标："
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:349
+msgid "Check autoscaling logs"
+msgstr "查看自动扩缩容日志"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:352
+msgid "Pod Autoscaler Logs"
+msgstr "Pod Autoscaler 日志"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:354
+msgid ""
+"Pod autoscaler is part of aibrix controller manager which plays the role "
+"of collecting the metrics from each pod. You can check its logs in this "
+"way."
+msgstr ""
+"Pod autoscaler 是 aibrix controller manager 的一部分，负责从每个 pod 采集指标。"
+"可用如下方式查看其日志。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:361
+msgid ""
+"Expected log output. You can see the current metric is "
+"gpu_cache_usage_perc. You can check each pod's current metric value."
+msgstr ""
+"预期日志输出。可以看到当前指标为 gpu_cache_usage_perc。你可以查看每个 pod 的当前指标值。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:363
+msgid "AiBrix controller manager output"
+msgstr "AIBrix controller manager 输出"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:370
+msgid "Custom Resource Status"
+msgstr "自定义资源状态"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:372
+msgid "To describe the PodAutoscaler custom resource, you can run"
+msgstr "要查看 PodAutoscaler 自定义资源，可以运行"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:378
+msgid ""
+"Example output is here, you can explore the scaling conditions and events"
+" for more details."
+msgstr "示例如下，可查看扩缩条件和事件以获取更多细节。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:380
+msgid "PodAutoscaler describe"
+msgstr "PodAutoscaler describe"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:387
+msgid "Preliminary experiments with different autoscalers"
+msgstr "不同自动扩缩容器的初步实验"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:389
+msgid ""
+"Here we show the preliminary experiment results to show how different "
+"autoscaling mechanism and configuration for autoscaler affect the "
+"performance(latency) and cost(compute cost). In AiBrix, user can easily "
+"deploy different autoscaler by simply applying K8s yaml."
+msgstr ""
+"以下初步实验结果展示不同自动扩缩机制及其配置如何影响性能（延迟）和成本（计算成本）。"
+"在 AIBrix 中，用户只需应用 K8s yaml 即可部署不同的自动扩缩容器。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:392
+msgid "Set up"
+msgstr "实验设置"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:393
+msgid "Model: Deepseek 7B chatbot model"
+msgstr "模型：Deepseek 7B chatbot 模型"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:394
+msgid "GPU type: V100"
+msgstr "GPU 类型：V100"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:395
+msgid "Max number of GPU: 8"
+msgstr "最大 GPU 数：8"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:396
+msgid "Target metric and value"
+msgstr "目标指标与取值"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:397
+msgid "Target metric: gpu_kv_cache_utilization"
+msgstr "目标指标：gpu_kv_cache_utilization"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:398
+msgid "Target value: 50%"
+msgstr "目标值：50%"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:399
+msgid "Workload"
+msgstr "工作负载"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:400
+msgid ""
+"The overall RPS trend starts with low RPS and goes up relatively fast "
+"until T=500 to evaluate how different autoscaler and config reacts to the"
+" rapid load increase. After that, it goes down to low RPS quickly to "
+"evaluate scaling down behavior and goes up again slowly."
+msgstr ""
+"整体 RPS 趋势从低 RPS 开始，到 T=500 较快上升，以评估不同自动扩缩容器及配置对负载快速增加的反应。"
+"之后迅速降到低 RPS 以评估缩容行为，然后再缓慢上升。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:401
+msgid "Average RPS trend: 1 RPS -> 4 RPS -> 8 RPS -> 10 RPS -> 2 RPS -> 6 RPS"
+msgstr "平均 RPS 趋势：1 RPS -> 4 RPS -> 8 RPS -> 10 RPS -> 2 RPS -> 6 RPS"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:402
+msgid "RPS can be found in the second subfigure."
+msgstr "RPS 见第二张子图。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:403
+msgid "Performance"
+msgstr "性能"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:404
+msgid ""
+"HPA has the highest latency since its slow reaction. KPA is the most "
+"reactive with panic mode. APA was running with small delay window to save"
+" cost. It does save cost but ends up having higher latency than KPA when "
+"it scales down too aggressively from T=700 to T=1000."
+msgstr ""
+"HPA 延迟最高，因其反应较慢。KPA 因 panic 模式反应最快。APA 使用较小延迟窗口以节省成本。"
+"确实节省了成本，但在 T=700 到 T=1000 缩容过于激进，延迟高于 KPA。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:405
+msgid "Cost"
+msgstr "成本"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:406
+msgid ""
+"The fourth figure shows the relative accumulated compute cost over time. "
+"The accumulated cost is calculated by multiplying the time by unit cost "
+"(in this example, 1). The actual compute cost can be calculated by "
+"multiplying the actual cost per unit time."
+msgstr ""
+"第四张图显示随时间累积的相对计算成本。累积成本由时间乘以单位成本（本例中为 1）得到。"
+"实际计算成本可将单位时间的实际成本相乘得到。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:407
+msgid "HPA is the most expensive due to the longer delay window for scaling down."
+msgstr "HPA 最贵，因其缩容延迟窗口更长。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:408
+msgid ""
+"APA is the most responsive and saves the cost most. You can see it "
+"fluctuating more than other two autoscalers."
+msgstr "APA 响应最快、节省成本最多。可以看到它比另外两种自动扩缩容器波动更大。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:409
+msgid ""
+"Note that scaling down window is not inherent feature of each autoscaling"
+" mechanism. It is configurable variable. We use the default value for HPA"
+" (300s)."
+msgstr ""
+"注意，缩容窗口并非各自动扩缩机制的固有特性，而是可配置变量。HPA 使用默认值（300s）。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:410
+msgid "Conclusion"
+msgstr "结论"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:411
+msgid ""
+"There is no one autoscaler that outperforms others for all metrics "
+"(latency, cost). In addition, the results might depend on the workloads. "
+"Infrastructure should provide easy way to configure whichever autoscaling"
+" mechanism they want and should be easily configurable since different "
+"users have different preference. For example, one might prefer cost over "
+"performance or vice versa."
+msgstr ""
+"没有一种自动扩缩容器在所有指标（延迟、成本）上都优于其他。此外，结果可能取决于工作负载。"
+"基础设施应便于配置用户想要的自动扩缩机制，因为不同用户偏好不同。"
+"例如，有人更看重成本而非性能，或相反。"
+
+#: ../../source/features/autoscaling/metric-based-autoscaling.rst:414
+msgid "result"
+msgstr "结果"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/autoscaling/optimizer-based-autoscaling.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/autoscaling/optimizer-based-autoscaling.po
@@ -1,0 +1,588 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:5
+msgid "Optimizer-based Autoscaler"
+msgstr "基于优化器的自动扩缩容器"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:8
+msgid "Overview"
+msgstr "概述"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:10
+msgid ""
+"Metric-based autoscalers react: they wait for a metric such as queue "
+"depth to cross a threshold, then add replicas. The optimizer-based "
+"autoscaler plans instead. It combines an offline benchmark of how each "
+"GPU type performs on a model with a latency or throughput SLO, watches "
+"the actual mix of request sizes arriving at the gateway, and computes how"
+" many replicas are needed to serve that mix within the SLO at the lowest "
+"cost. The result is handed to a ``PodAutoscaler`` as a metric, so the "
+"final scaling action still goes through the same controller as every "
+"other strategy."
+msgstr ""
+"基于指标的自动扩缩容器是被动的：等待队列深度等指标越过阈值后再增加副本。基于优化器的自动扩缩容器则是规划式的。它结合各 GPU 类型在某模型上的离线基准、延迟或吞吐 "
+"SLO，观察到达网关的实际请求大小分布，计算在 SLO 内以最低成本服务该分布所需的副本数。结果作为指标交给 ``PodAutoscaler`` "
+"，因此最终扩缩动作仍经过与其他策略相同的控制器。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:17
+msgid ""
+"Because it reasons about GPU capacity rather than a single utilisation "
+"number, it is also the mechanism behind :doc:`../heterogeneous-gpu`, "
+"where several GPU types serve one model and the optimizer decides how "
+"many of each to run."
+msgstr ""
+"因为它基于 GPU 容量而非单一利用率数字进行推理，也是 :doc:`../heterogeneous-gpu` "
+"背后的机制：多种 GPU 类型服务同一模型，由优化器决定每种运行多少。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:22
+msgid "How it works"
+msgstr "工作原理"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:34
+msgid ""
+"**Request tracing.** With ``AIBRIX_GPU_OPTIMIZER_TRACING_FLAG=true`` on "
+"the gateway plugin, every request's token statistics are recorded in "
+"Redis, giving the optimizer the live distribution of input and output "
+"lengths per model."
+msgstr ""
+"**请求追踪。** 在网关插件上设置 ``AIBRIX_GPU_OPTIMIZER_TRACING_FLAG=true`` 后，"
+"每个请求的 token 统计会记录到 Redis，为优化器提供每个模型的输入和输出长度实时分布。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:37
+msgid ""
+"**Profiles.** ``aibrix_benchmark`` measures a deployment on one GPU type "
+"across input and output length patterns. ``aibrix_gen_profile`` turns "
+"that benchmark into a capacity profile for a chosen SLO and GPU cost and "
+"stores it in Redis under the model's name. One profile per GPU type."
+msgstr ""
+"**画像。** ``aibrix_benchmark`` 在一种 GPU 类型上、跨输入和输出长度模式测量 deployment。"
+"``aibrix_gen_profile`` 将该基准转换为所选 SLO 和 GPU 成本下的容量画像，"
+"并以模型名称存入 Redis。每种 GPU 类型一份画像。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:41
+msgid ""
+"**Optimization.** The GPU optimizer (``aibrix-gpu-optimizer`` in "
+"``aibrix-system``) watches ``Deployment`` objects that carry the "
+"``model.aibrix.ai/name`` label, loads the profiles for that model, and "
+"solves for the replica count per deployment that covers the observed "
+"request mix within the SLO at minimum cost."
+msgstr ""
+"**优化。** GPU optimizer（``aibrix-system`` 中的 ``aibrix-gpu-optimizer`` ）监视带有 "
+"``model.aibrix.ai/name`` 标签的 ``Deployment`` 对象，加载该模型的画像，求解每个 deployment "
+"在 SLO 内以最低成本覆盖观测请求分布所需的副本数。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:45
+msgid ""
+"**Scaling.** The recommendation is exposed as the Prometheus metric "
+"``vllm:deployment_replicas`` at ``/metrics/<namespace>/<deployment>``. A "
+"``PodAutoscaler`` with an ``external`` metric source consumes it."
+msgstr ""
+"**扩缩。** 建议以 Prometheus 指标 ``vllm:deployment_replicas`` 暴露在 ``/metrics/<namespace>/<deployment>`` "
+"。带 ``external`` 指标源的 ``PodAutoscaler`` 消费该指标。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:50
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:52
+msgid ""
+"The GPU optimizer is part of the default AIBrix install "
+"(``config/default`` includes ``config/gpu-optimizer``). Confirm it is "
+"running: ``kubectl get deploy -n aibrix-system aibrix-gpu-optimizer``."
+msgstr ""
+"GPU optimizer 包含在默认 AIBrix 安装中（``config/default`` 包含 ``config/gpu-optimizer`` "
+"）。确认其正在运行：``kubectl get deploy -n aibrix-system aibrix-gpu-optimizer`` 。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:55
+msgid ""
+"Request tracing is **off** by default. Enable it by redeploying the "
+"gateway plugin with the experimental overlay, or by adding the "
+"environment variable yourself:"
+msgstr "请求追踪默认**关闭** 。可通过实验 overlay 重新部署网关插件，或自行添加环境变量来启用："
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:64
+msgid ""
+"The ``aibrix`` Python package on the machine where you run the benchmark:"
+" ``pip3 install aibrix``. The profiling tools additionally need "
+"``tiktoken`` and ``transformers``."
+msgstr ""
+"在运行基准的机器上安装 ``aibrix`` Python 包：``pip3 install aibrix`` 。画像工具还需要 ``tiktoken`` "
+"和 ``transformers`` 。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:67
+msgid ""
+"Access to the AIBrix Redis instance from that machine (a ``port-forward``"
+" is enough)."
+msgstr "从该机器访问 AIBrix Redis 实例（``port-forward`` 即可）。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:70
+msgid "Step 1: Benchmark the deployment"
+msgstr "步骤 1：对 deployment 做基准测试"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:72
+msgid ""
+"For each type of GPU, run ``aibrix_benchmark``. See `benchmark.sh "
+"<https://github.com/vllm-"
+"project/aibrix/tree/main/python/aibrix/aibrix/gpu_optimizer/optimizer/profiling/benchmark.sh>`_"
+" for more options."
+msgstr ""
+"对每种 GPU，运行 ``aibrix_benchmark`` 。更多选项见 `benchmark.sh <https://github.com/vllm-project/aibrix/tree/main/python/aibrix/aibrix/gpu_optimizer/optimizer/profiling/benchmark.sh>`_ "
+"。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:81
+msgid "Step 2: Decide the SLO and generate the profile"
+msgstr "步骤 2：确定 SLO 并生成画像"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:83
+msgid ""
+"Run ``aibrix_gen_profile -h`` for help. The first argument is the profile"
+" name; the samples use ``<model>-<gpu>`` so that one model can have one "
+"profile per GPU type."
+msgstr ""
+"运行 ``aibrix_gen_profile -h`` 查看帮助。第一个参数是画像名称；示例使用 ``<model>-<gpu>`` ，以便一个模型每种 "
+"GPU 类型有一份画像。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:92
+msgid ""
+"Now the GPU Optimizer is ready to work. Once it has enough trace data it "
+"reloads the profiles on its own; to force a reload right away:"
+msgstr "此时 GPU Optimizer 已可工作。一旦有足够的追踪数据，它会自行重新加载画像；若要立即强制重新加载："
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:101
+msgid "Step 3: Deploy the PodAutoscaler"
+msgstr "步骤 3：部署 PodAutoscaler"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:103
+msgid ""
+"It is simply a matter of applying the podautoscaler yaml file. The GPU "
+"optimizer exposes custom metrics which can be used by podautoscalers to "
+"make scaling decisions as explained above. One important thing you should"
+" note is that the deployment name and the name in scaleTargetRef in "
+"PodAutoscaler must be the same. That's how AIBrix PodAutoscaler refers to"
+" the right deployment."
+msgstr ""
+"只需应用 podautoscaler yaml 文件。如上所述，GPU optimizer 暴露自定义指标，"
+"供 PodAutoscaler 做扩缩决策。需要注意：deployment 名称必须与 PodAutoscaler 中 "
+"scaleTargetRef 的名称相同。AIBrix PodAutoscaler 据此关联到正确的 deployment。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:105
+msgid "All the sample files can be found in the following directory."
+msgstr "所有示例文件位于以下目录。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:112
+msgid "Example Optimizer-based KPA yaml config"
+msgstr "基于优化器的 KPA yaml 配置示例"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:117
+msgid ""
+"The part that makes this an optimizer-driven autoscaler is the "
+"``metricsSources`` entry: the controller requests "
+"``<protocolType>://<endpoint>/<path>`` and reads ``targetMetric`` from "
+"the response by its literal Prometheus name, so ``path`` must be the "
+"optimizer's per-deployment route ``/metrics/<namespace>/<deployment>`` "
+"and ``targetMetric`` stays ``vllm:deployment_replicas``. ``minReplicas`` "
+"and ``maxReplicas`` bound what the optimizer may request. The "
+"``autoscaling.aibrix.ai/scale-down-cooldown-window: 0s`` annotation "
+"removes the default five minute scale-down cooldown so replicas can "
+"follow the recommendation down without delay; :doc:`metric-based-"
+"autoscaling` lists the rest of that annotation family."
+msgstr ""
+"使其成为优化器驱动自动扩缩容器的关键是 ``metricsSources`` 条目：控制器请求 ``<protocolType>://<endpoint>/<path>`` "
+"，并按字面 Prometheus 名称从响应中读取 ``targetMetric`` ，因此 ``path`` 必须是优化器按 deployment "
+"划分的路由 ``/metrics/<namespace>/<deployment>`` ，且 ``targetMetric`` 保持为 ``vllm:deployment_replicas`` "
+"。``minReplicas`` 和 ``maxReplicas`` 限制优化器可请求的范围。注解 ``autoscaling.aibrix.ai/scale-down-cooldown-window: "
+"0s`` 会去掉默认的五分钟缩容冷却，使副本可立即跟随建议向下调整；该注解族的其余项见 :doc:`metric-based-autoscaling` "
+"。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:127
+msgid "Verify"
+msgstr "验证"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:129
+msgid ""
+"The optimizer-based autoscaler decides the number of GPUs based on the "
+"offline GPU capacity profiling. It proactively calculates the overall "
+"capacity needed for serving requests under SLO and ensures that the GPU "
+"capacity is fully used but not overloaded. The GPU optimizer's output is "
+"exposed as custom metrics. The following shows how these custom metrics "
+"can be checked."
+msgstr ""
+"基于优化器的自动扩缩容器根据离线 GPU 容量画像决定 GPU 数量。"
+"它主动计算在 SLO 下服务请求所需的总体容量，并确保 GPU 容量被充分利用但不超载。"
+"GPU optimizer 的输出作为自定义指标暴露。以下说明如何检查这些自定义指标。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:140
+msgid ""
+"You should observe that the number of workload pods changes in response "
+"to the requests sent to the gateway."
+msgstr "应能观察到工作负载 pod 数量随发往网关的请求而变化。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:144
+msgid "GPU optimizer logs"
+msgstr "GPU optimizer 日志"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:146
+msgid ""
+"Gpu optimizer is an individual component that plays the role of "
+"collecting metrics from each pod. You can check its logs in this way. "
+"``kubectl logs <aibrix-gpu-optimizer-podname> -n aibrix-system -f``"
+msgstr ""
+"GPU optimizer 是独立组件，负责从每个 pod 采集指标。可用如下方式查看其日志。"
+"``kubectl logs <aibrix-gpu-optimizer-podname> -n aibrix-system -f``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:152
+msgid ""
+"In the above logs, the GPU optimizer returns the number of GPUs "
+"suggested, which is 2 in this example."
+msgstr "在上述日志中，GPU optimizer 返回建议的 GPU 数量，本例中为 2。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:155
+msgid "Configuration reference"
+msgstr "配置参考"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:157
+msgid ""
+"**GPU optimizer deployment** (``aibrix-gpu-optimizer``, ``aibrix-"
+"system``). It runs ``python -m aibrix.gpu_optimizer.app`` and listens on "
+"port ``8080``."
+msgstr ""
+"**GPU optimizer deployment** （``aibrix-gpu-optimizer`` ，``aibrix-system`` "
+"）。运行 ``python -m aibrix.gpu_optimizer.app`` ，监听端口 ``8080`` 。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:164
+msgid "Environment variable"
+msgstr "环境变量"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:165
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:166
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:187
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:209
+msgid "Meaning"
+msgstr "含义"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:167
+msgid "``REDIS_HOST``"
+msgstr "``REDIS_HOST``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:168
+msgid ""
+"``localhost`` (the manifest sets ``aibrix-redis-master.aibrix-"
+"system.svc.cluster.local``)"
+msgstr "``localhost`` （清单中设置为 ``aibrix-redis-master.aibrix-system.svc.cluster.local`` ）"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:169
+msgid "Redis that holds request traces and profiles."
+msgstr "保存请求追踪和画像的 Redis。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:170
+msgid "``REDIS_PORT``"
+msgstr "``REDIS_PORT``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:171
+msgid "``6379``"
+msgstr "``6379``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:172
+msgid "Redis port."
+msgstr "Redis 端口。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:173
+msgid "``REDIS_PASSWORD``"
+msgstr "``REDIS_PASSWORD``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:174
+msgid "*(unset)*"
+msgstr "*(未设置)*"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:175
+msgid "Redis password, if any."
+msgstr "Redis 密码（如有）。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:177
+msgid ""
+"**Gateway plugin**: ``AIBRIX_GPU_OPTIMIZER_TRACING_FLAG`` (default "
+"``false``) turns request tracing on."
+msgstr "**网关插件** ：``AIBRIX_GPU_OPTIMIZER_TRACING_FLAG`` （默认 ``false`` ）用于开启请求追踪。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:180
+msgid "**Deployment labels** read by the optimizer:"
+msgstr "**Deployment 标签** （优化器读取）："
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:186
+msgid "Label"
+msgstr "标签"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:188
+msgid "``model.aibrix.ai/name``"
+msgstr "``model.aibrix.ai/name``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:189
+msgid ""
+"Required. Deployments without it are ignored, and the value must match "
+"the ``model`` query parameter used when the profile was stored."
+msgstr ""
+"必填。没有该标签的 Deployment 会被忽略，且取值必须与存储画像时使用的 ``model`` 查询参数一致。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:191
+msgid "``model.aibrix.ai/min_replicas``"
+msgstr "``model.aibrix.ai/min_replicas``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:192
+msgid ""
+"Replicas to keep when there is no traffic at all. Defaults to ``0``. "
+"Ignored while requests are flowing. Keep at least one deployment per "
+"model at ``\"1\"`` so a ready pod always exists."
+msgstr ""
+"完全没有流量时保留的副本数。默认为 ``0`` 。有请求流入时忽略。每个模型至少将一个 deployment 保持为 ``\"1\"`` ，以便始终存在就绪 "
+"pod。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:196
+msgid ""
+"**PodAutoscaler**: use ``scalingStrategy: KPA`` and an ``external`` "
+"metric source whose ``endpoint`` is ``aibrix-gpu-optimizer.aibrix-"
+"system.svc.cluster.local:8080``, ``path`` is "
+"``/metrics/<namespace>/<deployment>`` and ``targetMetric`` is "
+"``vllm:deployment_replicas``. Set ``minReplicas`` to ``0`` when the "
+"optimizer should be free to turn a deployment off; a higher value "
+"overrides the recommendation. See :doc:`autoscaling` for the remaining "
+"fields."
+msgstr ""
+"**PodAutoscaler** ：使用 ``scalingStrategy: KPA`` 以及 ``external`` 指标源，其 ``endpoint`` "
+"为 ``aibrix-gpu-optimizer.aibrix-system.svc.cluster.local:8080`` ，``path`` "
+"为 ``/metrics/<namespace>/<deployment>`` ，``targetMetric`` 为 ``vllm:deployment_replicas`` "
+"。若希望优化器可以关闭某个 deployment，将 ``minReplicas`` 设为 ``0`` ；更高的值会覆盖建议。其余字段见 :doc:`autoscaling` "
+"。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:202
+msgid "**aibrix_gen_profile**"
+msgstr "**aibrix_gen_profile**"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:208
+msgid "Argument"
+msgstr "参数"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:210
+msgid "``deployment`` (positional)"
+msgstr "``deployment`` （位置参数）"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:211
+msgid "Profile name. Use the deployment name of the GPU type being profiled."
+msgstr "画像名称。使用正在画像的 GPU 类型对应的 deployment 名称。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:212
+msgid "``--benchmark``"
+msgstr "``--benchmark``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:213
+msgid "Benchmark result file produced by ``aibrix_benchmark``."
+msgstr "``aibrix_benchmark`` 生成的基准结果文件。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:214
+msgid "``--tput``, ``--tt``"
+msgstr "``--tput`` 、``--tt``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:215
+msgid "Throughput SLO targets: requests per second, and tokens per second."
+msgstr "吞吐 SLO 目标：每秒请求数，以及每秒 token 数。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:216
+msgid "``--e2e``, ``--ttft``, ``--tpat``, ``--tpot``"
+msgstr "``--e2e`` 、``--ttft`` 、``--tpat`` 、``--tpot``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:217
+msgid ""
+"Latency SLO targets in seconds: end-to-end, time to first token, time per"
+" all tokens, time per output token. Set whichever ones your SLO is "
+"defined on."
+msgstr ""
+"延迟 SLO 目标（秒）：端到端、首 token 时间、全部 token 时间、每个输出 token 时间。"
+"按你的 SLO 定义设置相应项。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:219
+msgid "``--percentile``"
+msgstr "``--percentile``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:220
+msgid ""
+"``0`` (mean, default), ``50``, ``90`` or ``99``. Which percentile of the "
+"benchmark the SLO is checked against."
+msgstr "``0`` （均值，默认）、``50`` 、``90`` 或 ``99`` 。SLO 对照基准的哪个百分位进行检查。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:222
+msgid "``--cost``"
+msgstr "``--cost``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:223
+msgid ""
+"Relative cost of this GPU type, default ``1.0``. The optimizer minimises "
+"total cost, so only the ratio between GPU types matters."
+msgstr "该 GPU 类型的相对成本，默认 ``1.0`` 。优化器最小化总成本，因此只有 GPU 类型之间的比例有意义。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:225
+msgid "``-o``"
+msgstr "``-o``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:226
+msgid ""
+"Output. A file path, or "
+"``redis://[user:password@]host:port[/db]?model=<model>`` to store the "
+"profile where the optimizer reads it."
+msgstr ""
+"输出。文件路径，或 ``redis://[user:password@]host:port[/db]?model=<model>`` "
+"以将画像存到优化器读取的位置。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:228
+msgid "``-v``"
+msgstr "``-v``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:229
+msgid "Print details of the generated profile."
+msgstr "打印生成画像的详细信息。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:231
+msgid "**HTTP endpoints** on the optimizer:"
+msgstr "优化器上的 **HTTP 端点** ："
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:237
+msgid "Endpoint"
+msgstr "端点"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:238
+msgid "Purpose"
+msgstr "用途"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:239
+#, python-brace-format
+msgid "``GET /metrics/{namespace}/{deployment}``"
+msgstr "``GET /metrics/{namespace}/{deployment}``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:240
+msgid ""
+"Prometheus metrics for one deployment, including "
+"``vllm:deployment_replicas``."
+msgstr "单个 deployment 的 Prometheus 指标，包括 ``vllm:deployment_replicas`` 。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:241
+#, python-brace-format
+msgid "``GET /update_profile/{model}``"
+msgstr "``GET /update_profile/{model}``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:242
+msgid "Reload profiles for a model from Redis."
+msgstr "从 Redis 重新加载某模型的画像。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:243
+#, python-brace-format
+msgid "``POST`` / ``DELETE /monitor/{namespace}/{deployment}``"
+msgstr "``POST`` / ``DELETE /monitor/{namespace}/{deployment}``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:244
+msgid ""
+"Start or stop monitoring a deployment by hand. Normally unnecessary: the "
+"optimizer discovers labelled deployments itself."
+msgstr "手动开始或停止监视某个 deployment。通常不必：优化器会自行发现带标签的 deployment。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:246
+#, python-brace-format
+msgid "``PUT /scale/{namespace}/{deployment}``"
+msgstr "``PUT /scale/{namespace}/{deployment}``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:247
+msgid "Force a replica count for a monitored deployment."
+msgstr "强制设置被监视 deployment 的副本数。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:248
+#, python-brace-format
+msgid "``GET /dash/{model}``"
+msgstr "``GET /dash/{model}``"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:249
+msgid "Dashboard visualising the observed workload pattern for a model."
+msgstr "可视化某模型观测工作负载模式的仪表盘。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:252
+msgid "Preliminary experiments with different autoscalers"
+msgstr "不同自动扩缩容器的初步实验"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:254
+msgid ""
+"Here we show the preliminary experiment results to show how different "
+"autoscaling mechanisms and configurations for autoscalers affect "
+"performance(latency) and cost (compute cost)."
+msgstr ""
+"以下初步实验结果展示不同自动扩缩机制及其配置如何影响性能（延迟）和成本（计算成本）。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:256
+msgid "Set up"
+msgstr "实验设置"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:257
+msgid "Model: Deepseek 7B chatbot model"
+msgstr "模型：Deepseek 7B chatbot 模型"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:258
+msgid "GPU type: V100"
+msgstr "GPU 类型：V100"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:259
+msgid "Max number of GPU: 8"
+msgstr "最大 GPU 数：8"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:260
+msgid "HPA, KPA, and APA use metrics as the scaling metrics: 70."
+msgstr "HPA、KPA 和 APA 使用的扩缩指标：70。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:261
+msgid "Optimizer-based KPA SLO: E2E P99 100s"
+msgstr "基于优化器的 KPA SLO：E2E P99 100s"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:262
+msgid "Workload"
+msgstr "工作负载"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:263
+msgid ""
+"The overall RPS trend starts with low RPS and goes up relatively fast "
+"until T=500 to evaluate how different autoscaler and config reacts to the"
+" rapid load increase. After that, it goes down to low RPS quickly to "
+"evaluate scaling down behavior and goes up again slowly."
+msgstr ""
+"整体 RPS 趋势从低 RPS 开始，到 T=500 较快上升，以评估不同自动扩缩容器及配置对负载快速增加的反应。"
+"之后迅速降到低 RPS 以评估缩容行为，然后再缓慢上升。"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:264
+msgid "Average RPS trend: 0.5 RPS -> 2 RPS -> 4 RPS -> 5 RPS -> 1 RPS -> 3 RPS"
+msgstr "平均 RPS 趋势：0.5 RPS -> 2 RPS -> 4 RPS -> 5 RPS -> 1 RPS -> 3 RPS"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:268
+msgid "Experiments Results"
+msgstr "实验结果"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:270
+msgid "gpu_cache_usage_perc: 70"
+msgstr "gpu_cache_usage_perc: 70"
+
+#: ../../source/features/autoscaling/optimizer-based-autoscaling.rst:272
+msgid "result"
+msgstr "结果"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/batch-api.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/batch-api.po
@@ -1,0 +1,609 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/batch-api.rst:5
+#: ../../source/features/batch-api.rst:585
+msgid "Batch API"
+msgstr "Batch API"
+
+#: ../../source/features/batch-api.rst:7
+msgid ""
+"The AIBrix Batch API provides an efficient way to process large volumes "
+"of LLM inference requests asynchronously. It is fully compatible with the"
+" OpenAI Batch API, allowing you to send batches of requests that are "
+"processed in the background with results retrieved later."
+msgstr ""
+"AIBrix Batch API 提供异步处理大量 LLM 推理请求的高效方式。它与 OpenAI Batch API "
+"完全兼容，可提交批量请求在后台处理，稍后检索结果。"
+
+#: ../../source/features/batch-api.rst:10
+msgid "Overview"
+msgstr "概述"
+
+#: ../../source/features/batch-api.rst:12
+msgid ""
+"Batch processing is ideal for workloads that don't require immediate "
+"responses and can benefit from:"
+msgstr "批处理适合不需要立即响应、并能从以下方面受益的工作负载："
+
+#: ../../source/features/batch-api.rst:14
+msgid ""
+"**Cost efficiency**: Process requests during off-peak hours with "
+"optimized resource utilization"
+msgstr "**成本效率** ：在低峰时段处理请求，优化资源利用率"
+
+#: ../../source/features/batch-api.rst:15
+msgid ""
+"**Higher throughput**: Handle large volumes of requests without rate "
+"limiting concerns"
+msgstr "**更高吞吐** ：处理大量请求而无需担心速率限制"
+
+#: ../../source/features/batch-api.rst:16
+msgid ""
+"**Simplified workflows**: Submit thousands of requests in a single batch "
+"operation"
+msgstr "**简化工作流** ：在单次批操作中提交数千个请求"
+
+#: ../../source/features/batch-api.rst:17
+msgid "**Guaranteed processing**: Built-in retry mechanisms and failure handling"
+msgstr "**处理保障** ：内置重试机制和失败处理"
+
+#: ../../source/features/batch-api.rst:19
+msgid ""
+"The Batch API accepts a JSONL (JSON Lines) file containing multiple "
+"inference requests, processes them asynchronously using Kubernetes Jobs, "
+"and returns results in a corresponding JSONL output file."
+msgstr ""
+"Batch API 接受包含多个推理请求的 JSONL（JSON Lines）文件，使用 Kubernetes Jobs "
+"异步处理，并在对应的 JSONL 输出文件中返回结果。"
+
+#: ../../source/features/batch-api.rst:22
+msgid "Key Features"
+msgstr "主要特性"
+
+#: ../../source/features/batch-api.rst:24
+msgid ""
+"**OpenAI-compatible**: Drop-in replacement for OpenAI's Batch API with "
+"identical request/response format"
+msgstr "**兼容 OpenAI** ：可作为 OpenAI Batch API 的即插即用替代，请求/响应格式相同"
+
+#: ../../source/features/batch-api.rst:25
+msgid ""
+"**Distributed execution**: Leverages Kubernetes Jobs for scalable, fault-"
+"tolerant batch processing"
+msgstr "**分布式执行** ：利用 Kubernetes Jobs 实现可扩展、容错的批处理"
+
+#: ../../source/features/batch-api.rst:26
+msgid ""
+"**Metadata server workflow**: Centralized coordination for multi-node "
+"batch execution"
+msgstr "**元数据服务器工作流** ：集中协调多节点批执行"
+
+#: ../../source/features/batch-api.rst:27
+msgid ""
+"**Storage flexibility**: Supports S3, TOS, MinIO, Redis, and local "
+"storage backends"
+msgstr "**存储灵活** ：支持 S3、TOS、MinIO、Redis 和本地存储后端"
+
+#: ../../source/features/batch-api.rst:28
+msgid ""
+"**Request tracking**: Each request has a ``custom_id`` for precise result"
+" matching"
+msgstr "**请求跟踪** ：每个请求有 ``custom_id`` ，用于精确匹配结果"
+
+#: ../../source/features/batch-api.rst:29
+msgid "**Status monitoring**: Real-time progress tracking with detailed metrics"
+msgstr "**状态监控** ：实时进度跟踪及详细指标"
+
+#: ../../source/features/batch-api.rst:30
+msgid ""
+"**24-hour completion window**: Automatic expiration for long-running "
+"batches"
+msgstr "**24 小时完成窗口** ：长时间运行的批次会自动过期"
+
+#: ../../source/features/batch-api.rst:34
+msgid "Comparison with OpenAI Batch API"
+msgstr "与 OpenAI Batch API 的比较"
+
+#: ../../source/features/batch-api.rst:36
+msgid ""
+"AIBrix Batch API maintains full compatibility with OpenAI's Batch API "
+"while adding enterprise features:"
+msgstr "AIBrix Batch API 与 OpenAI Batch API 完全兼容，并增加企业级特性："
+
+#: ../../source/features/batch-api.rst:38
+msgid "**AIBrix Enhancements:**"
+msgstr "**AIBrix 增强：**"
+
+#: ../../source/features/batch-api.rst:40
+msgid "**Self-hosted**: Full control over infrastructure and data"
+msgstr "**自托管** ：完全控制基础设施和数据"
+
+#: ../../source/features/batch-api.rst:41
+msgid ""
+"**Kubernetes-native**: Leverages K8s for scheduling and resource "
+"management"
+msgstr "**Kubernetes 原生** ：利用 K8s 进行调度和资源管理"
+
+#: ../../source/features/batch-api.rst:42
+msgid "**Flexible storage**: S3, TOS, MinIO, Redis, or local storage backends"
+msgstr "**灵活存储** ：S3、TOS、MinIO、Redis 或本地存储后端"
+
+#: ../../source/features/batch-api.rst:43
+msgid ""
+"**Distributed execution**: Metadata server coordinates multi-node "
+"processing"
+msgstr "**分布式执行** ：元数据服务器协调多节点处理"
+
+#: ../../source/features/batch-api.rst:44
+msgid "**Cost control**: Use existing infrastructure without per-request pricing"
+msgstr "**成本控制** ：使用现有基础设施，无按请求计费"
+
+#: ../../source/features/batch-api.rst:46
+msgid "**Migration from OpenAI:**"
+msgstr "**从 OpenAI 迁移：**"
+
+#: ../../source/features/batch-api.rst:48
+msgid "Simply update the ``base_url`` in your OpenAI SDK configuration:"
+msgstr "只需更新 OpenAI SDK 配置中的 ``base_url`` ："
+
+#: ../../source/features/batch-api.rst:65
+msgid "**Known Differences:**"
+msgstr "**已知差异：**"
+
+#: ../../source/features/batch-api.rst:67
+msgid ""
+"**Pricing**: No usage-based pricing; controlled by your infrastructure "
+"costs"
+msgstr "**定价** ：无按用量计费；由你的基础设施成本决定"
+
+#: ../../source/features/batch-api.rst:68
+msgid "**Endpoints**: Supports a subset of OpenAI endpoints (see below)"
+msgstr "**端点** ：支持 OpenAI 端点的子集（见下文）"
+
+#: ../../source/features/batch-api.rst:69
+msgid "**Rate Limits**: Determined by your cluster capacity, not API limits"
+msgstr "**速率限制** ：由集群容量决定，而非 API 限额"
+
+#: ../../source/features/batch-api.rst:71
+msgid "**Supported Endpoints:**"
+msgstr "**支持的端点：**"
+
+#: ../../source/features/batch-api.rst:73
+msgid "``/v1/chat/completions`` - Chat completion requests"
+msgstr "``/v1/chat/completions`` - 聊天补全请求"
+
+#: ../../source/features/batch-api.rst:74
+msgid "``/v1/completions`` - Text completion requests"
+msgstr "``/v1/completions`` - 文本补全请求"
+
+#: ../../source/features/batch-api.rst:75
+msgid "``/v1/embeddings`` - Embedding generation requests"
+msgstr "``/v1/embeddings`` - Embedding 生成请求"
+
+#: ../../source/features/batch-api.rst:76
+msgid "``/v1/rerank`` - Rerank requests"
+msgstr "``/v1/rerank`` - Rerank 请求"
+
+#: ../../source/features/batch-api.rst:78
+msgid ""
+"All endpoints are fully supported if the underlying LLM engine supports "
+"them."
+msgstr "若底层 LLM 引擎支持，则所有端点均完全支持。"
+
+#: ../../source/features/batch-api.rst:80
+msgid "**Current Limitations:**"
+msgstr "**当前限制：**"
+
+#: ../../source/features/batch-api.rst:82
+msgid ""
+"Completion window is fixed at ``24h`` today. ``1h``, ``4h``, and "
+"``best_effort`` are accepted by the schema but not yet honored at "
+"runtime."
+msgstr "完成窗口目前固定为 ``24h`` 。schema 接受 ``1h`` 、``4h`` 和 ``best_effort`` ，但运行时尚未生效。"
+
+#: ../../source/features/batch-api.rst:84
+msgid "Moderation endpoint (``/v1/moderations``) not supported"
+msgstr "不支持审核端点（``/v1/moderations`` ）"
+
+#: ../../source/features/batch-api.rst:88
+msgid "Architecture"
+msgstr "架构"
+
+#: ../../source/features/batch-api.rst:91
+msgid "Workflow Overview"
+msgstr "工作流概述"
+
+#: ../../source/features/batch-api.rst:93
+msgid ""
+"The Batch API follows a metadata server architecture for distributed "
+"processing:"
+msgstr "Batch API 采用元数据服务器架构进行分布式处理："
+
+#: ../../source/features/batch-api.rst:127
+msgid "**Phase Transitions:**"
+msgstr "**阶段转换：**"
+
+#: ../../source/features/batch-api.rst:136
+msgid "**Status Lifecycle:**"
+msgstr "**状态生命周期：**"
+
+#: ../../source/features/batch-api.rst:138
+msgid ""
+"**validating**: Metadata server validates input file and prepares job "
+"configuration"
+msgstr "**validating** ：元数据服务器校验输入文件并准备作业配置"
+
+#: ../../source/features/batch-api.rst:139
+msgid ""
+"**in_progress**: Kubernetes Jobs are executing and processing batch "
+"requests"
+msgstr "**in_progress** ：Kubernetes Jobs 正在执行并处理批请求"
+
+#: ../../source/features/batch-api.rst:140
+msgid ""
+"**finalizing**: Workers have completed, metadata server is aggregating "
+"results"
+msgstr "**finalizing** ：Worker 已完成，元数据服务器正在聚合结果"
+
+#: ../../source/features/batch-api.rst:141
+msgid "**completed**: Output file is ready for download with all results"
+msgstr "**completed** ：输出文件已就绪，包含全部结果，可供下载"
+
+#: ../../source/features/batch-api.rst:143
+msgid "**Failed/Cancelled States:**"
+msgstr "**失败/取消状态：**"
+
+#: ../../source/features/batch-api.rst:145
+msgid "**failed**: Job execution encountered unrecoverable errors"
+msgstr "**failed** ：作业执行遇到不可恢复错误"
+
+#: ../../source/features/batch-api.rst:146
+msgid "**cancelled**: User explicitly cancelled the batch job"
+msgstr "**cancelled** ：用户显式取消了批作业"
+
+#: ../../source/features/batch-api.rst:147
+msgid "**expired**: Job exceeded the 24-hour completion window"
+msgstr "**expired** ：作业超过 24 小时完成窗口"
+
+#: ../../source/features/batch-api.rst:150
+msgid "Components"
+msgstr "组件"
+
+#: ../../source/features/batch-api.rst:152
+msgid ""
+"**Metadata Server**: Coordinates batch job lifecycle, manages files, and "
+"tracks progress"
+msgstr "**元数据服务器** ：协调批作业生命周期、管理文件并跟踪进度"
+
+#: ../../source/features/batch-api.rst:153
+msgid "**Job Scheduler**: Creates and manages Kubernetes Jobs for batch execution"
+msgstr "**作业调度器** ：创建并管理用于批执行的 Kubernetes Jobs"
+
+#: ../../source/features/batch-api.rst:154
+msgid "**Worker Jobs**: Kubernetes Jobs that process batch requests in parallel"
+msgstr "**Worker Jobs** ：并行处理批请求的 Kubernetes Jobs"
+
+#: ../../source/features/batch-api.rst:155
+msgid ""
+"**Storage Backend**: S3, TOS, MinIO, Redis, or local filesystem for file "
+"storage and job state"
+msgstr "**存储后端** ：S3、TOS、MinIO、Redis 或本地文件系统，用于文件存储和作业状态"
+
+#: ../../source/features/batch-api.rst:156
+msgid "**Files API**: OpenAI-compatible file upload/download endpoints"
+msgstr "**Files API** ：兼容 OpenAI 的文件上传/下载端点"
+
+#: ../../source/features/batch-api.rst:160
+msgid "Deployment"
+msgstr "部署"
+
+#: ../../source/features/batch-api.rst:163
+msgid "Storage Backend Configuration"
+msgstr "存储后端配置"
+
+#: ../../source/features/batch-api.rst:165
+msgid ""
+"The Batch API requires a storage backend for file operations. AIBrix "
+"supports multiple storage backends including S3, TOS, Redis, and local "
+"storage. MinIO is supported through the S3-compatible API: set "
+"``STORAGE_TYPE=minio`` and point ``STORAGE_AWS_ENDPOINT_URL`` at your "
+"MinIO endpoint, otherwise configure it exactly like S3. To enable cloud "
+"object storage, you need to configure credentials and enable the "
+"appropriate storage patches."
+msgstr ""
+"Batch API 需要存储后端进行文件操作。AIBrix 支持多种存储后端，包括 S3、TOS、Redis 和本地存储。MinIO 通过 S3 "
+"兼容 API 支持：设置 ``STORAGE_TYPE=minio`` ，并将 ``STORAGE_AWS_ENDPOINT_URL`` 指向 "
+"MinIO 端点，其余配置与 S3 完全相同。要启用云对象存储，需要配置凭据并启用相应的存储 patch。"
+
+#: ../../source/features/batch-api.rst:167
+msgid "**Enabling S3 Storage**"
+msgstr "**启用 S3 存储**"
+
+#: ../../source/features/batch-api.rst:169
+msgid "To enable S3 as the storage backend for batch operations:"
+msgstr "要将 S3 作为批操作的存储后端："
+
+#: ../../source/features/batch-api.rst:171
+msgid "**Generate S3 Credentials Secret:**"
+msgstr "**生成 S3 凭据 Secret：**"
+
+#: ../../source/features/batch-api.rst:173
+msgid ""
+"Use the AIBrix secret generation tool to create the necessary Kubernetes "
+"secrets:"
+msgstr "使用 AIBrix secret 生成工具创建所需的 Kubernetes secrets："
+
+#: ../../source/features/batch-api.rst:186
+msgid "This command will:"
+msgstr "该命令会："
+
+#: ../../source/features/batch-api.rst:188
+msgid ""
+"Create a Kubernetes secret named ``aibrix-s3-credentials`` in the "
+"``aibrix-system`` namespace"
+msgstr "在 ``aibrix-system`` 命名空间中创建名为 ``aibrix-s3-credentials`` 的 Kubernetes secret"
+
+#: ../../source/features/batch-api.rst:189
+msgid "Configure the secret with your S3 bucket name and credentials"
+msgstr "用你的 S3 bucket 名称和凭据配置该 secret"
+
+#: ../../source/features/batch-api.rst:190
+msgid "Set up the necessary environment variables for the metadata service"
+msgstr "为元数据服务设置所需环境变量"
+
+#: ../../source/features/batch-api.rst:192
+msgid "**Enable S3 Environment Variables:**"
+msgstr "**启用 S3 环境变量：**"
+
+#: ../../source/features/batch-api.rst:194
+msgid "Uncomment the S3 patch in the metadata service configuration:"
+msgstr "在元数据服务配置中取消注释 S3 patch："
+
+#: ../../source/features/batch-api.rst:201
+#: ../../source/features/batch-api.rst:245
+msgid "Find and uncomment the following line:"
+msgstr "找到并取消注释以下行："
+
+#: ../../source/features/batch-api.rst:208
+msgid ""
+"The patch will inject the S3 environment variables into the metadata "
+"service deployment."
+msgstr "该 patch 会将 S3 环境变量注入元数据服务 deployment。"
+
+#: ../../source/features/batch-api.rst:210
+#: ../../source/features/batch-api.rst:254
+msgid "**Apply the Configuration:**"
+msgstr "**应用配置：**"
+
+#: ../../source/features/batch-api.rst:212
+#: ../../source/features/batch-api.rst:256
+msgid "Deploy the job rbac and updated configuration:"
+msgstr "部署 job rbac 及更新后的配置："
+
+#: ../../source/features/batch-api.rst:219
+msgid "**Enabling TOS Storage**"
+msgstr "**启用 TOS 存储**"
+
+#: ../../source/features/batch-api.rst:221
+msgid "For TOS (Tencent Object Storage), follow similar steps:"
+msgstr "对 TOS（腾讯云对象存储），步骤类似："
+
+#: ../../source/features/batch-api.rst:223
+msgid "**Generate TOS Credentials Secret:**"
+msgstr "**生成 TOS 凭据 Secret：**"
+
+#: ../../source/features/batch-api.rst:236
+msgid "**Enable TOS Environment Variables:**"
+msgstr "**启用 TOS 环境变量：**"
+
+#: ../../source/features/batch-api.rst:238
+msgid "Uncomment the TOS patch in the metadata service configuration:"
+msgstr "在元数据服务配置中取消注释 TOS patch："
+
+#: ../../source/features/batch-api.rst:252
+msgid ""
+"The patch will inject the TOS environment variables into the metadata "
+"service deployment."
+msgstr "该 patch 会将 TOS 环境变量注入元数据服务 deployment。"
+
+#: ../../source/features/batch-api.rst:264
+msgid "Examples"
+msgstr "示例"
+
+#: ../../source/features/batch-api.rst:267
+msgid "End-to-End Example"
+msgstr "端到端示例"
+
+#: ../../source/features/batch-api.rst:269
+msgid "Here's a complete example of processing a batch of chat completions:"
+msgstr "以下是处理一批聊天补全的完整示例："
+
+#: ../../source/features/batch-api.rst:271
+msgid "**Step 1: Prepare Input File**"
+msgstr "**步骤 1：准备输入文件**"
+
+#: ../../source/features/batch-api.rst:273
+msgid "Create a file ``batch_input.jsonl`` with your requests:"
+msgstr "创建包含请求的文件 ``batch_input.jsonl`` ："
+
+#: ../../source/features/batch-api.rst:281
+msgid "**Step 2: Upload Input File**"
+msgstr "**步骤 2：上传输入文件**"
+
+#: ../../source/features/batch-api.rst:299
+msgid "**Step 3: Create Batch Job**"
+msgstr "**步骤 3：创建批作业**"
+
+#: ../../source/features/batch-api.rst:318
+msgid "**Step 4: Poll Batch Status**"
+msgstr "**步骤 4：轮询批状态**"
+
+#: ../../source/features/batch-api.rst:350
+msgid "**Step 5: Download Results**"
+msgstr "**步骤 5：下载结果**"
+
+#: ../../source/features/batch-api.rst:362
+msgid "**Step 6: Process Results**"
+msgstr "**步骤 6：处理结果**"
+
+#: ../../source/features/batch-api.rst:389
+msgid "Python SDK Example"
+msgstr "Python SDK 示例"
+
+#: ../../source/features/batch-api.rst:391
+msgid "Using the OpenAI Python SDK (works with AIBrix as a drop-in replacement):"
+msgstr "使用 OpenAI Python SDK（可作为即插即用替代与 AIBrix 配合）："
+
+#: ../../source/features/batch-api.rst:478
+msgid "API Reference"
+msgstr "API 参考"
+
+#: ../../source/features/batch-api.rst:481
+msgid "Files API"
+msgstr "Files API"
+
+#: ../../source/features/batch-api.rst:483
+msgid ""
+"The Files API manages input and output files for batch processing. "
+"ENDPOINT is the metadata service endpoint."
+msgstr "Files API 管理批处理的输入和输出文件。ENDPOINT 是元数据服务端点。"
+
+#: ../../source/features/batch-api.rst:490
+msgid "**Upload File**"
+msgstr "**上传文件**"
+
+#: ../../source/features/batch-api.rst:508
+msgid "**Get File Metadata**"
+msgstr "**获取文件元数据**"
+
+#: ../../source/features/batch-api.rst:527
+msgid "**List Files**"
+msgstr "**列出文件**"
+
+#: ../../source/features/batch-api.rst:529
+msgid "List all files with optional filtering and pagination:"
+msgstr "列出所有文件，可选过滤和分页："
+
+#: ../../source/features/batch-api.rst:542
+msgid "Response:"
+msgstr "响应："
+
+#: ../../source/features/batch-api.rst:562
+msgid "**Query Parameters:**"
+msgstr "**查询参数：**"
+
+#: ../../source/features/batch-api.rst:564
+msgid "``purpose`` (optional): Filter by file purpose (e.g., \"batch\")"
+msgstr "``purpose`` （可选）：按文件用途过滤（例如 \"batch\"）"
+
+#: ../../source/features/batch-api.rst:565
+msgid "``limit`` (optional): Number of files to return (1-100, default 20)"
+msgstr "``limit`` （可选）：返回的文件数（1-100，默认 20）"
+
+#: ../../source/features/batch-api.rst:566
+msgid "``after`` (optional): File ID to use as pagination cursor"
+msgstr "``after`` （可选）：用作分页游标的文件 ID"
+
+#: ../../source/features/batch-api.rst:568
+msgid "**Download File**"
+msgstr "**下载文件**"
+
+#: ../../source/features/batch-api.rst:582
+msgid "**Response:** Raw file content (JSONL format)"
+msgstr "**响应：** 原始文件内容（JSONL 格式）"
+
+#: ../../source/features/batch-api.rst:587
+msgid "The Batch API manages batch job lifecycle."
+msgstr "Batch API 管理批作业生命周期。"
+
+#: ../../source/features/batch-api.rst:589
+msgid "**Create Batch**"
+msgstr "**创建批次**"
+
+#: ../../source/features/batch-api.rst:624
+msgid "**Get Batch Status**"
+msgstr "**获取批状态**"
+
+#: ../../source/features/batch-api.rst:657
+msgid "**List Batches**"
+msgstr "**列出批次**"
+
+#: ../../source/features/batch-api.rst:699
+msgid "Input File Format"
+msgstr "输入文件格式"
+
+#: ../../source/features/batch-api.rst:701
+msgid ""
+"Input files must be in JSONL format with one request per line. Each "
+"request requires:"
+msgstr "输入文件必须为 JSONL 格式，每行一个请求。每个请求需要："
+
+#: ../../source/features/batch-api.rst:703
+msgid "``custom_id``: Unique identifier for matching results (required)"
+msgstr "``custom_id`` ：用于匹配结果的唯一标识符（必填）"
+
+#: ../../source/features/batch-api.rst:704
+msgid "``method``: HTTP method, typically \"POST\" (required)"
+msgstr "``method`` ：HTTP 方法，通常为 \"POST\"（必填）"
+
+#: ../../source/features/batch-api.rst:705
+msgid "``url``: Endpoint path, e.g., \"/v1/chat/completions\" (required)"
+msgstr "``url`` ：端点路径，例如 \"/v1/chat/completions\"（必填）"
+
+#: ../../source/features/batch-api.rst:706
+msgid "``body``: Request payload matching the endpoint's format (required)"
+msgstr "``body`` ：与端点格式匹配的请求负载（必填）"
+
+#: ../../source/features/batch-api.rst:708
+msgid "**Example batch_input.jsonl:**"
+msgstr "**batch_input.jsonl 示例：**"
+
+#: ../../source/features/batch-api.rst:718
+msgid "Output File Format"
+msgstr "输出文件格式"
+
+#: ../../source/features/batch-api.rst:720
+msgid ""
+"Output files are in JSONL format with one result per line matching each "
+"input request:"
+msgstr "输出文件为 JSONL 格式，每行一个结果，与每个输入请求对应："
+
+#: ../../source/features/batch-api.rst:722
+msgid "**Example batch_output.jsonl:**"
+msgstr "**batch_output.jsonl 示例：**"
+
+#: ../../source/features/batch-api.rst:730
+msgid "Each output line contains:"
+msgstr "每行输出包含："
+
+#: ../../source/features/batch-api.rst:732
+msgid "``id``: Unique result identifier"
+msgstr "``id`` ：唯一结果标识符"
+
+#: ../../source/features/batch-api.rst:733
+msgid "``custom_id``: Matches the input request's custom_id"
+msgstr "``custom_id`` ：与输入请求的 custom_id 匹配"
+
+#: ../../source/features/batch-api.rst:734
+msgid ""
+"``response``: Contains ``status_code``, ``request_id``, and ``body`` with"
+" the actual result"
+msgstr "``response`` ：包含 ``status_code`` 、``request_id`` 和带实际结果的 ``body``"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/batch-model-deployment-templates.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/batch-model-deployment-templates.po
@@ -1,0 +1,577 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/batch-model-deployment-templates.rst:5
+msgid "Batch Model Deployment Templates"
+msgstr "批处理模型部署模板"
+
+#: ../../source/features/batch-model-deployment-templates.rst:7
+msgid ""
+"AIBrix Batch carries model deployment intent through "
+"``extra_body.aibrix`` on the OpenAI-compatible Batch API. The current "
+"runtime contract is:"
+msgstr ""
+"AIBrix Batch 通过兼容 OpenAI 的 Batch API 上的 ``extra_body.aibrix`` "
+"传递模型部署意图。当前运行时约定为："
+
+#: ../../source/features/batch-model-deployment-templates.rst:11
+msgid ""
+"``aibrix.model_template`` describes the engine, model source, "
+"accelerator, parallelism, and supported endpoints."
+msgstr ""
+"``aibrix.model_template`` 描述引擎、模型源、加速器、并行度以及支持的端点。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:13
+msgid ""
+"``aibrix.runtime`` selects the MDS runtime backend, such as "
+"``Kubernetes``, ``KubernetesJob``, ``LambdaCloud``, ``RunPod``, or "
+"``External``."
+msgstr ""
+"``aibrix.runtime`` 选择 MDS 运行时后端，例如 ``Kubernetes`` 、``KubernetesJob`` 、``LambdaCloud`` "
+"、``RunPod`` 或 ``External`` 。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:16
+msgid ""
+"``aibrix.resource_allocation`` records resource-manager output, such as "
+"the provision id returned by Console's Resource Manager."
+msgstr ""
+"``aibrix.resource_allocation`` 记录资源管理器输出，例如 Console Resource Manager "
+"返回的 provision id。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:21
+msgid "Why Templates Exist"
+msgstr "模板存在的原因"
+
+#: ../../source/features/batch-model-deployment-templates.rst:23
+msgid ""
+"OpenAI's Batch API treats the model as a black-box string, for example "
+"``model: \"gpt-4-turbo\"``. Self-hosted deployments need more control:"
+msgstr "OpenAI 的 Batch API 将模型视为黑盒字符串，例如 ``model: \"gpt-4-turbo\"`` 。自托管部署需要更多控制："
+
+#: ../../source/features/batch-model-deployment-templates.rst:26
+msgid "inference engine and image, such as vLLM or SGLang"
+msgstr "推理引擎和镜像，例如 vLLM 或 SGLang"
+
+#: ../../source/features/batch-model-deployment-templates.rst:27
+msgid "GPU Type and GPU count"
+msgstr "GPU 类型和 GPU 数量"
+
+#: ../../source/features/batch-model-deployment-templates.rst:28
+msgid "model artifact location"
+msgstr "模型产物位置"
+
+#: ../../source/features/batch-model-deployment-templates.rst:29
+msgid "tensor, pipeline, data, and expert parallelism"
+msgstr "张量、流水线、数据和专家并行"
+
+#: ../../source/features/batch-model-deployment-templates.rst:30
+msgid "engine flags such as max model length or prefix caching"
+msgstr "引擎标志，例如最大模型长度或前缀缓存"
+
+#: ../../source/features/batch-model-deployment-templates.rst:31
+msgid "supported OpenAI endpoints for the selected model"
+msgstr "所选模型支持的 OpenAI 端点"
+
+#: ../../source/features/batch-model-deployment-templates.rst:33
+msgid ""
+"Templates keep those controls in platform-owned metadata while preserving"
+" the OpenAI SDK request shape."
+msgstr "模板将这些控制保留在平台侧元数据中，同时保持 OpenAI SDK 的请求形态。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:38
+msgid "Current Data Flow"
+msgstr "当前数据流"
+
+#: ../../source/features/batch-model-deployment-templates.rst:72
+msgid ""
+"Direct MDS callers can also submit ``extra_body.aibrix`` themselves. If "
+"the MDS deployment has no template registry configured, direct callers "
+"must include ``aibrix.model_template.spec`` inline."
+msgstr ""
+"直接调用 MDS 的调用方也可自行提交 ``extra_body.aibrix`` 。若 MDS 部署未配置模板注册表，直接调用方必须内联包含 "
+"``aibrix.model_template.spec`` 。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:77
+msgid "Quick Start: Console Path"
+msgstr "快速开始：Console 路径"
+
+#: ../../source/features/batch-model-deployment-templates.rst:79
+msgid ""
+"The Console path is the supported path for Resource Manager backed batch "
+"jobs, including RunPod and Lambda Cloud."
+msgstr "Console 路径是 Resource Manager 支持的批作业（包括 RunPod 和 Lambda Cloud）的受支持路径。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:82
+msgid ""
+"Register or create a model deployment template in the Console store. The "
+"template must include at least ``engine``, ``model_source``, "
+"``accelerator``, and ``supported_endpoints``."
+msgstr ""
+"在 Console store 中注册或创建模型部署模板。模板必须至少包含 ``engine`` 、``model_source`` 、``accelerator`` "
+"和 ``supported_endpoints`` 。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:86
+msgid "Submit a Console job with the selected template:"
+msgstr "使用所选模板提交 Console 作业："
+
+#: ../../source/features/batch-model-deployment-templates.rst:100
+msgid ""
+"Console resolves the template, sends ``aibrix.model_template.spec`` to "
+"MDS, and the planner uses the same spec to provision resources."
+msgstr ""
+"Console 解析模板，将 ``aibrix.model_template.spec`` 发送给 MDS，planner 使用同一 spec "
+"调配资源。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:103
+msgid ""
+"For cloud providers, the Console backend must also be configured with a "
+"single Resource Manager provider via ``PROVISIONER``. See :doc:`batch-"
+"resource-manager`."
+msgstr ""
+"对云厂商，Console 后端还必须通过 ``PROVISIONER`` 配置单一 Resource Manager 提供方。参见 :doc:`batch-resource-manager` "
+"。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:109
+msgid "Direct MDS Request Shape"
+msgstr "直接 MDS 请求形态"
+
+#: ../../source/features/batch-model-deployment-templates.rst:111
+msgid ""
+"Direct callers use the OpenAI SDK's ``extra_body`` escape hatch. This "
+"example uses an inline template spec so it does not depend on a ConfigMap"
+" registry:"
+msgstr ""
+"直接调用方使用 OpenAI SDK 的 ``extra_body`` 扩展通道。"
+"本示例使用内联模板 spec，因此不依赖 ConfigMap 注册表："
+
+#: ../../source/features/batch-model-deployment-templates.rst:165
+msgid ""
+"The response exposes the persisted AIBrix block in ``batch.aibrix``. "
+"There is no current ``_aibrix.resolved_endpoint`` response field."
+msgstr ""
+"响应在 ``batch.aibrix`` 中暴露已持久化的 AIBrix 块。"
+"当前没有 ``_aibrix.resolved_endpoint`` 响应字段。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:170
+msgid "ModelDeploymentTemplate Schema"
+msgstr "ModelDeploymentTemplate Schema"
+
+#: ../../source/features/batch-model-deployment-templates.rst:172
+msgid ""
+"The source of truth is :py:mod:`aibrix.batch.template.schema`. "
+"``ModelDeploymentTemplateSpec`` is strict: unknown fields are rejected. "
+"In particular, current templates do not have a ``provider_config`` field."
+" Provider selection belongs to Resource Manager / runtime selection, not "
+"to the template schema."
+msgstr ""
+"事实来源是 :py:mod:`aibrix.batch.template.schema` 。``ModelDeploymentTemplateSpec`` "
+"是严格的：未知字段会被拒绝。特别地，当前模板没有 ``provider_config`` 字段。提供方选择属于 Resource Manager "
+"/ 运行时选择，而非模板 schema。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:178
+msgid "**Required top-level fields when a complete template object is stored:**"
+msgstr "**存储完整模板对象时必填的顶层字段：**"
+
+#: ../../source/features/batch-model-deployment-templates.rst:180
+msgid "``name``: logical template name."
+msgstr "``name`` ：逻辑模板名称。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:181
+msgid ""
+"``version``: version string. If omitted in an inline spec path, consumers"
+" use the ref version or schema default."
+msgstr "``version`` ：版本字符串。若在内联 spec 路径中省略，消费方使用引用版本或 schema 默认值。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:183
+msgid ""
+"``status``: ``active``, ``deprecated``, or ``draft`` for registry-backed "
+"templates."
+msgstr "``status`` ：基于注册表的模板为 ``active`` 、``deprecated`` 或 ``draft`` 。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:185
+msgid "``spec``: the deployment body."
+msgstr "``spec`` ：部署主体。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:187
+msgid "**Required fields inside ``spec``:**"
+msgstr "**``spec`` 内的必填字段：**"
+
+#: ../../source/features/batch-model-deployment-templates.rst:193
+#: ../../source/features/batch-model-deployment-templates.rst:220
+#: ../../source/features/batch-model-deployment-templates.rst:254
+msgid "Field"
+msgstr "字段"
+
+#: ../../source/features/batch-model-deployment-templates.rst:194
+msgid "Required?"
+msgstr "是否必填？"
+
+#: ../../source/features/batch-model-deployment-templates.rst:195
+#: ../../source/features/batch-model-deployment-templates.rst:222
+msgid "Current meaning"
+msgstr "当前含义"
+
+#: ../../source/features/batch-model-deployment-templates.rst:196
+msgid "``engine``"
+msgstr "``engine``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:197
+#: ../../source/features/batch-model-deployment-templates.rst:201
+#: ../../source/features/batch-model-deployment-templates.rst:206
+#: ../../source/features/batch-model-deployment-templates.rst:210
+msgid "yes"
+msgstr "是"
+
+#: ../../source/features/batch-model-deployment-templates.rst:198
+msgid ""
+"Engine type, version, image, raw ``serve_args``, health endpoint, and "
+"readiness timeout. ``vllm`` and ``mock`` have manifest adapters today."
+msgstr "引擎类型、版本、镜像、原始 ``serve_args`` 、健康检查端点和就绪超时。目前 ``vllm`` 和 ``mock`` 有清单适配器。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:200
+#: ../../source/features/batch-model-deployment-templates.rst:268
+msgid "``model_source``"
+msgstr "``model_source``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:202
+msgid ""
+"Model artifact source. Kubernetes renderers can use this for model "
+"download and vLLM ``--model`` args. Cloud SSH runtimes require the "
+"resolved ``aibrix.model`` to be directly loadable by vLLM."
+msgstr ""
+"模型产物源。Kubernetes 渲染器可用它进行模型下载和 vLLM ``--model`` 参数。"
+"云 SSH 运行时要求解析后的 ``aibrix.model`` 可被 vLLM 直接加载。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:205
+#: ../../source/features/batch-model-deployment-templates.rst:272
+msgid "``accelerator``"
+msgstr "``accelerator``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:207
+msgid ""
+"Free-form GPU type and GPU count. Console Resource Manager reads ``type``"
+" and ``count`` to request cloud resources."
+msgstr ""
+"自由形式的 GPU 类型和 GPU 数量。Console Resource Manager 读取 ``type`` 和 ``count`` "
+"以请求云资源。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:209
+msgid "``supported_endpoints``"
+msgstr "``supported_endpoints``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:211
+msgid ""
+"OpenAI endpoints this deployment can serve, such as "
+"``/v1/chat/completions``."
+msgstr "该部署可服务的 OpenAI 端点，例如 ``/v1/chat/completions`` 。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:214
+msgid "**Optional/defaulted fields inside ``spec``:**"
+msgstr "**``spec`` 内的可选/有默认值字段：**"
+
+#: ../../source/features/batch-model-deployment-templates.rst:221
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/features/batch-model-deployment-templates.rst:223
+msgid "``parallelism``"
+msgstr "``parallelism``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:224
+msgid "all degrees ``1``"
+msgstr "所有维度为 ``1``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:225
+msgid "``tp * pp * dp * ep`` must equal ``accelerator.count``."
+msgstr "``tp * pp * dp * ep`` 必须等于 ``accelerator.count`` 。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:226
+#: ../../source/features/batch-model-deployment-templates.rst:265
+msgid "``engine_args``"
+msgstr "``engine_args``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:227
+#: ../../source/features/batch-model-deployment-templates.rst:232
+msgid "empty"
+msgstr "空"
+
+#: ../../source/features/batch-model-deployment-templates.rst:228
+msgid ""
+"Typed and extra engine flags. Kubernetes vLLM rendering converts these "
+"into CLI flags. Console cloud runtime construction does not pass this "
+"field today; use ``engine.serve_args`` for LambdaCloud/RunPod flags."
+msgstr ""
+"类型化及额外的引擎标志。Kubernetes vLLM 渲染会将其转换为 CLI 标志。目前 Console 云运行时构建不会传递该字段；对 LambdaCloud/RunPod "
+"标志请使用 ``engine.serve_args`` 。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:231
+msgid "``quantization``"
+msgstr "``quantization``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:233
+msgid ""
+"Kubernetes vLLM rendering maps weight and KV-cache quantization into CLI "
+"flags. Cloud SSH runtimes honor only flags that appear in "
+"``engine.serve_args`` today."
+msgstr ""
+"Kubernetes vLLM 渲染将权重和 KV-cache 量化映射为 CLI 标志。"
+"目前云 SSH 运行时只生效出现在 ``engine.serve_args`` 中的标志。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:236
+msgid "``service_id``"
+msgstr "``service_id``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:237
+msgid "``null``"
+msgstr "``null``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:238
+msgid ""
+"Optional service/discovery identifier for Kubernetes manifest labels and "
+"discovery paths."
+msgstr "可选的服务/发现标识符，用于 Kubernetes 清单标签和发现路径。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:240
+msgid "``deployment_mode``"
+msgstr "``deployment_mode``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:241
+msgid "``dedicated``"
+msgstr "``dedicated``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:242
+msgid ""
+"``dedicated`` is the only fully honored mode today. ``shared`` and "
+"``external`` are schema values but are not accepted by the Kubernetes Job"
+" renderer."
+msgstr ""
+"目前只有 ``dedicated`` 被完全支持。``shared`` 和 ``external`` 是 schema 取值，"
+"但不被 Kubernetes Job 渲染器接受。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:248
+msgid "Runtime Consumption Matrix"
+msgstr "运行时消费矩阵"
+
+#: ../../source/features/batch-model-deployment-templates.rst:255
+msgid "Kubernetes renderers"
+msgstr "Kubernetes 渲染器"
+
+#: ../../source/features/batch-model-deployment-templates.rst:256
+msgid "Console cloud path"
+msgstr "Console 云路径"
+
+#: ../../source/features/batch-model-deployment-templates.rst:257
+msgid "``engine.image``"
+msgstr "``engine.image``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:258
+msgid "Engine container image."
+msgstr "引擎容器镜像。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:259
+msgid ""
+"Passed to MDS runtime options. LambdaCloud uses it as the Docker image. "
+"RunPod provisioning uses ``RUNPOD_IMAGE`` for the pod image today."
+msgstr ""
+"传递给 MDS 运行时选项。LambdaCloud 将其用作 Docker 镜像。"
+"目前 RunPod 调配使用 ``RUNPOD_IMAGE`` 作为 pod 镜像。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:261
+msgid "``engine.serve_args``"
+msgstr "``engine.serve_args``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:262
+msgid ""
+"Appended last to engine CLI args, so admin raw flags can override "
+"generated args."
+msgstr "追加在引擎 CLI 参数末尾，因此管理员原始标志可覆盖生成的参数。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:264
+msgid "Passed as runtime ``vllm_args`` for LambdaCloud and RunPod."
+msgstr "作为 LambdaCloud 和 RunPod 的运行时 ``vllm_args`` 传递。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:266
+msgid "Converted to vLLM CLI flags by the engine adapter."
+msgstr "由引擎适配器转换为 vLLM CLI 标志。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:267
+msgid "Not consumed by Console's cloud runtime construction today."
+msgstr "目前不被 Console 的云运行时构建消费。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:269
+msgid "Used by downloader/model args and auth secret rendering."
+msgstr "用于 downloader/模型参数以及认证 secret 渲染。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:270
+msgid ""
+"Used by Console to resolve ``aibrix.model`` when no model serving name is"
+" set. Cloud SSH runtimes do not apply Kubernetes secrets."
+msgstr "当未设置模型服务名称时，Console 用它解析 ``aibrix.model`` 。云 SSH 运行时不会应用 Kubernetes secrets。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:273
+msgid "Used for resource requests and validation."
+msgstr "用于资源请求和校验。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:274
+msgid ""
+"Used by Resource Manager scheduling. RunPod requires provider-accepted "
+"GPU type strings; LambdaCloud normalizes common GPU family names."
+msgstr ""
+"由 Resource Manager 调度使用。RunPod 要求使用提供方接受的 GPU 类型字符串；"
+"LambdaCloud 会规范化常见 GPU 系列名称。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:276
+msgid "``parallelism`` and ``quantization``"
+msgstr "``parallelism`` 和 ``quantization``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:277
+msgid "Used by Kubernetes vLLM argument rendering."
+msgstr "由 Kubernetes vLLM 参数渲染使用。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:278
+msgid "Not read directly; express required cloud flags in ``serve_args``."
+msgstr "不直接读取；在 ``serve_args`` 中表达所需的云标志。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:282
+msgid "``extra_body.aibrix`` Contract"
+msgstr "``extra_body.aibrix`` 约定"
+
+#: ../../source/features/batch-model-deployment-templates.rst:284
+msgid "The MDS API accepts this AIBrix extension block:"
+msgstr "MDS API 接受此 AIBrix 扩展块："
+
+#: ../../source/features/batch-model-deployment-templates.rst:327
+#, python-format
+msgid ""
+"``client`` controls per-job smart-client behavior. ``max_concurrency`` is"
+" an absolute job-global in-flight cap, hard limited to 1024 (requests "
+"above are rejected). If adaptive concurrency is enabled, the cap limits "
+"adaptive growth; if adaptive concurrency is disabled, it becomes the "
+"fixed concurrency. Omitted fields fall back to metadata-service "
+"environment defaults and then built-in defaults. "
+"``adaptive_healthy_window`` is the number of healthy completions required"
+" for each growth step (default 8). During initial capacity probing, the "
+"controller increases by the greater of ``adaptive_additive_increase`` and"
+" 25% of the current limit. After the first overload or latency-driven "
+"decrease, probing ends permanently and the controller uses "
+"``adaptive_additive_increase`` as the fixed AIMD congestion-avoidance "
+"step (default 1). Smaller windows and larger increases ramp up faster but"
+" can overshoot backend capacity. Operators can set their process-wide "
+"fallbacks with ``AIBRIX_BATCH_ADAPTIVE_HEALTHY_WINDOW`` and "
+"``AIBRIX_BATCH_ADAPTIVE_ADDITIVE_INCREASE``. Other fine-grained adaptive "
+"controller internals remain private."
+msgstr ""
+"``client`` 控制每个作业的 smart-client 行为。``max_concurrency`` 是作业全局的绝对在途上限，"
+"硬限制为 1024（超过的请求会被拒绝）。若启用自适应并发，该上限限制自适应增长；"
+"若禁用自适应并发，它成为固定并发。省略的字段回退到 metadata-service 环境默认值，"
+"再回退到内置默认值。``adaptive_healthy_window`` 是每步增长所需的健康完成次数（默认 8）。"
+"初始容量探测期间，控制器按 ``adaptive_additive_increase`` 与 25% of 当前限制中的较大者增加。"
+"首次因过载或延迟导致下降后，探测永久结束，控制器将 ``adaptive_additive_increase`` "
+"作为固定的 AIMD 拥塞避免步长（默认 1）。更小的窗口和更大的增量会更快爬升，但可能超出后端容量。"
+"运维可通过 ``AIBRIX_BATCH_ADAPTIVE_HEALTHY_WINDOW`` 和 "
+"``AIBRIX_BATCH_ADAPTIVE_ADDITIVE_INCREASE`` 设置进程级回退。"
+"其他细粒度自适应控制器内部实现保持私有。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:345
+msgid "The known upstream runtime targets are:"
+msgstr "已知的上游运行时目标为："
+
+#: ../../source/features/batch-model-deployment-templates.rst:347
+msgid "``Kubernetes``"
+msgstr "``Kubernetes``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:348
+msgid "``KubernetesJob``"
+msgstr "``KubernetesJob``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:349
+msgid "``LambdaCloud``"
+msgstr "``LambdaCloud``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:350
+msgid "``RunPod``"
+msgstr "``RunPod``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:351
+msgid "``External``"
+msgstr "``External``"
+
+#: ../../source/features/batch-model-deployment-templates.rst:353
+msgid ""
+"``runtime.target`` is validated against the live runtime registry, so "
+"downstream runtimes can register additional target strings."
+msgstr "``runtime.target`` 对照实时运行时注册表校验，因此下游运行时可注册额外的目标字符串。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:358
+msgid "Operational Notes"
+msgstr "运维说明"
+
+#: ../../source/features/batch-model-deployment-templates.rst:360
+msgid ""
+"For Resource Manager backed jobs, submit through Console. Direct MDS "
+"``/v1/batches`` requests do not provision RunPod or Lambda Cloud "
+"resources."
+msgstr ""
+"对 Resource Manager 支持的作业，请通过 Console 提交。直接调用 MDS ``/v1/batches`` "
+"不会调配 RunPod 或 Lambda Cloud 资源。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:362
+msgid ""
+"Console currently selects one Resource Manager provider per backend "
+"process via ``PROVISIONER``. Per-job provider preference is not "
+"implemented."
+msgstr ""
+"Console 目前通过 ``PROVISIONER`` 为每个后端进程选择一个 Resource Manager 提供方。"
+"尚未实现按作业选择提供方。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:364
+msgid ""
+"Cloud SSH runtimes require ``aibrix.model`` to be directly loadable by "
+"vLLM on the remote host. Template ``auth_secret_ref`` is a Kubernetes "
+"manifest feature and is not automatically applied to LambdaCloud/RunPod."
+msgstr ""
+"云 SSH 运行时要求 ``aibrix.model`` 可在远程主机上被 vLLM 直接加载。"
+"模板 ``auth_secret_ref`` 是 Kubernetes 清单特性，不会自动应用到 LambdaCloud/RunPod。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:367
+msgid ""
+"Use ``AIBRIX_MDS_HTTP_BODY_LOG=1`` on MDS when debugging the exact "
+"``extra_body.aibrix`` payload received by the metadata service."
+msgstr ""
+"调试元数据服务收到的精确 ``extra_body.aibrix`` 负载时，在 MDS 上使用 ``AIBRIX_MDS_HTTP_BODY_LOG=1`` "
+"。"
+
+#: ../../source/features/batch-model-deployment-templates.rst:372
+msgid "See Also"
+msgstr "另见"
+
+#: ../../source/features/batch-model-deployment-templates.rst:374
+msgid ":doc:`batch-api` - OpenAI Batch API surface and request/response details"
+msgstr ":doc:`batch-api` - OpenAI Batch API 表面及请求/响应细节"
+
+#: ../../source/features/batch-model-deployment-templates.rst:375
+msgid ""
+":doc:`batch-resource-manager` - using RunPod and Lambda Cloud with the "
+"Console batch planner"
+msgstr ":doc:`batch-resource-manager` - 在 Console 批处理 planner 中使用 RunPod 和 Lambda Cloud"
+
+#: ../../source/features/batch-model-deployment-templates.rst:377
+msgid ":py:mod:`aibrix.batch.template.schema` - Pydantic source of truth"
+msgstr ":py:mod:`aibrix.batch.template.schema` - Pydantic 事实来源"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/batch-resource-manager.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/batch-resource-manager.po
@@ -1,0 +1,769 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/batch-resource-manager.rst:5
+msgid "Batch Resource Manager for Neoclouds"
+msgstr "面向 Neoclouds 的批处理 Resource Manager"
+
+#: ../../source/features/batch-resource-manager.rst:7
+msgid ""
+"The AIBrix batch Resource Manager lets the Console planner lease cloud "
+"GPU capacity before submitting a batch to the metadata service. This is "
+"useful when you want each batch job to run on provider-managed GPU "
+"machines instead of on the Kubernetes cluster where AIBrix is running."
+msgstr ""
+"AIBrix 批处理 Resource Manager 让 Console planner 在向元数据服务提交批次之前租用云 GPU 容量。"
+"适用于希望每个批作业运行在提供方管理的 GPU 机器上，而非 AIBrix 所在 Kubernetes 集群上的场景。"
+
+#: ../../source/features/batch-resource-manager.rst:12
+msgid "The currently supported cloud providers are:"
+msgstr "当前支持的云提供方为："
+
+#: ../../source/features/batch-resource-manager.rst:14
+msgid ""
+"``runpod`` - creates RunPod pods, injects an SSH public key, and runs "
+"vLLM inside the pod."
+msgstr "``runpod`` - 创建 RunPod pods，注入 SSH 公钥，并在 pod 内运行 vLLM。"
+
+#: ../../source/features/batch-resource-manager.rst:16
+msgid ""
+"``lambdaCloud`` - creates Lambda Cloud GPU instances, SSHes to the VM, "
+"and runs the vLLM serving container with Docker."
+msgstr "``lambdaCloud`` - 创建 Lambda Cloud GPU 实例，SSH 到虚拟机，并用 Docker 运行 vLLM 推理容器。"
+
+#: ../../source/features/batch-resource-manager.rst:21
+msgid ""
+"Automatic RunPod and Lambda Cloud provisioning is available through the "
+"Console Job API, ``/api/v1/jobs``. Direct calls to the metadata service "
+"``/v1/batches`` do not call Resource Manager by themselves. Direct "
+"metadata-service users can still pass a runtime manually in "
+"``extra_body.aibrix.runtime``, but then they own provisioning and "
+"cleanup."
+msgstr ""
+"可通过 Console Job API ``/api/v1/jobs`` 自动调配 RunPod 和 Lambda Cloud。"
+"直接调用元数据服务 ``/v1/batches`` 不会自行调用 Resource Manager。"
+"直接使用元数据服务的用户仍可在 ``extra_body.aibrix.runtime`` 中手动传入 runtime，"
+"但此时由他们自行负责调配和清理。"
+
+#: ../../source/features/batch-resource-manager.rst:29
+msgid "How It Works"
+msgstr "工作原理"
+
+#: ../../source/features/batch-resource-manager.rst:64
+msgid "The planner lifecycle is:"
+msgstr "planner 生命周期为："
+
+#: ../../source/features/batch-resource-manager.rst:66
+msgid "Console receives a job through ``POST /api/v1/jobs``."
+msgstr "Console 通过 ``POST /api/v1/jobs`` 接收作业。"
+
+#: ../../source/features/batch-resource-manager.rst:67
+msgid ""
+"Planner builds a resource request from the selected "
+"``ModelDeploymentTemplate``. Today the Console path requests one replica "
+"with ``accelerator.count`` GPUs."
+msgstr ""
+"Planner 根据所选 ``ModelDeploymentTemplate`` 构建资源请求。目前 Console 路径请求一个副本，GPU "
+"数为 ``accelerator.count`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:70
+msgid ""
+"Resource Manager provisions the cloud resource and stores a "
+"``ProvisionResult``."
+msgstr "Resource Manager 调配云资源并存储 ``ProvisionResult`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:72
+msgid "Planner polls Resource Manager until the provision is ``running``."
+msgstr "Planner 轮询 Resource Manager，直到调配状态为 ``running`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:73
+msgid ""
+"Planner submits the batch to the metadata service with ``aibrix.runtime``"
+" set to ``RunPod`` or ``LambdaCloud``."
+msgstr "Planner 向元数据服务提交批次，并将 ``aibrix.runtime`` 设为 ``RunPod`` 或 ``LambdaCloud`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:75
+msgid ""
+"Metadata Service SSHes into the provisioned machine, starts vLLM, waits "
+"for ``/health``, and dispatches the batch requests."
+msgstr "元数据服务 SSH 到已调配的机器，启动 vLLM，等待 ``/health`` ，然后分发批请求。"
+
+#: ../../source/features/batch-resource-manager.rst:77
+msgid ""
+"When the batch reaches a terminal state, or when the job is cancelled, "
+"Planner calls Resource Manager ``Release``. RunPod pods are deleted and "
+"Lambda Cloud instances are terminated."
+msgstr ""
+"当批次到达终态或作业被取消时，Planner 调用 Resource Manager ``Release`` 。RunPod pods 会被删除，Lambda "
+"Cloud 实例会被终止。"
+
+#: ../../source/features/batch-resource-manager.rst:83
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/features/batch-resource-manager.rst:85
+msgid "Before enabling a cloud provider, make sure you have:"
+msgstr "启用云提供方之前，请确保具备："
+
+#: ../../source/features/batch-resource-manager.rst:87
+msgid ""
+"A running AIBrix metadata service with batch file storage configured. See"
+" :ref:`batch_api`."
+msgstr "正在运行的 AIBrix 元数据服务，且已配置批文件存储。参见 :ref:`batch_api` 。"
+
+#: ../../source/features/batch-resource-manager.rst:89
+msgid ""
+"A running AIBrix Console backend. The Resource Manager path is owned by "
+"the Console planner."
+msgstr "正在运行的 AIBrix Console 后端。Resource Manager 路径由 Console planner 负责。"
+
+#: ../../source/features/batch-resource-manager.rst:91
+msgid ""
+"A private SSH key mounted into the metadata service and exposed through "
+"``AIBRIX_BATCH_SSH_KEY_FILE``."
+msgstr "挂载到元数据服务并通过 ``AIBRIX_BATCH_SSH_KEY_FILE`` 暴露的 SSH 私钥。"
+
+#: ../../source/features/batch-resource-manager.rst:93
+msgid ""
+"The matching public key configured for the selected provider: "
+"``RUNPOD_SSH_PUBLIC_KEY`` for RunPod, or an SSH key name in the Lambda "
+"Cloud account for Lambda Cloud."
+msgstr ""
+"为所选提供方配置匹配的公钥：RunPod 使用 ``RUNPOD_SSH_PUBLIC_KEY`` ，Lambda Cloud 使用 Lambda "
+"Cloud 账户中的 SSH 密钥名。"
+
+#: ../../source/features/batch-resource-manager.rst:96
+msgid ""
+"A ``ModelDeploymentTemplate`` for the model and GPU shape users can "
+"select when creating a job."
+msgstr "用户创建作业时可选择的模型和 GPU 规格对应的 ``ModelDeploymentTemplate`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:99
+msgid "Generate a dedicated key pair for batch resources:"
+msgstr "为批处理资源生成专用密钥对："
+
+#: ../../source/features/batch-resource-manager.rst:106
+msgid ""
+"Mount the private key into the metadata service. For Kubernetes "
+"deployments, create a secret and add a volume/env patch to the metadata "
+"service deployment:"
+msgstr ""
+"将私钥挂载到元数据服务。对 Kubernetes 部署，创建 secret，并向元数据服务 deployment "
+"添加 volume/env patch："
+
+#: ../../source/features/batch-resource-manager.rst:137
+msgid "Configure the Console Backend"
+msgstr "配置 Console 后端"
+
+#: ../../source/features/batch-resource-manager.rst:139
+msgid ""
+"The Console backend selects exactly one Resource Manager provider at "
+"startup. Use ``PROVISIONER=kubernetes`` for the default in-cluster path, "
+"``PROVISIONER=runpod`` for RunPod, or ``PROVISIONER=lambdaCloud`` for "
+"Lambda Cloud."
+msgstr ""
+"Console 后端在启动时恰好选择一个 Resource Manager 提供方。默认集群内路径使用 ``PROVISIONER=kubernetes`` "
+"，RunPod 使用 ``PROVISIONER=runpod`` ，Lambda Cloud 使用 ``PROVISIONER=lambdaCloud`` "
+"。"
+
+#: ../../source/features/batch-resource-manager.rst:146
+msgid ""
+"Provider identifiers are case-sensitive and intentionally differ by "
+"context: ``PROVISIONER`` takes the lowercase/camelCase values ``runpod`` "
+"and ``lambdaCloud``, while the ``aibrix.runtime.target`` field in "
+":ref:`batch_model_deployment_templates` uses the PascalCase values "
+"``RunPod`` and ``LambdaCloud``."
+msgstr ""
+"提供方标识符区分大小写，且按上下文故意不同：``PROVISIONER`` 使用小写/camelCase 取值 ``runpod`` 和 ``lambdaCloud`` "
+"，而 :ref:`batch_model_deployment_templates` 中的 ``aibrix.runtime.target`` "
+"字段使用 PascalCase 取值 ``RunPod`` 和 ``LambdaCloud`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:152
+msgid "Common environment variables:"
+msgstr "通用环境变量："
+
+#: ../../source/features/batch-resource-manager.rst:158
+#: ../../source/features/batch-resource-manager.rst:200
+#: ../../source/features/batch-resource-manager.rst:249
+msgid "Variable"
+msgstr "变量"
+
+#: ../../source/features/batch-resource-manager.rst:159
+msgid "Required?"
+msgstr "是否必填？"
+
+#: ../../source/features/batch-resource-manager.rst:160
+#: ../../source/features/batch-resource-manager.rst:201
+#: ../../source/features/batch-resource-manager.rst:250
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/features/batch-resource-manager.rst:161
+msgid "``PROVISIONER``"
+msgstr "``PROVISIONER``"
+
+#: ../../source/features/batch-resource-manager.rst:162
+#: ../../source/features/batch-resource-manager.rst:165
+msgid "yes"
+msgstr "是"
+
+#: ../../source/features/batch-resource-manager.rst:163
+msgid "``runpod`` or ``lambdaCloud`` for cloud Resource Manager mode."
+msgstr "云 Resource Manager 模式下为 ``runpod`` 或 ``lambdaCloud`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:164
+msgid "``METADATA_SERVICE_URL``"
+msgstr "``METADATA_SERVICE_URL``"
+
+#: ../../source/features/batch-resource-manager.rst:166
+msgid "Metadata service URL used by Console to submit ``/v1/batches``."
+msgstr "Console 提交 ``/v1/batches`` 所用的元数据服务 URL。"
+
+#: ../../source/features/batch-resource-manager.rst:167
+msgid "``STORE_URI``"
+msgstr "``STORE_URI``"
+
+#: ../../source/features/batch-resource-manager.rst:168
+msgid "recommended"
+msgstr "建议"
+
+#: ../../source/features/batch-resource-manager.rst:169
+msgid ""
+"Durable Console store URI. File-backed SQLite is enough for a single "
+"backend; production should use a shared database."
+msgstr "持久的 Console store URI。单后端使用基于文件的 SQLite 即可；生产环境应使用共享数据库。"
+
+#: ../../source/features/batch-resource-manager.rst:171
+msgid "``DEFAULT_BATCH_MODEL_DEPLOYMENT_TEMPLATE``"
+msgstr "``DEFAULT_BATCH_MODEL_DEPLOYMENT_TEMPLATE``"
+
+#: ../../source/features/batch-resource-manager.rst:172
+#: ../../source/features/batch-resource-manager.rst:175
+#: ../../source/features/batch-resource-manager.rst:179
+msgid "optional"
+msgstr "可选"
+
+#: ../../source/features/batch-resource-manager.rst:173
+msgid "Template name used when callers omit ``model_template_name``."
+msgstr "调用方省略 ``model_template_name`` 时使用的模板名称。"
+
+#: ../../source/features/batch-resource-manager.rst:174
+msgid "``PLANNING_POLICY``"
+msgstr "``PLANNING_POLICY``"
+
+#: ../../source/features/batch-resource-manager.rst:176
+msgid ""
+"Defaults to ``simple``. This is the only policy registered for RunPod and"
+" Lambda Cloud today."
+msgstr "默认为 ``simple`` 。目前这是 RunPod 和 Lambda Cloud 唯一注册的策略。"
+
+#: ../../source/features/batch-resource-manager.rst:178
+msgid "``PLANNER_WORKER_COUNT``"
+msgstr "``PLANNER_WORKER_COUNT``"
+
+#: ../../source/features/batch-resource-manager.rst:180
+msgid "Number of planner workers. Defaults to ``10``."
+msgstr "planner worker 数量。默认为 ``10`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:184
+msgid "RunPod"
+msgstr "RunPod"
+
+#: ../../source/features/batch-resource-manager.rst:186
+msgid "Required RunPod configuration:"
+msgstr "必填的 RunPod 配置："
+
+#: ../../source/features/batch-resource-manager.rst:194
+msgid "Optional RunPod configuration:"
+msgstr "可选的 RunPod 配置："
+
+#: ../../source/features/batch-resource-manager.rst:202
+msgid "``RUNPOD_BASE_URL``"
+msgstr "``RUNPOD_BASE_URL``"
+
+#: ../../source/features/batch-resource-manager.rst:203
+msgid "Override the RunPod API root. Defaults to ``https://rest.runpod.io/v1``."
+msgstr "覆盖 RunPod API 根路径。默认为 ``https://rest.runpod.io/v1`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:205
+msgid "``RUNPOD_DATA_CENTERS``"
+msgstr "``RUNPOD_DATA_CENTERS``"
+
+#: ../../source/features/batch-resource-manager.rst:206
+msgid ""
+"Comma-separated RunPod data center IDs. If unset, RunPod can pick any "
+"available data center."
+msgstr "逗号分隔的 RunPod 数据中心 ID。未设置时，RunPod 可选择任意可用数据中心。"
+
+#: ../../source/features/batch-resource-manager.rst:208
+msgid "``RUNPOD_IMAGE``"
+msgstr "``RUNPOD_IMAGE``"
+
+#: ../../source/features/batch-resource-manager.rst:209
+msgid ""
+"Pod image. Defaults to ``vllm/vllm-openai:latest``. The image must be "
+"able to run ``vllm serve`` and allow ``openssh-server`` to be installed "
+"at pod startup."
+msgstr ""
+"Pod 镜像。默认为 ``vllm/vllm-openai:latest`` 。镜像必须能运行 ``vllm serve`` ，并允许在 pod "
+"启动时安装 ``openssh-server`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:212
+msgid "``RUNPOD_CLOUD_TYPE``"
+msgstr "``RUNPOD_CLOUD_TYPE``"
+
+#: ../../source/features/batch-resource-manager.rst:213
+msgid "``SECURE`` or ``COMMUNITY``. Defaults to ``SECURE``."
+msgstr "``SECURE`` 或 ``COMMUNITY`` 。默认为 ``SECURE`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:215
+msgid ""
+"RunPod does not expose a full region, GPU type, or pricing catalog "
+"through the REST API used here. AIBrix therefore passes "
+"``ModelDeploymentTemplate.spec.accelerator.type`` directly as the RunPod "
+"``gpuTypeIds`` value. Use the exact GPU type string accepted by RunPod, "
+"for example ``NVIDIA H100 80GB HBM3``."
+msgstr ""
+"RunPod 未通过此处使用的 REST API 暴露完整的区域、GPU 类型或价格目录。因此 AIBrix 将 ``ModelDeploymentTemplate.spec.accelerator.type`` "
+"直接作为 RunPod ``gpuTypeIds`` 的值传递。请使用 RunPod 接受的精确 GPU 类型字符串，例如 ``NVIDIA H100 "
+"80GB HBM3`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:221
+msgid "RunPod networking:"
+msgstr "RunPod 网络："
+
+#: ../../source/features/batch-resource-manager.rst:223
+msgid "Resource Manager creates one pod per requested replica."
+msgstr "Resource Manager 为每个请求的副本创建一个 pod。"
+
+#: ../../source/features/batch-resource-manager.rst:224
+msgid "The pod starts ``sshd`` and injects ``RUNPOD_SSH_PUBLIC_KEY``."
+msgstr "pod 启动 ``sshd`` 并注入 ``RUNPOD_SSH_PUBLIC_KEY`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:225
+msgid ""
+"Planner passes ``root``, the public IP, SSH port, and ``https://<pod-"
+"id>-8000.proxy.runpod.net`` to the metadata service."
+msgstr ""
+"Planner 将 ``root`` 、公网 IP、SSH 端口和 ``https://<pod-id>-8000.proxy.runpod.net`` "
+"传递给元数据服务。"
+
+#: ../../source/features/batch-resource-manager.rst:227
+msgid ""
+"The RunPod runtime launches ``vllm serve`` over SSH and dispatches "
+"requests through the RunPod HTTP proxy."
+msgstr "RunPod 运行时通过 SSH 启动 ``vllm serve`` ，并通过 RunPod HTTP 代理分发请求。"
+
+#: ../../source/features/batch-resource-manager.rst:232
+msgid "Lambda Cloud"
+msgstr "Lambda Cloud"
+
+#: ../../source/features/batch-resource-manager.rst:234
+msgid ""
+"First add the public key to your Lambda Cloud account and note its key "
+"name. Then configure the Console backend:"
+msgstr "首先将公钥添加到 Lambda Cloud 账户并记下密钥名。然后配置 Console 后端："
+
+#: ../../source/features/batch-resource-manager.rst:243
+msgid "Optional Lambda Cloud configuration:"
+msgstr "可选的 Lambda Cloud 配置："
+
+#: ../../source/features/batch-resource-manager.rst:251
+msgid "``LAMBDA_CLOUD_BASE_URL``"
+msgstr "``LAMBDA_CLOUD_BASE_URL``"
+
+#: ../../source/features/batch-resource-manager.rst:252
+msgid ""
+"Override the Lambda Cloud API root. Defaults to "
+"``https://cloud.lambda.ai/api/v1``."
+msgstr "覆盖 Lambda Cloud API 根路径。默认为 ``https://cloud.lambda.ai/api/v1`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:254
+msgid "``LAMBDA_CLOUD_REGION``"
+msgstr "``LAMBDA_CLOUD_REGION``"
+
+#: ../../source/features/batch-resource-manager.rst:255
+msgid ""
+"Hard default region preference, such as ``us-west-1``. If unset, AIBrix "
+"picks the cheapest matching instance type with current capacity in any "
+"available region."
+msgstr "硬编码的默认区域偏好，例如 ``us-west-1`` 。未设置时，AIBrix 在任意可用区域中选择当前有容量、匹配且最便宜的实例类型。"
+
+#: ../../source/features/batch-resource-manager.rst:258
+msgid "``LAMBDA_CLOUD_SSH_KEYS``"
+msgstr "``LAMBDA_CLOUD_SSH_KEYS``"
+
+#: ../../source/features/batch-resource-manager.rst:259
+msgid ""
+"Comma-separated SSH key names already registered in Lambda Cloud. At "
+"least one key is required."
+msgstr "已在 Lambda Cloud 注册的 SSH 密钥名，逗号分隔。至少需要一个密钥。"
+
+#: ../../source/features/batch-resource-manager.rst:262
+msgid "Lambda Cloud capacity selection:"
+msgstr "Lambda Cloud 容量选择："
+
+#: ../../source/features/batch-resource-manager.rst:264
+msgid "``accelerator.count`` becomes the required GPU count per instance."
+msgstr "``accelerator.count`` 成为每个实例所需的 GPU 数量。"
+
+#: ../../source/features/batch-resource-manager.rst:265
+msgid ""
+"``accelerator.type`` is matched against Lambda Cloud instance type names "
+"and GPU descriptions. Names such as ``H100``, ``NVIDIA H100``, and "
+"``H100-SXM5`` normalize to the same GPU family."
+msgstr ""
+"``accelerator.type`` 与 Lambda Cloud 实例类型名称和 GPU 描述匹配。``H100`` 、``NVIDIA "
+"H100`` 和 ``H100-SXM5`` 这类名称会规范化为同一 GPU 系列。"
+
+#: ../../source/features/batch-resource-manager.rst:268
+msgid ""
+"If ``LAMBDA_CLOUD_REGION`` is set, AIBrix only accepts capacity in that "
+"region. Otherwise it chooses the cheapest matching instance type among "
+"regions with capacity."
+msgstr "若设置了 ``LAMBDA_CLOUD_REGION`` ，AIBrix 只接受该区域的容量。否则在有容量的区域中选择最便宜的匹配实例类型。"
+
+#: ../../source/features/batch-resource-manager.rst:272
+msgid "Lambda Cloud networking:"
+msgstr "Lambda Cloud 网络："
+
+#: ../../source/features/batch-resource-manager.rst:274
+msgid "Resource Manager launches a GPU VM and waits until it is ``active``."
+msgstr "Resource Manager 启动 GPU 虚拟机并等待其变为 ``active`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:275
+msgid ""
+"Planner passes ``ubuntu``, the public IP, SSH port ``22``, and the model "
+"template serving image to the metadata service."
+msgstr "Planner 将 ``ubuntu`` 、公网 IP、SSH 端口 ``22`` 以及模型模板推理镜像传递给元数据服务。"
+
+#: ../../source/features/batch-resource-manager.rst:277
+msgid ""
+"The Lambda Cloud runtime SSHes to the VM, verifies Docker, and runs the "
+"vLLM container with ``sudo docker run --gpus all``."
+msgstr "Lambda Cloud 运行时 SSH 到虚拟机，验证 Docker，并用 ``sudo docker run --gpus all`` 运行 vLLM 容器。"
+
+#: ../../source/features/batch-resource-manager.rst:279
+msgid ""
+"vLLM binds to ``127.0.0.1:8000`` on the VM. The metadata service opens an"
+" SSH local port-forward and dispatches through the tunnel, so the vLLM "
+"endpoint is not exposed publicly."
+msgstr "vLLM 绑定到虚拟机上的 ``127.0.0.1:8000`` 。元数据服务打开 SSH 本地端口转发并通过隧道分发，因此 vLLM 端点不会公网暴露。"
+
+#: ../../source/features/batch-resource-manager.rst:285
+msgid "Create a Model Deployment Template"
+msgstr "创建模型部署模板"
+
+#: ../../source/features/batch-resource-manager.rst:287
+msgid ""
+"The cloud Resource Manager path uses the Console "
+"``ModelDeploymentTemplate`` selected by the batch job. The template "
+"remains provider-agnostic; the active provider is selected by "
+"``PROVISIONER``."
+msgstr ""
+"云 Resource Manager 路径使用批作业所选的 Console ``ModelDeploymentTemplate`` 。模板与提供方无关；活动提供方由 "
+"``PROVISIONER`` 选择。"
+
+#: ../../source/features/batch-resource-manager.rst:291
+msgid "For a new model, create a Console model first:"
+msgstr "对新模型，先创建 Console 模型："
+
+#: ../../source/features/batch-resource-manager.rst:305
+msgid "Then create a deployment template:"
+msgstr "然后创建部署模板："
+
+#: ../../source/features/batch-resource-manager.rst:354
+msgid "Provider-specific notes:"
+msgstr "提供方特定说明："
+
+#: ../../source/features/batch-resource-manager.rst:356
+msgid ""
+"For Lambda Cloud, ``accelerator.type`` should be a GPU family or Lambda "
+"instance-type token, such as ``A10``, ``A100``, or ``H100``."
+msgstr ""
+"对 Lambda Cloud，``accelerator.type`` 应为 GPU 系列或 Lambda 实例类型标记，例如 ``A10`` "
+"、``A100`` 或 ``H100`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:358
+msgid ""
+"For RunPod, set ``accelerator.type`` to the exact RunPod GPU type ID "
+"accepted by the pod API, such as ``NVIDIA H100 80GB HBM3``."
+msgstr ""
+"对 RunPod，将 ``accelerator.type`` 设为 pod API 接受的精确 RunPod GPU 类型 ID，例如 ``NVIDIA "
+"H100 80GB HBM3`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:360
+msgid "For Lambda Cloud, ``engine.image`` is the Docker image run on the VM."
+msgstr "对 Lambda Cloud，``engine.image`` 是在虚拟机上运行的 Docker 镜像。"
+
+#: ../../source/features/batch-resource-manager.rst:361
+msgid ""
+"For RunPod, ``RUNPOD_IMAGE`` controls the pod image. The runtime still "
+"uses template fields such as ``model_source.uri`` and "
+"``engine.serve_args`` when launching ``vllm serve``."
+msgstr ""
+"对 RunPod，``RUNPOD_IMAGE`` 控制 pod 镜像。运行时在启动 ``vllm serve`` 时仍使用 "
+"``model_source.uri`` 和 ``engine.serve_args`` 等模板字段。"
+
+#: ../../source/features/batch-resource-manager.rst:367
+msgid "Submit a Batch Job"
+msgstr "提交批作业"
+
+#: ../../source/features/batch-resource-manager.rst:369
+msgid "Prepare a JSONL input file:"
+msgstr "准备 JSONL 输入文件："
+
+#: ../../source/features/batch-resource-manager.rst:376
+msgid "Upload it through the Console file proxy:"
+msgstr "通过 Console 文件代理上传："
+
+#: ../../source/features/batch-resource-manager.rst:384
+msgid "Create a job:"
+msgstr "创建作业："
+
+#: ../../source/features/batch-resource-manager.rst:400
+msgid "Watch the job and provision state:"
+msgstr "查看作业和调配状态："
+
+#: ../../source/features/batch-resource-manager.rst:407
+msgid "Expected high-level state flow:"
+msgstr "预期的高层状态流："
+
+#: ../../source/features/batch-resource-manager.rst:413
+msgid ""
+"If resource provisioning fails, the job moves to ``resource_failed`` and "
+"``error_message`` contains the provider error. If metadata-service "
+"submission fails after resources are ready, the job moves to "
+"``submit_failed`` and Planner attempts to release the provision."
+msgstr ""
+"若资源调配失败，作业进入 ``resource_failed`` ，``error_message`` 包含提供方错误。若资源就绪后元数据服务提交失败，作业进入 "
+"``submit_failed`` ，Planner 尝试释放调配。"
+
+#: ../../source/features/batch-resource-manager.rst:418
+msgid "Cancel a running job:"
+msgstr "取消正在运行的作业："
+
+#: ../../source/features/batch-resource-manager.rst:426
+msgid ""
+"Planner forwards cancellation to the metadata service if a batch has been"
+" submitted, then releases the cloud provision."
+msgstr "若批次已提交，Planner 将取消转发到元数据服务，然后释放云调配。"
+
+#: ../../source/features/batch-resource-manager.rst:431
+msgid "Read Results"
+msgstr "读取结果"
+
+#: ../../source/features/batch-resource-manager.rst:433
+msgid ""
+"When the job reaches ``completed``, download the output file through the "
+"Console file proxy:"
+msgstr "作业到达 ``completed`` 后，通过 Console 文件代理下载输出文件："
+
+#: ../../source/features/batch-resource-manager.rst:447
+msgid "Troubleshooting"
+msgstr "故障排查"
+
+#: ../../source/features/batch-resource-manager.rst:450
+msgid "``resource manager init: missing credential``"
+msgstr "``resource manager init: missing credential``"
+
+#: ../../source/features/batch-resource-manager.rst:452
+msgid ""
+"The selected provider was enabled without its required environment "
+"variables. Check:"
+msgstr "已启用所选提供方，但缺少其所需环境变量。请检查："
+
+#: ../../source/features/batch-resource-manager.rst:455
+msgid "RunPod: ``RUNPOD_API_KEY`` and ``RUNPOD_SSH_PUBLIC_KEY``."
+msgstr "RunPod：``RUNPOD_API_KEY`` 和 ``RUNPOD_SSH_PUBLIC_KEY`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:456
+msgid "Lambda Cloud: ``LAMBDA_CLOUD_API_KEY`` and ``LAMBDA_CLOUD_SSH_KEYS``."
+msgstr "Lambda Cloud：``LAMBDA_CLOUD_API_KEY`` 和 ``LAMBDA_CLOUD_SSH_KEYS`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:459
+msgid "``resource_failed`` with ``NoGpuType`` on RunPod"
+msgstr "RunPod 上 ``resource_failed`` 且带 ``NoGpuType``"
+
+#: ../../source/features/batch-resource-manager.rst:461
+msgid ""
+"RunPod requires at least one GPU type. Set "
+"``ModelDeploymentTemplate.spec.accelerator.type`` to an exact RunPod GPU "
+"type ID accepted by the pod API."
+msgstr ""
+"RunPod 至少需要一种 GPU 类型。将 ``ModelDeploymentTemplate.spec.accelerator.type`` "
+"设为 pod API 接受的精确 RunPod GPU 类型 ID。"
+
+#: ../../source/features/batch-resource-manager.rst:466
+msgid "``resource_failed`` with ``NoCapacity`` on Lambda Cloud"
+msgstr "Lambda Cloud 上 ``resource_failed`` 且带 ``NoCapacity``"
+
+#: ../../source/features/batch-resource-manager.rst:468
+msgid ""
+"Lambda Cloud had no currently available instance type matching "
+"``accelerator.type``, ``accelerator.count``, and ``LAMBDA_CLOUD_REGION``."
+" Try a different GPU family, lower GPU count, or unset/change the region."
+msgstr ""
+"Lambda Cloud 当前没有匹配 ``accelerator.type`` 、``accelerator.count`` 和 ``LAMBDA_CLOUD_REGION`` "
+"的可用实例类型。尝试不同 GPU 系列、更低 GPU 数量，或取消设置/更改区域。"
+
+#: ../../source/features/batch-resource-manager.rst:473
+msgid "Job is stuck in ``resource_preparing``"
+msgstr "作业卡在 ``resource_preparing``"
+
+#: ../../source/features/batch-resource-manager.rst:475
+msgid ""
+"The provider accepted the launch but AIBrix has not observed a ready "
+"public IP/SSH endpoint yet. Check the provider console, then inspect "
+"Console logs for provider API errors. For RunPod, the provision becomes "
+"ready only when the pod is ``RUNNING`` and has a public IP. For Lambda "
+"Cloud, it becomes ready when the instance is ``active`` and has a public "
+"IP."
+msgstr ""
+"提供方已接受启动，但 AIBrix 尚未观测到就绪的公网 IP/SSH 端点。检查提供方控制台，"
+"然后查看 Console 日志中的提供方 API 错误。对 RunPod，仅当 pod 为 ``RUNNING`` 且有公网 IP "
+"时调配才就绪。对 Lambda Cloud，当实例为 ``active`` 且有公网 IP 时才就绪。"
+
+#: ../../source/features/batch-resource-manager.rst:482
+msgid "Job reaches ``submit_failed`` or vLLM never becomes healthy"
+msgstr "作业到达 ``submit_failed`` 或 vLLM 始终未变为健康"
+
+#: ../../source/features/batch-resource-manager.rst:484
+msgid ""
+"The resource was created, but the metadata service could not launch or "
+"reach vLLM. Check:"
+msgstr "资源已创建，但元数据服务无法启动或访问 vLLM。请检查："
+
+#: ../../source/features/batch-resource-manager.rst:487
+msgid ""
+"``AIBRIX_BATCH_SSH_KEY_FILE`` points to the private key matching the "
+"provider-side public key."
+msgstr "``AIBRIX_BATCH_SSH_KEY_FILE`` 指向与提供方公钥匹配的私钥。"
+
+#: ../../source/features/batch-resource-manager.rst:489
+msgid "The private key file is readable only by the metadata-service process."
+msgstr "私钥文件仅元数据服务进程可读。"
+
+#: ../../source/features/batch-resource-manager.rst:490
+msgid "Lambda Cloud instances allow SSH for the registered key name."
+msgstr "Lambda Cloud 实例允许使用已注册密钥名进行 SSH。"
+
+#: ../../source/features/batch-resource-manager.rst:491
+msgid ""
+"RunPod pod image can install and run ``openssh-server`` and has ``vllm`` "
+"on ``PATH``."
+msgstr "RunPod pod 镜像能安装并运行 ``openssh-server`` ，且 ``PATH`` 上有 ``vllm`` 。"
+
+#: ../../source/features/batch-resource-manager.rst:493
+msgid ""
+"The model can be downloaded from ``model_source.uri``. If it requires "
+"authentication, configure the model source secret before submitting jobs."
+msgstr ""
+"模型可从 ``model_source.uri`` 下载。若需要认证，请在提交作业前配置模型源 secret。"
+
+#: ../../source/features/batch-resource-manager.rst:495
+msgid "Lambda Cloud images can be started with Docker and the NVIDIA runtime."
+msgstr "Lambda Cloud 镜像可用 Docker 和 NVIDIA runtime 启动。"
+
+#: ../../source/features/batch-resource-manager.rst:498
+msgid "Provider resources remain after a failed job"
+msgstr "作业失败后提供方资源仍残留"
+
+#: ../../source/features/batch-resource-manager.rst:500
+#, python-brace-format
+msgid ""
+"Planner releases resources on terminal states and cancellation, but "
+"cleanup is best-effort. If Console or the provider API fails during "
+"cleanup, use the ``provision.raw_json`` field from ``GET "
+"/api/v1/jobs/{id}`` to find the RunPod pod ID or Lambda Cloud instance "
+"IDs, then delete them in the provider console."
+msgstr ""
+"Planner 在终态和取消时释放资源，但清理是尽力而为。若清理期间 Console 或提供方 API 失败，"
+"使用 ``GET /api/v1/jobs/{id}`` 中的 ``provision.raw_json`` 字段查找 RunPod pod ID "
+"或 Lambda Cloud 实例 ID，然后在提供方控制台中删除。"
+
+#: ../../source/features/batch-resource-manager.rst:508
+msgid "Current Limitations"
+msgstr "当前限制"
+
+#: ../../source/features/batch-resource-manager.rst:510
+msgid ""
+"Cloud Resource Manager mode is selected once per Console backend with "
+"``PROVISIONER``. Per-job provider selection is not exposed yet."
+msgstr ""
+"云 Resource Manager 模式通过 ``PROVISIONER`` 为每个 Console 后端选择一次。"
+"尚未暴露按作业选择提供方。"
+
+#: ../../source/features/batch-resource-manager.rst:512
+msgid ""
+"The Console planner path requests one replica per batch job today. "
+"``ResourceGroupSpec`` supports richer groups internally, but the Console "
+"job path currently derives only one group from the selected template."
+msgstr ""
+"目前 Console planner 路径每个批作业请求一个副本。``ResourceGroupSpec`` 内部支持更丰富的组，"
+"但 Console 作业路径目前仅从所选模板派生一个组。"
+
+#: ../../source/features/batch-resource-manager.rst:515
+msgid ""
+"RunPod catalog, pricing, and region discovery return empty results "
+"because the RunPod REST API used by AIBrix does not expose those "
+"catalogs."
+msgstr "RunPod 目录、价格和区域发现返回空结果，因为 AIBrix 使用的 RunPod REST API 未暴露这些目录。"
+
+#: ../../source/features/batch-resource-manager.rst:517
+msgid ""
+"Lambda Cloud catalog data is fetched live from the Lambda Cloud API, but "
+"there is no public Console catalog endpoint for it yet."
+msgstr "Lambda Cloud 目录数据从 Lambda Cloud API 实时获取，但尚无公开的 Console 目录端点。"
+
+#: ../../source/features/batch-resource-manager.rst:519
+msgid ""
+"The cloud runtime path is designed for vLLM-compatible OpenAI HTTP "
+"serving over SSH. Other engines need matching runtime support before they"
+" can be used with RunPod or Lambda Cloud."
+msgstr ""
+"云运行时路径面向通过 SSH 的兼容 vLLM 的 OpenAI HTTP 推理。"
+"其他引擎需要匹配的运行时支持后才能用于 RunPod 或 Lambda Cloud。"
+
+#: ../../source/features/batch-resource-manager.rst:525
+msgid "See Also"
+msgstr "另见"
+
+#: ../../source/features/batch-resource-manager.rst:527
+msgid ":ref:`batch_api` - OpenAI-compatible batch API and file workflow."
+msgstr ":ref:`batch_api` - 兼容 OpenAI 的批处理 API 和文件工作流。"
+
+#: ../../source/features/batch-resource-manager.rst:528
+msgid ":ref:`batch_model_deployment_templates` - model deployment templates."
+msgstr ":ref:`batch_model_deployment_templates` - 模型部署模板。"
+
+#: ../../source/features/batch-resource-manager.rst:529
+msgid ""
+"``apps/console/api/resource_manager`` - Resource Manager provider "
+"implementations."
+msgstr "``apps/console/api/resource_manager`` - Resource Manager 提供方实现。"
+
+#: ../../source/features/batch-resource-manager.rst:531
+msgid ""
+"``python/aibrix/aibrix/batch/job_driver/runtime`` - metadata-service "
+"runtime implementations for Kubernetes, RunPod, and Lambda Cloud."
+msgstr ""
+"``python/aibrix/aibrix/batch/job_driver/runtime`` - Kubernetes、RunPod 和 "
+"Lambda Cloud 的元数据服务运行时实现。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/benchmark-and-generator.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/benchmark-and-generator.po
@@ -1,0 +1,454 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/benchmark-and-generator.rst:5
+msgid "Benchmark and Workload Generator"
+msgstr "基准测试与工作负载生成器"
+
+#: ../../source/features/benchmark-and-generator.rst:6
+msgid ""
+"`AIBrix Benchmark <https://github.com/vllm-"
+"project/aibrix/tree/main/benchmarks>`_ contains the following components:"
+msgstr ""
+"`AIBrix Benchmark <https://github.com/vllm-"
+"project/aibrix/tree/main/benchmarks>`_ 包含以下组件："
+
+#: ../../source/features/benchmark-and-generator.rst:8
+msgid "Dataset (Prompt) Generation"
+msgstr "数据集（Prompt）生成"
+
+#: ../../source/features/benchmark-and-generator.rst:9
+msgid "Workload Generation"
+msgstr "工作负载生成"
+
+#: ../../source/features/benchmark-and-generator.rst:10
+msgid "Benchmark Client"
+msgstr "基准客户端"
+
+#: ../../source/features/benchmark-and-generator.rst:11
+msgid "Benchmark Scenarios (Work-in-progress)"
+msgstr "基准场景（开发中）"
+
+#: ../../source/features/benchmark-and-generator.rst:13
+msgid ""
+"The diagram below shows the end-to-end steps of AIBrix benchmarks. Our "
+"components are highlighted as green rectangles in this diagram."
+msgstr "下图展示 AIBrix 基准测试的端到端步骤。图中绿色矩形高亮的是我们的组件。"
+
+#: ../../source/features/benchmark-and-generator.rst:15
+msgid "benchmark-component-doc"
+msgstr "benchmark-component-doc"
+
+#: ../../source/features/benchmark-and-generator.rst:21
+msgid ""
+"At its core, the AIBrix benchmark framework is built around a cleanly "
+"decoupled architecture: dataset generation, workload shaping, and "
+"benchmark execution. Each component can be customized independently, "
+"making it easy to plug in your own prompt logs, traffic traces, or "
+"experimental workloads—whether you're working on a new model deployment, "
+"scaling policy, or runtime optimization."
+msgstr ""
+"AIBrix 基准框架的核心是清晰解耦的架构：数据集生成、工作负载整形和基准执行。"
+"每个组件可独立定制，便于接入你自己的 prompt 日志、流量追踪或实验工作负载——"
+"无论你在做新的模型部署、扩缩策略还是运行时优化。"
+
+#: ../../source/features/benchmark-and-generator.rst:24
+msgid "Run AIBrix Benchmark End-to-End"
+msgstr "端到端运行 AIBrix Benchmark"
+
+#: ../../source/features/benchmark-and-generator.rst:27
+msgid ""
+"The benchmark script `benchmark.py <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/benchmark.py>`_ performs all steps up"
+" to the AIBrix workload format and triggers the benchmark client without "
+"setting up the benchmark environment for different scenarios. It assumes "
+"that AIBrix is already set up and expects a fully responsive endpoint."
+msgstr ""
+"基准脚本 `benchmark.py <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/benchmark.py>`_ 执行直到 AIBrix "
+"工作负载格式的所有步骤，并触发基准客户端，而不会为不同场景搭建基准环境。"
+"它假定 AIBrix 已经就绪，并期望端点完全可响应。"
+
+#: ../../source/features/benchmark-and-generator.rst:29
+msgid ""
+"For detailed usage and how to configure parameters, please refer to this "
+"`README <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/README.md>`_ for explaination in "
+"depth."
+msgstr ""
+"详细用法和参数配置请参见该 `README <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/README.md>`_ 的深入说明。"
+
+#: ../../source/features/benchmark-and-generator.rst:31
+msgid ""
+"First, make sure you have configured your API key as well as your "
+"endpoint like this:"
+msgstr "首先，确保已按如下方式配置 API key 和端点："
+
+#: ../../source/features/benchmark-and-generator.rst:39
+msgid "To run all steps using the default setting, try:"
+msgstr "使用默认设置运行全部步骤，可尝试："
+
+#: ../../source/features/benchmark-and-generator.rst:46
+msgid ""
+"If the script completes successfully, you should see something similar to"
+" the following output:"
+msgstr "若脚本成功完成，应看到类似如下输出："
+
+#: ../../source/features/benchmark-and-generator.rst:68
+msgid ""
+"All configuration files should be specified in a .yaml file. You can find"
+" an example configuration file `here <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_."
+msgstr ""
+"所有配置文件应在 .yaml 文件中指定。示例配置文件见 `here <https://github.com/vllm-project/aibrix/blob/main/benchmarks/config.yaml>`_ "
+"。"
+
+#: ../../source/features/benchmark-and-generator.rst:70
+msgid ""
+"To override the default configuration, use the `--override` flag. For "
+"example, to override the target model and the number of sessions in the "
+"dataset generation phase, use:"
+msgstr ""
+"要覆盖默认配置，使用 `--override` 标志。例如，要覆盖数据集生成阶段的目标模型和会话数，使用："
+
+#: ../../source/features/benchmark-and-generator.rst:80
+msgid "Run Dataset Generator"
+msgstr "运行数据集生成器"
+
+#: ../../source/features/benchmark-and-generator.rst:82
+msgid "benchmark-component-dataset-generator"
+msgstr "benchmark-component-dataset-generator"
+
+#: ../../source/features/benchmark-and-generator.rst:87
+msgid ""
+"The goal of AIBrix's dataset generator is to generate a prompt dataset or"
+" convert an existing dataset to a format that can be sampled from by the "
+"workload generator. The AIBrix dataset generator generates synthetic "
+"prompts that follow certain application patterns (i.e., cache sharing) or"
+" converts time-series traces (e.g., Open-source LLM trace like ShareGPT) "
+"to a standard dataset format. A synthetic dataset needs to be in one of "
+"the two formats:"
+msgstr ""
+"AIBrix 数据集生成器的目标是生成 prompt 数据集，或将现有数据集转换为工作负载生成器可采样的格式。"
+"AIBrix 数据集生成器可生成遵循特定应用模式（即 cache sharing）的合成 prompt，"
+"或将时序追踪（例如 ShareGPT 这类开源 LLM trace）转换为标准数据集格式。"
+"合成数据集需要是以下两种格式之一："
+
+#: ../../source/features/benchmark-and-generator.rst:90
+msgid "Plain format (no sessions)"
+msgstr "普通格式（无会话）"
+
+#: ../../source/features/benchmark-and-generator.rst:98
+msgid "Session format"
+msgstr "会话格式"
+
+#: ../../source/features/benchmark-and-generator.rst:105
+msgid ""
+"The dataset generator either generates a prompt dataset or converts an "
+"existing dataset which belongs to one of the two formats above."
+msgstr "数据集生成器要么生成 prompt 数据集，要么将现有数据集转换为上述两种格式之一。"
+
+#: ../../source/features/benchmark-and-generator.rst:107
+msgid "To run dataset generation, do:"
+msgstr "运行数据集生成："
+
+#: ../../source/features/benchmark-and-generator.rst:114
+msgid "Currently, we support four types of datasets:"
+msgstr "目前支持四种数据集："
+
+#: ../../source/features/benchmark-and-generator.rst:116
+msgid ""
+"**1. Controlled Synthetic Sharing** - This type allows users to generate "
+"a cache sharing *plain-format* dataset with *controlled prompt token "
+"length* and *controlled prefix sharing length*, as well as a controlled "
+"number of prefixes (i.e., sessions). To tune the prompt token length and "
+"shared length, set configuration variables under "
+"```dataset_configs.synthetic_shared``` in the `configuration file "
+"<https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_."
+msgstr ""
+"**1. Controlled Synthetic Sharing** - 该类型允许用户生成 cache sharing 的 "
+"*plain-format* 数据集，具有 *受控的 prompt token 长度* 和 *受控的前缀共享长度*，"
+"以及受控的前缀数量（即会话数）。要调整 prompt token 长度和共享长度，"
+"请在 `configuration file <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_ 中的 "
+"```dataset_configs.synthetic_shared``` 下设置配置变量。"
+
+#: ../../source/features/benchmark-and-generator.rst:119
+msgid ""
+"**2. Multiturn Synthetic** - Multiturn synthetic data generation produces"
+" a *sessioned-format* dataset. Each session ID maps to a *controlled "
+"number of prompts* per session and *controlled prompt lengths*. These "
+"variables are under the ```dataset_configs.synthetic_multiturn``` in the "
+"`configuration file <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_."
+msgstr ""
+"**2. Multiturn Synthetic** - 多轮合成数据生成产生 *sessioned-format* 数据集。"
+"每个会话 ID 映射到每个会话 *受控的 prompt 数量* 和 *受控的 prompt 长度*。"
+"这些变量位于 `configuration file <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_ 中的 "
+"```dataset_configs.synthetic_multiturn``` 下。"
+
+#: ../../source/features/benchmark-and-generator.rst:122
+msgid ""
+"**3. ShareGPT** - This generation type converts the ShareGPT dataset to a"
+" *sessioned-format* dataset that has session_id, prompts, and "
+"completions. Configuration variables are under `dataset_configs.sharegpt`"
+" in the `configuration file <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_."
+msgstr ""
+"**3. ShareGPT** - 该生成类型将 ShareGPT 数据集转换为含 session_id、prompts 和 "
+"completions 的 *sessioned-format* 数据集。配置变量位于 `configuration file "
+"<https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_ 中的 "
+"`dataset_configs.sharegpt` 下。"
+
+#: ../../source/features/benchmark-and-generator.rst:125
+msgid ""
+"**4. Client trace** - This generation type converts client output into a "
+"*plain-format* dataset. Configuration variables are under the "
+"`dataset_configs.client_trace` in the `configuration file "
+"<https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_."
+msgstr ""
+"**4. Client trace** - 该生成类型将客户端输出转换为 *plain-format* 数据集。配置变量位于 "
+"`configuration file <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_ 中的 "
+"`dataset_configs.client_trace` 下。"
+
+#: ../../source/features/benchmark-and-generator.rst:128
+msgid ""
+"The first two types generate synthetic prompts, while the latter two "
+"convert external data sources or benchmark data."
+msgstr "前两种生成合成 prompt，后两种转换外部数据源或基准数据。"
+
+#: ../../source/features/benchmark-and-generator.rst:130
+msgid ""
+"To set the type of dataset to be generated, set the environment variable "
+"`prompt_type` in the configuration file to one of the following values: "
+"```synthetic_multiturn```, ```synthetic_shared```, ```sharegpt```, "
+"```client_trace```."
+msgstr ""
+"要设置生成的数据集类型，将配置文件中的环境变量 `prompt_type` 设为以下取值之一："
+"```synthetic_multiturn```、```synthetic_shared```、```sharegpt```、"
+"```client_trace```。"
+
+#: ../../source/features/benchmark-and-generator.rst:132
+msgid ""
+"For details of the dataset generator, check out the `dataset_generator "
+"<https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/generator/dataset_generator>`_ "
+"directory."
+msgstr ""
+"数据集生成器的细节见 `dataset_generator <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/generator/dataset_generator>`_ 目录。"
+
+#: ../../source/features/benchmark-and-generator.rst:135
+msgid "Run Workload Generator"
+msgstr "运行工作负载生成器"
+
+#: ../../source/features/benchmark-and-generator.rst:137
+#: ../../source/features/benchmark-and-generator.rst:199
+msgid "benchmark-component-workload-generator"
+msgstr "benchmark-component-workload-generator"
+
+#: ../../source/features/benchmark-and-generator.rst:143
+msgid ""
+"The goal of AIBrix's workload generator is to perform workload shaping. "
+"The workload generator specifies the timing and requests to be dispatched"
+" by the benchmark client. A workload generator accepts either "
+"trace/metrics files (where either time and requests are specified, or "
+"QPS/input/output volume are specified) or user-specified static or "
+"dynamic load patterns. The workload generator will sample the workload "
+"based on a dataset in one of the two formats discussed in the dataset "
+"generator section. There are four types of workloads the generator "
+"currently supports:"
+msgstr ""
+"AIBrix 工作负载生成器的目标是进行工作负载整形。工作负载生成器指定基准客户端要分发的时间和请求。"
+"工作负载生成器接受 trace/metrics 文件（指定时间和请求，或指定 QPS/输入/输出量），"
+"或用户指定的静态或动态负载模式。工作负载生成器会基于数据集生成器一节中讨论的两种格式之一采样工作负载。"
+"生成器目前支持四种工作负载："
+
+#: ../../source/features/benchmark-and-generator.rst:145
+msgid "**1. The \"constant\" and \"synthetic\" workload type**"
+msgstr "**1. \"constant\" 和 \"synthetic\" 工作负载类型**"
+
+#: ../../source/features/benchmark-and-generator.rst:147
+msgid ""
+"The workload generator can produce two types of *synthetic load "
+"patterns*, with multiple workload configurations that can be manually "
+"tuned (e.g., traffic/QPS distribution, input request token length "
+"distribution, output token length distribution, maximum concurrent "
+"sessions, etc.):"
+msgstr ""
+"工作负载生成器可产生两种 *合成负载模式*，并有多项可手动调整的工作负载配置"
+"（例如流量/QPS 分布、输入请求 token 长度分布、输出 token 长度分布、最大并发会话数等）："
+
+#: ../../source/features/benchmark-and-generator.rst:148
+msgid ""
+"Constant load (**constant**): The mean load (QPS/input length/output "
+"length) stays constant with controllable fluctuation. Configuration "
+"variables are under the `workload_configs.constant` in the `configuration"
+" file <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_."
+msgstr ""
+"恒定负载（**constant** ）：平均负载（QPS/输入长度/输出长度）保持恒定，波动可控。配置变量位于 `configuration file "
+"<https://github.com/vllm-project/aibrix/blob/main/benchmarks/config.yaml>`_ "
+"中的 `workload_configs.constant` 下。"
+
+#: ../../source/features/benchmark-and-generator.rst:149
+msgid ""
+"Synthetic fluctuation load (**synthetic**): The loads (QPS/input "
+"length/output length) fluctuate based on configurable parameters. "
+"Configuration variables are under the `workload_configs.synthetic` in the"
+" `configuration file <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_."
+msgstr ""
+"合成波动负载（**synthetic** ）：负载（QPS/输入长度/输出长度）根据可配置参数波动。配置变量位于 `configuration "
+"file <https://github.com/vllm-project/aibrix/blob/main/benchmarks/config.yaml>`_ "
+"中的 `workload_configs.synthetic` 下。"
+
+#: ../../source/features/benchmark-and-generator.rst:151
+msgid "**2. The \"stat\" workload type**"
+msgstr "**2. \"stat\" 工作负载类型**"
+
+#: ../../source/features/benchmark-and-generator.rst:153
+msgid ""
+"For *metrics files (e.g., .csv files exported from Grafana dashboard)*, "
+"the workload generator will generate the QPS/input length/output length "
+"distribution that follows the collected time-series metrics specified in "
+"the file. The actual prompts used in the workload will be based on one of"
+" the synthetic datasets generated by the previous section. Configuration "
+"variables are under the `workload_configs.stat` in the `configuration "
+"file <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_."
+msgstr ""
+"对 *指标文件（例如从 Grafana dashboard 导出的 .csv 文件）*，工作负载生成器会生成遵循文件中"
+"所指定采集时序指标的 QPS/输入长度/输出长度分布。工作负载中实际使用的 prompt 基于上一节生成的"
+"合成数据集之一。配置变量位于 `configuration file <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_ 中的 `workload_configs.stat` 下。"
+
+#: ../../source/features/benchmark-and-generator.rst:155
+msgid "**3. The \"azure\" workload type**"
+msgstr "**3. \"azure\" 工作负载类型**"
+
+#: ../../source/features/benchmark-and-generator.rst:157
+msgid ""
+"For a trace (e.g., `Azure LLM trace "
+"<https://github.com/Azure/AzurePublicDataset/blob/master/data/AzureLLMInferenceTrace_conv.csv>`_),"
+" both the requests and timestamps associated with the requests are "
+"provided, and the workload generator will generate a workload that simply"
+" replays requests based on the timestamp. Configuration variables are "
+"under the `workload_configs.azure` in the `configuration file "
+"<https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_."
+msgstr ""
+"对 trace（例如 `Azure LLM trace <https://github.com/Azure/AzurePublicDataset/blob/master/data/AzureLLMInferenceTrace_conv.csv>`_ "
+"），同时提供请求及其关联时间戳，工作负载生成器会生成按时间戳回放请求的工作负载。配置变量位于 `configuration file <https://github.com/vllm-project/aibrix/blob/main/benchmarks/config.yaml>`_ "
+"中的 `workload_configs.azure` 下。"
+
+#: ../../source/features/benchmark-and-generator.rst:159
+msgid "**4. The \"mooncake\" workload type**"
+msgstr "**4. \"mooncake\" 工作负载类型**"
+
+#: ../../source/features/benchmark-and-generator.rst:161
+msgid ""
+"For a `Mooncake LLM trace <https://github.com/kvcache-"
+"ai/Mooncake/tree/main/FAST25-release/traces>`_, the request input/output,"
+" the cache block ID along with timestamps associated with the requests "
+"are provided, and the workload generator will generate a workload that "
+"simulates requests following the same traffic pattern. Configuration "
+"variables are under the `workload_configs.mooncake` in the `configuration"
+" file <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_."
+msgstr ""
+"对 `Mooncake LLM trace <https://github.com/kvcache-ai/Mooncake/tree/main/FAST25-release/traces>`_ "
+"，提供请求输入/输出、cache block ID 以及请求关联时间戳，工作负载生成器会生成遵循相同流量模式的模拟请求工作负载。配置变量位于 `configuration "
+"file <https://github.com/vllm-project/aibrix/blob/main/benchmarks/config.yaml>`_ "
+"中的 `workload_configs.mooncake` 下。"
+
+#: ../../source/features/benchmark-and-generator.rst:163
+msgid "The workload generator can be run by:"
+msgstr "可通过如下方式运行工作负载生成器："
+
+#: ../../source/features/benchmark-and-generator.rst:169
+msgid ""
+"The workload generator will generate a workload file in the "
+"`output/workload` directory. The file will look like this:"
+msgstr "工作负载生成器会在 `output/workload` 目录生成工作负载文件。文件类似如下："
+
+#: ../../source/features/benchmark-and-generator.rst:192
+msgid ""
+"To choose a different workload type, set the environment variable "
+"`workload_type` in the configuration file to one of the following values:"
+" ```constant```, ```synthetic```, ```stat```, ```azure```, "
+"```mooncake```."
+msgstr ""
+"要选择不同的工作负载类型，将配置文件中的环境变量 `workload_type` 设为以下取值之一："
+"```constant```、```synthetic```、```stat```、```azure```、```mooncake```。"
+
+#: ../../source/features/benchmark-and-generator.rst:194
+msgid ""
+"For details of the workload generator, check out the `workload_generator "
+"<https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/generator/workload_generator>`_ "
+"directory."
+msgstr ""
+"工作负载生成器的细节见 `workload_generator <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/generator/workload_generator>`_ 目录。"
+
+#: ../../source/features/benchmark-and-generator.rst:197
+msgid "Run Benchmark Client"
+msgstr "运行基准客户端"
+
+#: ../../source/features/benchmark-and-generator.rst:204
+msgid ""
+"The benchmark client supports both batch and streaming modes. Streaming "
+"mode supports intra-request metrics like TTFT/TPOT. Configure the "
+"endpoint and target model via `config.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_ or command line "
+"arguments."
+msgstr ""
+"基准客户端支持批处理和流式两种模式。流式模式支持 TTFT/TPOT 等请求内指标。"
+"通过 `config.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_ 或命令行参数配置端点和目标模型。"
+
+#: ../../source/features/benchmark-and-generator.rst:206
+msgid "The benchmark client can be run using:"
+msgstr "可通过如下方式运行基准客户端："
+
+#: ../../source/features/benchmark-and-generator.rst:213
+msgid "Run Analysis"
+msgstr "运行分析"
+
+#: ../../source/features/benchmark-and-generator.rst:215
+msgid "Run analysis on the benchmark results using:"
+msgstr "使用如下方式对基准结果运行分析："
+
+#: ../../source/features/benchmark-and-generator.rst:221
+msgid ""
+"Configure the path and performance target via `config.yaml "
+"<https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_ or command line "
+"arguments."
+msgstr ""
+"通过 `config.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/benchmarks/config.yaml>`_ 或命令行参数配置路径和性能目标。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/brixbench.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/brixbench.po
@@ -1,0 +1,486 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/brixbench.rst:5
+msgid "Brixbench"
+msgstr "BrixBench"
+
+#: ../../source/features/brixbench.rst:7
+msgid ""
+"``brixbench`` is a Go test based benchmark harness for comparing AIBrix-"
+"routed serving paths with direct-engine baselines. It uses reproducible "
+"scenario YAML files, runs benchmark clients inside the target Kubernetes "
+"cluster, and stores shared result artifacts for later analysis."
+msgstr ""
+"``brixbench`` 是基于 Go test 的基准测试框架，用于比较 AIBrix 路由的推理路径与直连引擎基线。"
+"它使用可复现的场景 YAML 文件，在目标 Kubernetes 集群内运行基准客户端，并保存共享结果产物供后续分析。"
+
+#: ../../source/features/brixbench.rst:12
+msgid ""
+"Use ``brixbench`` when you want to compare AIBrix gateway behavior, "
+"routing configuration, release versions, source commits, or direct vLLM "
+"baselines under repeatable benchmark scenarios."
+msgstr "当你要在可重复的基准场景下比较 AIBrix 网关行为、路由配置、发行版本、源码 commit 或直连 vLLM 基线时，使用 ``brixbench`` 。"
+
+#: ../../source/features/brixbench.rst:16
+msgid ""
+"For the older Python benchmark, dataset generator, and workload "
+"generator, see :doc:`benchmark-and-generator`."
+msgstr "更早的 Python 基准、数据集生成器和工作负载生成器见 :doc:`benchmark-and-generator` 。"
+
+#: ../../source/features/brixbench.rst:21
+msgid "Requirements"
+msgstr "要求"
+
+#: ../../source/features/brixbench.rst:23
+msgid "Before running benchmarks, make sure the local environment has:"
+msgstr "运行基准测试前，请确保本地环境具备："
+
+#: ../../source/features/brixbench.rst:25
+msgid "Go 1.22 or newer."
+msgstr "Go 1.22 或更高版本。"
+
+#: ../../source/features/brixbench.rst:26
+msgid "``kubectl`` on ``PATH``."
+msgstr "``PATH`` 上有 ``kubectl`` 。"
+
+#: ../../source/features/brixbench.rst:27
+msgid ""
+"Access to the target Kubernetes cluster through the active kubeconfig "
+"context."
+msgstr "通过当前 kubeconfig context 访问目标 Kubernetes 集群。"
+
+#: ../../source/features/brixbench.rst:29
+msgid ""
+"Permission to create, update, list, watch, and delete resources in the "
+"benchmark namespace."
+msgstr "在基准命名空间中创建、更新、列出、监视和删除资源的权限。"
+
+#: ../../source/features/brixbench.rst:31
+msgid ""
+"Optional: ``uv``, ``.venv``, and ``matplotlib`` for comparison figure "
+"generation."
+msgstr "可选：用于生成对比图的 ``uv`` 、``.venv`` 和 ``matplotlib`` 。"
+
+#: ../../source/features/brixbench.rst:34
+msgid "Quick cluster preflight:"
+msgstr "集群快速预检："
+
+#: ../../source/features/brixbench.rst:45
+msgid "Core Concepts"
+msgstr "核心概念"
+
+#: ../../source/features/brixbench.rst:47
+msgid ""
+"Each benchmark run is driven by a scenario file under "
+"``brixbench/benchmark/testdata/scenarios/``. A scenario contains one or "
+"more test cases. Each test case wires together three kinds of inputs:"
+msgstr ""
+"每次基准运行由 ``brixbench/benchmark/testdata/scenarios/`` 下的场景文件驱动。"
+"一个场景包含一个或多个测试用例。每个测试用例组合三类输入："
+
+#: ../../source/features/brixbench.rst:51
+msgid ""
+"``engine.manifest``: Kubernetes workload manifest for the model serving "
+"path."
+msgstr "``engine.manifest`` ：模型推理路径的 Kubernetes 工作负载清单。"
+
+#: ../../source/features/brixbench.rst:53
+msgid "``benchmark``: request workload YAML consumed by the benchmark client."
+msgstr "``benchmark`` ：基准客户端消费的请求工作负载 YAML。"
+
+#: ../../source/features/brixbench.rst:54
+msgid ""
+"``gateway``: optional AIBrix gateway image, environment, or resource "
+"overrides."
+msgstr "``gateway`` ：可选的 AIBrix 网关镜像、环境或资源覆盖。"
+
+#: ../../source/features/brixbench.rst:57
+msgid ""
+"The runner deploys the selected serving path, waits for readiness, runs "
+"the benchmark client in the cluster, persists artifacts, and then tears "
+"down the run-scoped benchmark namespace."
+msgstr ""
+"运行器部署所选推理路径，等待就绪，在集群中运行基准客户端，持久化产物，然后拆除本次运行范围的基准命名空间。"
+
+#: ../../source/features/brixbench.rst:61
+msgid ""
+"By default, the runner resets the benchmark namespace before each test "
+"case and cleans it up after the case finishes. Set "
+"``BENCHMARK_RESET_BEFORE_TEST=false`` or pass ``-benchmark.reset=false`` "
+"to reuse the existing benchmark namespace at the start of a case. Set "
+"``BENCHMARK_CLEANUP_AFTER_TEST=false`` or pass "
+"``-benchmark.cleanup=false`` to leave resources in place after a test "
+"case finishes."
+msgstr ""
+"默认情况下，运行器在每个测试用例前重置基准命名空间，并在用例结束后清理。设置 ``BENCHMARK_RESET_BEFORE_TEST=false`` "
+"或传入 ``-benchmark.reset=false`` ，可在用例开始时复用现有基准命名空间。设置 ``BENCHMARK_CLEANUP_AFTER_TEST=false`` "
+"或传入 ``-benchmark.cleanup=false`` ，可在测试用例结束后保留资源。"
+
+#: ../../source/features/brixbench.rst:71
+msgid "Scenario Files"
+msgstr "场景文件"
+
+#: ../../source/features/brixbench.rst:73
+msgid ""
+"Scenario files define the benchmark cases to run and the deployment "
+"inputs for each case."
+msgstr "场景文件定义要运行的基准用例以及每个用例的部署输入。"
+
+#: ../../source/features/brixbench.rst:76
+msgid "Example:"
+msgstr "示例："
+
+#: ../../source/features/brixbench.rst:96
+msgid "Important scenario fields:"
+msgstr "重要的场景字段："
+
+#: ../../source/features/brixbench.rst:102
+msgid "Field"
+msgstr "字段"
+
+#: ../../source/features/brixbench.rst:103
+msgid "Meaning"
+msgstr "含义"
+
+#: ../../source/features/brixbench.rst:104
+msgid "``provider: aibrix``"
+msgstr "``provider: aibrix``"
+
+#: ../../source/features/brixbench.rst:105
+msgid "Use the AIBrix deployer."
+msgstr "使用 AIBrix 部署器。"
+
+#: ../../source/features/brixbench.rst:106
+msgid "``provider: null``"
+msgstr "``provider: null``"
+
+#: ../../source/features/brixbench.rst:107
+msgid "Use the plain vLLM direct baseline."
+msgstr "使用普通 vLLM 直连基线。"
+
+#: ../../source/features/brixbench.rst:108
+msgid "``fullstack: false``"
+msgstr "``fullstack: false``"
+
+#: ../../source/features/brixbench.rst:109
+msgid ""
+"Reuse an existing shared AIBrix control plane and update only run-scoped "
+"workloads and gateway overrides."
+msgstr "复用现有共享 AIBrix 控制面，仅更新本次运行范围的工作负载和网关覆盖。"
+
+#: ../../source/features/brixbench.rst:111
+msgid "``fullstack: true``"
+msgstr "``fullstack: true``"
+
+#: ../../source/features/brixbench.rst:112
+msgid ""
+"Reinstall the AIBrix control plane from the checked-out workspace and "
+"Helm chart."
+msgstr "从已检出的工作区和 Helm chart 重新安装 AIBrix 控制面。"
+
+#: ../../source/features/brixbench.rst:114
+msgid "``version``, ``commit``, or ``localPath``"
+msgstr "``version`` 、``commit`` 或 ``localPath``"
+
+#: ../../source/features/brixbench.rst:115
+msgid ""
+"Select the AIBrix release, source revision, or local source tree used by "
+"the test case."
+msgstr "选择测试用例使用的 AIBrix 发行版、源码修订或本地源码树。"
+
+#: ../../source/features/brixbench.rst:117
+msgid "``engine.type``"
+msgstr "``engine.type``"
+
+#: ../../source/features/brixbench.rst:118
+msgid "Serving engine type. The supported benchmark paths currently use ``vllm``."
+msgstr "推理引擎类型。当前支持的基准路径使用 ``vllm`` 。"
+
+#: ../../source/features/brixbench.rst:120
+msgid "``engine.manifest``"
+msgstr "``engine.manifest``"
+
+#: ../../source/features/brixbench.rst:121
+msgid "Kubernetes model deployment manifest."
+msgstr "Kubernetes 模型部署清单。"
+
+#: ../../source/features/brixbench.rst:122
+msgid "``benchmark``"
+msgstr "``benchmark``"
+
+#: ../../source/features/brixbench.rst:123
+msgid "Request workload configuration consumed by the benchmark client."
+msgstr "基准客户端消费的请求工作负载配置。"
+
+#: ../../source/features/brixbench.rst:127
+msgid "Benchmark Workload Config"
+msgstr "基准工作负载配置"
+
+#: ../../source/features/brixbench.rst:129
+msgid ""
+"The ``benchmark`` field points to request-side workload YAML. This is "
+"where RPS, concurrency, arrival rate, dataset shape, and routing-specific"
+" benchmark settings live. It is separate from ``engine.manifest``, which "
+"only describes how to deploy the model workload."
+msgstr ""
+"``benchmark`` 字段指向请求侧工作负载 YAML。RPS、并发、到达率、数据集形态以及路由相关基准设置都在这里。"
+"它与 ``engine.manifest`` 分开，后者只描述如何部署模型工作负载。"
+
+#: ../../source/features/brixbench.rst:134
+msgid "Example benchmark config:"
+msgstr "基准配置示例："
+
+#: ../../source/features/brixbench.rst:167
+msgid "Key request-side fields:"
+msgstr "关键请求侧字段："
+
+#: ../../source/features/brixbench.rst:169
+msgid ""
+"``base-url``: gateway or direct service endpoint used by the benchmark "
+"client. The runner can override this with the resolved serving endpoint "
+"at runtime."
+msgstr "``base-url`` ：基准客户端使用的网关或直连服务端点。运行器可在运行时用解析后的推理端点覆盖该值。"
+
+#: ../../source/features/brixbench.rst:172
+msgid ""
+"``endpoint``: OpenAI-compatible API path, such as "
+"``/v1/chat/completions``."
+msgstr "``endpoint`` ：兼容 OpenAI 的 API 路径，例如 ``/v1/chat/completions`` 。"
+
+#: ../../source/features/brixbench.rst:174
+msgid "``model``: served model name sent in benchmark requests."
+msgstr "``model`` ：基准请求中发送的已服务模型名称。"
+
+#: ../../source/features/brixbench.rst:175
+msgid "``num-prompts``: total number of benchmark requests."
+msgstr "``num-prompts`` ：基准请求总数。"
+
+#: ../../source/features/brixbench.rst:176
+msgid ""
+"``request-rate``: target request arrival rate used by ``vllm bench "
+"serve``."
+msgstr "``request-rate`` ：``vllm bench serve`` 使用的目标请求到达率。"
+
+#: ../../source/features/brixbench.rst:178
+msgid "``concurrency``: maximum in-flight request concurrency."
+msgstr "``concurrency`` ：最大在途请求并发。"
+
+#: ../../source/features/brixbench.rst:179
+msgid ""
+"``dataset-name``: workload generator, such as ``random`` or "
+"``prefix_repetition``."
+msgstr "``dataset-name`` ：工作负载生成器，例如 ``random`` 或 ``prefix_repetition`` 。"
+
+#: ../../source/features/brixbench.rst:181
+msgid ""
+"``goodput``: optional latency SLO expression used by ``vllm bench`` "
+"reporting."
+msgstr "``goodput`` ：可选的延迟 SLO 表达式，供 ``vllm bench`` 报告使用。"
+
+#: ../../source/features/brixbench.rst:183
+msgid ""
+"``routing-strategy``: optional routing label for routing-specific "
+"benchmark cases."
+msgstr "``routing-strategy`` ：可选的路由标签，用于路由相关基准用例。"
+
+#: ../../source/features/brixbench.rst:185
+msgid ""
+"``prefix-repetition-*``: prefix-repetition dataset shape for shared-"
+"prefix workload tests."
+msgstr "``prefix-repetition-*`` ：共享前缀工作负载测试用的 prefix-repetition 数据集形态。"
+
+#: ../../source/features/brixbench.rst:188
+msgid "Existing request workload examples:"
+msgstr "现有请求工作负载示例："
+
+#: ../../source/features/brixbench.rst:190
+msgid "``brixbench/benchmark/testdata/benchmarks/vllm-chat-smoke.yaml``"
+msgstr "``brixbench/benchmark/testdata/benchmarks/vllm-chat-smoke.yaml``"
+
+#: ../../source/features/brixbench.rst:191
+msgid "``brixbench/benchmark/testdata/benchmarks/vllm-chat-smoke-pd.yaml``"
+msgstr "``brixbench/benchmark/testdata/benchmarks/vllm-chat-smoke-pd.yaml``"
+
+#: ../../source/features/brixbench.rst:192
+msgid "``brixbench/benchmark/testdata/benchmarks/routing/*.yaml``"
+msgstr "``brixbench/benchmark/testdata/benchmarks/routing/*.yaml``"
+
+#: ../../source/features/brixbench.rst:196
+msgid "Running Benchmarks"
+msgstr "运行基准测试"
+
+#: ../../source/features/brixbench.rst:198
+msgid "Run from the ``brixbench/`` directory."
+msgstr "从 ``brixbench/`` 目录运行。"
+
+#: ../../source/features/brixbench.rst:200
+msgid "Run the scenario selected by ``BENCHMARK_SCENARIO``:"
+msgstr "运行 ``BENCHMARK_SCENARIO`` 所选场景："
+
+#: ../../source/features/brixbench.rst:207
+msgid "Run one scenario directly:"
+msgstr "直接运行一个场景："
+
+#: ../../source/features/brixbench.rst:214
+msgid "Keep resources after the run for inspection:"
+msgstr "运行后保留资源以便检查："
+
+#: ../../source/features/brixbench.rst:222
+msgid "Reuse existing benchmark namespace resources and keep them after the run:"
+msgstr "复用现有基准命名空间资源，并在运行后保留："
+
+#: ../../source/features/brixbench.rst:230
+msgid "Run a single test case:"
+msgstr "运行单个测试用例："
+
+#: ../../source/features/brixbench.rst:240
+msgid "Deployment Inputs"
+msgstr "部署输入"
+
+#: ../../source/features/brixbench.rst:242
+msgid "For ``provider: aibrix``, the runner supports these source modes:"
+msgstr "对 ``provider: aibrix`` ，运行器支持以下源模式："
+
+#: ../../source/features/brixbench.rst:244
+msgid "``version``: download release artifacts on demand into ``.tmp/releases/``."
+msgstr "``version`` ：按需将发行产物下载到 ``.tmp/releases/`` 。"
+
+#: ../../source/features/brixbench.rst:245
+msgid ""
+"``commit``: check out the requested AIBrix source revision and use the "
+"workspace chart and overlays."
+msgstr "``commit`` ：检出请求的 AIBrix 源码修订，并使用工作区 chart 和 overlays。"
+
+#: ../../source/features/brixbench.rst:247
+msgid ""
+"``localPath``: stage a local AIBrix source tree and use its workspace "
+"chart and overlays."
+msgstr "``localPath`` ：暂存本地 AIBrix 源码树，并使用其工作区 chart 和 overlays。"
+
+#: ../../source/features/brixbench.rst:250
+msgid ""
+"The benchmark suite should not check in large generated AIBrix core or "
+"dependency manifests. Version-based runs should use downloaded release "
+"artifacts, and source-based runs should use the checked-out workspace and"
+" Helm chart path."
+msgstr ""
+"基准套件不应提交大型生成的 AIBrix 核心或依赖清单。基于版本的运行应使用下载的发行产物，"
+"基于源码的运行应使用已检出的工作区和 Helm chart 路径。"
+
+#: ../../source/features/brixbench.rst:257
+msgid "Metrics Export"
+msgstr "指标导出"
+
+#: ../../source/features/brixbench.rst:259
+msgid "Metrics export is disabled by default."
+msgstr "指标导出默认关闭。"
+
+#: ../../source/features/brixbench.rst:261
+msgid ""
+"Without ``BENCHMARK_PUSHGATEWAY_URL``, the runner skips external metric "
+"export."
+msgstr "未设置 ``BENCHMARK_PUSHGATEWAY_URL`` 时，运行器跳过外部指标导出。"
+
+#: ../../source/features/brixbench.rst:263
+msgid ""
+"With ``BENCHMARK_PUSHGATEWAY_URL``, the runner enables the Pushgateway "
+"exporter."
+msgstr "设置 ``BENCHMARK_PUSHGATEWAY_URL`` 时，运行器启用 Pushgateway 导出器。"
+
+#: ../../source/features/brixbench.rst:265
+msgid ""
+"The current Pushgateway exporter returns an explicit not-implemented "
+"error until real export behavior is implemented."
+msgstr "当前 Pushgateway 导出器在真正的导出行为实现之前会返回明确的未实现错误。"
+
+#: ../../source/features/brixbench.rst:270
+msgid "Artifacts"
+msgstr "产物"
+
+#: ../../source/features/brixbench.rst:272
+msgid "Run artifacts are written under:"
+msgstr "运行产物写入："
+
+#: ../../source/features/brixbench.rst:278
+msgid "Typical artifacts include:"
+msgstr "典型产物包括："
+
+#: ../../source/features/brixbench.rst:280
+msgid "``metadata.json``"
+msgstr "``metadata.json``"
+
+#: ../../source/features/brixbench.rst:281
+msgid "``summary.json``"
+msgstr "``summary.json``"
+
+#: ../../source/features/brixbench.rst:282
+msgid "``summary.csv``"
+msgstr "``summary.csv``"
+
+#: ../../source/features/brixbench.rst:283
+msgid "per-case ``bench_results.json``"
+msgstr "每个用例的 ``bench_results.json``"
+
+#: ../../source/features/brixbench.rst:284
+msgid "per-case ``vllm-bench-client.log``"
+msgstr "每个用例的 ``vllm-bench-client.log``"
+
+#: ../../source/features/brixbench.rst:285
+msgid "per-case ``vllm-bench-pod.yaml``"
+msgstr "每个用例的 ``vllm-bench-pod.yaml``"
+
+#: ../../source/features/brixbench.rst:286
+msgid "optional comparison figures under ``figures/``"
+msgstr "``figures/`` 下可选的对比图"
+
+#: ../../source/features/brixbench.rst:290
+msgid "Optional Figure Generation"
+msgstr "可选图表生成"
+
+#: ../../source/features/brixbench.rst:292
+msgid ""
+"If ``brixbench/.venv/bin/python`` and ``matplotlib`` are available, the "
+"Go runner generates figures automatically after writing the scenario "
+"summary."
+msgstr ""
+"若 ``brixbench/.venv/bin/python`` 和 ``matplotlib`` 可用，Go 运行器在写入场景摘要后会自动生成图表。"
+
+#: ../../source/features/brixbench.rst:295
+msgid "Manual setup:"
+msgstr "手动设置："
+
+#: ../../source/features/brixbench.rst:303
+msgid "Manual regeneration:"
+msgstr "手动重新生成："
+
+#: ../../source/features/brixbench.rst:312
+msgid "Troubleshooting"
+msgstr "故障排查"
+
+#: ../../source/features/brixbench.rst:314
+msgid "If a run stalls before benchmark execution, check pending model pods:"
+msgstr "若运行在基准执行前卡住，检查处于 pending 的模型 pods："
+
+#: ../../source/features/brixbench.rst:321
+msgid ""
+"Common causes include insufficient GPU capacity or a missing shared "
+"AIBrix control plane when using ``fullstack: false``."
+msgstr "常见原因包括 GPU 容量不足，或使用 ``fullstack: false`` 时缺少共享 AIBrix 控制面。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/gateway-plugins.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/gateway-plugins.po
@@ -1,0 +1,1317 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/gateway-plugins.rst:5
+msgid "Gateway Routing"
+msgstr "网关路由"
+
+#: ../../source/features/gateway-plugins.rst:7
+msgid ""
+"The AIBrix gateway is built on Envoy Gateway and acts as the single entry"
+" point for all LLM inference requests. It handles dynamic model "
+"discovery, request routing, rate limiting, and response streaming. For a "
+"deep dive into the internal design, see the `AIBrix Router <../designs"
+"/aibrix-router.html>`_ architecture guide."
+msgstr ""
+"AIBrix 网关基于 Envoy Gateway 构建，是所有 LLM 推理请求的统一入口。它负责动态模型发现、请求路由、限流和响应流式传输。内部设计详见 `AIBrix Router <../designs/aibrix-router.html>`_ 架构指南。"
+
+#: ../../source/features/gateway-plugins.rst:10
+msgid "Dynamic Routing"
+msgstr "动态路由"
+
+#: ../../source/features/gateway-plugins.rst:12
+msgid ""
+"When a model or LoRA adapter is deployed, the respective controller "
+"automatically creates an ``HTTPRoute`` object. The gateway dynamically "
+"discovers these routes to forward incoming requests without any manual "
+"configuration."
+msgstr ""
+"部署模型或 LoRA adapter 时，对应 controller 会自动创建 ``HTTPRoute`` 对象。网关动态发现这些路由并转发入站请求，无需手工配置。"
+
+#: ../../source/features/gateway-plugins.rst:14
+msgid "First, retrieve the external IP and port of the Envoy proxy:"
+msgstr "首先获取 Envoy 代理的外部 IP 和端口："
+
+#: ../../source/features/gateway-plugins.rst:22
+msgid ""
+"In most Kubernetes setups, ``LoadBalancer`` is supported by default. "
+"Capture the external IP:"
+msgstr "多数 Kubernetes 环境默认支持 ``LoadBalancer`` 。获取外部 IP："
+
+#: ../../source/features/gateway-plugins.rst:29
+msgid ""
+"Verify that the ``HTTPRoute`` status is ``Accepted`` before sending "
+"traffic:"
+msgstr "发送流量前确认 ``HTTPRoute`` 状态为 ``Accepted`` ："
+
+#: ../../source/features/gateway-plugins.rst:100
+msgid ""
+"As of v0.5.0, each model's ``HTTPRoute`` is created with a default set of"
+" path prefixes (e.g. ``/v1/chat/completions``, ``/v1/completions``). To "
+"expose additional custom paths, add the ``model.aibrix.ai/model-router-"
+"custom-paths`` annotation to your ``Deployment``, ``ModelAdapter``, or "
+"``RayClusterFleet`` manifest:"
+msgstr ""
+"自 v0.5.0 起，每个模型的 ``HTTPRoute`` 会带一组默认路径前缀（例如 ``/v1/chat/completions`` 、``/v1/completions`` "
+"）。要暴露额外自定义路径，在 ``Deployment`` 、``ModelAdapter`` 或 ``RayClusterFleet`` 清单上添加 "
+"``model.aibrix.ai/model-router-custom-paths`` annotation："
+
+#: ../../source/features/gateway-plugins.rst:115
+msgid ""
+"The model name in the request body must match the "
+"``model.aibrix.ai/name`` label in your deployment:"
+msgstr "请求体中的模型名必须与 Deployment 中的 ``model.aibrix.ai/name`` 标签一致："
+
+#: ../../source/features/gateway-plugins.rst:129
+msgid ""
+"AIBrix exposes a public endpoint to the internet. Enable authentication "
+"to secure it. For vLLM backends, pass the ``--api-key`` argument or set "
+"the ``VLLM_API_KEY`` environment variable to require an API key in the "
+"``Authorization`` header. See `vLLM OpenAI-Compatible Server "
+"<https://docs.vllm.ai/en/latest/getting_started/quickstart.html#openai-"
+"compatible-server>`_ for details."
+msgstr ""
+"AIBrix 会向公网暴露端点。请启用认证以保护它。对 vLLM 后端，传入 ``--api-key`` 参数或设置 ``VLLM_API_KEY`` "
+"环境变量，以要求 ``Authorization`` 请求头中带 API key。详见 `vLLM OpenAI-Compatible Server "
+"<https://docs.vllm.ai/en/latest/getting_started/quickstart.html#openai-compatible-server>`_ "
+"。"
+
+#: ../../source/features/gateway-plugins.rst:133
+msgid ""
+"After enabling authentication, include the ``Authorization`` header in "
+"every request:"
+msgstr "启用认证后，每个请求都要带 ``Authorization`` 请求头："
+
+#: ../../source/features/gateway-plugins.rst:148
+msgid "Routing Strategies"
+msgstr "路由策略"
+
+#: ../../source/features/gateway-plugins.rst:150
+msgid ""
+"The routing strategy controls how the gateway selects the target pod for "
+"each request. It can be set per-request via the ``routing-strategy`` "
+"header, or globally via the ``ROUTING_ALGORITHM`` environment variable."
+msgstr ""
+"路由策略控制网关如何为每个请求选择目标 Pod。可通过 ``routing-strategy`` 请求头按请求设置，或通过 ``ROUTING_ALGORITHM`` 环境变量全局设置。"
+
+#: ../../source/features/gateway-plugins.rst:152
+msgid ""
+"Some strategies rely on metrics queried from the Prometheus HTTP API "
+"(PromQL). See `Prometheus API Access <../production/observability.html"
+"#prometheus-api-access>`_ for configuration."
+msgstr ""
+"部分策略依赖从 Prometheus HTTP API（PromQL）查询的指标。配置见 `Prometheus API Access <../production/observability.html#prometheus-api-access>`_ "
+"。"
+
+#: ../../source/features/gateway-plugins.rst:155
+msgid "General load balancing"
+msgstr "通用负载均衡"
+
+#: ../../source/features/gateway-plugins.rst:157
+msgid ""
+"``random``: routes to a randomly selected pod. Suitable as a baseline or "
+"when all pods are equivalent."
+msgstr "``random`` ：路由到随机选取的 Pod。适合作为基线，或所有 Pod 等价时使用。"
+
+#: ../../source/features/gateway-plugins.rst:158
+msgid "``least-request``: routes to the pod with the fewest in-flight requests."
+msgstr "``least-request`` ：路由到正在处理请求数最少的 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:159
+msgid ""
+"``least-busy-time``: routes to the pod with the least cumulative busy "
+"processing time."
+msgstr "``least-busy-time`` ：路由到累计繁忙处理时间最短的 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:160
+msgid ""
+"``least-latency``: routes to the pod with the lowest average processing "
+"latency."
+msgstr "``least-latency`` ：路由到平均处理延迟最低的 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:161
+msgid ""
+"``least-kv-cache``: routes to the pod with the smallest KV cache "
+"occupancy (least VRAM used)."
+msgstr "``least-kv-cache`` ：路由到 KV cache 占用最小（VRAM 使用最少）的 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:162
+msgid ""
+"``least-gpu-cache``: routes to the pod with the lowest GPU cache "
+"utilization."
+msgstr "``least-gpu-cache`` ：路由到 GPU cache 利用率最低的 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:163
+msgid ""
+"``least-utilization``: routes to the pod with the lowest overall "
+"utilization score."
+msgstr "``least-utilization`` ：路由到综合利用率分数最低的 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:164
+msgid ""
+"``load-balance``: capacity-aware weighted least-request routing. Scores "
+"each pod as ``running_requests / drain_rate`` (pending time), where "
+"``drain_rate`` is the observed request completion rate. Selects the pod "
+"with the lowest pending time, breaking ties using least combined GPU+CPU "
+"KV-cache usage (falling back to a random pick if cache metrics are "
+"unavailable for the tied pods). Falls back to uniform capacity "
+"(``drain_rate = 1``) when metrics are unavailable. Its load-imbalance "
+"gate, which restricts candidates to the least-loaded pods when load is "
+"severely skewed, is applied centrally by the gateway ahead of whichever "
+"strategy actually routes each request — not just when ``load-balance`` "
+"itself is selected (see ``pkg/plugins/gateway/ENV_VARS.md``)."
+msgstr ""
+"``load-balance`` ：容量感知的加权 least-request 路由。按 ``running_requests / drain_rate`` "
+"（pending time）为每个 Pod 打分，其中 ``drain_rate`` 是观测到的请求完成速率。选择 pending time 最低的 "
+"Pod；并列时取 GPU+CPU KV-cache 合计占用最小者（若并列 Pod 缺少 cache 指标则随机选取）。指标不可用时回退为均匀容量（``drain_rate "
+"= 1`` ）。其负载不均衡门控会在负载严重倾斜时将候选限制为负载最低的 Pod；该门控由网关在实际执行任一路由策略之前集中应用，并非仅在选择 "
+"``load-balance`` 时生效（见 ``pkg/plugins/gateway/ENV_VARS.md`` ）。"
+
+#: ../../source/features/gateway-plugins.rst:165
+msgid ""
+"``throughput``: routes to the pod that has processed the fewest total "
+"weighted tokens, favoring underloaded pods."
+msgstr "``throughput`` ：路由到已处理加权 token 总数最少的 Pod，偏向负载较低的 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:166
+msgid ""
+"``power-of-two``: applies power-of-two-choices — randomly samples two "
+"pods and selects the better one."
+msgstr "``power-of-two`` ：采用 power-of-two-choices——随机抽取两个 Pod 并选择更优者。"
+
+#: ../../source/features/gateway-plugins.rst:169
+msgid "KV-cache aware"
+msgstr "KV-cache 感知"
+
+#: ../../source/features/gateway-plugins.rst:171
+msgid ""
+"``prefix-cache``: routes to a pod that already holds a KV cache matching "
+"the request's prompt prefix, selecting the best prefix-matched pod within"
+" a configurable stddev threshold. Purely about prefix caching — it does "
+"not itself gate on cluster-wide load imbalance (the gateway applies that "
+"gate centrally ahead of it; see ``load-balance`` above). Supports two "
+"modes: standard (local hash table) and KV sync (real-time distributed "
+"index via ``AIBRIX_PREFIX_CACHE_KV_EVENT_SYNC_ENABLED=true``)."
+msgstr ""
+"``prefix-cache`` ：路由到已持有与请求 prompt 前缀匹配的 KV cache 的 Pod，在可配置的标准差阈值内选择前缀匹配最好的 "
+"Pod。仅关注前缀缓存——自身不做集群级负载不均衡门控（网关在其之前集中应用该门控；见上文 ``load-balance`` ）。支持两种模式：标准（本地哈希表）和 "
+"KV sync（通过 ``AIBRIX_PREFIX_CACHE_KV_EVENT_SYNC_ENABLED=true`` 使用实时分布式索引）。"
+
+#: ../../source/features/gateway-plugins.rst:172
+msgid ""
+"``prefix-cache-preble``: routes considering both prefix cache hits and "
+"pod load, based on `Preble: Efficient Distributed Prompt Scheduling for "
+"LLM Serving <https://arxiv.org/abs/2407.00023>`_."
+msgstr ""
+"``prefix-cache-preble`` ：同时考虑 prefix cache 命中和 Pod 负载进行路由，基于 `Preble: Efficient "
+"Distributed Prompt Scheduling for LLM Serving <https://arxiv.org/abs/2407.00023>`_ "
+"。"
+
+#: ../../source/features/gateway-plugins.rst:175
+msgid "Fairness"
+msgstr "公平性"
+
+#: ../../source/features/gateway-plugins.rst:177
+msgid ""
+"``vtc-basic``: routes using a hybrid score that balances per-user token "
+"fairness and pod utilization. A simplified variant of the Virtual Token "
+"Counter (VTC) algorithm. See `VTC-artifact <https://github.com/Ying1123"
+"/VTC-artifact>`_ for background."
+msgstr ""
+"``vtc-basic`` ：使用混合分数路由，在每用户 token 公平性与 Pod 利用率之间平衡。是 Virtual Token Counter（VTC）算法的简化变体。背景见 "
+"`VTC-artifact <https://github.com/Ying1123/VTC-artifact>`_ 。"
+
+#: ../../source/features/gateway-plugins.rst:180
+msgid "SLO-aware"
+msgstr "SLO 感知"
+
+#: ../../source/features/gateway-plugins.rst:182
+msgid "``slo``: routes with awareness of per-request service-level objectives."
+msgstr "``slo`` ：按每请求的服务水平目标进行路由。"
+
+#: ../../source/features/gateway-plugins.rst:183
+msgid ""
+"``slo-pack-load``: SLO-aware routing that consolidates load onto fewer "
+"pods."
+msgstr "``slo-pack-load`` ：SLO 感知路由，将负载集中到更少的 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:184
+msgid ""
+"``slo-least-load``: SLO-aware routing that spreads load to the least "
+"loaded pod."
+msgstr "``slo-least-load`` ：SLO 感知路由，将负载分散到负载最低的 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:185
+msgid ""
+"``slo-least-load-pulling``: variant of ``slo-least-load`` that pulls "
+"metrics directly instead of using cached snapshots."
+msgstr "``slo-least-load-pulling`` ：``slo-least-load`` 的变体，直接拉取指标而非使用缓存快照。"
+
+#: ../../source/features/gateway-plugins.rst:188
+msgid "Specialized"
+msgstr "专用策略"
+
+#: ../../source/features/gateway-plugins.rst:190
+msgid ""
+"``pd``: prefill-decode disaggregation routing. Splits processing between "
+"dedicated prefill pods and decode pods for optimized end-to-end latency."
+msgstr "``pd`` ：prefill-decode 分离路由。将处理拆分到专用 prefill Pod 和 decode Pod，以优化端到端延迟。"
+
+#: ../../source/features/gateway-plugins.rst:203
+msgid ""
+"``session-affinity``: sticky session routing. Encodes the target pod's "
+"address (``IP:Port``) as a base64 value in the ``x-session-id`` response "
+"header. Subsequent requests that include this header are routed to the "
+"same pod. If that pod is no longer available, the gateway transparently "
+"fails over to a new pod and issues a fresh session ID."
+msgstr ""
+"``session-affinity`` ：粘性会话路由。将目标 Pod 地址（``IP:Port`` ）编码为 base64，写入 ``x-session-id`` "
+"响应头。后续带该请求头的请求路由到同一 Pod。若该 Pod 不可用，网关透明故障转移到新 Pod 并签发新的 session ID。"
+
+#: ../../source/features/gateway-plugins.rst:205
+msgid "How it works:"
+msgstr "工作方式："
+
+#: ../../source/features/gateway-plugins.rst:207
+msgid ""
+"On the first request (no ``x-session-id``), the gateway picks a ready pod"
+" and returns an ``x-session-id`` response header."
+msgstr "首次请求（无 ``x-session-id`` ）时，网关选择一个就绪 Pod，并返回 ``x-session-id`` 响应头。"
+
+#: ../../source/features/gateway-plugins.rst:208
+msgid ""
+"The client stores and resends this header on follow-up requests (e.g., in"
+" multi-turn conversations)."
+msgstr "客户端保存该请求头，并在后续请求中回传（例如多轮对话）。"
+
+#: ../../source/features/gateway-plugins.rst:209
+msgid ""
+"The gateway decodes the session ID to recover the original pod address "
+"and routes to it."
+msgstr "网关解码 session ID，还原原始 Pod 地址并路由到该 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:210
+msgid ""
+"If the pod is unavailable (scaled down or evicted), it falls over to a "
+"new pod and issues a new session ID."
+msgstr "若 Pod 不可用（缩容或被驱逐），则故障转移到新 Pod 并签发新的 session ID。"
+
+#: ../../source/features/gateway-plugins.rst:213
+msgid ""
+"``x-session-id`` encodes only network location. It is not a security "
+"token and must not be used for authentication or authorization."
+msgstr "``x-session-id`` 仅编码网络位置。它不是安全令牌，不得用于认证或授权。"
+
+#: ../../source/features/gateway-plugins.rst:215
+msgid ""
+"Callers can instead send a stable, opaque ``x-aibrix-session-key`` value."
+" The gateway consistently maps that value to a ready pod without exposing"
+" a backend address. The key is only used when ``routing-strategy`` is "
+"``session-affinity`` and must not be used for authentication or "
+"authorization."
+msgstr ""
+"调用方也可改发稳定、不透明的 ``x-aibrix-session-key`` 。网关将该值一致地映射到就绪 Pod，且不暴露后端地址。该 key "
+"仅在 ``routing-strategy`` 为 ``session-affinity`` 时使用，不得用于认证或授权。"
+
+#: ../../source/features/gateway-plugins.rst:229
+msgid "Auto-blended capacity awareness"
+msgstr "自动混合的容量感知"
+
+#: ../../source/features/gateway-plugins.rst:231
+msgid ""
+"This auto-blend is **enabled by default** — no opt-in is required. Every "
+"strategy above, except the exclusive ones (``pd``, ``slo``/``slo-*``) and"
+" an explicit standalone ``load-balance`` selection, silently gets ``load-"
+"balance``'s capacity-aware scoring blended in behind the scenes — and "
+"``least-request`` too, when the selected strategy doesn't already route "
+"by request count, to keep multi-port/data-parallel pod routing working "
+"under the blend. The caller never sees this: ``ctx.Algorithm``, response "
+"headers, and ``Validate()`` all still reflect exactly the strategy that "
+"was requested. This keeps any single strategy from steering traffic at an"
+" already-hot pod even outside the load-imbalance gate described above. "
+"Both blend weights default to ``1`` (see "
+"``pkg/plugins/gateway/ENV_VARS.md``); set "
+"``AIBRIX_ROUTING_AUTO_BLEND_LOAD_BALANCE_WEIGHT=0`` to disable it."
+msgstr ""
+"该自动混合**默认启用** ，无需显式开启。除互斥策略（``pd`` 、``slo``/``slo-*`` ）以及显式单独选择 ``load-balance`` "
+"外，上述每种策略都会在后台静默混入 ``load-balance`` 的容量感知打分；当所选策略本身不按请求数路由时，还会混入 ``least-request`` "
+"，以保证混合后多端口/数据并行 Pod 路由仍可用。调用方看不到这一点：``ctx.Algorithm`` 、响应头和 ``Validate()`` "
+"仍精确反映所请求的策略。这样即使不在上文所述负载不均衡门控范围内，任一策略也不会把流量导向已经过热的 Pod。两个混合权重默认均为 ``1`` "
+"（见 ``pkg/plugins/gateway/ENV_VARS.md`` ）；设置 ``AIBRIX_ROUTING_AUTO_BLEND_LOAD_BALANCE_WEIGHT=0`` "
+"可关闭。"
+
+#: ../../source/features/gateway-plugins.rst:242
+msgid ""
+"To override the strategy for a single request, pass the ``routing-"
+"strategy`` header with any of the values above:"
+msgstr "要覆盖单次请求的策略，传入 ``routing-strategy`` 请求头，值为上述任一策略："
+
+#: ../../source/features/gateway-plugins.rst:257
+msgid "Rate Limiting"
+msgstr "限流"
+
+#: ../../source/features/gateway-plugins.rst:259
+msgid ""
+"The gateway supports per-user rate limiting on requests per minute (RPM) "
+"and tokens per minute (TPM). Pass the ``user`` header with a unique "
+"identifier to enable rate-limit enforcement for that client."
+msgstr ""
+"网关支持按用户的每分钟请求数（RPM）和每分钟 token 数（TPM）限流。传入带唯一标识的 ``user`` 请求头，即可对该客户端启用限流。"
+
+#: ../../source/features/gateway-plugins.rst:261
+msgid ""
+"For details on managing users, see the `User Management documentation "
+"<https://github.com/vllm-"
+"project/aibrix/blob/main/pkg/metadata/README.md>`_."
+msgstr ""
+"用户管理详见 `User Management documentation <https://github.com/vllm-project/aibrix/blob/main/pkg/metadata/README.md>`_ "
+"。"
+
+#: ../../source/features/gateway-plugins.rst:276
+msgid "If rate limiting is not needed, the ``user`` header can be omitted."
+msgstr "若不需要限流，可省略 ``user`` 请求头。"
+
+#: ../../source/features/gateway-plugins.rst:280
+msgid "External Filter"
+msgstr "外部过滤器"
+
+#: ../../source/features/gateway-plugins.rst:282
+msgid ""
+"The ``external-filter`` header restricts the candidate pod pool using "
+"Kubernetes label selector syntax before the routing strategy makes its "
+"final selection. It is evaluated before routing and only takes effect "
+"when a ``routing-strategy`` is also set."
+msgstr ""
+"``external-filter`` 请求头在路由策略最终选择前，用 Kubernetes 标签选择器语法限制候选 Pod 池。在路由之前求值，且仅在同时设置了 ``routing-strategy`` 时生效。"
+
+#: ../../source/features/gateway-plugins.rst:284
+msgid "Supported selector forms:"
+msgstr "支持的选择器形式："
+
+#: ../../source/features/gateway-plugins.rst:286
+msgid "``key=value``"
+msgstr "``key=value``"
+
+#: ../../source/features/gateway-plugins.rst:287
+msgid "``key in (a, b)``"
+msgstr "``key in (a, b)``"
+
+#: ../../source/features/gateway-plugins.rst:288
+msgid "``key!=value``"
+msgstr "``key!=value``"
+
+#: ../../source/features/gateway-plugins.rst:289
+msgid "comma-separated list of selectors"
+msgstr "逗号分隔的选择器列表"
+
+#: ../../source/features/gateway-plugins.rst:291
+msgid ""
+"See the `Kubernetes label selector reference "
+"<https://kubernetes.io/docs/concepts/overview/working-with-"
+"objects/labels/>`_ for the full syntax."
+msgstr ""
+"完整语法见 `Kubernetes label selector reference <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/>`_ "
+"。"
+
+#: ../../source/features/gateway-plugins.rst:308
+msgid ""
+"Filtering happens **before** the routing strategy and does not change "
+"which pod the strategy considers optimal."
+msgstr "过滤发生在路由策略**之前** ，不会改变策略认为最优的 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:309
+msgid "``external-filter`` only takes effect when ``routing-strategy`` is set."
+msgstr "``external-filter`` 仅在设置了 ``routing-strategy`` 时生效。"
+
+#: ../../source/features/gateway-plugins.rst:310
+msgid ""
+"It further narrows down the pods already selected by "
+"``model.aibrix.ai/name``."
+msgstr "它会进一步缩小已由 ``model.aibrix.ai/name`` 选出的 Pod 范围。"
+
+#: ../../source/features/gateway-plugins.rst:311
+msgid ""
+"If the filter eliminates all pods, the request fails with ``no ready pods"
+" for routing``."
+msgstr "若过滤器排除了全部 Pod，请求失败并返回 ``no ready pods for routing`` 。"
+
+#: ../../source/features/gateway-plugins.rst:312
+msgid ""
+"``external-filter`` is optional. When omitted, no extra filtering is "
+"applied."
+msgstr "``external-filter`` 是可选的。省略时不做额外过滤。"
+
+#: ../../source/features/gateway-plugins.rst:316
+msgid "Headers Reference"
+msgstr "请求头参考"
+
+#: ../../source/features/gateway-plugins.rst:318
+msgid ""
+"This section describes the custom headers used in request processing for "
+"routing, debugging, and rate limiting."
+msgstr "本节说明请求处理中用于路由、调试和限流的自定义请求头。"
+
+#: ../../source/features/gateway-plugins.rst:321
+msgid "Target and General Headers"
+msgstr "目标与通用请求头"
+
+#: ../../source/features/gateway-plugins.rst:327
+#: ../../source/features/gateway-plugins.rst:380
+#: ../../source/features/gateway-plugins.rst:407
+#: ../../source/features/gateway-plugins.rst:424
+msgid "Header Name"
+msgstr "请求头名称"
+
+#: ../../source/features/gateway-plugins.rst:328
+msgid "Direction"
+msgstr "方向"
+
+#: ../../source/features/gateway-plugins.rst:329
+#: ../../source/features/gateway-plugins.rst:381
+#: ../../source/features/gateway-plugins.rst:408
+#: ../../source/features/gateway-plugins.rst:425
+#: ../../source/features/gateway-plugins.rst:665
+#: ../../source/features/gateway-plugins.rst:680
+#: ../../source/features/gateway-plugins.rst:718
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/features/gateway-plugins.rst:330
+msgid "``request-id``"
+msgstr "``request-id``"
+
+#: ../../source/features/gateway-plugins.rst:331
+#: ../../source/features/gateway-plugins.rst:340
+#: ../../source/features/gateway-plugins.rst:355
+#: ../../source/features/gateway-plugins.rst:367
+#: ../../source/features/gateway-plugins.rst:370
+msgid "Response"
+msgstr "响应"
+
+#: ../../source/features/gateway-plugins.rst:332
+msgid ""
+"Unique request ID associated with the client request. Useful for "
+"correlating logs."
+msgstr "与客户端请求关联的唯一请求 ID。用于关联日志。"
+
+#: ../../source/features/gateway-plugins.rst:333
+msgid "``x-went-into-req-headers``"
+msgstr "``x-went-into-req-headers``"
+
+#: ../../source/features/gateway-plugins.rst:334
+#: ../../source/features/gateway-plugins.rst:337
+msgid "Backend request, Response"
+msgstr "后端请求、响应"
+
+#: ../../source/features/gateway-plugins.rst:335
+msgid ""
+"Indicates whether request headers were processed correctly. Used for "
+"debugging header parsing issues."
+msgstr "指示请求头是否被正确处理。用于调试请求头解析问题。"
+
+#: ../../source/features/gateway-plugins.rst:336
+msgid "``target-pod``"
+msgstr "``target-pod``"
+
+#: ../../source/features/gateway-plugins.rst:338
+msgid ""
+"Identifies the destination selected by the routing algorithm: the backend"
+" request receives its ``IP:port`` address, while the response reports its"
+" pod name."
+msgstr "标识路由算法选出的目标：后端请求收到其 ``IP:port`` 地址，响应中报告其 Pod 名称。"
+
+#: ../../source/features/gateway-plugins.rst:339
+msgid "``target-pod-ip``"
+msgstr "``target-pod-ip``"
+
+#: ../../source/features/gateway-plugins.rst:341
+msgid ""
+"``IP:port`` address of the destination pod selected by the routing "
+"algorithm."
+msgstr "路由算法选出的目标 Pod 的 ``IP:port`` 地址。"
+
+#: ../../source/features/gateway-plugins.rst:342
+msgid "``routing-strategy``"
+msgstr "``routing-strategy``"
+
+#: ../../source/features/gateway-plugins.rst:343
+msgid "Request, Backend request, Response"
+msgstr "请求、后端请求、响应"
+
+#: ../../source/features/gateway-plugins.rst:344
+msgid ""
+"Selects the routing strategy for the request, forwards the applied "
+"strategy to the backend, and reports it in the response."
+msgstr "选择该请求的路由策略，将实际应用的策略转发到后端，并在响应中报告。"
+
+#: ../../source/features/gateway-plugins.rst:345
+msgid "``external-filter``"
+msgstr "``external-filter``"
+
+#: ../../source/features/gateway-plugins.rst:346
+#: ../../source/features/gateway-plugins.rst:352
+#: ../../source/features/gateway-plugins.rst:361
+msgid "Request"
+msgstr "请求"
+
+#: ../../source/features/gateway-plugins.rst:347
+msgid ""
+"Label selector expression used to further filter candidate pods before "
+"routing."
+msgstr "路由前用于进一步过滤候选 Pod 的标签选择器表达式。"
+
+#: ../../source/features/gateway-plugins.rst:348
+msgid "``model``"
+msgstr "``model``"
+
+#: ../../source/features/gateway-plugins.rst:349
+msgid "Backend request"
+msgstr "后端请求"
+
+#: ../../source/features/gateway-plugins.rst:350
+msgid ""
+"Model name injected into the backend request when no explicit routing "
+"strategy is selected."
+msgstr "未显式选择路由策略时注入到后端请求的模型名。"
+
+#: ../../source/features/gateway-plugins.rst:351
+msgid "``config-profile``"
+msgstr "``config-profile``"
+
+#: ../../source/features/gateway-plugins.rst:353
+msgid "Selects a model configuration profile for the request."
+msgstr "为该请求选择模型配置 profile。"
+
+#: ../../source/features/gateway-plugins.rst:354
+msgid "``x-aibrix-config-profile``"
+msgstr "``x-aibrix-config-profile``"
+
+#: ../../source/features/gateway-plugins.rst:356
+msgid "Reports the concrete profile selected when ``config-profile`` is ``auto``."
+msgstr "当 ``config-profile`` 为 ``auto`` 时，报告实际选中的具体 profile。"
+
+#: ../../source/features/gateway-plugins.rst:357
+msgid "``x-session-id``"
+msgstr "``x-session-id``"
+
+#: ../../source/features/gateway-plugins.rst:358
+msgid "Request, Response"
+msgstr "请求、响应"
+
+#: ../../source/features/gateway-plugins.rst:359
+msgid ""
+"Session identifier used by ``session-affinity`` routing. The response "
+"value should be sent on subsequent requests to retain affinity."
+msgstr "``session-affinity`` 路由使用的会话标识。应在后续请求中回传响应值以保持亲和性。"
+
+#: ../../source/features/gateway-plugins.rst:360
+msgid "``x-aibrix-session-key``"
+msgstr "``x-aibrix-session-key``"
+
+#: ../../source/features/gateway-plugins.rst:362
+msgid ""
+"Caller-owned opaque session key used by ``session-affinity`` routing and,"
+" under ``pd`` routing with the ``token_load`` or ``hybrid_cache_load`` "
+"prefill policy, to charge a multi-turn conversation only for its new "
+"tokens."
+msgstr ""
+"调用方持有的不透明会话 key，用于 ``session-affinity`` 路由；在 ``pd`` 路由且 prefill 策略为 ``token_load`` 或 ``hybrid_cache_load`` 时，用于使多轮对话仅计费新增 token。"
+
+#: ../../source/features/gateway-plugins.rst:363
+msgid "``traceparent``"
+msgstr "``traceparent``"
+
+#: ../../source/features/gateway-plugins.rst:364
+msgid "Request, Backend request"
+msgstr "请求、后端请求"
+
+#: ../../source/features/gateway-plugins.rst:365
+msgid ""
+"W3C Trace Context propagated through requests initiated by the gateway, "
+"including prefill-decode routing."
+msgstr "网关发起的请求中传播的 W3C Trace Context，包括 prefill-decode 路由。"
+
+#: ../../source/features/gateway-plugins.rst:366
+msgid "``prefill-target-pod``"
+msgstr "``prefill-target-pod``"
+
+#: ../../source/features/gateway-plugins.rst:368
+msgid "Name of the prefill pod selected by ``pd`` routing."
+msgstr "``pd`` 路由选出的 prefill Pod 名称。"
+
+#: ../../source/features/gateway-plugins.rst:369
+msgid "``prefill-target-pod-ip``"
+msgstr "``prefill-target-pod-ip``"
+
+#: ../../source/features/gateway-plugins.rst:371
+msgid "IP address of the prefill pod selected by ``pd`` routing."
+msgstr "``pd`` 路由选出的 prefill Pod 的 IP 地址。"
+
+#: ../../source/features/gateway-plugins.rst:374
+msgid "Routing and Error Debugging Headers"
+msgstr "路由与错误调试请求头"
+
+#: ../../source/features/gateway-plugins.rst:382
+msgid "``x-error-user``"
+msgstr "``x-error-user``"
+
+#: ../../source/features/gateway-plugins.rst:383
+msgid "Identifies errors caused by incorrect user input."
+msgstr "标识由错误用户输入引起的错误。"
+
+#: ../../source/features/gateway-plugins.rst:384
+msgid "``x-error-routing``"
+msgstr "``x-error-routing``"
+
+#: ../../source/features/gateway-plugins.rst:385
+msgid "Indicates a routing failure, such as being unable to select a target pod."
+msgstr "表示路由失败，例如无法选择目标 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:386
+msgid "``x-error-response-unmarshal``"
+msgstr "``x-error-response-unmarshal``"
+
+#: ../../source/features/gateway-plugins.rst:387
+msgid ""
+"Signals that the response body could not be parsed, typically due to an "
+"internal error."
+msgstr "表示响应体无法解析，通常由内部错误引起。"
+
+#: ../../source/features/gateway-plugins.rst:388
+msgid "``x-error-response-unknown``"
+msgstr "``x-error-response-unknown``"
+
+#: ../../source/features/gateway-plugins.rst:389
+msgid "Generic error header when no specific cause is identified."
+msgstr "未识别到具体原因时的通用错误请求头。"
+
+#: ../../source/features/gateway-plugins.rst:390
+msgid "``x-error-request-body-processing``"
+msgstr "``x-error-request-body-processing``"
+
+#: ../../source/features/gateway-plugins.rst:391
+msgid "Marks a request body parsing failure, such as invalid JSON."
+msgstr "标记请求体解析失败，例如无效 JSON。"
+
+#: ../../source/features/gateway-plugins.rst:392
+msgid "``x-error-no-model-in-request``"
+msgstr "``x-error-no-model-in-request``"
+
+#: ../../source/features/gateway-plugins.rst:393
+msgid "Indicates that no model was specified in the request."
+msgstr "表示请求中未指定模型。"
+
+#: ../../source/features/gateway-plugins.rst:394
+msgid "``x-error-no-model-backends``"
+msgstr "``x-error-no-model-backends``"
+
+#: ../../source/features/gateway-plugins.rst:395
+msgid "Indicates that the requested model exists but has no active backend pods."
+msgstr "表示请求的模型存在，但没有活跃的后端 Pod。"
+
+#: ../../source/features/gateway-plugins.rst:396
+msgid "``x-error-invalid-routing-strategy``"
+msgstr "``x-error-invalid-routing-strategy``"
+
+#: ../../source/features/gateway-plugins.rst:397
+msgid "Indicates that an unsupported routing strategy was specified."
+msgstr "表示指定了不支持的路由策略。"
+
+#: ../../source/features/gateway-plugins.rst:401
+msgid "Streaming Headers"
+msgstr "流式请求头"
+
+#: ../../source/features/gateway-plugins.rst:409
+msgid "``x-error-streaming``"
+msgstr "``x-error-streaming``"
+
+#: ../../source/features/gateway-plugins.rst:410
+msgid "Signals an error during response streaming."
+msgstr "表示响应流式传输过程中出错。"
+
+#: ../../source/features/gateway-plugins.rst:411
+msgid "``x-error-stream``"
+msgstr "``x-error-stream``"
+
+#: ../../source/features/gateway-plugins.rst:412
+msgid "Indicates an incorrect ``stream`` value in the request body."
+msgstr "表示请求体中的 ``stream`` 值不正确。"
+
+#: ../../source/features/gateway-plugins.rst:413
+msgid "``x-error-no-stream-options-include-usage``"
+msgstr "``x-error-no-stream-options-include-usage``"
+
+#: ../../source/features/gateway-plugins.rst:414
+msgid ""
+"Indicates whether usage statistics were included in the streaming "
+"response."
+msgstr "表示流式响应中是否包含用量统计。"
+
+#: ../../source/features/gateway-plugins.rst:418
+msgid "Rate Limiting Headers"
+msgstr "限流请求头"
+
+#: ../../source/features/gateway-plugins.rst:426
+msgid "``x-update-rpm``"
+msgstr "``x-update-rpm``"
+
+#: ../../source/features/gateway-plugins.rst:427
+msgid "Indicates the RPM (requests per minute) counter was updated successfully."
+msgstr "表示 RPM（每分钟请求数）计数器更新成功。"
+
+#: ../../source/features/gateway-plugins.rst:428
+msgid "``x-update-tpm``"
+msgstr "``x-update-tpm``"
+
+#: ../../source/features/gateway-plugins.rst:429
+msgid "Indicates the TPM (tokens per minute) counter was updated successfully."
+msgstr "表示 TPM（每分钟 token 数）计数器更新成功。"
+
+#: ../../source/features/gateway-plugins.rst:430
+msgid "``x-error-rpm-exceeded``"
+msgstr "``x-error-rpm-exceeded``"
+
+#: ../../source/features/gateway-plugins.rst:431
+msgid "Signals that the request exceeded the allowed RPM limit."
+msgstr "表示请求超出允许的 RPM 限制。"
+
+#: ../../source/features/gateway-plugins.rst:432
+msgid "``x-error-tpm-exceeded``"
+msgstr "``x-error-tpm-exceeded``"
+
+#: ../../source/features/gateway-plugins.rst:433
+msgid "Signals that the request exceeded the allowed TPM limit."
+msgstr "表示请求超出允许的 TPM 限制。"
+
+#: ../../source/features/gateway-plugins.rst:434
+msgid "``x-error-incr-rpm``"
+msgstr "``x-error-incr-rpm``"
+
+#: ../../source/features/gateway-plugins.rst:435
+msgid "Error encountered while incrementing the RPM counter."
+msgstr "递增 RPM 计数器时出错。"
+
+#: ../../source/features/gateway-plugins.rst:436
+msgid "``x-error-incr-tpm``"
+msgstr "``x-error-incr-tpm``"
+
+#: ../../source/features/gateway-plugins.rst:437
+msgid "Error encountered while incrementing the TPM counter."
+msgstr "递增 TPM 计数器时出错。"
+
+#: ../../source/features/gateway-plugins.rst:440
+msgid "Debugging Guidelines"
+msgstr "调试指南"
+
+#: ../../source/features/gateway-plugins.rst:442
+msgid ""
+"**Identify error headers** — inspect ``x-error-routing``, ``x-error-"
+"user``, ``x-error-response-unmarshal``, and ``x-error-response-unknown`` "
+"to locate the root cause. For request body issues, check ``x-error-"
+"request-body-processing`` and ``x-error-no-model-in-request``."
+msgstr ""
+"**识别错误请求头** — 检查 ``x-error-routing`` 、``x-error-user`` 、``x-error-response-unmarshal`` "
+"和 ``x-error-response-unknown`` 以定位根因。请求体问题请检查 ``x-error-request-body-processing`` "
+"和 ``x-error-no-model-in-request`` 。"
+
+#: ../../source/features/gateway-plugins.rst:444
+msgid ""
+"**Verify routing and model assignment** — confirm ``target-pod`` is set. "
+"If ``x-error-no-model-in-request`` or ``x-error-no-model-backends`` "
+"appears, verify the request body includes a valid model name and that the"
+" model has active backend pods. If ``x-error-invalid-routing-strategy`` "
+"is present, confirm the strategy name is supported."
+msgstr ""
+"**验证路由与模型分配** — 确认已设置 ``target-pod`` 。若出现 ``x-error-no-model-in-request`` "
+"或 ``x-error-no-model-backends`` ，请确认请求体包含有效模型名且该模型有活跃后端 Pod。若出现 ``x-error-invalid-routing-strategy`` "
+"，请确认策略名受支持。"
+
+#: ../../source/features/gateway-plugins.rst:446
+msgid ""
+"**Diagnose streaming issues** — check ``x-error-streaming`` and ``x"
+"-error-stream``. If usage statistics are missing from a streaming "
+"response, inspect ``x-error-no-stream-options-include-usage``."
+msgstr ""
+"**诊断流式问题** — 检查 ``x-error-streaming`` 和 ``x-error-stream`` 。若流式响应缺少用量统计，检查 "
+"``x-error-no-stream-options-include-usage`` 。"
+
+#: ../../source/features/gateway-plugins.rst:448
+msgid ""
+"**Investigate rate limiting** — if a request was rejected, check ``x"
+"-error-rpm-exceeded`` or ``x-error-tpm-exceeded``. If counters failed to "
+"update, look for ``x-error-incr-rpm`` or ``x-error-incr-tpm``. Successful"
+" updates are indicated by ``x-update-rpm`` and ``x-update-tpm``."
+msgstr ""
+"**排查限流** — 若请求被拒绝，检查 ``x-error-rpm-exceeded`` 或 ``x-error-tpm-exceeded`` "
+"。若计数器更新失败，查看 ``x-error-incr-rpm`` 或 ``x-error-incr-tpm`` 。更新成功由 ``x-update-rpm`` "
+"和 ``x-update-tpm`` 表示。"
+
+#: ../../source/features/gateway-plugins.rst:450
+msgid "Verify that all gateway objects have ``status.conditions == Accepted``:"
+msgstr "确认所有网关对象的 ``status.conditions == Accepted`` ："
+
+#: ../../source/features/gateway-plugins.rst:466
+msgid ""
+"Collect logs from the Envoy proxy and the gateway plugin for deeper "
+"investigation:"
+msgstr "收集 Envoy 代理和网关插件的日志以便深入排查："
+
+#: ../../source/features/gateway-plugins.rst:495
+msgid "Observability & Telemetry"
+msgstr "可观测性与遥测"
+
+#: ../../source/features/gateway-plugins.rst:497
+msgid ""
+"The gateway plugins feature built-in support for distributed tracing "
+"using OpenTelemetry (OTel). This allows you to trace end-to-end request "
+"lifecycles across the external processing pipeline."
+msgstr ""
+"网关插件内置基于 OpenTelemetry（OTel）的分布式追踪，可追踪外部处理流水线中的端到端请求生命周期。"
+
+#: ../../source/features/gateway-plugins.rst:499
+msgid ""
+"Tracing is strictly opt-in by default to conserve system resources. To "
+"enable the telemetry components, you need to complete the following two "
+"steps:"
+msgstr "追踪默认严格按需开启以节省系统资源。要启用遥测组件，需完成以下两步："
+
+#: ../../source/features/gateway-plugins.rst:502
+msgid "Step 1: Enable OpenTelemetry in EnvoyProxy"
+msgstr "步骤 1：在 EnvoyProxy 中启用 OpenTelemetry"
+
+#: ../../source/features/gateway-plugins.rst:504
+msgid ""
+"Enable ``openTelemetry.enable`` in your helm chart or add the telemetry "
+"configuration directly to your ``EnvoyProxy`` resource."
+msgstr "在 Helm chart 中启用 ``openTelemetry.enable`` ，或直接在 ``EnvoyProxy`` 资源中添加遥测配置。"
+
+#: ../../source/features/gateway-plugins.rst:527
+msgid "Step 2: Configure the OTLP Exporter Endpoint"
+msgstr "步骤 2：配置 OTLP Exporter 端点"
+
+#: ../../source/features/gateway-plugins.rst:529
+msgid ""
+"Next, you must explicitly configure an OTLP exporter endpoint in your "
+"environment. You can enable it by setting either the global endpoint or "
+"the traces-specific endpoint."
+msgstr "接下来必须在环境中显式配置 OTLP exporter 端点。可设置全局端点或 traces 专用端点来启用。"
+
+#: ../../source/features/gateway-plugins.rst:531
+msgid ""
+"For example, if you are running a cluster local OTel Collector, inject "
+"the following environment variables:"
+msgstr "例如，若在集群内运行 OTel Collector，注入以下环境变量："
+
+#: ../../source/features/gateway-plugins.rst:562
+msgid "**Advanced Configuration**"
+msgstr "**高级配置**"
+
+#: ../../source/features/gateway-plugins.rst:564
+msgid ""
+"For a comprehensive list of supported telemetry configurations—including "
+"sampling rates, TLS options and custom headers, please refer to the full "
+"configuration guide in: `pkg/plugins/gateway/ENV_VARS.md`"
+msgstr ""
+"支持的遥测配置完整列表（含采样率、TLS 选项和自定义请求头）见：`pkg/plugins/gateway/ENV_VARS.md`"
+
+#: ../../source/features/gateway-plugins.rst:570
+msgid "Config Profiles"
+msgstr "配置 Profile"
+
+#: ../../source/features/gateway-plugins.rst:572
+msgid ""
+"A **config profile** lets you embed routing settings directly in a "
+"model's pod annotation, so every request to that model picks up the right"
+" configuration automatically. You can define multiple named profiles in "
+"one annotation and switch between them per-request with a single header."
+msgstr ""
+"**config profile** 可将路由设置直接嵌入模型 Pod 的 annotation，使发往该模型的每个请求自动获得正确配置。可在一条 annotation 中定义多个命名 profile，并通过单个请求头按请求切换。"
+
+#: ../../source/features/gateway-plugins.rst:574
+msgid "**Setting up a profile**"
+msgstr "**设置 profile**"
+
+#: ../../source/features/gateway-plugins.rst:576
+msgid ""
+"Add the ``model.aibrix.ai/config`` annotation to the pod template of your"
+" ``Deployment``, ``StormService``, or ``RayClusterFleet``:"
+msgstr ""
+"在 ``Deployment`` 、``StormService`` 或 ``RayClusterFleet`` 的 Pod 模板上添加 ``model.aibrix.ai/config`` "
+"annotation："
+
+#: ../../source/features/gateway-plugins.rst:612
+msgid ""
+"Optionally pin a single routing strategy model-wide so it cannot be "
+"overridden at request time (see Routing strategy priority below). "
+"``lockedRoutingStrategy`` only locks the strategy: the remaining per-"
+"profile knobs (``requestsPerSecond``, ``routingConfig``) still follow the"
+" profile selected by ``config-profile``:"
+msgstr ""
+"也可在模型范围固定单一路由策略，使其无法在请求时被覆盖（见下文路由策略优先级）。``lockedRoutingStrategy`` 只锁定策略：其余按 "
+"profile 生效的项（``requestsPerSecond`` 、``routingConfig`` ）仍遵循 ``config-profile`` "
+"选出的 profile："
+
+#: ../../source/features/gateway-plugins.rst:635
+msgid "**Selecting a profile at request time**"
+msgstr "**在请求时选择 profile**"
+
+#: ../../source/features/gateway-plugins.rst:637
+msgid "Two request headers drive the config at request time:"
+msgstr "请求时由两个请求头驱动配置："
+
+#: ../../source/features/gateway-plugins.rst:639
+msgid ""
+"``config-profile`` selects a named profile; when absent, "
+"``defaultProfile`` (or ``\"default\"``) is used. ``config-profile: auto``"
+" asks the gateway to select a concrete profile from request-local hints "
+"in each profile's ``routingConfig``."
+msgstr ""
+"``config-profile`` 选择命名 profile；缺省时使用 ``defaultProfile`` （或 ``\"default\"`` "
+"）。``config-profile: auto`` 让网关根据各 profile 的 ``routingConfig`` 中的请求级提示选择具体 "
+"profile。"
+
+#: ../../source/features/gateway-plugins.rst:640
+msgid ""
+"``routing-strategy`` overrides the selected profile's "
+"``routingStrategy``, unless ``lockedRoutingStrategy`` is set (see Routing"
+" strategy priority below)."
+msgstr ""
+"``routing-strategy`` 覆盖所选 profile 的 ``routingStrategy`` ，除非设置了 ``lockedRoutingStrategy`` "
+"（见下文路由策略优先级）。"
+
+#: ../../source/features/gateway-plugins.rst:658
+msgid "**Top-level fields**"
+msgstr "**顶层字段**"
+
+#: ../../source/features/gateway-plugins.rst:664
+#: ../../source/features/gateway-plugins.rst:679
+msgid "Field"
+msgstr "字段"
+
+#: ../../source/features/gateway-plugins.rst:666
+msgid "``lockedRoutingStrategy``"
+msgstr "``lockedRoutingStrategy``"
+
+#: ../../source/features/gateway-plugins.rst:667
+msgid ""
+"Pins a single routing strategy model-wide. When set, it takes precedence "
+"over the ``routing-strategy`` header, the per-profile ``routingStrategy``"
+" and the ``ROUTING_ALGORITHM`` env. The remaining per-profile knobs "
+"(``requestsPerSecond``, ``routingConfig``) are still applied normally."
+msgstr ""
+"在模型范围固定单一路由策略。设置后优先于 ``routing-strategy`` 请求头、按 profile 的 ``routingStrategy`` "
+"以及 ``ROUTING_ALGORITHM`` 环境变量。其余按 profile 生效的项（``requestsPerSecond`` 、``routingConfig`` "
+"）仍正常应用。"
+
+#: ../../source/features/gateway-plugins.rst:668
+msgid "``defaultProfile``"
+msgstr "``defaultProfile``"
+
+#: ../../source/features/gateway-plugins.rst:669
+msgid ""
+"Profile name used when no ``config-profile`` header is sent. Falls back "
+"to ``\"default\"`` when omitted."
+msgstr "未发送 ``config-profile`` 请求头时使用的 profile 名。省略时回退到 ``\"default\"`` 。"
+
+#: ../../source/features/gateway-plugins.rst:670
+msgid "``profiles``"
+msgstr "``profiles``"
+
+#: ../../source/features/gateway-plugins.rst:671
+msgid "Map of named profiles, each carrying the per-profile fields below."
+msgstr "命名 profile 的映射，每个包含下方按 profile 的字段。"
+
+#: ../../source/features/gateway-plugins.rst:673
+msgid "**Profile fields**"
+msgstr "**Profile 字段**"
+
+#: ../../source/features/gateway-plugins.rst:681
+msgid "``routingStrategy``"
+msgstr "``routingStrategy``"
+
+#: ../../source/features/gateway-plugins.rst:682
+msgid ""
+"The routing algorithm for this profile (e.g. ``least-latency``, ``prefix-"
+"cache``, ``pd``). See the Routing Strategies section above for the full "
+"list."
+msgstr "该 profile 的路由算法（例如 ``least-latency`` 、``prefix-cache`` 、``pd`` ）。完整列表见上文路由策略一节。"
+
+#: ../../source/features/gateway-plugins.rst:683
+msgid "``requestsPerSecond``"
+msgstr "``requestsPerSecond``"
+
+#: ../../source/features/gateway-plugins.rst:684
+msgid ""
+"Model-level RPS cap for this profile. Requests that exceed the limit are "
+"rejected with HTTP 429. Omit or set to ``0`` for no limit. See "
+"`Production Model Deployments <../production/model-deployment.html>`_ for"
+" details."
+msgstr ""
+"该 profile 的模型级 RPS 上限。超出限制的请求以 HTTP 429 拒绝。省略或设为 ``0`` 表示不限。详见 `Production "
+"Model Deployments <../production/model-deployment.html>`_ 。"
+
+#: ../../source/features/gateway-plugins.rst:685
+msgid "``routingConfig``"
+msgstr "``routingConfig``"
+
+#: ../../source/features/gateway-plugins.rst:686
+msgid ""
+"Algorithm-specific settings as a nested JSON object. ``config-profile: "
+"auto`` also reads request-local selection hints from this object. "
+"Currently supported auto-selection hints are ``promptTokensGte``, "
+"``promptTokensLt``, ``maxTokensGte`` and ``maxTokensLt``. Existing "
+"strategy-specific fields, such as ``promptLenBucketMinLength`` for "
+"``pd``, remain available. See `Prefill-Decode Disaggregation <pd-"
+"disaggregation.html>`_ for details."
+msgstr ""
+"算法相关设置，嵌套 JSON 对象。``config-profile: auto`` 也会从该对象读取请求级选择提示。当前支持的自动选择提示为 "
+"``promptTokensGte`` 、``promptTokensLt`` 、``maxTokensGte`` 和 ``maxTokensLt`` "
+"。已有的策略专用字段（例如 ``pd`` 的 ``promptLenBucketMinLength`` ）仍可用。详见 `Prefill-Decode "
+"Disaggregation <pd-disaggregation.html>`_ 。"
+
+#: ../../source/features/gateway-plugins.rst:688
+msgid ""
+"When ``config-profile: auto`` is used, the gateway evaluates the "
+"supported request-local hints inside each profile's ``routingConfig``. A "
+"profile matches only when all of its supported hints match the request. "
+"If no profile matches, the gateway uses ``defaultProfile`` (or "
+"``\"default\"``). ``promptTokens*`` uses the gateway's existing prompt "
+"text extraction and local token estimation. ``maxTokens*`` reads "
+"``max_tokens`` first, then ``max_completion_tokens`` when ``max_tokens`` "
+"is absent."
+msgstr ""
+"使用 ``config-profile: auto`` 时，网关评估每个 profile 的 ``routingConfig`` 中受支持的请求级提示。仅当该 "
+"profile 的全部受支持提示都匹配请求时才匹配。若无 profile 匹配，网关使用 ``defaultProfile`` （或 ``\"default\"`` "
+"）。``promptTokens*`` 使用网关已有的 prompt 文本提取和本地 token 估算。``maxTokens*`` 先读 ``max_tokens`` "
+"，缺省时再读 ``max_completion_tokens`` 。"
+
+#: ../../source/features/gateway-plugins.rst:696
+msgid "**Routing strategy priority** (highest to lowest):"
+msgstr "**路由策略优先级** （从高到低）："
+
+#: ../../source/features/gateway-plugins.rst:698
+msgid ""
+"``lockedRoutingStrategy`` pinned model-wide in the config — always wins "
+"when set, even over the ``routing-strategy`` header."
+msgstr "配置中模型范围固定的 ``lockedRoutingStrategy`` — 设置后始终优先，即使覆盖 ``routing-strategy`` 请求头。"
+
+#: ../../source/features/gateway-plugins.rst:699
+msgid "``routing-strategy`` request header."
+msgstr "``routing-strategy`` 请求头。"
+
+#: ../../source/features/gateway-plugins.rst:700
+msgid ""
+"``routingStrategy`` from the resolved profile. The resolved profile comes"
+" from the concrete ``config-profile`` header, ``config-profile: auto`` "
+"routingConfig hints, or ``defaultProfile``."
+msgstr ""
+"解析后 profile 中的 ``routingStrategy`` 。解析来源为具体的 ``config-profile`` 请求头、``config-profile: "
+"auto`` 的 routingConfig 提示，或 ``defaultProfile`` 。"
+
+#: ../../source/features/gateway-plugins.rst:701
+msgid "``ROUTING_ALGORITHM`` environment variable on the gateway plugin."
+msgstr "网关插件上的 ``ROUTING_ALGORITHM`` 环境变量。"
+
+#: ../../source/features/gateway-plugins.rst:703
+msgid ""
+"**Backward compatibility**: if a pod has no ``model.aibrix.ai/config`` "
+"annotation, the gateway falls back to the ``routing-strategy`` request "
+"header and then the ``ROUTING_ALGORITHM`` env (steps 2 and 4 above). No "
+"migration is required for existing deployments."
+msgstr ""
+"**向后兼容** ：若 Pod 没有 ``model.aibrix.ai/config`` annotation，网关回退到 ``routing-strategy`` "
+"请求头，再回退到 ``ROUTING_ALGORITHM`` 环境变量（上文第 2、4 步）。现有部署无需迁移。"
+
+#: ../../source/features/gateway-plugins.rst:708
+msgid "Prometheus API Access"
+msgstr "Prometheus API 访问"
+
+#: ../../source/features/gateway-plugins.rst:710
+msgid ""
+"Some routing strategies rely on metrics queried from the Prometheus HTTP "
+"API (PromQL). Configure the endpoint and optional Basic Auth credentials "
+"with the following environment variables."
+msgstr ""
+"部分路由策略依赖从 Prometheus HTTP API（PromQL）查询的指标。用以下环境变量配置端点和可选的 Basic Auth 凭据。"
+
+#: ../../source/features/gateway-plugins.rst:716
+msgid "Environment Variable"
+msgstr "环境变量"
+
+#: ../../source/features/gateway-plugins.rst:717
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/features/gateway-plugins.rst:719
+msgid "``PROMETHEUS_ENDPOINT``"
+msgstr "``PROMETHEUS_ENDPOINT``"
+
+#: ../../source/features/gateway-plugins.rst:720
+#: ../../source/features/gateway-plugins.rst:723
+#: ../../source/features/gateway-plugins.rst:735
+#: ../../source/features/gateway-plugins.rst:738
+msgid "(empty)"
+msgstr "（空）"
+
+#: ../../source/features/gateway-plugins.rst:721
+msgid ""
+"Prometheus HTTP API base URL (e.g. ``http://prometheus-"
+"operated.prometheus.svc:9090``). If empty, PromQL-based metrics are "
+"skipped."
+msgstr ""
+"Prometheus HTTP API 基 URL（例如 ``http://prometheus-operated.prometheus.svc:9090`` "
+"）。为空则跳过基于 PromQL 的指标。"
+
+#: ../../source/features/gateway-plugins.rst:722
+msgid "``PROMETHEUS_BASIC_AUTH_SECRET_NAME``"
+msgstr "``PROMETHEUS_BASIC_AUTH_SECRET_NAME``"
+
+#: ../../source/features/gateway-plugins.rst:724
+msgid ""
+"Kubernetes Secret name containing Basic Auth credentials. When set, takes"
+" precedence over the plaintext env vars below."
+msgstr "包含 Basic Auth 凭据的 Kubernetes Secret 名称。设置后优先于下方明文环境变量。"
+
+#: ../../source/features/gateway-plugins.rst:725
+msgid "``PROMETHEUS_BASIC_AUTH_SECRET_NAMESPACE``"
+msgstr "``PROMETHEUS_BASIC_AUTH_SECRET_NAMESPACE``"
+
+#: ../../source/features/gateway-plugins.rst:726
+msgid "``aibrix-system``"
+msgstr "``aibrix-system``"
+
+#: ../../source/features/gateway-plugins.rst:727
+msgid ""
+"Namespace of the Secret specified by "
+"``PROMETHEUS_BASIC_AUTH_SECRET_NAME``."
+msgstr "``PROMETHEUS_BASIC_AUTH_SECRET_NAME`` 指定的 Secret 所在命名空间。"
+
+#: ../../source/features/gateway-plugins.rst:728
+msgid "``PROMETHEUS_BASIC_AUTH_USERNAME_KEY``"
+msgstr "``PROMETHEUS_BASIC_AUTH_USERNAME_KEY``"
+
+#: ../../source/features/gateway-plugins.rst:729
+msgid "``username``"
+msgstr "``username``"
+
+#: ../../source/features/gateway-plugins.rst:730
+msgid "Key in ``Secret.data`` used as the Basic Auth username."
+msgstr "``Secret.data`` 中用作 Basic Auth 用户名的 key。"
+
+#: ../../source/features/gateway-plugins.rst:731
+msgid "``PROMETHEUS_BASIC_AUTH_PASSWORD_KEY``"
+msgstr "``PROMETHEUS_BASIC_AUTH_PASSWORD_KEY``"
+
+#: ../../source/features/gateway-plugins.rst:732
+msgid "``password``"
+msgstr "``password``"
+
+#: ../../source/features/gateway-plugins.rst:733
+msgid "Key in ``Secret.data`` used as the Basic Auth password."
+msgstr "``Secret.data`` 中用作 Basic Auth 密码的 key。"
+
+#: ../../source/features/gateway-plugins.rst:734
+msgid "``PROMETHEUS_BASIC_AUTH_USERNAME``"
+msgstr "``PROMETHEUS_BASIC_AUTH_USERNAME``"
+
+#: ../../source/features/gateway-plugins.rst:736
+msgid ""
+"Basic Auth username. Used only when ``PROMETHEUS_BASIC_AUTH_SECRET_NAME``"
+" is not set."
+msgstr "Basic Auth 用户名。仅在未设置 ``PROMETHEUS_BASIC_AUTH_SECRET_NAME`` 时使用。"
+
+#: ../../source/features/gateway-plugins.rst:737
+msgid "``PROMETHEUS_BASIC_AUTH_PASSWORD``"
+msgstr "``PROMETHEUS_BASIC_AUTH_PASSWORD``"
+
+#: ../../source/features/gateway-plugins.rst:739
+msgid ""
+"Basic Auth password. Used only when ``PROMETHEUS_BASIC_AUTH_SECRET_NAME``"
+" is not set."
+msgstr "Basic Auth 密码。仅在未设置 ``PROMETHEUS_BASIC_AUTH_SECRET_NAME`` 时使用。"
+
+#: ../../source/features/gateway-plugins.rst:742
+msgid "Example (plaintext env vars)"
+msgstr "示例（明文环境变量）"
+
+#: ../../source/features/gateway-plugins.rst:751
+msgid "Example (Kubernetes Secret)"
+msgstr "示例（Kubernetes Secret）"
+
+#: ../../source/features/gateway-plugins.rst:772
+msgid "Message Size Configuration"
+msgstr "消息大小配置"
+
+#: ../../source/features/gateway-plugins.rst:774
+msgid ""
+"Two independent size limits apply to requests flowing through the "
+"gateway. Both default to **4 MiB** and must be kept in sync when you "
+"raise or lower the limit."
+msgstr "流经网关的请求受两个独立大小限制。二者默认均为 **4 MiB** ，提高或降低限制时必须保持一致。"
+
+#: ../../source/features/gateway-plugins.rst:777
+msgid "Gateway Plugin gRPC Buffer (``AIBRIX_GRPC_MAX_MESSAGE_SIZE_BYTES``)"
+msgstr "网关插件 gRPC 缓冲区（``AIBRIX_GRPC_MAX_MESSAGE_SIZE_BYTES`` ）"
+
+#: ../../source/features/gateway-plugins.rst:779
+msgid ""
+"Envoy communicates with the AIBrix gateway plugin over an external-"
+"processing (ext_proc) gRPC connection. This env var controls the maximum "
+"size of a single gRPC message on that connection. Requests or responses "
+"larger than this value are rejected before they reach routing logic."
+msgstr ""
+"Envoy 通过外部处理（ext_proc）gRPC 连接与 AIBrix 网关插件通信。该环境变量控制该连接上单条 gRPC 消息的最大大小。超过该值的请求或响应会在到达路由逻辑之前被拒绝。"
+
+#: ../../source/features/gateway-plugins.rst:781
+msgid "Configure it under ``gatewayPlugin.envs`` in ``values.yaml``:"
+msgstr "在 ``values.yaml`` 的 ``gatewayPlugin.envs`` 下配置："
+
+#: ../../source/features/gateway-plugins.rst:790
+msgid "Envoy Connection Buffer (``clientTrafficPolicy.connection.bufferLimit``)"
+msgstr "Envoy 连接缓冲区（``clientTrafficPolicy.connection.bufferLimit`` ）"
+
+#: ../../source/features/gateway-plugins.rst:792
+msgid ""
+"Envoy itself buffers each incoming HTTP connection up to ``bufferLimit`` "
+"bytes before it begins processing. If a request body exceeds this limit "
+"Envoy returns a ``413`` before the ext_proc filter is even invoked."
+msgstr ""
+"Envoy 自身会在开始处理前将每条入站 HTTP 连接缓冲至最多 ``bufferLimit`` 字节。若请求体超出该限制，Envoy 在调用 "
+"ext_proc 过滤器之前就会返回 ``413`` 。"
+
+#: ../../source/features/gateway-plugins.rst:794
+msgid ""
+"Configure it under ``envoyGateway.clientTrafficPolicy`` in "
+"``values.yaml``:"
+msgstr "在 ``values.yaml`` 的 ``envoyGateway.clientTrafficPolicy`` 下配置："
+
+#: ../../source/features/gateway-plugins.rst:804
+msgid "Keeping the two values in sync"
+msgstr "保持两个值一致"
+
+#: ../../source/features/gateway-plugins.rst:806
+msgid ""
+"Because Envoy drops the connection before the gateway plugin sees it when"
+" ``bufferLimit`` is the binding limit, both values should always be set "
+"to the same size. When you need to support larger payloads (e.g. large "
+"KV-cache state-sync messages), update **both** fields together:"
+msgstr ""
+"当 ``bufferLimit`` 是约束上限时，Envoy 会在网关插件看到请求之前断开连接，因此两个值应始终设为相同大小。需要支持更大负载（例如大型 "
+"KV-cache 状态同步消息）时，请**同时** 更新这两个字段："

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/heterogeneous-gpu.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/heterogeneous-gpu.po
@@ -1,0 +1,450 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/heterogeneous-gpu.rst:5
+msgid "Heterogeneous GPU Inference (Experimental)"
+msgstr "异构 GPU 推理（实验性）"
+
+#: ../../source/features/heterogeneous-gpu.rst:7
+msgid ""
+"Heterogeneous GPU Inference is a feature that enables users to utilize "
+"different types of GPUs for deploying the same model. This feature "
+"addresses two primary challenges associated with Large Language Model "
+"(LLM) inference: (1) As the demand for large-scale model inference "
+"increases, ensuring consistent GPU availability has become a challenge, "
+"particularly within regions where identical GPU types are often "
+"unavailable due to capacity constraints. (2) Users may seek to "
+"incorporate lower-cost, lower-performance GPUs to reduce overall "
+"expenses."
+msgstr ""
+"异构 GPU 推理允许使用不同类型的 GPU 部署同一模型。该特性针对大语言模型（LLM）推理中的两个主要问题：（1）随着大规模模型推理需求增长，保证 GPU 供应一致变得困难，尤其在容量受限、同类型 GPU 经常不可用的区域。（2）用户可能希望引入成本更低、性能较低的 GPU 以降低总体费用。"
+
+#: ../../source/features/heterogeneous-gpu.rst:10
+msgid "Design Overview"
+msgstr "设计概览"
+
+#: ../../source/features/heterogeneous-gpu.rst:12
+msgid ""
+"There are three main components in Heterogeneous GPU Inference Feature: "
+"(1) LLM Request Monitoring, (2) Heterogeneous GPU Optimizer, (3) Request "
+"Routing. The following figure shows the overall architecture. First, LLM "
+"Request Monitoring component is responsible for monitoring the past "
+"inference requests and their request patterns. Second, Heterogeneous GPU "
+"Optimizer component is responsible for selecting the optimal GPU type and"
+" the corresponding GPU count. Third, Request Routing component is "
+"responsible for routing the request to the optimal GPU."
+msgstr ""
+"异构 GPU 推理包含三个主要组件：（1）LLM 请求监控，（2）异构 GPU Optimizer，（3）请求路由。下图展示整体架构。首先，LLM 请求监控负责观察历史推理请求及其模式。其次，异构 GPU Optimizer 负责选择最优 GPU 类型及对应数量。第三，请求路由负责将请求路由到最优 GPU。"
+
+#: ../../source/features/heterogeneous-gpu.rst:14
+msgid "heterogeneous-gpu-diagram"
+msgstr "heterogeneous-gpu-diagram"
+
+#: ../../source/features/heterogeneous-gpu.rst:20
+msgid ""
+"This feature is the heterogeneous form of :doc:`autoscaling/optimizer-"
+"based-autoscaling`: the same GPU optimizer, fed one benchmark profile per"
+" GPU type, decides how many replicas of each type to run. Read that page "
+"first for the request-tracing and profiling workflow; this page covers "
+"what is specific to mixing GPU types."
+msgstr ""
+"该特性是 :doc:`autoscaling/optimizer-based-autoscaling` 的异构形态：同一 GPU optimizer 为每种 GPU 类型提供一份基准 profile，并据此决定各类型运行多少副本。请先阅读该页了解请求追踪与 profiling 流程；本页仅说明混用 GPU 类型时的差异。"
+
+#: ../../source/features/heterogeneous-gpu.rst:26
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/features/heterogeneous-gpu.rst:28
+msgid ""
+"One ``Deployment`` per GPU type, all carrying the same "
+"``model.aibrix.ai/name`` label and each pinned to its GPU type through "
+"node selectors or affinity. The gateway treats them as one model."
+msgstr ""
+"每种 GPU 类型对应一个 ``Deployment`` ，均带有相同的 ``model.aibrix.ai/name`` 标签，并通过节点选择器或亲和性绑定到对应 "
+"GPU 类型。网关将其视为同一模型。"
+
+#: ../../source/features/heterogeneous-gpu.rst:31
+msgid ""
+"One ``PodAutoscaler`` per deployment, each reading the optimizer's metric"
+" for its own deployment."
+msgstr "每个 Deployment 对应一个 ``PodAutoscaler`` ，各自读取 optimizer 针对该 Deployment 的指标。"
+
+#: ../../source/features/heterogeneous-gpu.rst:33
+msgid ""
+"Request tracing enabled on the gateway plugin and the ``aibrix`` Python "
+"package installed locally for benchmarking, as described in "
+":doc:`autoscaling/optimizer-based-autoscaling`."
+msgstr ""
+"网关插件已启用请求追踪，并且本机已安装用于基准测试的 ``aibrix`` Python 包，详见 :doc:`autoscaling/optimizer-based-autoscaling` "
+"。"
+
+#: ../../source/features/heterogeneous-gpu.rst:35
+msgid ""
+"For SLO-aware routing across the GPU types, profiling data for each "
+"workload on each GPU type (see `Routing Support`_)."
+msgstr ""
+"若要在 GPU 类型之间做 SLO 感知路由，需要每种工作负载在每种 GPU 类型上的 profiling 数据（见 `Routing Support`_ "
+"）。"
+
+#: ../../source/features/heterogeneous-gpu.rst:39
+msgid "Example"
+msgstr "示例"
+
+#: ../../source/features/heterogeneous-gpu.rst:41
+msgid ""
+"**Preparation: Enable related components, including request tracking at "
+"the gateway.**"
+msgstr "**准备：启用相关组件，包括网关上的请求追踪。**"
+
+#: ../../source/features/heterogeneous-gpu.rst:50
+msgid ""
+"Alternatively, you can enable the feature by editing the gateway plugin "
+"deployment using ``kubectl edit deployment aibrix-gateway-plugins -n "
+"aibrix-system`` and append env."
+msgstr ""
+"也可以用 ``kubectl edit deployment aibrix-gateway-plugins -n aibrix-system`` 编辑网关插件 Deployment，并追加环境变量来启用该特性。"
+
+#: ../../source/features/heterogeneous-gpu.rst:63
+msgid "**Step 1: Deploy the heterogeneous deployments.**"
+msgstr "**步骤 1：部署异构 Deployment。**"
+
+#: ../../source/features/heterogeneous-gpu.rst:65
+msgid ""
+"One deployment and corresponding PodAutoscaler should be deployed for "
+"each GPU type. See `sample heterogeneous configuration "
+"<https://github.com/vllm-"
+"project/aibrix/tree/main/samples/heterogeneous>`_ for an example of "
+"heterogeneous configuration composed of two GPU types. The following "
+"command deploys heterogeneous deployments using L20 and V100 GPUs."
+msgstr ""
+"每种 GPU 类型应部署一个 Deployment 及对应的 PodAutoscaler。两种 GPU 类型组成的异构配置示例见 `sample "
+"heterogeneous configuration <https://github.com/vllm-project/aibrix/tree/main/samples/heterogeneous>`_ "
+"。以下命令使用 L20 和 V100 GPU 部署异构 Deployment。"
+
+#: ../../source/features/heterogeneous-gpu.rst:73
+msgid ""
+"The sample is a kustomization that creates one Service and two "
+"deployments, ``deepseek-coder-7b-l20`` (4 replicas) and ``deepseek-coder-"
+"7b-v100`` (0 replicas), each pinned to its GPU type through node affinity"
+" on the ``machine.cluster.vke.volcengine.com/gpu-name`` label. Adjust the"
+" affinity and replica counts to your cluster. The output below comes from"
+" a test environment with one pod per GPU type:"
+msgstr ""
+"该示例是一个 kustomization，会创建 1 个 Service 和 2 个 Deployment：``deepseek-coder-7b-l20`` "
+"（4 副本）和 ``deepseek-coder-7b-v100`` （0 副本），各自通过 ``machine.cluster.vke.volcengine.com/gpu-name`` "
+"标签的节点亲和性绑定到对应 GPU 类型。请按集群情况调整亲和性与副本数。以下输出来自每种 GPU 类型各有一个 Pod 的测试环境："
+
+#: ../../source/features/heterogeneous-gpu.rst:86
+msgid ""
+"Incoming requests are routed through the gateway and directed to the "
+"optimal pod based on request patterns:"
+msgstr "入站请求经网关路由，并根据请求模式定向到最优 Pod："
+
+#: ../../source/features/heterogeneous-gpu.rst:95
+msgid "**Step 2: Install aibrix python module.**"
+msgstr "**步骤 2：安装 aibrix Python 模块。**"
+
+#: ../../source/features/heterogeneous-gpu.rst:101
+msgid ""
+"The GPU Optimizer runs continuously in the background, dynamically "
+"adjusting GPU allocation for each model based on workload patterns. Note "
+"that GPU optimizer requires offline inference performance benchmark data "
+"for each type of GPU on each specific LLM model."
+msgstr ""
+"GPU Optimizer 在后台持续运行，根据负载模式动态调整每个模型的 GPU 分配。注意：GPU optimizer 需要每种 GPU 在每个具体 LLM 模型上的离线推理性能基准数据。"
+
+#: ../../source/features/heterogeneous-gpu.rst:104
+msgid ""
+"If local heterogeneous deployments is used, you can find the prepared "
+"benchmark data under "
+"`python/aibrix/aibrix/gpu_optimizer/optimizer/profiling/result/ "
+"<https://github.com/vllm-"
+"project/aibrix/tree/main/python/aibrix/aibrix/gpu_optimizer/optimizer/profiling/result/>`_"
+" and skip Step 3. See :ref:`Development` for details on deploying a local"
+" heterogeneous deployments."
+msgstr ""
+"若使用本地异构部署，可在 `python/aibrix/aibrix/gpu_optimizer/optimizer/profiling/result/ "
+"<https://github.com/vllm-project/aibrix/tree/main/python/aibrix/aibrix/gpu_optimizer/optimizer/profiling/result/>`_ "
+"找到已准备的基准数据并跳过步骤 3。本地异构部署详见 :ref:`Development` 。"
+
+#: ../../source/features/heterogeneous-gpu.rst:106
+msgid "**Step 3: Benchmark model.**"
+msgstr "**步骤 3：对模型做基准测试。**"
+
+#: ../../source/features/heterogeneous-gpu.rst:108
+msgid ""
+"For each type of GPU, run ``aibrix_benchmark``. See `benchmark.sh "
+"<https://github.com/vllm-"
+"project/aibrix/tree/main/python/aibrix/aibrix/gpu_optimizer/optimizer/profiling/benchmark.sh>`_"
+" for more options."
+msgstr ""
+"对每种 GPU 运行 ``aibrix_benchmark`` 。更多选项见 `benchmark.sh <https://github.com/vllm-project/aibrix/tree/main/python/aibrix/aibrix/gpu_optimizer/optimizer/profiling/benchmark.sh>`_ "
+"。"
+
+#: ../../source/features/heterogeneous-gpu.rst:116
+msgid "**Step 4: Decide SLO and generate profile.**"
+msgstr "**步骤 4：确定 SLO 并生成 profile。**"
+
+#: ../../source/features/heterogeneous-gpu.rst:118
+msgid "Run ``aibrix_gen_profile -h`` for help."
+msgstr "运行 ``aibrix_gen_profile -h`` 查看帮助。"
+
+#: ../../source/features/heterogeneous-gpu.rst:127
+msgid ""
+"Now the GPU Optimizer is ready to work. You should observe that the "
+"number of workload pods changes in response to the requests sent to the "
+"gateway. Once the GPU optimizer finishes the scaling optimization, the "
+"output of the GPU optimizer is passed to PodAutoscaler as a metricSource "
+"via a designated HTTP endpoint for the final scaling decision.  The "
+"following is an example of PodAutoscaler spec."
+msgstr ""
+"此时 GPU Optimizer 已可工作。向网关发送请求后，应能观察到工作负载 Pod 数量随之变化。GPU optimizer 完成扩缩容优化后，其输出会作为 metricSource，经指定 HTTP 端点传给 PodAutoscaler 以做出最终扩缩容决策。以下是 PodAutoscaler spec 示例。"
+
+#: ../../source/features/heterogeneous-gpu.rst:129
+msgid "A simple example of PodAutoscaler spec for v100 GPU is as follows:"
+msgstr "v100 GPU 的简单 PodAutoscaler spec 示例如下："
+
+#: ../../source/features/heterogeneous-gpu.rst:135
+msgid "Miscellaneous"
+msgstr "其他说明"
+
+#: ../../source/features/heterogeneous-gpu.rst:137
+msgid ""
+"A new label label ``model.aibrix.ai/min_replicas`` is added to specifies "
+"the minimum number of replicas to maintain when there is no workload. We "
+"recommend setting this to 1 for at least one Deployment spec to ensure "
+"there is always one READY pod available. For example, while the GPU "
+"optimizer might recommend 0 replicas for an v100 GPU during periods of no"
+" activity, setting ``model.aibrix.ai/min_replicas: \"1\"`` will maintain "
+"one v100 replica. This label only affects the system when there is no "
+"workload - it is ignored when there are active requests."
+msgstr ""
+"新增标签 ``model.aibrix.ai/min_replicas`` ，用于指定无负载时要维持的最小副本数。建议至少在一个 Deployment "
+"spec 中将其设为 1，以确保始终有一个 READY Pod。例如，无活动时 GPU optimizer 可能建议 v100 GPU 为 0 "
+"副本，设置 ``model.aibrix.ai/min_replicas: \"1\"`` 仍会保留一个 v100 副本。该标签仅在无负载时生效，有活跃请求时会被忽略。"
+
+#: ../../source/features/heterogeneous-gpu.rst:150
+#, python-brace-format
+msgid ""
+"Important: The ``minReplicas`` field in the PodAutoscaler spec must be "
+"set to 0 to allow proper scaling behavior. Setting it to any value "
+"greater than 0 will interfere with the GPU optimizer's scaling decisions."
+" For instance, if the GPU optimizer determines an optimal configuration "
+"of ``{v100: 0, l20: 4}`` but the v100 PodAutoscaler has ``minReplicas: "
+"1``, the system won't be able to scale the v100 down to 0 as recommended."
+msgstr ""
+"重要：PodAutoscaler spec 中的 ``minReplicas`` 必须设为 0，扩缩容才能按预期工作。设为大于 0 的值会干扰 "
+"GPU optimizer 的扩缩容决策。例如，若 GPU optimizer 给出最优配置 ``{v100: 0, l20: 4}`` ，而 "
+"v100 的 PodAutoscaler 设置了 ``minReplicas: 1`` ，系统将无法按建议将 v100 缩到 0。"
+
+#: ../../source/features/heterogeneous-gpu.rst:153
+msgid "Configuration reference"
+msgstr "配置参考"
+
+#: ../../source/features/heterogeneous-gpu.rst:159
+msgid "Setting"
+msgstr "配置项"
+
+#: ../../source/features/heterogeneous-gpu.rst:160
+msgid "Meaning"
+msgstr "含义"
+
+#: ../../source/features/heterogeneous-gpu.rst:161
+msgid ""
+"``AIBRIX_GPU_OPTIMIZER_TRACING_FLAG`` (gateway plugin env, default "
+"``false``)"
+msgstr "``AIBRIX_GPU_OPTIMIZER_TRACING_FLAG`` （网关插件环境变量，默认 ``false`` ）"
+
+#: ../../source/features/heterogeneous-gpu.rst:162
+msgid "Records per-request token statistics for the optimizer. Required."
+msgstr "为 optimizer 记录每请求 token 统计。必需。"
+
+#: ../../source/features/heterogeneous-gpu.rst:163
+msgid "``model.aibrix.ai/name`` (label on every deployment)"
+msgstr "``model.aibrix.ai/name`` （每个 Deployment 上的标签）"
+
+#: ../../source/features/heterogeneous-gpu.rst:164
+msgid ""
+"The shared model name. Must match the ``model`` used when profiles were "
+"stored."
+msgstr "共享模型名。必须与存储 profile 时使用的 ``model`` 一致。"
+
+#: ../../source/features/heterogeneous-gpu.rst:165
+msgid "``model.aibrix.ai/min_replicas`` (label on a deployment)"
+msgstr "``model.aibrix.ai/min_replicas`` （Deployment 上的标签）"
+
+#: ../../source/features/heterogeneous-gpu.rst:166
+msgid ""
+"Replicas to keep for that GPU type when there is no traffic. Set it to "
+"``\"1\"`` on at least one deployment so the model always has a ready pod."
+msgstr "无流量时该 GPU 类型保留的副本数。至少在一个 Deployment 上设为 ``\"1\"`` ，以确保模型始终有就绪 Pod。"
+
+#: ../../source/features/heterogeneous-gpu.rst:168
+msgid "``spec.minReplicas: 0`` (on each PodAutoscaler)"
+msgstr "``spec.minReplicas: 0`` （每个 PodAutoscaler）"
+
+#: ../../source/features/heterogeneous-gpu.rst:169
+msgid ""
+"Required. Any higher value prevents the optimizer from scaling that GPU "
+"type to zero."
+msgstr "必需。设为更高值会阻止 optimizer 将该 GPU 类型缩到 0。"
+
+#: ../../source/features/heterogeneous-gpu.rst:170
+msgid "``aibrix_gen_profile ... --cost <n>``"
+msgstr "``aibrix_gen_profile ... --cost <n>``"
+
+#: ../../source/features/heterogeneous-gpu.rst:171
+msgid ""
+"Relative cost of the GPU type. The optimizer minimises total cost, so "
+"give each GPU type its own value."
+msgstr "该 GPU 类型的相对成本。optimizer 会最小化总成本，因此每种 GPU 类型应设置各自的值。"
+
+#: ../../source/features/heterogeneous-gpu.rst:173
+msgid "``routing-strategy: slo`` (request header)"
+msgstr "``routing-strategy: slo`` （请求头）"
+
+#: ../../source/features/heterogeneous-gpu.rst:174
+msgid ""
+"Turn on SLO-aware routing for the request. Variants: ``slo-pack-load``, "
+"``slo-least-load``, ``slo-least-load-pulling`` (the default for ``slo``)."
+msgstr ""
+"为该请求启用 SLO 感知路由。变体：``slo-pack-load`` 、``slo-least-load`` 、``slo-least-load-pulling`` "
+"（``slo`` 的默认值）。"
+
+#: ../../source/features/heterogeneous-gpu.rst:178
+msgid "Routing Support"
+msgstr "路由支持"
+
+#: ../../source/features/heterogeneous-gpu.rst:180
+msgid ""
+"During the performance evaluation, we observed that the existing routing "
+"policy does not adequately account for the varying serving capacities of "
+"heterogeneous GPUs. Specifically, the subsequent plot illustrates that "
+"the current routing strategy fails to adhere to the specified Service "
+"Level Objective (SLO)."
+msgstr ""
+"性能评估中发现，现有路由策略未能充分反映异构 GPU 不同的服务能力。下图表明当前路由策略无法满足指定的服务水平目标（SLO）。"
+
+#: ../../source/features/heterogeneous-gpu.rst:182
+#: ../../source/features/heterogeneous-gpu.rst:214
+#: ../../source/features/heterogeneous-gpu.rst:227
+msgid "SLO Routing Motivation Plot"
+msgstr "SLO 路由动机图"
+
+#: ../../source/features/heterogeneous-gpu.rst:187
+msgid "The experimental configuration is as follows:"
+msgstr "实验配置如下："
+
+#: ../../source/features/heterogeneous-gpu.rst:189
+msgid "SLO: P99 latency per token ≤ 0.05 seconds."
+msgstr "SLO：每 token 的 P99 延迟 ≤ 0.05 秒。"
+
+#: ../../source/features/heterogeneous-gpu.rst:190
+msgid ""
+"Workloads: A mixed workload comprising `ShareGPT "
+"<https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered>`_"
+" (7 RPS) and CodeGeneration tasks (4 RPS), characterized by long prompts "
+"(over 4K tokens) and short responses (32-64 tokens)."
+msgstr ""
+"工作负载：由 `ShareGPT <https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered>`_ "
+"（7 RPS）和 CodeGeneration 任务（4 RPS）组成的混合负载，特征为长 prompt（超过 4K token）和短响应（32-64 "
+"token）。"
+
+#: ../../source/features/heterogeneous-gpu.rst:191
+msgid ""
+"GPUs: A heterogeneous GPU environment consisting of NVIDIA A10 and NVIDIA"
+" L20 GPUs."
+msgstr "GPU：由 NVIDIA A10 和 NVIDIA L20 组成的异构 GPU 环境。"
+
+#: ../../source/features/heterogeneous-gpu.rst:193
+msgid ""
+"Our experiments indicate that an ideal routing scenario (Oracle) would "
+"assign ShareGPT workloads exclusively to A10 GPUs and CodeGeneration "
+"workloads exclusively to L20 GPUs. However, the existing routing policy "
+"(woRouting) randomly distributes requests between A10 and L20 GPUs, "
+"failing to replicate this ideal scenario. For comparative purposes, we "
+"also evaluated a scenario where all requests are handled solely by the "
+"more capable L20 GPUs (Scalar). Results demonstrated that although GPU "
+"optimizers can identify an optimal GPU configuration (Oracle Cost), the "
+"current routing policy results in significant performance degradation, "
+"queue accumulation at the gateway, unstable GPU configurations, and "
+"consistent violations of the SLO."
+msgstr ""
+"实验表明，理想路由场景（Oracle）会将 ShareGPT 负载全部交给 A10 GPU，将 CodeGeneration 负载全部交给 L20 GPU。现有路由策略（woRouting）则在 A10 与 L20 之间随机分配请求，无法复现该理想场景。作为对比，还评估了全部请求仅由能力更强的 L20 GPU 处理的场景（Scalar）。结果表明，尽管 GPU optimizer 能找出最优 GPU 配置（Oracle Cost），当前路由策略仍会导致明显性能下降、网关排队积压、GPU 配置不稳定，并持续违反 SLO。"
+
+#: ../../source/features/heterogeneous-gpu.rst:195
+msgid ""
+"SLO routing policy was introduced in version v0.4.0 to address "
+"performance issues in heterogeneous GPU deployments. Requests must "
+"explicitly specify the ``routing-strategy: slo`` header to enable the SLO"
+" routing policy. Additionally, profiling data for each workload on each "
+"GPU is required to activate this policy effectively."
+msgstr ""
+"SLO 路由策略在 v0.4.0 引入，用于解决异构 GPU 部署中的性能问题。请求必须显式指定 ``routing-strategy: slo`` 请求头才能启用该策略。此外，每种工作负载在每种 GPU 上的 profiling 数据也是有效启用该策略所必需的。"
+
+#: ../../source/features/heterogeneous-gpu.rst:197
+msgid "An example request applying the SLO routing policy is shown below:"
+msgstr "应用 SLO 路由策略的请求示例如下："
+
+#: ../../source/features/heterogeneous-gpu.rst:212
+msgid ""
+"In the same experimental settings, the SLO routing policy demonstrated "
+"its capability to achieve the targeted performance objectives."
+msgstr "在相同实验设置下，SLO 路由策略能够达到目标性能。"
+
+#: ../../source/features/heterogeneous-gpu.rst:219
+msgid ""
+"The SLO routing policy currently supports three variations: ``slo-pack-"
+"load``, ``slo-least-load``, and ``slo-least-load-pulling``(default policy"
+" when ``slo`` is specified). Each variation routes requests to GPUs "
+"likely to meet their respective SLOs but differ in handling requests "
+"among GPUs of the same type:"
+msgstr ""
+"SLO 路由策略目前支持三种变体：``slo-pack-load`` 、``slo-least-load`` 和 ``slo-least-load-pulling`` "
+"（指定 ``slo`` 时的默认策略）。各变体都会将请求路由到更可能满足对应 SLO 的 GPU，但在同类型 GPU 之间的分配方式不同："
+
+#: ../../source/features/heterogeneous-gpu.rst:221
+msgid ""
+"``slo-pack-load``: Prefers consolidating requests onto a single GPU if "
+"profiling suggests no SLO violation."
+msgstr "``slo-pack-load`` ：若 profiling 表明不会违反 SLO，优先将请求集中到单个 GPU。"
+
+#: ../../source/features/heterogeneous-gpu.rst:222
+msgid ""
+"``slo-least-load``: Prefers routing requests to the least-loaded GPU of "
+"the same type, ignoring SLO violation predictions from profiling."
+msgstr "``slo-least-load`` ：优先将请求路由到同类型中负载最低的 GPU，忽略 profiling 对 SLO 违反的预测。"
+
+#: ../../source/features/heterogeneous-gpu.rst:223
+msgid ""
+"``slo-least-load-pulling``: Prefers routing requests to the least-loaded "
+"GPU of the same type. Requests predicted to violate the SLO are queued at"
+" the gateway and rejected if the SLO has already been breached."
+msgstr ""
+"``slo-least-load-pulling`` ：优先将请求路由到同类型中负载最低的 GPU。预测会违反 SLO 的请求在网关排队，若 SLO "
+"已被突破则拒绝。"
+
+#: ../../source/features/heterogeneous-gpu.rst:225
+msgid ""
+"The following figure compares the performance of the ``slo/slo-least-"
+"load-pulling`` and ``slo-pack-load`` variations. ``least-request`` policy"
+" is used as the baseline for a fair comparison."
+msgstr ""
+"下图比较 ``slo/slo-least-load-pulling`` 与 ``slo-pack-load`` 变体的性能。以 ``least-request`` 策略作为公平对比的基线。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/kv-event-sync.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/kv-event-sync.po
@@ -1,0 +1,512 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/kv-event-sync.rst:3
+msgid "KV Cache Events Synchronization"
+msgstr "KV Cache 事件同步"
+
+#: ../../source/features/kv-event-sync.rst:6
+msgid "Overview"
+msgstr "概述"
+
+#: ../../source/features/kv-event-sync.rst:8
+msgid ""
+"KV Cache Event Synchronization is a feature that enables multiple vLLM "
+"instances to share key-value cache states through ZMQ-based event "
+"publishing. This improves prefix cache hit rates and reduces redundant "
+"computation by allowing the AIBrix gateway to make intelligent routing "
+"decisions based on real-time cache state."
+msgstr ""
+"KV Cache 事件同步使多个 vLLM 实例通过基于 ZMQ 的事件发布共享 key-value cache 状态。AIBrix 网关据此根据实时 cache 状态做智能路由，从而提高 prefix cache 命中率并减少重复计算。"
+
+#: ../../source/features/kv-event-sync.rst:11
+msgid "Architecture"
+msgstr "架构"
+
+#: ../../source/features/kv-event-sync.rst:13
+msgid "The KV event synchronization system consists of:"
+msgstr "KV 事件同步系统由以下部分组成："
+
+#: ../../source/features/kv-event-sync.rst:15
+msgid "**vLLM Instances**: Publish KV cache events via ZMQ pub/sub pattern"
+msgstr "**vLLM 实例** ：通过 ZMQ pub/sub 模式发布 KV cache 事件"
+
+#: ../../source/features/kv-event-sync.rst:16
+msgid "**AIBrix Cache**: Manages subscriptions and processes events"
+msgstr "**AIBrix Cache** ：管理订阅并处理事件"
+
+#: ../../source/features/kv-event-sync.rst:17
+msgid "**Sync Prefix Cache Indexer**: Maintains global prefix cache state"
+msgstr "**Sync Prefix Cache Indexer** ：维护全局 prefix cache 状态"
+
+#: ../../source/features/kv-event-sync.rst:18
+msgid "**Gateway Router**: Uses cache state for intelligent routing decisions"
+msgstr "**网关路由器** ：根据 cache 状态做智能路由决策"
+
+#: ../../source/features/kv-event-sync.rst:21
+msgid "Event Flow"
+msgstr "事件流程"
+
+#: ../../source/features/kv-event-sync.rst:29
+msgid "The system uses a two-stage initialization:"
+msgstr "系统采用两阶段初始化："
+
+#: ../../source/features/kv-event-sync.rst:31
+msgid ""
+"**Cache Initialization**: Using ``InitWithOptions`` pattern with "
+"``EnableKVSync=true``"
+msgstr "**Cache 初始化** ：使用 ``InitWithOptions`` 模式，并设置 ``EnableKVSync=true``"
+
+#: ../../source/features/kv-event-sync.rst:32
+msgid "**KV Event Manager**: Automatically created when conditions are met"
+msgstr "**KV Event Manager** ：条件满足时自动创建"
+
+#: ../../source/features/kv-event-sync.rst:35
+msgid "Requirements"
+msgstr "要求"
+
+#: ../../source/features/kv-event-sync.rst:37
+msgid "vLLM version 0.7.0 or later with KV cache events support"
+msgstr "vLLM 0.7.0 或更高版本，且支持 KV cache 事件"
+
+#: ../../source/features/kv-event-sync.rst:38
+msgid "AIBrix gateway-plugins built with ZMQ support (``-tags=\"zmq\"``)"
+msgstr "带 ZMQ 支持构建的 AIBrix gateway-plugins（``-tags=\"zmq\"`` ）"
+
+#: ../../source/features/kv-event-sync.rst:39
+msgid "ZMQ library (libzmq3-dev) installed on gateway nodes"
+msgstr "网关节点已安装 ZMQ 库（libzmq3-dev）"
+
+#: ../../source/features/kv-event-sync.rst:40
+msgid "Remote tokenizer enabled (strict prerequisite)"
+msgstr "已启用 remote tokenizer（硬性前置条件）"
+
+#: ../../source/features/kv-event-sync.rst:41
+msgid "Redis client configured (for production deployments)"
+msgstr "已配置 Redis 客户端（生产部署）"
+
+#: ../../source/features/kv-event-sync.rst:44
+msgid ""
+"KV event sync has a strict dependency on remote tokenizer to ensure "
+"consistent tokenization between gateway and vLLM instances. The system "
+"will not initialize if remote tokenizer is disabled."
+msgstr ""
+"KV 事件同步严格依赖 remote tokenizer，以保证网关与 vLLM 实例之间的 tokenization 一致。若 remote tokenizer 未启用，系统不会初始化。"
+
+#: ../../source/features/kv-event-sync.rst:47
+msgid "Configuration"
+msgstr "配置"
+
+#: ../../source/features/kv-event-sync.rst:50
+msgid "Environment Variables"
+msgstr "环境变量"
+
+#: ../../source/features/kv-event-sync.rst:56
+#: ../../source/features/kv-event-sync.rst:205
+msgid "Variable"
+msgstr "变量"
+
+#: ../../source/features/kv-event-sync.rst:57
+#: ../../source/features/kv-event-sync.rst:206
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/features/kv-event-sync.rst:58
+#: ../../source/features/kv-event-sync.rst:78
+#: ../../source/features/kv-event-sync.rst:207
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/features/kv-event-sync.rst:59
+msgid "``AIBRIX_PREFIX_CACHE_KV_EVENT_SYNC_ENABLED``"
+msgstr "``AIBRIX_PREFIX_CACHE_KV_EVENT_SYNC_ENABLED``"
+
+#: ../../source/features/kv-event-sync.rst:60
+#: ../../source/features/kv-event-sync.rst:63
+msgid "``false``"
+msgstr "``false``"
+
+#: ../../source/features/kv-event-sync.rst:61
+msgid "Enable KV event synchronization"
+msgstr "启用 KV 事件同步"
+
+#: ../../source/features/kv-event-sync.rst:62
+msgid "``AIBRIX_PREFIX_CACHE_USE_REMOTE_TOKENIZER``"
+msgstr "``AIBRIX_PREFIX_CACHE_USE_REMOTE_TOKENIZER``"
+
+#: ../../source/features/kv-event-sync.rst:64
+msgid "Must be ``true`` for KV sync"
+msgstr "KV 同步时必须为 ``true``"
+
+#: ../../source/features/kv-event-sync.rst:65
+msgid "``AIBRIX_PREFIX_CACHE_REMOTE_TOKENIZER_ENDPOINT``"
+msgstr "``AIBRIX_PREFIX_CACHE_REMOTE_TOKENIZER_ENDPOINT``"
+
+#: ../../source/features/kv-event-sync.rst:67
+msgid "vLLM service endpoint"
+msgstr "vLLM 服务端点"
+
+#: ../../source/features/kv-event-sync.rst:70
+msgid "Pod Labels"
+msgstr "Pod 标签"
+
+#: ../../source/features/kv-event-sync.rst:76
+msgid "Label"
+msgstr "标签"
+
+#: ../../source/features/kv-event-sync.rst:77
+msgid "Value"
+msgstr "值"
+
+#: ../../source/features/kv-event-sync.rst:79
+msgid "``model.aibrix.ai/kv-events-enabled``"
+msgstr "``model.aibrix.ai/kv-events-enabled``"
+
+#: ../../source/features/kv-event-sync.rst:80
+msgid "``true``"
+msgstr "``true``"
+
+#: ../../source/features/kv-event-sync.rst:81
+msgid "Enable KV events for this pod"
+msgstr "为此 Pod 启用 KV 事件"
+
+#: ../../source/features/kv-event-sync.rst:82
+msgid "``model.aibrix.ai/lora-id``"
+msgstr "``model.aibrix.ai/lora-id``"
+
+#: ../../source/features/kv-event-sync.rst:83
+msgid "string"
+msgstr "string"
+
+#: ../../source/features/kv-event-sync.rst:84
+msgid "LoRA adapter ID (optional)"
+msgstr "LoRA adapter ID（可选）"
+
+#: ../../source/features/kv-event-sync.rst:87
+msgid "vLLM Configuration"
+msgstr "vLLM 配置"
+
+#: ../../source/features/kv-event-sync.rst:89
+msgid "Add these arguments to your vLLM container:"
+msgstr "向 vLLM 容器添加以下参数："
+
+#: ../../source/features/kv-event-sync.rst:100
+msgid "Add corresponding ports:"
+msgstr "添加对应端口："
+
+#: ../../source/features/kv-event-sync.rst:113
+msgid "Deployment"
+msgstr "部署"
+
+#: ../../source/features/kv-event-sync.rst:116
+msgid "Quick Start"
+msgstr "快速开始"
+
+#: ../../source/features/kv-event-sync.rst:118
+msgid "**Enable Remote Tokenizer** (mandatory prerequisite)::"
+msgstr "**启用 Remote Tokenizer** （强制前置条件）::"
+
+#: ../../source/features/kv-event-sync.rst:124
+msgid "**Enable KV Event Sync**::"
+msgstr "**启用 KV 事件同步**::"
+
+#: ../../source/features/kv-event-sync.rst:129
+msgid "**Deploy vLLM with KV Events**:"
+msgstr "**部署带 KV 事件的 vLLM** ："
+
+#: ../../source/features/kv-event-sync.rst:153
+msgid "Build Considerations"
+msgstr "构建说明"
+
+#: ../../source/features/kv-event-sync.rst:155
+msgid "AIBrix uses conditional compilation to manage ZMQ dependencies:"
+msgstr "AIBrix 使用条件编译管理 ZMQ 依赖："
+
+#: ../../source/features/kv-event-sync.rst:157
+msgid "**Components requiring ZMQ support:**"
+msgstr "**需要 ZMQ 支持的组件：**"
+
+#: ../../source/features/kv-event-sync.rst:159
+msgid "``gateway-plugins``: Main component for KV event sync"
+msgstr "``gateway-plugins`` ：KV 事件同步的主要组件"
+
+#: ../../source/features/kv-event-sync.rst:160
+msgid "``kvcache-watcher``: Optional component for cache monitoring"
+msgstr "``kvcache-watcher`` ：可选的 cache 监控组件"
+
+#: ../../source/features/kv-event-sync.rst:162
+msgid "**Build commands:**"
+msgstr "**构建命令：**"
+
+#: ../../source/features/kv-event-sync.rst:172
+msgid "**Components that do NOT require ZMQ:**"
+msgstr "**不需要 ZMQ 的组件：**"
+
+#: ../../source/features/kv-event-sync.rst:174
+msgid "``controller-manager``: Uses default build"
+msgstr "``controller-manager`` ：使用默认构建"
+
+#: ../../source/features/kv-event-sync.rst:175
+msgid "``metadata-service``: Uses default build"
+msgstr "``metadata-service`` ：使用默认构建"
+
+#: ../../source/features/kv-event-sync.rst:176
+msgid "``runtime``: Python component, no ZMQ needed"
+msgstr "``runtime`` ：Python 组件，不需要 ZMQ"
+
+#: ../../source/features/kv-event-sync.rst:179
+msgid "Routing Behavior"
+msgstr "路由行为"
+
+#: ../../source/features/kv-event-sync.rst:181
+msgid ""
+"The KV sync router applies the same prefix-match-with-stddev-filter "
+"selection logic as the standard prefix-cache router. It does not apply a "
+"load-imbalance gate itself — that concern is handled centrally by the "
+"gateway, which applies the load-balance router's "
+"(``algorithms/load_balance.go``) ``ApplyLoadImbalanceGate`` once ahead of"
+" whichever strategy actually routes the request, KV sync included."
+msgstr ""
+"KV sync 路由器使用与标准 prefix-cache 路由器相同的 prefix-match-with-stddev-filter 选择逻辑。它自身不应用负载不均衡门控——该逻辑由网关集中处理：网关在实际执行任一路由策略（含 "
+"KV sync）之前，先调用一次 load-balance 路由器（``algorithms/load_balance.go`` ）的 ``ApplyLoadImbalanceGate`` "
+"。"
+
+#: ../../source/features/kv-event-sync.rst:187
+msgid "**Prefix match with stddev filter**"
+msgstr "**带标准差过滤的前缀匹配**"
+
+#: ../../source/features/kv-event-sync.rst:189
+msgid ""
+"Pods are matched against the sync indexer and sorted by prefix-match "
+"percentage (descending), then by running requests (ascending). The first "
+"pod satisfying:"
+msgstr "Pod 对照 sync indexer 匹配，先按前缀匹配百分比降序、再按正在处理的请求数升序排序。选取第一个满足以下条件的 Pod："
+
+#: ../../source/features/kv-event-sync.rst:196
+msgid ""
+"is selected. If no matched pod meets the threshold, the router falls back"
+" to the globally least-loaded ready pod."
+msgstr "若没有匹配的 Pod 达到阈值，路由器回退到全局负载最低的就绪 Pod。"
+
+#: ../../source/features/kv-event-sync.rst:199
+msgid "Relevant environment variables:"
+msgstr "相关环境变量："
+
+#: ../../source/features/kv-event-sync.rst:208
+msgid "``AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR``"
+msgstr "``AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR``"
+
+#: ../../source/features/kv-event-sync.rst:209
+msgid "``1``"
+msgstr "``1``"
+
+#: ../../source/features/kv-event-sync.rst:210
+msgid ""
+"Controls how aggressively overloaded cache-holding pods are skipped "
+"during selection."
+msgstr "控制选择时跳过过载且持有 cache 的 Pod 的激进程度。"
+
+#: ../../source/features/kv-event-sync.rst:213
+msgid "Event Types"
+msgstr "事件类型"
+
+#: ../../source/features/kv-event-sync.rst:216
+msgid "BlockStoredEvent"
+msgstr "BlockStoredEvent"
+
+#: ../../source/features/kv-event-sync.rst:218
+msgid "Published when new KV cache blocks are stored:"
+msgstr "新的 KV cache block 被存储时发布："
+
+#: ../../source/features/kv-event-sync.rst:232
+msgid "BlockRemovedEvent"
+msgstr "BlockRemovedEvent"
+
+#: ../../source/features/kv-event-sync.rst:234
+msgid "Published when blocks are removed from cache:"
+msgstr "block 从 cache 中移除时发布："
+
+#: ../../source/features/kv-event-sync.rst:246
+msgid "Troubleshooting"
+msgstr "故障排查"
+
+#: ../../source/features/kv-event-sync.rst:249
+msgid "Initialization Failures"
+msgstr "初始化失败"
+
+#: ../../source/features/kv-event-sync.rst:251
+msgid "**Check initialization logs**::"
+msgstr "**查看初始化日志**::"
+
+#: ../../source/features/kv-event-sync.rst:255
+msgid "**Verify remote tokenizer**::"
+msgstr "**验证 remote tokenizer**::"
+
+#: ../../source/features/kv-event-sync.rst:261
+msgid "Events Not Publishing"
+msgstr "事件未发布"
+
+#: ../../source/features/kv-event-sync.rst:263
+msgid "**Check vLLM logs**::"
+msgstr "**查看 vLLM 日志**::"
+
+#: ../../source/features/kv-event-sync.rst:267
+msgid "**Verify ZMQ connectivity**::"
+msgstr "**验证 ZMQ 连通性**::"
+
+#: ../../source/features/kv-event-sync.rst:271
+msgid "**Check ZMQ build support**::"
+msgstr "**检查 ZMQ 构建支持**::"
+
+#: ../../source/features/kv-event-sync.rst:276
+msgid "Connection Issues"
+msgstr "连接问题"
+
+#: ../../source/features/kv-event-sync.rst:278
+msgid "**Verify pod labels**::"
+msgstr "**验证 Pod 标签**::"
+
+#: ../../source/features/kv-event-sync.rst:282
+msgid "**Check network policies**:"
+msgstr "**检查网络策略** ："
+
+#: ../../source/features/kv-event-sync.rst:284
+msgid "Ensure ports 5557-5558 are accessible"
+msgstr "确保端口 5557-5558 可访问"
+
+#: ../../source/features/kv-event-sync.rst:285
+msgid "No blocking NetworkPolicies"
+msgstr "没有会阻断的 NetworkPolicy"
+
+#: ../../source/features/kv-event-sync.rst:287
+msgid "**Validate tokenizer**::"
+msgstr "**验证 tokenizer**::"
+
+#: ../../source/features/kv-event-sync.rst:292
+msgid "Performance Tuning"
+msgstr "性能调优"
+
+#: ../../source/features/kv-event-sync.rst:294
+msgid "**High Memory Usage**: Reduce buffer steps in vLLM"
+msgstr "**内存占用高** ：减少 vLLM 中的 buffer steps"
+
+#: ../../source/features/kv-event-sync.rst:295
+msgid "**Event Processing Lag**: Adjust batch size and polling timeout"
+msgstr "**事件处理滞后** ：调整 batch size 和轮询超时"
+
+#: ../../source/features/kv-event-sync.rst:296
+msgid "**Network Overhead**: ~1MB/s per pod at high load"
+msgstr "**网络开销** ：高负载时每个 Pod 约 1MB/s"
+
+#: ../../source/features/kv-event-sync.rst:299
+msgid "Migration from Existing Deployments"
+msgstr "从现有部署迁移"
+
+#: ../../source/features/kv-event-sync.rst:302
+msgid "Enable on Existing vLLM"
+msgstr "在现有 vLLM 上启用"
+
+#: ../../source/features/kv-event-sync.rst:304
+msgid "Add labels::"
+msgstr "添加标签::"
+
+#: ../../source/features/kv-event-sync.rst:308
+msgid "Update deployment with KV event args (see Configuration section)"
+msgstr "用 KV 事件参数更新 Deployment（见配置一节）"
+
+#: ../../source/features/kv-event-sync.rst:310
+msgid "Restart pods::"
+msgstr "重启 Pod::"
+
+#: ../../source/features/kv-event-sync.rst:315
+msgid "Rollback"
+msgstr "回滚"
+
+#: ../../source/features/kv-event-sync.rst:317
+msgid "To disable KV event sync::"
+msgstr "禁用 KV 事件同步::"
+
+#: ../../source/features/kv-event-sync.rst:327
+msgid "Best Practices"
+msgstr "最佳实践"
+
+#: ../../source/features/kv-event-sync.rst:329
+msgid "**Deployment Order**:"
+msgstr "**部署顺序** ："
+
+#: ../../source/features/kv-event-sync.rst:331
+msgid "Enable remote tokenizer first and verify it's working"
+msgstr "先启用 remote tokenizer 并确认其正常工作"
+
+#: ../../source/features/kv-event-sync.rst:332
+msgid "Deploy vLLM with KV events configuration"
+msgstr "部署带 KV 事件配置的 vLLM"
+
+#: ../../source/features/kv-event-sync.rst:333
+msgid "Enable KV sync in gateway last"
+msgstr "最后在网关启用 KV 同步"
+
+#: ../../source/features/kv-event-sync.rst:335
+msgid "**Monitoring**:"
+msgstr "**监控** ："
+
+#: ../../source/features/kv-event-sync.rst:337
+msgid "Enable prefix cache metrics for visibility"
+msgstr "启用 prefix cache 指标以便观察"
+
+#: ../../source/features/kv-event-sync.rst:338
+msgid "Monitor ZMQ connection status in logs"
+msgstr "在日志中监控 ZMQ 连接状态"
+
+#: ../../source/features/kv-event-sync.rst:339
+msgid "Track prefix cache hit rates in Grafana"
+msgstr "在 Grafana 中跟踪 prefix cache 命中率"
+
+#: ../../source/features/kv-event-sync.rst:341
+msgid "**Resource Planning**:"
+msgstr "**资源规划** ："
+
+#: ../../source/features/kv-event-sync.rst:343
+msgid "ZMQ traffic: ~1MB/s per vLLM pod at high load"
+msgstr "ZMQ 流量：高负载时每个 vLLM Pod 约 1MB/s"
+
+#: ../../source/features/kv-event-sync.rst:344
+msgid "Memory: Sync indexer uses ~64 bytes per prefix entry"
+msgstr "内存：sync indexer 每个前缀条目约 64 字节"
+
+#: ../../source/features/kv-event-sync.rst:345
+msgid "CPU: Minimal overhead (<1% per pod)"
+msgstr "CPU：开销很小（每个 Pod <1%）"
+
+#: ../../source/features/kv-event-sync.rst:347
+msgid "**Production Considerations**:"
+msgstr "**生产环境注意事项** ："
+
+#: ../../source/features/kv-event-sync.rst:349
+msgid "Use dedicated network for ZMQ traffic if possible"
+msgstr "如有可能，为 ZMQ 流量使用专用网络"
+
+#: ../../source/features/kv-event-sync.rst:350
+msgid "Configure appropriate timeouts based on network latency"
+msgstr "根据网络延迟配置合适的超时"
+
+#: ../../source/features/kv-event-sync.rst:351
+msgid "Plan for graceful degradation if KV sync fails"
+msgstr "规划 KV 同步失败时的优雅降级"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/kvcache-offloading.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/kvcache-offloading.po
@@ -1,0 +1,813 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/kvcache-offloading.rst:5
+msgid "KVCache Offloading"
+msgstr "KVCache 卸载"
+
+#: ../../source/features/kvcache-offloading.rst:8
+msgid ""
+"If you’re not yet familiar with the concepts of KVCache L1 and L2, please"
+" refer to AIBrix KVCache Offloading document at :ref:`aibrix_kvcache-"
+"offloading-framework`."
+msgstr "若尚不熟悉 KVCache L1 和 L2 的概念，请参阅 :ref:`aibrix_kvcache-offloading-framework` 。"
+
+#: ../../source/features/kvcache-offloading.rst:11
+msgid ""
+"The AIBrix KVCache Offloading framework can be used as a standalone "
+"component — there’s no need to install the entire AIBrix stack."
+msgstr "AIBrix KVCache Offloading 框架可单独使用，无需安装完整 AIBrix 栈。"
+
+#: ../../source/features/kvcache-offloading.rst:14
+msgid "Since v0.4.0, both vLLM V0 and V1 connectors are supported."
+msgstr "自 v0.4.0 起，同时支持 vLLM V0 和 V1 connector。"
+
+#: ../../source/features/kvcache-offloading.rst:17
+msgid ""
+"Since v0.5.0, both vLLM and `SGLang <https://github.com/sgl-"
+"project/sglang/tree/main/python/sglang/srt/mem_cache/storage/aibrix_kvcache>`_"
+" are supported."
+msgstr ""
+"自 v0.5.0 起，同时支持 vLLM 和 `SGLang <https://github.com/sgl-project/sglang/tree/main/python/sglang/srt/mem_cache/storage/aibrix_kvcache>`_ "
+"。"
+
+#: ../../source/features/kvcache-offloading.rst:20
+msgid "Currently, only FlashAttention and XFormers are supported."
+msgstr "目前仅支持 FlashAttention 和 XFormers。"
+
+#: ../../source/features/kvcache-offloading.rst:23
+msgid "Overview"
+msgstr "概述"
+
+#: ../../source/features/kvcache-offloading.rst:25
+msgid ""
+"An inference engine keeps the key/value tensors of every token it has "
+"processed in GPU memory, and evicts them when that memory fills up. Any "
+"later request that shares a prefix with an evicted sequence has to "
+"recompute it, which shows up directly as time to first token."
+msgstr ""
+"推理引擎将已处理每个 token 的 key/value 张量保存在 GPU 内存中，内存满时会驱逐它们。之后若有请求与被驱逐序列共享前缀，就必须重新计算，这会直接体现在首 token 时间上。"
+
+#: ../../source/features/kvcache-offloading.rst:29
+msgid "KVCache offloading extends the engine's KV cache beyond the GPU:"
+msgstr "KVCache 卸载将引擎的 KV cache 扩展到 GPU 之外："
+
+#: ../../source/features/kvcache-offloading.rst:31
+msgid ""
+"**L1** is a DRAM cache inside the engine pod. It is managed by the AIBrix"
+" connector that runs in the engine process, so it needs no extra "
+"deployment. Computed blocks are saved to host memory and reloaded when a "
+"matching prefix comes back."
+msgstr ""
+"**L1** 是引擎 Pod 内的 DRAM cache。由运行在引擎进程中的 AIBrix connector 管理，无需额外部署。已计算的 block 会保存到主机内存，匹配前缀再次出现时再加载回来。"
+
+#: ../../source/features/kvcache-offloading.rst:34
+msgid ""
+"**L2** is a distributed KV cache cluster outside the engine pods. Several"
+" engine replicas share it, so a prefix computed by one replica can be "
+"reused by another. AIBrix provisions and tracks the cluster through the "
+"``KVCache`` custom resource and connects engines to it through a "
+"pluggable backend."
+msgstr ""
+"**L2** 是引擎 Pod 外的分布式 KV cache 集群。多个引擎副本共享它，一个副本计算过的前缀可被另一个副本复用。AIBrix 通过 ``KVCache`` 自定义资源创建并跟踪该集群，引擎经可插拔后端接入。"
+
+#: ../../source/features/kvcache-offloading.rst:39
+msgid ""
+"The two levels are independent: you can run L1 alone, L2 alone, or both. "
+"This page shows how to turn each on. The design page, :doc:`../designs"
+"/aibrix-kvcache-offloading-framework`, explains the cache management "
+"algorithms and holds the complete environment variable reference."
+msgstr ""
+"两级相互独立：可以只开 L1、只开 L2，或两者都开。本页说明如何分别启用。设计文档 :doc:`../designs/aibrix-kvcache-offloading-framework` 解释 cache 管理算法，并提供完整环境变量参考。"
+
+#: ../../source/features/kvcache-offloading.rst:43
+msgid ""
+"This feature is different from :doc:`kv-event-sync`, which only publishes"
+" *which* prefixes each engine holds so the gateway can route to the "
+"warmest pod. Offloading moves the cache contents themselves."
+msgstr "该特性不同于 :doc:`kv-event-sync` ：后者只发布各引擎持有*哪些*前缀，以便网关路由到最热的 Pod。卸载则会搬移 cache 内容本身。"
+
+#: ../../source/features/kvcache-offloading.rst:48
+msgid "Architecture"
+msgstr "架构"
+
+#: ../../source/features/kvcache-offloading.rst:63
+#, python-brace-format
+msgid ""
+"The **connector** is loaded by the engine. For vLLM it is selected with "
+"``--kv-transfer-config "
+"'{\"kv_connector\":\"AIBrixOffloadingConnectorV1Type3\", "
+"\"kv_role\":\"kv_both\"}'`` (V1 engine, ``VLLM_USE_V1=1``). For SGLang, "
+"use the ``aibrix_kvcache`` storage backend linked in the note above."
+msgstr ""
+"**connector** 由引擎加载。对 vLLM，通过 ``--kv-transfer-config '{\"kv_connector\":\"AIBrixOffloadingConnectorV1Type3\", "
+"\"kv_role\":\"kv_both\"}'`` 选择（V1 引擎，``VLLM_USE_V1=1`` ）。对 SGLang，使用上文注释中链接的 "
+"``aibrix_kvcache`` 存储后端。"
+
+#: ../../source/features/kvcache-offloading.rst:67
+msgid ""
+"**L1** lives in the engine process. Its size and eviction policy are "
+"environment variables; ``S3FIFO`` is the default policy."
+msgstr "**L1** 位于引擎进程内。其大小和驱逐策略由环境变量控制；默认策略为 ``S3FIFO`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:69
+msgid ""
+"**L2** is reached through a backend connector chosen by "
+"``AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND``. The framework ships connectors "
+"for InfiniStore, HPKV, PrisKV, RocksDB, EIC, SHFS and a mock backend used"
+" in tests."
+msgstr ""
+"**L2** 通过 ``AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND`` 选定的后端 connector 访问。框架内置 InfiniStore、HPKV、PrisKV、RocksDB、EIC、SHFS 以及测试用 mock 后端。"
+
+#: ../../source/features/kvcache-offloading.rst:72
+msgid ""
+"For InfiniStore and HPKV, the **meta service** is a Redis instance that "
+"holds the L2 cluster membership. Engines read it to learn where cache "
+"nodes are; a watcher pod keeps it current as cache pods come and go."
+msgstr ""
+"对 InfiniStore 和 HPKV，**meta service** 是保存 L2 集群成员信息的 Redis 实例。引擎从中获知 cache 节点位置；watcher Pod 随 cache Pod 增减保持其最新。"
+
+#: ../../source/features/kvcache-offloading.rst:75
+msgid ""
+"The ``KVCache`` custom resource creates the cache pods and a ``Service``,"
+" plus the backend's metadata store: an etcd for Vineyard, or the Redis "
+"meta service and (when ``spec.watcher`` is set) the watcher pod for "
+"InfiniStore and HPKV. Which backend it deploys is set by an annotation."
+msgstr ""
+"``KVCache`` 自定义资源会创建 cache Pod 和 ``Service`` ，以及后端的元数据存储：Vineyard 使用 etcd；InfiniStore "
+"和 HPKV 使用 Redis meta service，并在设置 ``spec.watcher`` 时创建 watcher Pod。部署哪种后端由 "
+"annotation 决定。"
+
+#: ../../source/features/kvcache-offloading.rst:81
+msgid "Choosing a configuration"
+msgstr "选择配置"
+
+#: ../../source/features/kvcache-offloading.rst:87
+msgid "Setup"
+msgstr "方案"
+
+#: ../../source/features/kvcache-offloading.rst:88
+msgid "What you get"
+msgstr "效果"
+
+#: ../../source/features/kvcache-offloading.rst:89
+msgid "Use it when"
+msgstr "适用场景"
+
+#: ../../source/features/kvcache-offloading.rst:90
+msgid "L1 only"
+msgstr "仅 L1"
+
+#: ../../source/features/kvcache-offloading.rst:91
+msgid "Host-memory cache per engine pod. No extra components."
+msgstr "每个引擎 Pod 的主机内存 cache。无额外组件。"
+
+#: ../../source/features/kvcache-offloading.rst:92
+msgid ""
+"You have spare pod memory and repeated prefixes mostly hit the same "
+"replica. Start here."
+msgstr "Pod 有多余内存，且重复前缀大多打到同一副本。建议从此开始。"
+
+#: ../../source/features/kvcache-offloading.rst:93
+msgid "L2 only"
+msgstr "仅 L2"
+
+#: ../../source/features/kvcache-offloading.rst:94
+msgid "A shared cache across replicas, no host-memory cache."
+msgstr "跨副本的共享 cache，无主机内存 cache。"
+
+#: ../../source/features/kvcache-offloading.rst:95
+msgid ""
+"Pod memory is tight, or replicas are many and prefix reuse across them "
+"matters more than per-pod locality. Requires the ``KVCache`` cluster; "
+"InfiniStore performs best over RDMA and also supports TCP."
+msgstr ""
+"Pod 内存紧张，或副本很多且跨副本前缀复用比单 Pod 局部性更重要。需要 ``KVCache`` 集群；InfiniStore 在 RDMA 上表现最好，也支持 TCP。"
+
+#: ../../source/features/kvcache-offloading.rst:98
+msgid "L1 + L2"
+msgstr "L1 + L2"
+
+#: ../../source/features/kvcache-offloading.rst:99
+msgid ""
+"Every replica keeps its own L1. Blocks that become hot in L1 are also "
+"written to L2 (the default ``HOT`` ingestion policy) so other replicas "
+"can reuse them."
+msgstr "每个副本保留自己的 L1。L1 中变热的 block 也会写入 L2（默认 ``HOT`` 摄入策略），以便其他副本复用。"
+
+#: ../../source/features/kvcache-offloading.rst:101
+msgid ""
+"Both conditions above hold. L1 absorbs the fast path and L2 catches "
+"cross-replica reuse."
+msgstr "上述两种情况同时成立。L1 承接快路径，L2 承接跨副本复用。"
+
+#: ../../source/features/kvcache-offloading.rst:104
+msgid "Configuration reference"
+msgstr "配置参考"
+
+#: ../../source/features/kvcache-offloading.rst:106
+msgid ""
+"**Engine-side environment variables.** All of them start with "
+"``AIBRIX_KV_CACHE_OL_`` and are read by the connector at engine start. "
+"The most commonly changed ones are below; the complete list with every "
+"backend's settings is in the :ref:`environment variables reference "
+"<kvcache_env_reference>` of the design page."
+msgstr ""
+"**引擎侧环境变量。** 均以 ``AIBRIX_KV_CACHE_OL_`` 开头，由 connector 在引擎启动时读取。最常修改的如下；各后端的完整列表见设计页的 "
+":ref:`environment variables reference <kvcache_env_reference>` 。"
+
+#: ../../source/features/kvcache-offloading.rst:115
+msgid "Variable"
+msgstr "变量"
+
+#: ../../source/features/kvcache-offloading.rst:116
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/features/kvcache-offloading.rst:117
+#: ../../source/features/kvcache-offloading.rst:176
+#: ../../source/features/kvcache-offloading.rst:205
+msgid "Meaning"
+msgstr "含义"
+
+#: ../../source/features/kvcache-offloading.rst:118
+msgid "``AIBRIX_KV_CACHE_OL_L1_CACHE_ENABLED``"
+msgstr "``AIBRIX_KV_CACHE_OL_L1_CACHE_ENABLED``"
+
+#: ../../source/features/kvcache-offloading.rst:119
+msgid "``1``"
+msgstr "``1``"
+
+#: ../../source/features/kvcache-offloading.rst:120
+msgid "Turn L1 on or off. Set ``0`` for an L2-only setup."
+msgstr "开启或关闭 L1。仅 L2 时设为 ``0`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:121
+msgid "``AIBRIX_KV_CACHE_OL_L1_CACHE_CAPACITY_GB``"
+msgstr "``AIBRIX_KV_CACHE_OL_L1_CACHE_CAPACITY_GB``"
+
+#: ../../source/features/kvcache-offloading.rst:122
+msgid "``10``"
+msgstr "``10``"
+
+#: ../../source/features/kvcache-offloading.rst:123
+msgid ""
+"DRAM budget for L1. Must fit inside the pod's memory request together "
+"with the engine's own host-memory needs; see the note in the L1 example."
+msgstr "L1 的 DRAM 配额。须与引擎自身的主机内存需求一起落在 Pod 的 memory request 之内；见 L1 示例中的说明。"
+
+#: ../../source/features/kvcache-offloading.rst:125
+msgid "``AIBRIX_KV_CACHE_OL_L1_CACHE_EVICTION_POLICY``"
+msgstr "``AIBRIX_KV_CACHE_OL_L1_CACHE_EVICTION_POLICY``"
+
+#: ../../source/features/kvcache-offloading.rst:126
+msgid "``S3FIFO``"
+msgstr "``S3FIFO``"
+
+#: ../../source/features/kvcache-offloading.rst:127
+msgid "Eviction policy for L1."
+msgstr "L1 的驱逐策略。"
+
+#: ../../source/features/kvcache-offloading.rst:128
+msgid "``AIBRIX_KV_CACHE_OL_DEVICE``"
+msgstr "``AIBRIX_KV_CACHE_OL_DEVICE``"
+
+#: ../../source/features/kvcache-offloading.rst:129
+msgid "``cpu``"
+msgstr "``cpu``"
+
+#: ../../source/features/kvcache-offloading.rst:130
+msgid "Device used for cache operations, ``cpu`` or ``cuda``."
+msgstr "cache 操作使用的设备，``cpu`` 或 ``cuda`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:131
+msgid "``AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND``"
+msgstr "``AIBRIX_KV_CACHE_OL_L2_CACHE_BACKEND``"
+
+#: ../../source/features/kvcache-offloading.rst:132
+#: ../../source/features/kvcache-offloading.rst:139
+#: ../../source/features/kvcache-offloading.rst:142
+#: ../../source/features/kvcache-offloading.rst:145
+#: ../../source/features/kvcache-offloading.rst:158
+msgid "*(empty)*"
+msgstr "*(空)*"
+
+#: ../../source/features/kvcache-offloading.rst:133
+msgid ""
+"Empty disables L2. Otherwise one of ``INFINISTORE``, ``HPKV``, "
+"``PRISKV``, ``ROCKSDB``, ``EIC``, ``SHFS`` or ``MOCK``; the value is "
+"case-insensitive."
+msgstr ""
+"为空则禁用 L2。否则为 ``INFINISTORE`` 、``HPKV`` 、``PRISKV`` 、``ROCKSDB`` 、``EIC`` "
+"、``SHFS`` 或 ``MOCK`` 之一；大小写不敏感。"
+
+#: ../../source/features/kvcache-offloading.rst:135
+msgid "``AIBRIX_KV_CACHE_OL_L2_CACHE_NAMESPACE``"
+msgstr "``AIBRIX_KV_CACHE_OL_L2_CACHE_NAMESPACE``"
+
+#: ../../source/features/kvcache-offloading.rst:136
+msgid "``aibrix``"
+msgstr "``aibrix``"
+
+#: ../../source/features/kvcache-offloading.rst:137
+msgid ""
+"Key namespace in the L2 store. Engines only share entries within the same"
+" namespace."
+msgstr "L2 存储中的 key 命名空间。引擎仅在同一命名空间内共享条目。"
+
+#: ../../source/features/kvcache-offloading.rst:138
+msgid "``AIBRIX_KV_CACHE_OL_META_SERVICE_BACKEND``"
+msgstr "``AIBRIX_KV_CACHE_OL_META_SERVICE_BACKEND``"
+
+#: ../../source/features/kvcache-offloading.rst:140
+msgid "``redis`` when using a ``KVCache``-managed cluster."
+msgstr "使用 ``KVCache`` 管理的集群时为 ``redis`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:141
+msgid "``AIBRIX_KV_CACHE_OL_META_SERVICE_URL``"
+msgstr "``AIBRIX_KV_CACHE_OL_META_SERVICE_URL``"
+
+#: ../../source/features/kvcache-offloading.rst:143
+msgid ""
+"Redis URL of the meta service, for example ``redis://kvcache-cluster-"
+"redis:6379``."
+msgstr "meta service 的 Redis URL，例如 ``redis://kvcache-cluster-redis:6379`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:144
+msgid "``AIBRIX_KV_CACHE_OL_META_SERVICE_CLUSTER_META_KEY``"
+msgstr "``AIBRIX_KV_CACHE_OL_META_SERVICE_CLUSTER_META_KEY``"
+
+#: ../../source/features/kvcache-offloading.rst:146
+msgid ""
+"Key under which the membership list is stored. Must match what the "
+"watcher writes: ``kvcache_nodes`` for InfiniStore, "
+"``hpkv_cluster_metadata`` for HPKV."
+msgstr ""
+"成员列表所在的 key。必须与 watcher 写入的一致：InfiniStore 为 ``kvcache_nodes`` ，HPKV 为 ``hpkv_cluster_metadata`` "
+"。"
+
+#: ../../source/features/kvcache-offloading.rst:148
+msgid "``AIBRIX_KV_CACHE_OL_META_SERVICE_REFRESH_INTERVAL_S``"
+msgstr "``AIBRIX_KV_CACHE_OL_META_SERVICE_REFRESH_INTERVAL_S``"
+
+#: ../../source/features/kvcache-offloading.rst:149
+msgid "``30``"
+msgstr "``30``"
+
+#: ../../source/features/kvcache-offloading.rst:150
+msgid "How often the engine re-reads the membership list."
+msgstr "引擎重新读取成员列表的间隔。"
+
+#: ../../source/features/kvcache-offloading.rst:151
+msgid "``AIBRIX_KV_CACHE_OL_INFINISTORE_CONNECTION_TYPE``"
+msgstr "``AIBRIX_KV_CACHE_OL_INFINISTORE_CONNECTION_TYPE``"
+
+#: ../../source/features/kvcache-offloading.rst:152
+msgid "``RDMA``"
+msgstr "``RDMA``"
+
+#: ../../source/features/kvcache-offloading.rst:153
+msgid "InfiniStore transport, ``RDMA`` or ``TCP``."
+msgstr "InfiniStore 传输，``RDMA`` 或 ``TCP`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:154
+msgid "``AIBRIX_KV_CACHE_OL_INFINISTORE_LINK_TYPE``"
+msgstr "``AIBRIX_KV_CACHE_OL_INFINISTORE_LINK_TYPE``"
+
+#: ../../source/features/kvcache-offloading.rst:155
+msgid "``Ethernet``"
+msgstr "``Ethernet``"
+
+#: ../../source/features/kvcache-offloading.rst:156
+msgid "``Ethernet`` for RoCE, ``IB`` for InfiniBand."
+msgstr "RoCE 用 ``Ethernet`` ，InfiniBand 用 ``IB`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:157
+msgid "``AIBRIX_KV_CACHE_OL_INFINISTORE_VISIBLE_DEV_LIST``"
+msgstr "``AIBRIX_KV_CACHE_OL_INFINISTORE_VISIBLE_DEV_LIST``"
+
+#: ../../source/features/kvcache-offloading.rst:159
+msgid ""
+"Comma-separated RDMA devices the engine may use, optionally with a GID "
+"index (``mlx5_1:7,mlx5_2:7``)."
+msgstr "引擎可用的 RDMA 设备，逗号分隔，可选附带 GID 索引（``mlx5_1:7,mlx5_2:7`` ）。"
+
+#: ../../source/features/kvcache-offloading.rst:161
+msgid "``AIBRIX_KV_CACHE_OL_PROFILING_ENABLED``"
+msgstr "``AIBRIX_KV_CACHE_OL_PROFILING_ENABLED``"
+
+#: ../../source/features/kvcache-offloading.rst:162
+msgid "``0``"
+msgstr "``0``"
+
+#: ../../source/features/kvcache-offloading.rst:163
+msgid ""
+"Send connector profiles to the profiling service; see the profiling "
+"example."
+msgstr "将 connector profile 发送到 profiling 服务；见 profiling 示例。"
+
+#: ../../source/features/kvcache-offloading.rst:164
+msgid "``AIBRIX_KV_CACHE_OL_PROFILING_SERVER_ADDRESS``"
+msgstr "``AIBRIX_KV_CACHE_OL_PROFILING_SERVER_ADDRESS``"
+
+#: ../../source/features/kvcache-offloading.rst:165
+msgid "``http://0.0.0.0:4040``"
+msgstr "``http://0.0.0.0:4040``"
+
+#: ../../source/features/kvcache-offloading.rst:166
+msgid "Address of that service."
+msgstr "该服务的地址。"
+
+#: ../../source/features/kvcache-offloading.rst:168
+msgid ""
+"**The KVCache custom resource** (``orchestration.aibrix.ai/v1alpha1``, "
+"kind ``KVCache``) describes an L2 cluster."
+msgstr ""
+"**KVCache 自定义资源** （``orchestration.aibrix.ai/v1alpha1`` ，kind ``KVCache`` "
+"）描述一个 L2 集群。"
+
+#: ../../source/features/kvcache-offloading.rst:175
+msgid "Field"
+msgstr "字段"
+
+#: ../../source/features/kvcache-offloading.rst:177
+msgid "``spec.mode``"
+msgstr "``spec.mode``"
+
+#: ../../source/features/kvcache-offloading.rst:178
+msgid ""
+"``distributed`` or ``centralized``. Present in the API but not read by "
+"the current controller; the backend annotation below decides what is "
+"deployed."
+msgstr ""
+"``distributed`` 或 ``centralized`` 。存在于 API 中，但当前 controller 不读取；实际部署由下方的后端 "
+"annotation 决定。"
+
+#: ../../source/features/kvcache-offloading.rst:180
+msgid "``spec.metadata.redis``"
+msgstr "``spec.metadata.redis``"
+
+#: ../../source/features/kvcache-offloading.rst:181
+msgid ""
+"Used by the InfiniStore and HPKV backends. Give it a ``runtime`` block "
+"(image, replicas, resources) to have the controller deploy Redis, or an "
+"``externalConnection`` (``address``, ``passwordSecretRef``) to reuse an "
+"existing instance."
+msgstr ""
+"InfiniStore 和 HPKV 后端使用。提供 ``runtime`` 块（image、replicas、resources）让 controller "
+"部署 Redis，或提供 ``externalConnection`` （``address`` 、``passwordSecretRef`` "
+"）以复用已有实例。"
+
+#: ../../source/features/kvcache-offloading.rst:184
+msgid "``spec.metadata.etcd``"
+msgstr "``spec.metadata.etcd``"
+
+#: ../../source/features/kvcache-offloading.rst:185
+msgid ""
+"Used by the Vineyard backend. Only the ``runtime`` block is supported; "
+"``externalConnection`` is not implemented for etcd."
+msgstr "Vineyard 后端使用。仅支持 ``runtime`` 块；etcd 的 ``externalConnection`` 尚未实现。"
+
+#: ../../source/features/kvcache-offloading.rst:187
+msgid "``spec.cache``"
+msgstr "``spec.cache``"
+
+#: ../../source/features/kvcache-offloading.rst:188
+msgid ""
+"The cache pods: ``replicas`` (default 1), ``image``, ``imagePullPolicy``,"
+" ``env``, ``resources``, or a full ``template`` for advanced pod "
+"settings."
+msgstr ""
+"cache Pod：``replicas`` （默认 1）、``image`` 、``imagePullPolicy`` 、``env`` 、``resources`` "
+"，或用于高级 Pod 设置的完整 ``template`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:190
+msgid "``spec.watcher``"
+msgstr "``spec.watcher``"
+
+#: ../../source/features/kvcache-offloading.rst:191
+msgid ""
+"InfiniStore and HPKV only. The watcher registers cache members in Redis; "
+"without it the engines never learn the cluster membership, so set it for "
+"those backends. ``image``, ``imagePullPolicy``, ``env`` and ``resources``"
+" are honoured; ``replicas`` and ``template`` are ignored."
+msgstr ""
+"仅 InfiniStore 和 HPKV。watcher 在 Redis 中注册 cache 成员；没有它引擎无法获知集群成员，因此这些后端必须设置。``image`` "
+"、``imagePullPolicy`` 、``env`` 和 ``resources`` 生效；``replicas`` 和 ``template`` "
+"被忽略。"
+
+#: ../../source/features/kvcache-offloading.rst:195
+msgid "``spec.service``"
+msgstr "``spec.service``"
+
+#: ../../source/features/kvcache-offloading.rst:196
+msgid "``type`` (default ``ClusterIP``) and ``ports`` for the cache service."
+msgstr "cache Service 的 ``type`` （默认 ``ClusterIP`` ）和 ``ports`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:198
+msgid ""
+"Annotations on the ``KVCache`` object select the backend and its "
+"placement:"
+msgstr "``KVCache`` 对象上的 annotation 选择后端及其放置："
+
+#: ../../source/features/kvcache-offloading.rst:204
+msgid "Annotation"
+msgstr "Annotation"
+
+#: ../../source/features/kvcache-offloading.rst:206
+msgid "``kvcache.orchestration.aibrix.ai/backend``"
+msgstr "``kvcache.orchestration.aibrix.ai/backend``"
+
+#: ../../source/features/kvcache-offloading.rst:207
+msgid ""
+"``infinistore``, ``hpkv`` or ``vineyard``. Defaults to ``vineyard`` when "
+"absent."
+msgstr "``infinistore`` 、``hpkv`` 或 ``vineyard`` 。缺省时默认为 ``vineyard`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:208
+msgid "``kvcache.orchestration.aibrix.ai/pod-affinity-workload``"
+msgstr "``kvcache.orchestration.aibrix.ai/pod-affinity-workload``"
+
+#: ../../source/features/kvcache-offloading.rst:209
+msgid ""
+"Vineyard backend only. Name of the model workload the cache pods should "
+"be co-located with."
+msgstr "仅 Vineyard 后端。cache Pod 应与之同置的模型工作负载名称。"
+
+#: ../../source/features/kvcache-offloading.rst:211
+msgid "``kvcache.orchestration.aibrix.ai/pod-anti-affinity``"
+msgstr "``kvcache.orchestration.aibrix.ai/pod-anti-affinity``"
+
+#: ../../source/features/kvcache-offloading.rst:212
+msgid "Vineyard backend only. Spread cache pods away from each other."
+msgstr "仅 Vineyard 后端。将 cache Pod 相互打散。"
+
+#: ../../source/features/kvcache-offloading.rst:213
+msgid ""
+"``kvcache.orchestration.aibrix.ai/node-affinity-key`` and ``.../node-"
+"affinity-gpu-type``"
+msgstr "``kvcache.orchestration.aibrix.ai/node-affinity-key`` 和 ``.../node-affinity-gpu-type``"
+
+#: ../../source/features/kvcache-offloading.rst:214
+msgid ""
+"Vineyard backend only. Pin cache pods to nodes carrying a given label and"
+" value."
+msgstr "仅 Vineyard 后端。将 cache Pod 固定到带有指定标签和值的节点。"
+
+#: ../../source/features/kvcache-offloading.rst:215
+msgid ""
+"``infinistore.kvcache.orchestration.aibrix.ai/link-type`` and ``.../hint-"
+"gid-index``"
+msgstr "``infinistore.kvcache.orchestration.aibrix.ai/link-type`` 和 ``.../hint-gid-index``"
+
+#: ../../source/features/kvcache-offloading.rst:216
+msgid "InfiniStore transport settings passed to the cache pods."
+msgstr "传给 cache Pod 的 InfiniStore 传输设置。"
+
+#: ../../source/features/kvcache-offloading.rst:217
+msgid "``hpkv.kvcache.orchestration.aibrix.ai/*``"
+msgstr "``hpkv.kvcache.orchestration.aibrix.ai/*``"
+
+#: ../../source/features/kvcache-offloading.rst:218
+msgid ""
+"HPKV sizing: ``block-size-bytes``, ``block-count``, ``total-slots``, "
+"``virtual-node-count``, ``rdma-port``, ``admin-port``."
+msgstr ""
+"HPKV 规模：``block-size-bytes`` 、``block-count`` 、``total-slots`` 、``virtual-node-count`` "
+"、``rdma-port`` 、``admin-port`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:224
+msgid "L1 Cache Example"
+msgstr "L1 Cache 示例"
+
+#: ../../source/features/kvcache-offloading.rst:227
+msgid ""
+"We use a customized version of vLLM integrated with *AIBrix Offloading "
+"Connectors* to showcase the usage."
+msgstr "以下使用集成了 *AIBrix Offloading Connectors* 的定制 vLLM 展示用法。"
+
+#: ../../source/features/kvcache-offloading.rst:230
+msgid ""
+"Before deploying the inference engine, please use ``kubectl get pods -n "
+"aibrix-system`` and ``kubectl get pods -n envoy-gateway-system`` to "
+"ensure ``envoy-gateway`` and ``aibrix-gateway`` are running. Other "
+"components are optional."
+msgstr ""
+"部署推理引擎前，请用 ``kubectl get pods -n aibrix-system`` 和 ``kubectl get pods -n envoy-gateway-system`` 确认 ``envoy-gateway`` 和 ``aibrix-gateway`` 正在运行。其他组件可选。"
+
+#: ../../source/features/kvcache-offloading.rst:251
+#: ../../source/features/kvcache-offloading.rst:384
+msgid "Now let's use the following yaml to create an engine deployment:"
+msgstr "接下来用以下 yaml 创建引擎 Deployment："
+
+#: ../../source/features/kvcache-offloading.rst:268
+msgid ""
+"``AIBRIX_KV_CACHE_OL_L1_CACHE_CAPACITY_GB`` needs to choose a proper "
+"value based on the pod memory resource requirement. For instance, if the "
+"pod memory resource requirement is ``P`` GB and the estimated memory "
+"consumption of the inference engine is ``E`` GB, we can set "
+"``AIBRIX_KV_CACHE_OL_L1_CACHE_CAPACITY_GB`` to ``P / tensor-parallel-size"
+" - E``."
+msgstr ""
+"``AIBRIX_KV_CACHE_OL_L1_CACHE_CAPACITY_GB`` 需根据 Pod 内存资源需求选择合适的值。例如，若 Pod "
+"内存需求为 ``P`` GB、推理引擎预估内存消耗为 ``E`` GB，可将 ``AIBRIX_KV_CACHE_OL_L1_CACHE_CAPACITY_GB`` "
+"设为 ``P / tensor-parallel-size - E`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:270
+#: ../../source/features/kvcache-offloading.rst:409
+msgid ""
+"Now let's use ``kubectl get pods`` command to ensure the inference "
+"service is running:"
+msgstr "接下来用 ``kubectl get pods`` 确认推理服务正在运行："
+
+#: ../../source/features/kvcache-offloading.rst:281
+#: ../../source/features/kvcache-offloading.rst:424
+msgid ""
+"Once the inference service is running, let's set up port forwarding so "
+"that we can test the service from local:"
+msgstr "推理服务运行后，设置端口转发以便从本地测试："
+
+#: ../../source/features/kvcache-offloading.rst:283
+#: ../../source/features/kvcache-offloading.rst:426
+msgid ""
+"Run ``kubectl get svc -n envoy-gateway-system`` to get the name of the "
+"Envoy Gateway service."
+msgstr "运行 ``kubectl get svc -n envoy-gateway-system`` 获取 Envoy Gateway Service 的名称。"
+
+#: ../../source/features/kvcache-offloading.rst:293
+#: ../../source/features/kvcache-offloading.rst:436
+msgid ""
+"Run ``kubectl -n envoy-gateway-system port-forward svc/envoy-aibrix-"
+"system-aibrix-eg-903790dc 8888:80 &`` to set up port forwarding"
+msgstr ""
+"运行 ``kubectl -n envoy-gateway-system port-forward svc/envoy-aibrix-system-aibrix-eg-903790dc 8888:80 &`` 设置端口转发"
+
+#: ../../source/features/kvcache-offloading.rst:302
+#: ../../source/features/kvcache-offloading.rst:445
+msgid "Now, let's test the service:"
+msgstr "接下来测试服务："
+
+#: ../../source/features/kvcache-offloading.rst:315
+#: ../../source/features/kvcache-offloading.rst:458
+msgid "and its output would be:"
+msgstr "输出类似："
+
+#: ../../source/features/kvcache-offloading.rst:346
+msgid "L2 Cache Example"
+msgstr "L2 Cache 示例"
+
+#: ../../source/features/kvcache-offloading.rst:349
+msgid ""
+"let's deploy the distributed KV cache cluster with the following yaml "
+"configuration:"
+msgstr "用以下 yaml 配置部署分布式 KV cache 集群："
+
+#: ../../source/features/kvcache-offloading.rst:357
+msgid ""
+"We have changed L45 from one replica to three replicas in this example, "
+"thus we will find three KV cache pods running in the cluster."
+msgstr "本示例将第 45 行从 1 副本改为 3 副本，因此集群中会有 3 个 KV cache Pod 在运行。"
+
+#: ../../source/features/kvcache-offloading.rst:401
+msgid ""
+"In this example, we set ``AIBRIX_KV_CACHE_OL_L1_CACHE_ENABLED=0`` to "
+"explicitly disable ``L1Cache`` and use ``L2Cache`` only."
+msgstr ""
+"本示例设置 ``AIBRIX_KV_CACHE_OL_L1_CACHE_ENABLED=0`` ，显式禁用 ``L1Cache`` ，仅使用 ``L2Cache`` "
+"。"
+
+#: ../../source/features/kvcache-offloading.rst:402
+msgid ""
+"Current version only supports using ``InfiniStore`` with RDMA transport. "
+"Please ensure ``AIBRIX_KV_CACHE_OL_INFINISTORE_CONNECTION_TYPE=RDMA`` is "
+"configured."
+msgstr ""
+"当前版本仅支持使用 RDMA 传输的 ``InfiniStore`` 。请确保配置 ``AIBRIX_KV_CACHE_OL_INFINISTORE_CONNECTION_TYPE=RDMA`` "
+"。"
+
+#: ../../source/features/kvcache-offloading.rst:403
+msgid ""
+"For InfiniBand, please set "
+"``AIBRIX_KV_CACHE_OL_INFINISTORE_LINK_TYPE=IB``. For RoCE, please keep "
+"the default value ``Ethernet``."
+msgstr ""
+"InfiniBand 请设置 ``AIBRIX_KV_CACHE_OL_INFINISTORE_LINK_TYPE=IB`` 。RoCE 请保持默认值 "
+"``Ethernet`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:404
+msgid ""
+"``AIBRIX_KV_CACHE_OL_INFINISTORE_VISIBLE_DEV_LIST`` is used to configure "
+"which RDMA device can be used by the engine to access remote KV cache "
+"servers. For instance, if you allocate 8 GPUs for the engine pod and set "
+"``AIBRIX_KV_CACHE_OL_INFINISTORE_VISIBLE_DEV_LIST=\"mlx5_1,mlx5_2\"``, "
+"then engine processes using GPU 0 to 3 will use ``mlx5_1``, and engine "
+"processes using GPU 4 to 7 will use ``mlx5_2``."
+msgstr ""
+"``AIBRIX_KV_CACHE_OL_INFINISTORE_VISIBLE_DEV_LIST`` 用于配置引擎访问远程 KV cache "
+"服务器时可使用的 RDMA 设备。例如，若引擎 Pod 分配 8 块 GPU 并设置 ``AIBRIX_KV_CACHE_OL_INFINISTORE_VISIBLE_DEV_LIST=\"mlx5_1,mlx5_2\"`` "
+"，则使用 GPU 0 到 3 的引擎进程使用 ``mlx5_1`` ，使用 GPU 4 到 7 的引擎进程使用 ``mlx5_2`` 。"
+
+#: ../../source/features/kvcache-offloading.rst:405
+msgid ""
+"If GID indexes of RDMA devices are required in your environment, please "
+"append the GID index to each RDMA device (e.g., ``mlx5_1:6,mlx5_2:7``) in"
+" ``AIBRIX_KV_CACHE_OL_INFINISTORE_VISIBLE_DEV_LIST``."
+msgstr ""
+"若环境需要 RDMA 设备的 GID 索引，请在 ``AIBRIX_KV_CACHE_OL_INFINISTORE_VISIBLE_DEV_LIST`` "
+"中为每个 RDMA 设备追加 GID 索引（例如 ``mlx5_1:6,mlx5_2:7`` ）。"
+
+#: ../../source/features/kvcache-offloading.rst:406
+msgid ""
+"``AIBRIX_KV_CACHE_OL_META_SERVICE_URL`` points to the Redis instance "
+"managing KV cache cluster metadata. In this example, it is set to ``redis"
+"://kvcache-cluster-redis:6379``, where ``kvcache-cluster`` is the KV "
+"cache deployment name."
+msgstr ""
+"``AIBRIX_KV_CACHE_OL_META_SERVICE_URL`` 指向管理 KV cache 集群元数据的 Redis 实例。本示例设为 "
+"``redis://kvcache-cluster-redis:6379`` ，其中 ``kvcache-cluster`` 是 KV cache "
+"Deployment 名称。"
+
+#: ../../source/features/kvcache-offloading.rst:407
+msgid ""
+"``AIBRIX_KV_CACHE_OL_META_SERVICE_BACKEND`` and "
+"``AIBRIX_KV_CACHE_OL_META_SERVICE_CLUSTER_META_KEY`` are fixed in current"
+" version and should not be modified."
+msgstr ""
+"当前版本中 ``AIBRIX_KV_CACHE_OL_META_SERVICE_BACKEND`` 和 ``AIBRIX_KV_CACHE_OL_META_SERVICE_CLUSTER_META_KEY`` 为固定值，不应修改。"
+
+#: ../../source/features/kvcache-offloading.rst:486
+msgid "Profiling Example"
+msgstr "Profiling 示例"
+
+#: ../../source/features/kvcache-offloading.rst:488
+msgid ""
+"To profile the AIBrix Offloading Connectors, before launching the "
+"inference engines, you need to start the profiling service with the "
+"following sample YAML file:"
+msgstr "要对 AIBrix Offloading Connectors 做 profiling，启动推理引擎前需用以下示例 YAML 启动 profiling 服务："
+
+#: ../../source/features/kvcache-offloading.rst:504
+msgid ""
+"Once the profiling service is running, let's set up port forwarding so "
+"that we can browse the profiling results and flamegraphs from local:"
+msgstr "profiling 服务运行后，设置端口转发以便从本地浏览 profiling 结果和火焰图："
+
+#: ../../source/features/kvcache-offloading.rst:506
+msgid ""
+"Run ``kubectl port-forward svc/aibrix-kvcache-profiling 4040:4040 &`` to "
+"set up port forwarding"
+msgstr "运行 ``kubectl port-forward svc/aibrix-kvcache-profiling 4040:4040 &`` 设置端口转发"
+
+#: ../../source/features/kvcache-offloading.rst:508
+msgid ""
+"Now let's launch the inference engine with the following environment "
+"variables set in engine's YAML file (please refer to "
+":ref:`l1_cache_example` and :ref:`l2_cache_example` for more details)."
+msgstr ""
+"接下来在引擎 YAML 中设置以下环境变量并启动推理引擎（详见 :ref:`l1_cache_example` 和 :ref:`l2_cache_example` "
+"）。"
+
+#: ../../source/features/kvcache-offloading.rst:518
+msgid ""
+"Run a task to generate requests to the inference engine, and you can "
+"browse the profiling results and flamegraphs from local after a while:"
+msgstr "运行任务向推理引擎生成请求，稍后即可从本地浏览 profiling 结果和火焰图："
+
+#: ../../source/features/kvcache-offloading.rst:520
+msgid "Open `http://localhost:4040` in your browser"
+msgstr "在浏览器中打开 `http://localhost:4040`"
+
+#: ../../source/features/kvcache-offloading.rst:521
+msgid ""
+"Adjust the query parameters as illustrated in the following figure to "
+"show the flamegraph of AIBrix Offloading Connectors"
+msgstr "按下图调整查询参数，以显示 AIBrix Offloading Connectors 的火焰图"
+
+#: ../../source/features/kvcache-offloading.rst:523
+msgid "aibrix-kvcache-profiling"
+msgstr "aibrix-kvcache-profiling"
+
+#: ../../source/features/kvcache-offloading.rst:530
+msgid ":doc:`../designs/aibrix-kvcache-offloading-framework`"
+msgstr ":doc:`../designs/aibrix-kvcache-offloading-framework`"
+
+#: ../../source/features/kvcache-offloading.rst:531
+msgid "Internal design of the KV cache offloading framework."
+msgstr "KV cache 卸载框架的内部设计。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/lora-dynamic-loading.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/lora-dynamic-loading.po
@@ -1,0 +1,1157 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/lora-dynamic-loading.rst:5
+msgid "Lora Dynamic Loading"
+msgstr "LoRA 动态加载"
+
+#: ../../source/features/lora-dynamic-loading.rst:7
+msgid ""
+"The LoRA Model Adapter support is crucial for improving model density and"
+" reducing inference costs in large language models (LLMs). By enabling "
+"dynamic loading and unloading of LoRA adapters, it allows multiple models"
+" to be deployed more efficiently on a shared infrastructure."
+msgstr ""
+"LoRA Model Adapter 支持对提高大语言模型（LLM）的模型密度并降低推理成本至关重要。通过动态加载和卸载 LoRA adapter，可在共享基础设施上更高效地部署多个模型。"
+
+#: ../../source/features/lora-dynamic-loading.rst:10
+msgid ""
+"This reduces resource consumption by reusing base models across different"
+" tasks while swapping in lightweight LoRA adapters for specific model "
+"tuning. The approach optimizes GPU memory usage, decreases cold start "
+"times, and enhances scalability, making it ideal for high-density "
+"deployment and cost-effective inference in production environments."
+msgstr ""
+"通过在不同任务间复用基座模型，并换入轻量 LoRA adapter 做特定调优，可降低资源消耗。该方式优化 GPU 内存使用、缩短冷启动时间并提升可扩展性，适合生产环境中的高密度部署和低成本推理。"
+
+#: ../../source/features/lora-dynamic-loading.rst:14
+msgid "High Level Design"
+msgstr "高层设计"
+
+#: ../../source/features/lora-dynamic-loading.rst:17
+msgid "Model Adapter Controller"
+msgstr "Model Adapter Controller"
+
+#: ../../source/features/lora-dynamic-loading.rst:19
+msgid ""
+"We develop a ModelAdapter `controller "
+"<https://kubernetes.io/docs/concepts/architecture/controller/>`_ to "
+"manage the lora model adapter lifecycle. User can submit a lora `Custom "
+"Resource <https://kubernetes.io/docs/concepts/extend-kubernetes/api-"
+"extension/custom-resources/>`_ and controller will register to the "
+"matching pods, configure the service discovery and expose the adapter "
+"status."
+msgstr ""
+"我们开发了 ModelAdapter `controller <https://kubernetes.io/docs/concepts/architecture/controller/>`_ 来管理 LoRA model adapter 的生命周期。用户提交 LoRA `Custom Resource <https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/>`_ 后，controller 会注册到匹配的 Pod、配置服务发现并暴露 adapter 状态。"
+
+#: ../../source/features/lora-dynamic-loading.rst:22
+msgid "lora-controller-workflow"
+msgstr "lora-controller-workflow"
+
+#: ../../source/features/lora-dynamic-loading.rst:28
+msgid "ModelAdapter Lifecycle and Phase Transitions"
+msgstr "ModelAdapter 生命周期与阶段转换"
+
+#: ../../source/features/lora-dynamic-loading.rst:30
+msgid ""
+"The ModelAdapter goes through several distinct phases during its "
+"lifecycle. Understanding these phases helps users monitor and "
+"troubleshoot their LoRA deployments:"
+msgstr "ModelAdapter 生命周期中会经历若干阶段。了解这些阶段有助于监控和排查 LoRA 部署："
+
+#: ../../source/features/lora-dynamic-loading.rst:32
+msgid "**Phase Transition Flow:**"
+msgstr "**阶段转换流程：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:43
+msgid "**Phase Details:**"
+msgstr "**阶段说明：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:45
+msgid ""
+"**Pending**: The controller has started reconciliation but no adapter "
+"instance is loaded yet. The ``Ready`` condition says why: reason "
+"``NoReadyPods`` means no ready pod matches the ``podSelector`` (with "
+"``replicas: 1`` it also covers pods that became ready too recently to be "
+"scheduled); reason ``ModelAdapterUnavailable`` means candidate pods exist"
+" but the adapter is not loaded on any of them yet."
+msgstr ""
+"**Pending** ：controller 已开始调和，但尚未加载任何 adapter 实例。``Ready`` condition 说明原因：``NoReadyPods`` "
+"表示没有匹配 ``podSelector`` 的就绪 Pod（在 ``replicas: 1`` 时也包括刚就绪、尚不能调度的 Pod）；``ModelAdapterUnavailable`` "
+"表示已有候选 Pod，但 adapter 尚未加载到其中任何一个。"
+
+#: ../../source/features/lora-dynamic-loading.rst:47
+msgid ""
+"**Scheduled**: Only with ``replicas: 1``. The controller has selected a "
+"pod that matches the ``podSelector`` and is loading the adapter on it. "
+"Pods are validated for readiness and stability before selection. Loading "
+"includes:"
+msgstr ""
+"**Scheduled** ：仅在 ``replicas: 1`` 时出现。controller 已选出匹配 ``podSelector`` 的 "
+"Pod，并正在其上加载 adapter。选择前会校验 Pod 就绪与稳定。加载包括："
+
+#: ../../source/features/lora-dynamic-loading.rst:49
+msgid "Downloading the adapter from the specified ``artifactURL``"
+msgstr "从指定的 ``artifactURL`` 下载 adapter"
+
+#: ../../source/features/lora-dynamic-loading.rst:50
+msgid "Registering the adapter with the vLLM engine"
+msgstr "向 vLLM 引擎注册 adapter"
+
+#: ../../source/features/lora-dynamic-loading.rst:51
+msgid "Retrying with exponential backoff if loading fails"
+msgstr "加载失败时以指数退避重试"
+
+#: ../../source/features/lora-dynamic-loading.rst:53
+msgid ""
+"Without ``replicas`` (load on all matching pods) the adapter moves from "
+"``Pending`` straight to ``Running``."
+msgstr "未设置 ``replicas`` （在所有匹配 Pod 上加载）时，adapter 从 ``Pending`` 直接进入 ``Running`` 。"
+
+#: ../../source/features/lora-dynamic-loading.rst:55
+msgid ""
+"**Running**: The adapter is loaded on at least one pod and the Kubernetes"
+" Service and EndpointSlice for service discovery exist. The LoRA model is"
+" accessible through the gateway using the adapter name. ``readyReplicas``"
+" out of ``desiredReplicas`` in the status shows how many candidate pods "
+"have the adapter loaded."
+msgstr ""
+"**Running** ：adapter 已加载到至少一个 Pod，且用于服务发现的 Kubernetes Service 和 EndpointSlice "
+"已存在。可通过网关使用 adapter 名称访问该 LoRA 模型。status 中的 ``readyReplicas`` / ``desiredReplicas`` "
+"表示有多少候选 Pod 已加载该 adapter。"
+
+#: ../../source/features/lora-dynamic-loading.rst:57
+msgid ""
+"**Failed**: Loading failed on every candidate pod. The ``Ready`` "
+"condition carries reason ``ModelAdapterLoadingError`` and the per-pod "
+"errors in its message. The controller keeps retrying and the adapter "
+"returns to ``Running`` as soon as one load succeeds."
+msgstr ""
+"**Failed** ：在每个候选 Pod 上加载都失败。``Ready`` condition 的 reason 为 ``ModelAdapterLoadingError`` "
+"，message 中含各 Pod 错误。controller 持续重试，一旦有一次加载成功，adapter 即回到 ``Running`` 。"
+
+#: ../../source/features/lora-dynamic-loading.rst:59
+msgid ""
+"``ResourceCreated`` is not a step of the normal flow. It shows up as the "
+"phase only when creating the Service or EndpointSlice fails; the "
+"condition of the same name carries the error details, and the controller "
+"keeps retrying. ``Bound`` is a condition, not a phase: it is ``True`` "
+"(together with the ``Scheduled`` condition) while the adapter is loaded, "
+"and turns ``False`` with reason ``ModelAdapterLoadingError`` when a "
+"loading pass fails, while the phase stays ``Pending`` or ``Failed``."
+msgstr ""
+"``ResourceCreated`` 不是正常流程中的一步。仅在创建 Service 或 EndpointSlice 失败时才会作为 phase "
+"出现；同名 condition 携带错误详情，controller 会持续重试。``Bound`` 是 condition 而非 phase：adapter "
+"已加载时为 ``True`` （同时伴随 ``Scheduled`` condition）；某次加载失败时变为 ``False`` ，reason "
+"为 ``ModelAdapterLoadingError`` ，而 phase 仍为 ``Pending`` 或 ``Failed`` 。"
+
+#: ../../source/features/lora-dynamic-loading.rst:61
+msgid "**Error Handling and Reliability Features:**"
+msgstr "**错误处理与可靠性特性：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:63
+msgid ""
+"**Retry Mechanism**: Up to 5 retry attempts per pod with exponential "
+"backoff (starting at 5 seconds)"
+msgstr "**重试机制** ：每个 Pod 最多重试 5 次，指数退避（起始 5 秒）"
+
+#: ../../source/features/lora-dynamic-loading.rst:64
+msgid ""
+"**Pod Switching**: Automatic selection of alternative pods if loading "
+"fails on initial pods"
+msgstr "**Pod 切换** ：初始 Pod 加载失败时自动选择其他 Pod"
+
+#: ../../source/features/lora-dynamic-loading.rst:65
+msgid ""
+"**Pod Health Validation**: Ensures pods are ready and stable before "
+"scheduling adapters"
+msgstr "**Pod 健康校验** ：调度 adapter 前确保 Pod 就绪且稳定"
+
+#: ../../source/features/lora-dynamic-loading.rst:66
+msgid ""
+"**Connection Error Handling**: Graceful handling of common startup errors"
+" like \"connection refused\""
+msgstr "**连接错误处理** ：优雅处理常见启动错误，例如 \"connection refused\""
+
+#: ../../source/features/lora-dynamic-loading.rst:68
+msgid "**Monitoring Phase Transitions:**"
+msgstr "**监控阶段转换：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:70
+msgid ""
+"``kubectl get modeladapter`` shows the phase, the replica counters and "
+"the reason of the ``Ready`` condition at a glance. While the base model "
+"pod is still starting:"
+msgstr ""
+"``kubectl get modeladapter`` 可一眼看到 phase、副本计数以及 ``Ready`` condition 的 reason。基座模型 Pod 仍在启动时："
+
+#: ../../source/features/lora-dynamic-loading.rst:78
+msgid "Once the adapter is loaded:"
+msgstr "adapter 加载完成后："
+
+#: ../../source/features/lora-dynamic-loading.rst:86
+msgid ""
+"Blank counter cells mean zero. ``-o wide`` adds the base model, the pods "
+"hosting the adapter and the full ``Ready`` condition message:"
+msgstr "空白计数单元格表示 0。``-o wide`` 会额外显示基座模型、承载 adapter 的 Pod 以及完整的 ``Ready`` condition message："
+
+#: ../../source/features/lora-dynamic-loading.rst:94
+msgid ""
+"For the full condition history with timestamps and reasons for each state"
+" change, use:"
+msgstr "要查看带时间戳和每次状态变更 reason 的完整 condition 历史，使用："
+
+#: ../../source/features/lora-dynamic-loading.rst:101
+msgid "Model Adapter Service Discovery"
+msgstr "Model Adapter 服务发现"
+
+#: ../../source/features/lora-dynamic-loading.rst:103
+msgid ""
+"We aim to reuse the `Kubernetes Service "
+"<https://kubernetes.io/docs/concepts/services-networking/service/>`_ as "
+"the abstraction layer for each lora model. Traditionally, a single pod "
+"belongs to one service. However, for LoRA scenarios, we have multiple "
+"lora adapters in one pod which breaks kubernete native design. To support"
+" lora cases in kubernetes native way, we customize the lora endpoints and"
+" allow a single pod with different LoRAs belong to multiple services."
+msgstr ""
+"我们复用 `Kubernetes Service <https://kubernetes.io/docs/concepts/services-networking/service/>`_ 作为每个 LoRA 模型的抽象层。传统上一个 Pod 属于一个 Service。但 LoRA 场景下一个 Pod 会有多个 LoRA adapter，这打破了 Kubernetes 原生设计。为以 Kubernetes 原生方式支持 LoRA，我们定制了 LoRA endpoints，允许带有不同 LoRA 的单个 Pod 属于多个 Service。"
+
+#: ../../source/features/lora-dynamic-loading.rst:108
+msgid "vLLM Engine Changes"
+msgstr "vLLM 引擎改动"
+
+#: ../../source/features/lora-dynamic-loading.rst:110
+msgid ""
+"High density Lora support can not be done solely in the control plane "
+"side, we also write an RFC about improving the **Visibility of LoRA "
+"metadata**, **Dynamic Loading and Unloading**, **Remote Registry "
+"Support**, **Observability** to enhance LoRA management for production "
+"grade serving. Please check `[RFC]: Enhancing LoRA Management for "
+"Production Environments in vLLM <https://github.com/vllm-"
+"project/vllm/issues/6275>`_ for more details. Majority of the changes are"
+" done in vLLM, we just need to use the latest vLLM image and that would "
+"be ready for production."
+msgstr ""
+"高密度 LoRA 支持无法仅在控制面完成。我们还写了 RFC，改进 **LoRA 元数据可见性** 、**动态加载与卸载** 、**远程仓库支持** "
+"、**可观测性** ，以增强生产级 LoRA 管理。详见 `[RFC]: Enhancing LoRA Management for Production "
+"Environments in vLLM <https://github.com/vllm-project/vllm/issues/6275>`_ "
+"。大部分改动已在 vLLM 中完成，使用最新 vLLM 镜像即可用于生产。"
+
+#: ../../source/features/lora-dynamic-loading.rst:117
+msgid "Examples"
+msgstr "示例"
+
+#: ../../source/features/lora-dynamic-loading.rst:119
+msgid "Here's one example of how to create a lora adapter."
+msgstr "以下是创建 LoRA adapter 的示例。"
+
+#: ../../source/features/lora-dynamic-loading.rst:122
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/features/lora-dynamic-loading.rst:124
+msgid "You have a base model deployed in the same namespace."
+msgstr "同一命名空间中已部署基座模型。"
+
+#: ../../source/features/lora-dynamic-loading.rst:125
+msgid ""
+"vLLM engine needs to enable `VLLM_ALLOW_RUNTIME_LORA_UPDATING "
+"<https://docs.vllm.ai/en/stable/features/lora.html#dynamically-serving-"
+"lora-adapters>`_ feature flag."
+msgstr ""
+"vLLM 引擎需启用 `VLLM_ALLOW_RUNTIME_LORA_UPDATING <https://docs.vllm.ai/en/stable/features/lora.html#dynamically-serving-lora-adapters>`_ 特性开关。"
+
+#: ../../source/features/lora-dynamic-loading.rst:126
+msgid "You have a lora model hosted on Huggingface or S3 compatible storage."
+msgstr "LoRA 模型托管在 Hugging Face 或 S3 兼容存储上。"
+
+#: ../../source/features/lora-dynamic-loading.rst:127
+msgid ""
+"(Optional) You have a Huggingface token to enable faster model downloads "
+"from Hugging Face."
+msgstr "（可选）有 Hugging Face token，以便更快从 Hugging Face 下载模型。"
+
+#: ../../source/features/lora-dynamic-loading.rst:135
+msgid "Create base model"
+msgstr "创建基座模型"
+
+#: ../../source/features/lora-dynamic-loading.rst:157
+msgid "Create lora model adapter"
+msgstr "创建 LoRA model adapter"
+
+#: ../../source/features/lora-dynamic-loading.rst:162
+msgid ""
+"If you run ```kubectl describe modeladapter qwen-code-lora``, you will "
+"see the status of the lora adapter progressing through different phases:"
+msgstr ""
+"If you run ```kubectl describe modeladapter qwen-code-lora``, you will "
+"see the status of the lora adapter progressing through different phases:"
+
+#: ../../source/features/lora-dynamic-loading.rst:164
+msgid "**Phase 1: Pending**"
+msgstr "**阶段 1：Pending**"
+
+#: ../../source/features/lora-dynamic-loading.rst:178
+msgid "**Phase 2: Scheduled** (only with ``replicas: 1``)"
+msgstr "**阶段 2：Scheduled** （仅在 ``replicas: 1`` 时）"
+
+#: ../../source/features/lora-dynamic-loading.rst:197
+msgid "**Phase 3: Running**"
+msgstr "**阶段 3：Running**"
+
+#: ../../source/features/lora-dynamic-loading.rst:226
+msgid "Send request using lora model name to the gateway."
+msgstr "使用 LoRA 模型名向网关发送请求。"
+
+#: ../../source/features/lora-dynamic-loading.rst:241
+msgid "Here's the resources created associated with the lora custom resource."
+msgstr "以下是与 LoRA 自定义资源关联创建的资源。"
+
+#: ../../source/features/lora-dynamic-loading.rst:243
+msgid "lora-service-discovery-resources"
+msgstr "lora-service-discovery-resources"
+
+#: ../../source/features/lora-dynamic-loading.rst:249
+msgid ""
+"A new Kubernetes service will be created with the exact same name as "
+"ModelAdapter name."
+msgstr "会创建一个名称与 ModelAdapter 名称完全相同的 Kubernetes Service。"
+
+#: ../../source/features/lora-dynamic-loading.rst:251
+msgid ""
+"2. The ``podSelector`` is used to filter the matching pods. In this case,"
+" it will match pods with label ``model.aibrix.ai/name=qwen-coder-1-5b-"
+"instruct``. Make sure your base model have this label. This ensures that "
+"the LoRA adapter is correctly associated with the right pods."
+msgstr ""
+"2. ``podSelector`` 用于过滤匹配的 Pod。本例中会匹配标签 ``model.aibrix.ai/name=qwen-coder-1-5b-instruct`` 的 Pod。请确保基座模型带有该标签，以便 LoRA adapter 正确关联到对应 Pod。"
+
+#: ../../source/features/lora-dynamic-loading.rst:256
+msgid ""
+"Note: this is only working with vLLM engine. If you use other engine, "
+"feel free to open an issue."
+msgstr "注意：目前仅适用于 vLLM 引擎。若使用其他引擎，可开 issue。"
+
+#: ../../source/features/lora-dynamic-loading.rst:260
+msgid "Troubleshooting Phase Transitions"
+msgstr "阶段转换故障排查"
+
+#: ../../source/features/lora-dynamic-loading.rst:262
+msgid ""
+"If your ModelAdapter gets stuck in a particular phase, here are common "
+"issues and solutions:"
+msgstr "若 ModelAdapter 卡在某一阶段，常见问题与解决办法如下："
+
+#: ../../source/features/lora-dynamic-loading.rst:264
+msgid "**Stuck in Pending Phase:**"
+msgstr "**卡在 Pending 阶段：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:266
+msgid "Check if pods matching ``podSelector`` exist and are running"
+msgstr "检查匹配 ``podSelector`` 的 Pod 是否存在且正在运行"
+
+#: ../../source/features/lora-dynamic-loading.rst:267
+msgid ""
+"Verify that pods have the correct labels (``model.aibrix.ai/name`` and "
+"``adapter.model.aibrix.ai/enabled=true``)"
+msgstr ""
+"确认 Pod 带有正确标签（``model.aibrix.ai/name`` 和 ``adapter.model.aibrix.ai/enabled=true`` "
+"）"
+
+#: ../../source/features/lora-dynamic-loading.rst:268
+msgid "Ensure pods are in Ready state"
+msgstr "确保 Pod 处于 Ready 状态"
+
+#: ../../source/features/lora-dynamic-loading.rst:270
+msgid "**Stuck in Scheduled Phase:**"
+msgstr "**卡在 Scheduled 阶段：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:272
+msgid "This was a known issue in earlier versions that has been fixed"
+msgstr "这是早期版本中的已知问题，现已修复"
+
+#: ../../source/features/lora-dynamic-loading.rst:273
+msgid ""
+"Check controller logs for any loading errors: ``kubectl logs -n aibrix-"
+"system deployment/aibrix-controller-manager``"
+msgstr "检查 controller 日志中的加载错误：``kubectl logs -n aibrix-system deployment/aibrix-controller-manager``"
+
+#: ../../source/features/lora-dynamic-loading.rst:274
+msgid "Verify vLLM pods have ``VLLM_ALLOW_RUNTIME_LORA_UPDATING`` enabled"
+msgstr "确认 vLLM Pod 已启用 ``VLLM_ALLOW_RUNTIME_LORA_UPDATING``"
+
+#: ../../source/features/lora-dynamic-loading.rst:276
+msgid "**Stuck in Failed Phase (loading errors):**"
+msgstr "**卡在 Failed 阶段（加载错误）：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:278
+msgid "Check if the ``artifactURL`` is accessible and valid"
+msgstr "检查 ``artifactURL`` 是否可访问且有效"
+
+#: ../../source/features/lora-dynamic-loading.rst:279
+msgid "For Hugging Face models, ensure the model path exists"
+msgstr "对于 Hugging Face 模型，确认模型路径存在"
+
+#: ../../source/features/lora-dynamic-loading.rst:280
+msgid "Check authentication if using private repositories"
+msgstr "使用私有仓库时检查认证"
+
+#: ../../source/features/lora-dynamic-loading.rst:281
+msgid "Review controller logs for specific loading errors"
+msgstr "查看 controller 日志中的具体加载错误"
+
+#: ../../source/features/lora-dynamic-loading.rst:282
+msgid ""
+"The controller will retry up to 5 times with exponential backoff before "
+"switching to alternative pods"
+msgstr "controller 会以指数退避最多重试 5 次，然后切换到其他 Pod"
+
+#: ../../source/features/lora-dynamic-loading.rst:284
+msgid "**Failed to Reach Running Phase:**"
+msgstr "**未能进入 Running 阶段：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:286
+msgid ""
+"Check if Kubernetes Service creation succeeded: ``kubectl get svc "
+"<adapter-name>``"
+msgstr "检查 Kubernetes Service 是否创建成功：``kubectl get svc <adapter-name>``"
+
+#: ../../source/features/lora-dynamic-loading.rst:287
+msgid "Verify EndpointSlice creation: ``kubectl get endpointslices``"
+msgstr "确认 EndpointSlice 已创建：``kubectl get endpointslices``"
+
+#: ../../source/features/lora-dynamic-loading.rst:288
+msgid "Check pod readiness and health status"
+msgstr "检查 Pod 就绪与健康状态"
+
+#: ../../source/features/lora-dynamic-loading.rst:290
+msgid "**Useful Commands for Debugging:**"
+msgstr "**有用的调试命令：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:307
+msgid "Reliability Features"
+msgstr "可靠性特性"
+
+#: ../../source/features/lora-dynamic-loading.rst:309
+msgid ""
+"AIBrix ModelAdapter includes several advanced reliability features to "
+"ensure robust LoRA adapter deployments in production environments:"
+msgstr "AIBrix ModelAdapter 包含若干高级可靠性特性，以确保生产环境中 LoRA adapter 部署稳健："
+
+#: ../../source/features/lora-dynamic-loading.rst:312
+msgid "Automatic Retry Mechanism"
+msgstr "自动重试机制"
+
+#: ../../source/features/lora-dynamic-loading.rst:314
+msgid "The controller implements an intelligent retry system for adapter loading:"
+msgstr "controller 为 adapter 加载实现了智能重试："
+
+#: ../../source/features/lora-dynamic-loading.rst:316
+msgid "**Up to 5 retry attempts** per pod with exponential backoff"
+msgstr "每个 Pod **最多重试 5 次** ，指数退避"
+
+#: ../../source/features/lora-dynamic-loading.rst:317
+msgid ""
+"**Base interval of 5 seconds**, doubling on each retry (5s, 10s, 20s, "
+"40s, 80s)"
+msgstr "**基础间隔 5 秒** ，每次重试加倍（5s、10s、20s、40s、80s）"
+
+#: ../../source/features/lora-dynamic-loading.rst:318
+msgid "**Intelligent error detection** for retriable vs. non-retriable errors"
+msgstr "**智能错误检测** ，区分可重试与不可重试错误"
+
+#: ../../source/features/lora-dynamic-loading.rst:319
+msgid "**Graceful handling** of common startup errors like \"connection refused\""
+msgstr "**优雅处理** 常见启动错误，例如 \"connection refused\""
+
+#: ../../source/features/lora-dynamic-loading.rst:329
+msgid "Pod Switching and Failover"
+msgstr "Pod 切换与故障转移"
+
+#: ../../source/features/lora-dynamic-loading.rst:331
+msgid "When adapter loading fails on initial pods after maximum retries:"
+msgstr "在初始 Pod 上达到最大重试次数后加载仍失败时："
+
+#: ../../source/features/lora-dynamic-loading.rst:333
+msgid "**Automatic pod selection** of alternative healthy pods"
+msgstr "**自动选择** 其他健康 Pod"
+
+#: ../../source/features/lora-dynamic-loading.rst:334
+msgid "**Maintains desired replica count** by switching to available pods"
+msgstr "通过切换到可用 Pod **维持期望副本数**"
+
+#: ../../source/features/lora-dynamic-loading.rst:335
+msgid ""
+"**Preserves scheduler preferences** (least-adapters, default) for new "
+"selections"
+msgstr "新选择时**保留调度偏好** （least-adapters、default）"
+
+#: ../../source/features/lora-dynamic-loading.rst:336
+msgid "**Ensures eventual consistency** - adapters will load on healthy pods"
+msgstr "**保证最终一致性** — adapter 会加载到健康 Pod 上"
+
+#: ../../source/features/lora-dynamic-loading.rst:339
+msgid "Pod Health Validation"
+msgstr "Pod 健康校验"
+
+#: ../../source/features/lora-dynamic-loading.rst:341
+msgid "The controller implements comprehensive pod health checks:"
+msgstr "controller 实现了全面的 Pod 健康检查："
+
+#: ../../source/features/lora-dynamic-loading.rst:343
+msgid "**Readiness validation**: Pods must be in Ready state before selection"
+msgstr "**就绪校验** ：选择前 Pod 必须处于 Ready 状态"
+
+#: ../../source/features/lora-dynamic-loading.rst:344
+msgid ""
+"**Stability requirements**: Pods must be stable (ready for 5+ seconds) to"
+" avoid flapping"
+msgstr "**稳定性要求** ：Pod 必须稳定（就绪 5 秒以上）以避免抖动"
+
+#: ../../source/features/lora-dynamic-loading.rst:345
+msgid ""
+"**Continuous monitoring**: Unhealthy pods are automatically removed from "
+"instances list"
+msgstr "**持续监控** ：不健康的 Pod 会自动从实例列表中移除"
+
+#: ../../source/features/lora-dynamic-loading.rst:346
+msgid "**Startup tolerance**: Handles pod startup delays gracefully"
+msgstr "**启动容忍** ：优雅处理 Pod 启动延迟"
+
+#: ../../source/features/lora-dynamic-loading.rst:349
+msgid "Connection Error Handling"
+msgstr "连接错误处理"
+
+#: ../../source/features/lora-dynamic-loading.rst:351
+msgid "Robust error handling for various network and startup conditions:"
+msgstr "针对多种网络与启动情况的稳健错误处理："
+
+#: ../../source/features/lora-dynamic-loading.rst:371
+msgid "Advanced Configuration Examples"
+msgstr "高级配置示例"
+
+#: ../../source/features/lora-dynamic-loading.rst:373
+msgid "**High-Availability Setup with Multi-Replica:**"
+msgstr "**多副本高可用配置：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:375
+msgid ""
+"Here’s a production-ready configuration demonstrating load balancing "
+"across multiple pods:"
+msgstr "以下是可在生产使用的配置，演示跨多个 Pod 的负载均衡："
+
+#: ../../source/features/lora-dynamic-loading.rst:381
+msgid "**Testing Commands:**"
+msgstr "**测试命令：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:402
+msgid "Monitoring and Observability"
+msgstr "监控与可观测性"
+
+#: ../../source/features/lora-dynamic-loading.rst:404
+msgid "**Phase Monitoring:**"
+msgstr "**阶段监控：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:406
+msgid ""
+"The reliability features are transparent through the standard "
+"ModelAdapter status:"
+msgstr "可靠性特性可通过标准 ModelAdapter status 透明观察："
+
+#: ../../source/features/lora-dynamic-loading.rst:416
+msgid "**Controller Logs:**"
+msgstr "**Controller 日志：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:418
+msgid "Monitor retry behavior and pod switching in controller logs:"
+msgstr "在 controller 日志中监控重试行为与 Pod 切换："
+
+#: ../../source/features/lora-dynamic-loading.rst:430
+msgid "**Events and Conditions:**"
+msgstr "**Events 与 Conditions：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:432
+msgid "Reliability events are recorded in the ModelAdapter status conditions:"
+msgstr "可靠性事件记录在 ModelAdapter status conditions 中："
+
+#: ../../source/features/lora-dynamic-loading.rst:448
+msgid "Best Practices for Production"
+msgstr "生产最佳实践"
+
+#: ../../source/features/lora-dynamic-loading.rst:450
+msgid "**Deploy Multiple Base Model Replicas:**"
+msgstr "**部署多个基座模型副本：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:458
+msgid "**Use Multiple Adapter Replicas:**"
+msgstr "**使用多个 adapter 副本：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:467
+msgid "**Configure Appropriate Health Checks:**"
+msgstr "**配置合适的健康检查：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:480
+msgid "**Monitor Adapter Health:**"
+msgstr "**监控 adapter 健康：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:492
+msgid "More configurations"
+msgstr "更多配置"
+
+#: ../../source/features/lora-dynamic-loading.rst:495
+msgid "Multi-LoRA Inference"
+msgstr "多 LoRA 推理"
+
+#: ../../source/features/lora-dynamic-loading.rst:497
+msgid ""
+"vLLM can serve requests for different LoRA adapters in a single batch. "
+"SGLang supports `a similar feature "
+"<https://lmsysorg.mintlify.app/docs/advanced_features/lora>`_. The base "
+"model in ``samples/adapter/base.yaml`` uses the following arguments to "
+"allow up to four distinct adapters per batch:"
+msgstr ""
+"vLLM 可在单个 batch 中服务不同 LoRA adapter 的请求。SGLang 支持 `类似特性 <https://lmsysorg.mintlify.app/docs/advanced_features/lora>`_ "
+"。``samples/adapter/base.yaml`` 中的基座模型使用以下参数，使每个 batch 最多允许四个不同 adapter："
+
+#: ../../source/features/lora-dynamic-loading.rst:508
+msgid ""
+"The vLLM `max_loras "
+"<https://docs.vllm.ai/en/latest/api/vllm/config/lora/#vllm.config.lora.LoRAConfig.max_loras>`_"
+" setting limits the number of distinct adapters in one batch, not the "
+"total number of requests or ``ModelAdapter`` resources. ``max_cpu_loras``"
+" controls the CPU LoRA cache and must be greater than or equal to "
+"``max_loras``."
+msgstr ""
+"vLLM 的 `max_loras <https://docs.vllm.ai/en/latest/api/vllm/config/lora/#vllm.config.lora.LoRAConfig.max_loras>`_ "
+"限制单个 batch 中不同 adapter 的数量，而非请求总数或 ``ModelAdapter`` 资源数。``max_cpu_loras`` "
+"控制 CPU LoRA cache，必须大于或等于 ``max_loras`` 。"
+
+#: ../../source/features/lora-dynamic-loading.rst:512
+msgid ""
+"Create one ``ModelAdapter`` resource for each LoRA. The adapters must all"
+" be compatible with the base model. For a readily reproducible example, "
+"the following manifest assigns four names to the same public LoRA "
+"artifact. Consequently, their generated outputs may be similar. Replace "
+"the ``artifactURL`` values with different compatible adapters when "
+"testing your own models. Each resource omits ``spec.replicas``, so AIBrix"
+" loads every adapter on all matching base-model pods."
+msgstr ""
+"为每个 LoRA 创建一个 ``ModelAdapter`` 资源。adapter 必须都与基座模型兼容。为便于复现，以下清单为同一公开 LoRA "
+"artifact 分配四个名称，因此生成输出可能相似。测试自有模型时请将 ``artifactURL`` 换成不同的兼容 adapter。每个资源都省略 "
+"``spec.replicas`` ，因此 AIBrix 会在所有匹配的基座模型 Pod 上加载每个 adapter。"
+
+#: ../../source/features/lora-dynamic-loading.rst:521
+msgid ""
+"From the AIBrix repository root, create or update the base model. If you "
+"completed the single-LoRA example above, delete its adapter first so that"
+" all four cache slots are available. Then create the four adapters and "
+"wait until they are ready:"
+msgstr ""
+"在 AIBrix 仓库根目录创建或更新基座模型。若已完成上文单 LoRA 示例，请先删除该 adapter，以便四个 cache 槽都可用。然后创建四个 adapter 并等待就绪："
+
+#: ../../source/features/lora-dynamic-loading.rst:540
+msgid ""
+"In one terminal, forward a local port to the AIBrix gateway and leave the"
+" command running:"
+msgstr "在一个终端将本地端口转发到 AIBrix 网关，并保持该命令运行："
+
+#: ../../source/features/lora-dynamic-loading.rst:551
+msgid ""
+"In a second terminal, send one request to each adapter concurrently. The "
+"response from each adapter is saved and then printed after all four "
+"requests finish:"
+msgstr "在第二个终端并发向每个 adapter 发送一个请求。各 adapter 的响应会先保存，四个请求都完成后打印："
+
+#: ../../source/features/lora-dynamic-loading.rst:582
+msgid "Model Registry"
+msgstr "模型仓库"
+
+#: ../../source/features/lora-dynamic-loading.rst:584
+msgid ""
+"Currently, we support Huggingface model registry, S3 compatible storage "
+"and local file system."
+msgstr "目前支持 Hugging Face 模型仓库、S3 兼容存储和本地文件系统。"
+
+#: ../../source/features/lora-dynamic-loading.rst:586
+msgid ""
+"If your model is hosted on Huggingface, you can use the ``artifactURL`` "
+"with ``huggingface://`` prefix to specify the model url. vLLM will "
+"download the model from Huggingface and load it into the pod in runtime."
+msgstr ""
+"若模型托管在 Hugging Face，可用带 ``huggingface://`` 前缀的 ``artifactURL`` 指定模型 URL。vLLM 会在运行时从 Hugging Face 下载模型并加载到 Pod。"
+
+#: ../../source/features/lora-dynamic-loading.rst:588
+msgid ""
+"If you put your model in S3 compatible storage, you have to use AIBrix AI"
+" Runtime at the same time. You can use the ``artifactURL`` with ``s3://``"
+" prefix to specify the model url. AIBrix AI Runtime will download the "
+"model from S3 on the pod and load it with ``local model path`` in vLLM."
+msgstr ""
+"若模型放在 S3 兼容存储，必须同时使用 AIBrix AI Runtime。可用带 ``s3://`` 前缀的 ``artifactURL`` 指定模型 URL。AIBrix AI Runtime 会在 Pod 上从 S3 下载模型，并以 ``local model path`` 在 vLLM 中加载。"
+
+#: ../../source/features/lora-dynamic-loading.rst:590
+msgid ""
+"If you use shared storage like NFS, you can use the ``artifactURL`` with "
+"``/`` absolute path to specify the model url (``/models/yard1/llama-2-7b-"
+"sql-lora-test`` as an example). It's users's responsibility to make sure "
+"the model is mounted to the pod."
+msgstr ""
+"若使用 NFS 等共享存储，可用以 ``/`` 开头的绝对路径作为 ``artifactURL`` 指定模型路径（例如 ``/models/yard1/llama-2-7b-sql-lora-test`` "
+"）。用户需自行确保模型已挂载到 Pod。"
+
+#: ../../source/features/lora-dynamic-loading.rst:594
+msgid "Model api-key Authentication"
+msgstr "模型 api-key 认证"
+
+#: ../../source/features/lora-dynamic-loading.rst:596
+msgid ""
+"User may pass in the argument ``--api-key`` or environment variable "
+"``VLLM_API_KEY`` to enable the server to check for API key in the header."
+msgstr "用户可传入参数 ``--api-key`` 或环境变量 ``VLLM_API_KEY`` ，使服务端检查请求头中的 API key。"
+
+#: ../../source/features/lora-dynamic-loading.rst:602
+msgid ""
+"We already have an example and you can ``kubectl apply -f samples/adapter"
+"/base-api-key.yaml``."
+msgstr "已有示例，可执行 ``kubectl apply -f samples/adapter/base-api-key.yaml`` 。"
+
+#: ../../source/features/lora-dynamic-loading.rst:605
+#, python-brace-format
+msgid ""
+"In that case, lora model adapter can not query the vLLM server correctly,"
+" showing ``{\"error\":\"Unauthorized\"}`` error. You need to update "
+"``additionalConfig`` field to pass in the API key."
+msgstr ""
+"此时 LoRA model adapter 无法正确查询 vLLM 服务，会显示 ``{\"error\":\"Unauthorized\"}`` 错误。需更新 ``additionalConfig`` 字段以传入 API key。"
+
+#: ../../source/features/lora-dynamic-loading.rst:611
+msgid ""
+"You need to send the request with ``--header 'Authorization: Bearer your-"
+"api-key'``"
+msgstr "发送请求时需带 ``--header 'Authorization: Bearer your-api-key'``"
+
+#: ../../source/features/lora-dynamic-loading.rst:628
+msgid "Runtime Support Sidecar"
+msgstr "Runtime 支持 Sidecar"
+
+#: ../../source/features/lora-dynamic-loading.rst:630
+msgid ""
+"Starting from v0.2.0, controller manager by default will talk to runtime "
+"sidecar to register the lora first and then the runtime sidecar will sync"
+" with inference engine to finish the eventual registration. This is used "
+"to build the abstraction between controller manager and inference engine."
+" If you like to directly sync with vLLM to load the loras, you can update"
+" the controller-manager ``kubectl edit deployment aibrix-controller-"
+"manager -n aibrix-system`` and remove the ``"
+msgstr ""
+"Starting from v0.2.0, controller manager by default will talk to runtime "
+"sidecar to register the lora first and then the runtime sidecar will sync"
+" with inference engine to finish the eventual registration. This is used "
+"to build the abstraction between controller manager and inference engine."
+" If you like to directly sync with vLLM to load the loras, you can update"
+" the controller-manager ``kubectl edit deployment aibrix-controller-"
+"manager -n aibrix-system`` and remove the ``"
+
+#: ../../source/features/lora-dynamic-loading.rst:646
+msgid "Private Artifact Storage Support"
+msgstr "私有 Artifact 存储支持"
+
+#: ../../source/features/lora-dynamic-loading.rst:648
+msgid ""
+"AIBrix supports loading LoRA adapters from private cloud storage backends"
+" including AWS S3, Google Cloud Storage (GCS), and Volcano Engine TOS. "
+"This feature requires the AIBrix runtime sidecar to handle artifact "
+"delegation - downloading artifacts from private storage and forwarding "
+"them to the inference engine."
+msgstr ""
+"AIBrix 支持从私有云存储后端加载 LoRA adapter，包括 AWS S3、Google Cloud Storage（GCS）和火山引擎 TOS。该特性需要 AIBrix runtime sidecar 处理 artifact 代理：从私有存储下载 artifact 并转发给推理引擎。"
+
+#: ../../source/features/lora-dynamic-loading.rst:650
+msgid "**Supported Storage Backends:**"
+msgstr "**支持的存储后端：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:652
+msgid "**AWS S3**: ``s3://bucket/path/to/adapter``"
+msgstr "**AWS S3** ：``s3://bucket/path/to/adapter``"
+
+#: ../../source/features/lora-dynamic-loading.rst:653
+msgid "**Google Cloud Storage**: ``gs://bucket/path/to/adapter``"
+msgstr "**Google Cloud Storage** ：``gs://bucket/path/to/adapter``"
+
+#: ../../source/features/lora-dynamic-loading.rst:654
+msgid "**Volcano Engine TOS**: ``tos://bucket/path/to/adapter``"
+msgstr "**火山引擎 TOS** ：``tos://bucket/path/to/adapter``"
+
+#: ../../source/features/lora-dynamic-loading.rst:655
+msgid "**Private HuggingFace**: ``huggingface://org/private-model`` (with token)"
+msgstr "**私有 Hugging Face** ：``huggingface://org/private-model`` （需 token）"
+
+#: ../../source/features/lora-dynamic-loading.rst:656
+msgid "**HTTP(S) with Authentication**: Any URL with custom headers"
+msgstr "**带认证的 HTTP(S)** ：任意带自定义请求头的 URL"
+
+#: ../../source/features/lora-dynamic-loading.rst:658
+msgid "**How It Works:**"
+msgstr "**工作原理：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:671
+msgid "The runtime sidecar:"
+msgstr "runtime sidecar："
+
+#: ../../source/features/lora-dynamic-loading.rst:673
+msgid "Receives the artifact URL and credentials from the controller"
+msgstr "从 controller 接收 artifact URL 和凭据"
+
+#: ../../source/features/lora-dynamic-loading.rst:674
+msgid "Downloads the artifact from private storage to local filesystem"
+msgstr "从私有存储将 artifact 下载到本地文件系统"
+
+#: ../../source/features/lora-dynamic-loading.rst:675
+msgid "Forwards the local path to the inference engine"
+msgstr "将本地路径转发给推理引擎"
+
+#: ../../source/features/lora-dynamic-loading.rst:676
+msgid "Manages artifact lifecycle (cleanup on unload)"
+msgstr "管理 artifact 生命周期（卸载时清理）"
+
+#: ../../source/features/lora-dynamic-loading.rst:678
+msgid "**Prerequisites:**"
+msgstr "**前置条件：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:680
+msgid "AIBrix runtime sidecar deployed alongside your inference engine"
+msgstr "AIBrix runtime sidecar 与推理引擎一起部署"
+
+#: ../../source/features/lora-dynamic-loading.rst:681
+msgid "Controller flag ``--enable-runtime-sidecar=true`` enabled"
+msgstr "已启用 controller 标志 ``--enable-runtime-sidecar=true``"
+
+#: ../../source/features/lora-dynamic-loading.rst:682
+msgid "Kubernetes secrets configured with storage credentials"
+msgstr "已配置含存储凭据的 Kubernetes Secret"
+
+#: ../../source/features/lora-dynamic-loading.rst:683
+msgid "Shared volume between runtime and engine containers"
+msgstr "runtime 与引擎容器之间有共享卷"
+
+#: ../../source/features/lora-dynamic-loading.rst:687
+msgid ""
+"When the AIBrix sidecar injection webhook is enabled, AIBrix injects a "
+"shared volume named ``adapter-storage`` mounted at "
+"``/tmp/aibrix/adapters`` into both the runtime and engine containers. The"
+" runtime downloads LoRA adapter artifacts into this directory by default."
+" See ``DefaultAdapterVolumeName`` and ``DefaultAdapterMountPath`` in "
+"``pkg/webhook/sidecar_injection.go``."
+msgstr ""
+"启用 AIBrix sidecar 注入 webhook 时，AIBrix 会向 runtime 和引擎容器注入名为 ``adapter-storage`` "
+"、挂载于 ``/tmp/aibrix/adapters`` 的共享卷。runtime 默认将 LoRA adapter artifact 下载到该目录。见 "
+"``pkg/webhook/sidecar_injection.go`` 中的 ``DefaultAdapterVolumeName`` 和 ``DefaultAdapterMountPath`` "
+"。"
+
+#: ../../source/features/lora-dynamic-loading.rst:693
+msgid "Setup: AWS S3 Storage"
+msgstr "配置：AWS S3 存储"
+
+#: ../../source/features/lora-dynamic-loading.rst:695
+msgid "**Step 1: Create S3 Credentials Secret**"
+msgstr "**步骤 1：创建 S3 凭据 Secret**"
+
+#: ../../source/features/lora-dynamic-loading.rst:710
+msgid "**Step 2: Deploy Pod with Runtime Sidecar**"
+msgstr "**步骤 2：部署带 Runtime Sidecar 的 Pod**"
+
+#: ../../source/features/lora-dynamic-loading.rst:759
+msgid "**Step 3: Create ModelAdapter with S3 URL**"
+msgstr "**步骤 3：用 S3 URL 创建 ModelAdapter**"
+
+#: ../../source/features/lora-dynamic-loading.rst:779
+msgid "**Step 4: Verify Artifact Delegation**"
+msgstr "**步骤 4：验证 Artifact 代理**"
+
+#: ../../source/features/lora-dynamic-loading.rst:797
+msgid "Setup: Google Cloud Storage (GCS)"
+msgstr "配置：Google Cloud Storage（GCS）"
+
+#: ../../source/features/lora-dynamic-loading.rst:799
+msgid "**Step 1: Create GCS Credentials Secret**"
+msgstr "**步骤 1：创建 GCS 凭据 Secret**"
+
+#: ../../source/features/lora-dynamic-loading.rst:822
+msgid "**Step 2: Create ModelAdapter with GCS URL**"
+msgstr "**步骤 2：用 GCS URL 创建 ModelAdapter**"
+
+#: ../../source/features/lora-dynamic-loading.rst:842
+msgid "Setup: Private HuggingFace Models"
+msgstr "配置：私有 Hugging Face 模型"
+
+#: ../../source/features/lora-dynamic-loading.rst:844
+msgid "**Step 1: Create HuggingFace Token Secret**"
+msgstr "**步骤 1：创建 Hugging Face Token Secret**"
+
+#: ../../source/features/lora-dynamic-loading.rst:856
+msgid "**Step 2: Create ModelAdapter with Private HuggingFace URL**"
+msgstr "**步骤 2：用私有 Hugging Face URL 创建 ModelAdapter**"
+
+#: ../../source/features/lora-dynamic-loading.rst:876
+msgid "Troubleshooting Artifact Delegation"
+msgstr "Artifact 代理故障排查"
+
+#: ../../source/features/lora-dynamic-loading.rst:878
+msgid "**Runtime Not Receiving Requests:**"
+msgstr "**Runtime 未收到请求：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:890
+msgid "**Download Failures:**"
+msgstr "**下载失败：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:902
+msgid "**Credential Issues:**"
+msgstr "**凭据问题：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:917
+msgid "**Engine Connection Errors:**"
+msgstr "**引擎连接错误：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:928
+msgid "**Supported URL Schemes Summary:**"
+msgstr "**支持的 URL scheme 汇总：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:934
+msgid "URL Scheme"
+msgstr "URL Scheme"
+
+#: ../../source/features/lora-dynamic-loading.rst:935
+msgid "Example"
+msgstr "示例"
+
+#: ../../source/features/lora-dynamic-loading.rst:936
+msgid "Requires Runtime"
+msgstr "需要 Runtime"
+
+#: ../../source/features/lora-dynamic-loading.rst:937
+msgid "Requires Credentials"
+msgstr "需要凭据"
+
+#: ../../source/features/lora-dynamic-loading.rst:938
+msgid "``s3://``"
+msgstr "``s3://``"
+
+#: ../../source/features/lora-dynamic-loading.rst:939
+msgid "``s3://bucket/path/``"
+msgstr "``s3://bucket/path/``"
+
+#: ../../source/features/lora-dynamic-loading.rst:940
+#: ../../source/features/lora-dynamic-loading.rst:941
+#: ../../source/features/lora-dynamic-loading.rst:944
+#: ../../source/features/lora-dynamic-loading.rst:945
+#: ../../source/features/lora-dynamic-loading.rst:948
+msgid "Yes"
+msgstr "是"
+
+#: ../../source/features/lora-dynamic-loading.rst:942
+msgid "``gs://``"
+msgstr "``gs://``"
+
+#: ../../source/features/lora-dynamic-loading.rst:943
+msgid "``gs://bucket/path/``"
+msgstr "``gs://bucket/path/``"
+
+#: ../../source/features/lora-dynamic-loading.rst:946
+msgid "``huggingface://`` (private)"
+msgstr "``huggingface://`` （私有）"
+
+#: ../../source/features/lora-dynamic-loading.rst:947
+msgid "``huggingface://org/model``"
+msgstr "``huggingface://org/model``"
+
+#: ../../source/features/lora-dynamic-loading.rst:949
+msgid "Yes (token)"
+msgstr "是（token）"
+
+#: ../../source/features/lora-dynamic-loading.rst:950
+msgid "``huggingface://`` (public)"
+msgstr "``huggingface://`` （公开）"
+
+#: ../../source/features/lora-dynamic-loading.rst:951
+msgid "``huggingface://meta-llama/model``"
+msgstr "``huggingface://meta-llama/model``"
+
+#: ../../source/features/lora-dynamic-loading.rst:952
+#: ../../source/features/lora-dynamic-loading.rst:953
+#: ../../source/features/lora-dynamic-loading.rst:956
+msgid "No"
+msgstr "否"
+
+#: ../../source/features/lora-dynamic-loading.rst:954
+msgid "``http://`` / ``https://``"
+msgstr "``http://`` / ``https://``"
+
+#: ../../source/features/lora-dynamic-loading.rst:955
+msgid "``https://example.com/adapter``"
+msgstr "``https://example.com/adapter``"
+
+#: ../../source/features/lora-dynamic-loading.rst:957
+msgid "Optional"
+msgstr "可选"
+
+#: ../../source/features/lora-dynamic-loading.rst:959
+msgid "**Best Practices:**"
+msgstr "**最佳实践：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:961
+msgid ""
+"**Use Separate Secrets per Storage Type**: Create dedicated secrets for "
+"S3, GCS credentials rather than mixing them"
+msgstr "**按存储类型使用独立 Secret** ：为 S3、GCS 凭据创建专用 Secret，不要混用"
+
+#: ../../source/features/lora-dynamic-loading.rst:962
+msgid ""
+"**Test Credentials First**: Verify credentials work by manually "
+"downloading from storage before creating ModelAdapter"
+msgstr "**先测试凭据** ：创建 ModelAdapter 前先手动从存储下载，确认凭据可用"
+
+#: ../../source/features/lora-dynamic-loading.rst:963
+msgid ""
+"**Monitor Runtime Logs**: Watch runtime logs during first deployment to "
+"catch credential or connectivity issues early"
+msgstr "**监控 Runtime 日志** ：首次部署时查看 runtime 日志，尽早发现凭据或连通性问题"
+
+#: ../../source/features/lora-dynamic-loading.rst:964
+msgid ""
+"**Shared Storage Volume**: Ensure the ``adapter-storage`` volume is "
+"properly shared between runtime and engine containers"
+msgstr "**共享存储卷** ：确保 ``adapter-storage`` 卷在 runtime 与引擎容器之间正确共享"
+
+#: ../../source/features/lora-dynamic-loading.rst:965
+msgid ""
+"**Artifact Size**: Large artifacts may take time to download; adjust "
+"timeout values if needed"
+msgstr "**Artifact 大小** ：大 artifact 下载可能较久；必要时调整超时"
+
+#: ../../source/features/lora-dynamic-loading.rst:968
+msgid "Runtime Metrics Configuration"
+msgstr "Runtime 指标配置"
+
+#: ../../source/features/lora-dynamic-loading.rst:970
+msgid ""
+"The AIBrix runtime provides flexible metrics transformation options to "
+"handle different inference engines (vLLM, SGLang) and ensure "
+"compatibility. You can control metrics behavior using environment "
+"variables:"
+msgstr ""
+"AIBrix runtime 提供灵活的指标转换选项，以处理不同推理引擎（vLLM、SGLang）并保证兼容。可用环境变量控制指标行为："
+
+#: ../../source/features/lora-dynamic-loading.rst:972
+msgid "**Default Mode (Recommended):**"
+msgstr "**默认模式（推荐）：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:982
+msgid ""
+"This mode standardizes metrics from different engines to a common "
+"``aibrix:`` namespace:"
+msgstr "该模式将不同引擎的指标标准化到统一的 ``aibrix:`` 命名空间："
+
+#: ../../source/features/lora-dynamic-loading.rst:984
+msgid "``vllm:num_requests_waiting`` → ``aibrix:queue_size``"
+msgstr "``vllm:num_requests_waiting`` → ``aibrix:queue_size``"
+
+#: ../../source/features/lora-dynamic-loading.rst:985
+msgid "``sglang:num_queue_reqs`` → ``aibrix:queue_size``"
+msgstr "``sglang:num_queue_reqs`` → ``aibrix:queue_size``"
+
+#: ../../source/features/lora-dynamic-loading.rst:986
+msgid "``vllm:prompt_tokens_total`` → ``aibrix:prompt_tokens_total``"
+msgstr "``vllm:prompt_tokens_total`` → ``aibrix:prompt_tokens_total``"
+
+#: ../../source/features/lora-dynamic-loading.rst:987
+msgid "``sglang:prompt_tokens_total`` → ``aibrix:prompt_tokens_total``"
+msgstr "``sglang:prompt_tokens_total`` → ``aibrix:prompt_tokens_total``"
+
+#: ../../source/features/lora-dynamic-loading.rst:989
+msgid "**Raw Passthrough Mode (Debugging/Fallback):**"
+msgstr "**原始透传模式（调试/回退）：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:996
+msgid "Use this mode when:"
+msgstr "在以下情况使用该模式："
+
+#: ../../source/features/lora-dynamic-loading.rst:998
+msgid "Debugging metrics transformation issues"
+msgstr "调试指标转换问题"
+
+#: ../../source/features/lora-dynamic-loading.rst:999
+msgid "Different engines have scale/semantic differences"
+msgstr "不同引擎存在量纲/语义差异"
+
+#: ../../source/features/lora-dynamic-loading.rst:1000
+msgid "You need engine-specific metric names preserved"
+msgstr "需要保留引擎专用指标名"
+
+#: ../../source/features/lora-dynamic-loading.rst:1001
+msgid "Fallback during transformation errors"
+msgstr "转换出错时回退"
+
+#: ../../source/features/lora-dynamic-loading.rst:1003
+msgid "**Complete Transformation Disable (Emergency):**"
+msgstr "**完全禁用转换（应急）：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:1010
+msgid ""
+"This is the safest fallback option that guarantees raw metrics regardless"
+" of any errors."
+msgstr "这是最安全的回退选项，无论是否出错都保证输出原始指标。"
+
+#: ../../source/features/lora-dynamic-loading.rst:1012
+msgid "**Automatic Error Recovery:**"
+msgstr "**自动错误恢复：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:1014
+msgid ""
+"The runtime automatically falls back to raw passthrough mode if metrics "
+"transformation encounters errors, ensuring metrics collection never fails"
+" completely."
+msgstr "若指标转换出错，runtime 会自动回退到原始透传模式，确保指标采集不会完全失败。"
+
+#: ../../source/features/lora-dynamic-loading.rst:1016
+msgid "**Configuration Priority:**"
+msgstr "**配置优先级：**"
+
+#: ../../source/features/lora-dynamic-loading.rst:1018
+msgid ""
+"``METRICS_ENABLE_TRANSFORMATION=0`` forces raw passthrough (highest "
+"priority)"
+msgstr "``METRICS_ENABLE_TRANSFORMATION=0`` 强制原始透传（最高优先级）"
+
+#: ../../source/features/lora-dynamic-loading.rst:1019
+msgid ""
+"``METRICS_RAW_PASSTHROUGH_MODE=1`` enables raw mode when transformation "
+"is enabled"
+msgstr "``METRICS_RAW_PASSTHROUGH_MODE=1`` 在启用转换时开启原始模式"
+
+#: ../../source/features/lora-dynamic-loading.rst:1020
+msgid "Automatic fallback on transformation errors (lowest priority)"
+msgstr "转换出错时自动回退（最低优先级）"
+
+#: ../../source/features/lora-dynamic-loading.rst:1022
+msgid ""
+"This configuration affects the ``/metrics`` endpoint exposed by the "
+"AIBrix runtime sidecar."
+msgstr "该配置影响 AIBrix runtime sidecar 暴露的 ``/metrics`` 端点。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/modelclaim.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/modelclaim.po
@@ -1,0 +1,930 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/modelclaim.rst:5
+msgid "ModelClaim High-Density GPU Runtime Pools"
+msgstr "ModelClaim 高密度 GPU 运行时池"
+
+#: ../../source/features/modelclaim.rst:9
+msgid ""
+"ModelClaim is an experimental feature. It currently supports one engine "
+"replica per claim, uses a fixed GPU topology per warm pool, and requires "
+"a dedicated kvcached runtime image. Validate the feature with your "
+"engine, model, GPU, and workload before using it for production traffic."
+msgstr ""
+"ModelClaim 是实验性功能。目前每个 claim 只支持一个引擎副本，每个热池使用固定"
+"GPU 拓扑，并需要专用的 kvcached runtime 镜像。用于生产流量前，请先用你的引擎、"
+"模型、GPU 和工作负载验证该功能。"
+
+#: ../../source/features/modelclaim.rst:14
+msgid ""
+"ModelClaim lets several independently managed model engines share a warm "
+"GPU runtime Pod. Instead of creating one Kubernetes Deployment per model,"
+" an operator first creates a pool of topology-homogeneous GPU Pods. A "
+"user then creates a ``ModelClaim`` for each model that should run in the "
+"pool."
+msgstr ""
+"ModelClaim 让多个独立管理的模型引擎共享一个预热 GPU runtime Pod。不必为每个模型创建一个 Kubernetes Deployment，运维人员先创建一批拓扑同构的 "
+"GPU Pod 池，再为每个要在池中运行的模型创建一个 ``ModelClaim`` 。"
+
+#: ../../source/features/modelclaim.rst:19
+msgid ""
+"The ModelClaim controller selects a compatible Pod, asks the AIBrix "
+"runtime agent to start a separate engine process, and publishes the "
+"engine's port to the AIBrix gateway only after the engine is ready. The "
+"default experimental image contains vLLM; SGLang requires a custom "
+"compatible runtime image. The kvcached framework provides elastic KV-"
+"cache memory across colocated engines. An optional pool policy can "
+"redistribute KV capacity according to observed requests and put idle vLLM"
+" engines into sleep mode."
+msgstr ""
+"ModelClaim 控制器会选择兼容的 Pod，让 AIBrix runtime agent 启动独立的引擎进程，"
+"并仅在引擎就绪后把引擎端口发布给 AIBrix 网关。默认实验镜像包含 vLLM；SGLang "
+"需要自定义兼容的 runtime 镜像。kvcached 框架在同驻引擎之间提供弹性 KV cache "
+"内存。可选的池策略可根据观测到的请求重新分配 KV 容量，并把空闲的 vLLM 引擎"
+"置于 sleep 模式。"
+
+#: ../../source/features/modelclaim.rst:28
+msgid "Architecture"
+msgstr "架构"
+
+#: ../../source/features/modelclaim.rst:45
+msgid "The main responsibilities are:"
+msgstr "主要职责如下："
+
+#: ../../source/features/modelclaim.rst:47
+msgid ""
+"**ModelClaim** declares the served model, artifact, pool selector, "
+"engine, and engine arguments. It does not request GPUs directly."
+msgstr ""
+"**ModelClaim** 声明要服务的模型、制品、池选择器、引擎和引擎参数。它不直接申请"
+" GPU。"
+
+#: ../../source/features/modelclaim.rst:49
+msgid ""
+"**Warm pool Deployment** owns the GPU resources and fixes the Pod-visible"
+" GPU topology."
+msgstr "**热池 Deployment** 持有 GPU 资源，并固定 Pod 可见的 GPU 拓扑。"
+
+#: ../../source/features/modelclaim.rst:51
+msgid ""
+"**ModelClaim controller** performs placement, lifecycle reconciliation, "
+"route gating, and the optional pool policy."
+msgstr ""
+"**ModelClaim 控制器** 负责放置、生命周期调和、路由放行，以及可选的池策略。"
+
+#: ../../source/features/modelclaim.rst:53
+msgid ""
+"**AIBrix runtime agent** starts and supervises one process per claim and "
+"exposes actual engine, memory, and request state through a runtime "
+"snapshot."
+msgstr ""
+"**AIBrix runtime agent** 为每个 claim 启动并监管一个进程，并通过 runtime "
+"snapshot 暴露实际的引擎、内存和请求状态。"
+
+#: ../../source/features/modelclaim.rst:55
+msgid ""
+"**AIBrix gateway** routes a served model to its per-engine port. It can "
+"trigger a wake for a sleeping model but does not hold the original "
+"request."
+msgstr ""
+"**AIBrix 网关** 将已服务模型路由到其按引擎划分的端口。它可以为处于 sleep 的"
+"模型触发唤醒，但不会持有原始请求。"
+
+#: ../../source/features/modelclaim.rst:59
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/features/modelclaim.rst:61
+msgid "You need:"
+msgstr "你需要："
+
+#: ../../source/features/modelclaim.rst:63
+msgid ""
+"an existing Kubernetes cluster with NVIDIA GPUs and the NVIDIA device "
+"plugin;"
+msgstr "已有带 NVIDIA GPU 和 NVIDIA device plugin 的 Kubernetes 集群；"
+
+#: ../../source/features/modelclaim.rst:65
+msgid "the latest AIBrix nightly control plane from the ``main`` branch;"
+msgstr "来自 ``main`` 分支的最新 AIBrix nightly 控制面；"
+
+#: ../../source/features/modelclaim.rst:66
+msgid "a kvcached-compatible image for the selected engine;"
+msgstr "所选引擎的 kvcached 兼容镜像；"
+
+#: ../../source/features/modelclaim.rst:67
+msgid ""
+"enough host memory for vLLM sleep level 1 and enough ``/dev/shm`` "
+"capacity for kvcached metadata and IPC;"
+msgstr ""
+"足够的宿主机内存以支持 vLLM sleep level 1，以及足够的 ``/dev/shm`` 容量用于 "
+"kvcached 元数据和 IPC；"
+
+#: ../../source/features/modelclaim.rst:69
+msgid "a node-local or otherwise persistent model-weight cache;"
+msgstr "节点本地或其他持久化的模型权重缓存；"
+
+#: ../../source/features/modelclaim.rst:70
+msgid "``kubectl`` access to create CRDs, Deployments, Services, and ModelClaims."
+msgstr "有 ``kubectl`` 权限以创建 CRD、Deployment、Service 和 ModelClaim。"
+
+#: ../../source/features/modelclaim.rst:73
+msgid "Install the nightly control plane"
+msgstr "安装 nightly 控制面"
+
+#: ../../source/features/modelclaim.rst:75
+msgid ""
+"ModelClaim is included in the current ``main`` branch, including its CRD,"
+" controller reconciliation, and gateway wake support. Follow the "
+"**Nightly Version** section of the :doc:`AIBrix installation guide "
+"<../getting_started/installation/installation>`. The standard "
+"``config/crd`` and ``config/default`` manifests install the ModelClaim "
+"API and use the public nightly controller and gateway images. No custom "
+"control-plane build is required."
+msgstr ""
+"ModelClaim 已包含在当前 ``main`` 分支中，含其 CRD、控制器调和以及网关唤醒支持。"
+"请遵循 :doc:`AIBrix installation guide "
+"<../getting_started/installation/installation>` 中的 **Nightly Version** 小节。"
+"标准的 ``config/crd`` 和 ``config/default`` 清单会安装 ModelClaim API，并使用"
+"公开的 nightly 控制器和网关镜像。无需自定义构建控制面。"
+
+#: ../../source/features/modelclaim.rst:83
+msgid "Verify the installation before creating a runtime pool:"
+msgstr "创建 runtime 池之前，先验证安装："
+
+#: ../../source/features/modelclaim.rst:93
+msgid ""
+"Nightly tags are mutable. For a repeatable experiment, record the AIBrix "
+"commit and resolved controller and gateway image digests together with "
+"the runtime image digest."
+msgstr ""
+"Nightly 标签可变。为了可复现实验，请记录 AIBrix commit，以及解析后的控制器、"
+"网关镜像 digest 和 runtime 镜像 digest。"
+
+#: ../../source/features/modelclaim.rst:98
+msgid "Build the experimental runtime image"
+msgstr "构建实验性 runtime 镜像"
+
+#: ../../source/features/modelclaim.rst:100
+msgid ""
+"Only the kvcached runtime agent image needs a feature-specific build. Its"
+" dedicated target is intentionally not part of ``docker-build-all``, "
+"``docker-push-all``, or the public nightly image workflow."
+msgstr ""
+"只有 kvcached runtime agent 镜像需要按本功能单独构建。其专用 target 有意不包含在 ``docker-build-all`` "
+"、``docker-push-all`` 或公开 nightly 镜像工作流中。"
+
+#: ../../source/features/modelclaim.rst:104
+msgid ""
+"Use the same current ``main`` checkout used by the nightly installation. "
+"Build the image and push it to a registry accessible from the cluster:"
+msgstr ""
+"使用与 nightly 安装相同的当前 ``main`` 检出。构建镜像并推送到集群可访问的仓库："
+
+#: ../../source/features/modelclaim.rst:118
+msgid ""
+"``KVCACHED_RUNTIME_BASE_IMAGE`` defaults to ``ghcr.io/ovg-project"
+"/kvcached-vllm:latest``. Pin it to a tested digest or tag for a "
+"reproducible deployment:"
+msgstr ""
+"``KVCACHED_RUNTIME_BASE_IMAGE`` 默认为 ``ghcr.io/ovg-project/kvcached-vllm:latest`` "
+"。为可复现部署，请将其固定到已验证的 digest 或 tag："
+
+#: ../../source/features/modelclaim.rst:128
+msgid ""
+"The default base image contains vLLM. The runtime launcher also has an "
+"SGLang path, but using ``engine: sglang`` requires a custom base image "
+"that contains a compatible SGLang and kvcached integration. Automatic "
+"idle sleep currently applies only to vLLM."
+msgstr ""
+"默认基础镜像包含 vLLM。runtime 启动器也有 SGLang 路径，但使用 ``engine: "
+"sglang`` 需要包含兼容 SGLang 与 kvcached 集成的自定义基础镜像。自动空闲 sleep "
+"目前仅适用于 vLLM。"
+
+#: ../../source/features/modelclaim.rst:133
+#, python-brace-format
+msgid ""
+"Update the warm-pool manifest to use "
+"``${AIBRIX_CONTAINER_REGISTRY_NAMESPACE}/kvcached-runtime:${IMAGE_TAG}``."
+" Keep the runtime source revision aligned with the nightly control plane "
+"revision used for the test."
+msgstr ""
+"将热池清单中的镜像更新为 ``${AIBRIX_CONTAINER_REGISTRY_NAMESPACE}/kvcached-runtime:${IMAGE_TAG}`` "
+"。保持 runtime 源码版本与测试所用 nightly 控制面版本一致。"
+
+#: ../../source/features/modelclaim.rst:139
+msgid "Create a warm runtime pool"
+msgstr "创建预热 runtime 池"
+
+#: ../../source/features/modelclaim.rst:141
+msgid ""
+"The repository sample creates one single-GPU runtime Pod and a metrics "
+"Service:"
+msgstr "仓库示例会创建一个单 GPU runtime Pod 和一个 metrics Service："
+
+#: ../../source/features/modelclaim.rst:148
+msgid "Before applying it, review these fields:"
+msgstr "应用前请检查以下字段："
+
+#: ../../source/features/modelclaim.rst:150
+msgid "``pool.aibrix.ai/name``"
+msgstr "``pool.aibrix.ai/name``"
+
+#: ../../source/features/modelclaim.rst:151
+msgid ""
+"The logical pool selected by ModelClaims. Put the label on both the "
+"Deployment and Pod template."
+msgstr "ModelClaim 选择的逻辑池。请将该标签同时打在 Deployment 和 Pod 模板上。"
+
+#: ../../source/features/modelclaim.rst:154
+msgid "``pool.aibrix.ai/enabled: \"true\"``"
+msgstr "``pool.aibrix.ai/enabled: \"true\"``"
+
+#: ../../source/features/modelclaim.rst:155
+msgid ""
+"Required on candidate Pods. Removing or changing it keeps the Pod out of "
+"ModelClaim placement."
+msgstr "候选 Pod 必须带此标签。删除或修改后，该 Pod 不会进入 ModelClaim 放置。"
+
+#: ../../source/features/modelclaim.rst:158
+msgid "``image``"
+msgstr "``image``"
+
+#: ../../source/features/modelclaim.rst:159
+msgid ""
+"Replace ``aibrix/kvcached-runtime:dev`` when using a remote registry or a"
+" pinned image."
+msgstr "使用远程仓库或固定镜像时，请替换 ``aibrix/kvcached-runtime:dev`` 。"
+
+#: ../../source/features/modelclaim.rst:162
+msgid "``nvidia.com/gpu``"
+msgstr "``nvidia.com/gpu``"
+
+#: ../../source/features/modelclaim.rst:163
+msgid ""
+"Defines the fixed topology for this pool. Every Pod in one pool should "
+"expose the same number of GPUs."
+msgstr "定义该池的固定拓扑。同一池中每个 Pod 应暴露相同数量的 GPU。"
+
+#: ../../source/features/modelclaim.rst:166
+msgid "``/dev/shm``"
+msgstr "``/dev/shm``"
+
+#: ../../source/features/modelclaim.rst:167
+msgid ""
+"The sample uses a 16 GiB memory-backed ``emptyDir``. Size it for the "
+"chosen kvcached and engine configuration."
+msgstr "示例使用 16 GiB 内存型 ``emptyDir`` 。请按所选 kvcached 和引擎配置调整大小。"
+
+#: ../../source/features/modelclaim.rst:170
+msgid "``AIBRIX_WEIGHT_CACHE_DIR``"
+msgstr "``AIBRIX_WEIGHT_CACHE_DIR``"
+
+#: ../../source/features/modelclaim.rst:171
+msgid ""
+"Points to the model-weight cache inspected by runtime snapshots. The "
+"sample mounts a node-local ``hostPath`` so recreated Pods on that node "
+"can reuse downloads."
+msgstr "指向 runtime snapshot 检查的模型权重缓存。示例挂载节点本地 ``hostPath`` ，以便该节点上重建的 Pod 可以复用已下载内容。"
+
+#: ../../source/features/modelclaim.rst:175
+msgid "``/var/run/aibrix``"
+msgstr "``/var/run/aibrix``"
+
+#: ../../source/features/modelclaim.rst:176
+msgid ""
+"Stores the engine registry. The ``emptyDir`` survives an agent process "
+"restart within the Pod, but not a Pod replacement."
+msgstr ""
+"存放引擎注册表。``emptyDir`` 可在 Pod 内 agent 进程重启后保留，但不能跨 Pod "
+"替换保留。"
+
+#: ../../source/features/modelclaim.rst:179
+msgid ""
+"The runtime image still contains kvcached, ``kvctl``, and the shared-"
+"memory control interfaces when ``ENABLE_KVCACHED=false``. This variable "
+"controls whether the current Python process is patched; it does not "
+"remove kvcached from the image. Keep ``ENABLE_KVCACHED=false`` and "
+"``KVCACHED_AUTOPATCH=0`` on the runtime agent. The launcher overrides "
+"both values and assigns a unique ``KVCACHED_IPC_NAME`` for each child "
+"engine. Autopatching the agent itself can load the engine stack into the "
+"supervisor, create an unrelated CUDA context, and blur the isolation "
+"boundary between independently managed engines."
+msgstr ""
+"即使 ``ENABLE_KVCACHED=false`` ，runtime 镜像仍包含 kvcached、``kvctl`` 和共享内存控制接口。该变量只控制当前 "
+"Python 进程是否被 patch，并不会从镜像中移除 kvcached。请在 runtime agent 上保持 ``ENABLE_KVCACHED=false`` "
+"和 ``KVCACHED_AUTOPATCH=0`` 。启动器会覆盖这两个值，并为每个子引擎分配唯一的 ``KVCACHED_IPC_NAME`` "
+"。对 agent 自身做 autopatch 可能把引擎栈加载进 supervisor，创建无关的 CUDA context，并模糊独立管理引擎之间的隔离边界。"
+
+#: ../../source/features/modelclaim.rst:188
+msgid "Apply the pool and wait for the runtime agent:"
+msgstr "应用该池并等待 runtime agent："
+
+#: ../../source/features/modelclaim.rst:197
+msgid "Create ModelClaims"
+msgstr "创建 ModelClaim"
+
+#: ../../source/features/modelclaim.rst:199
+msgid "The sample attaches two small Qwen models to the same pool:"
+msgstr "示例将两个小型 Qwen 模型挂到同一池："
+
+#: ../../source/features/modelclaim.rst:205
+msgid "Apply the claims and watch their lifecycle:"
+msgstr "应用这些 claim 并观察其生命周期："
+
+#: ../../source/features/modelclaim.rst:217
+msgid "The supported spec fields are:"
+msgstr "支持的 spec 字段如下："
+
+#: ../../source/features/modelclaim.rst:223
+msgid "Field"
+msgstr "字段"
+
+#: ../../source/features/modelclaim.rst:224
+msgid "Required"
+msgstr "是否必需"
+
+#: ../../source/features/modelclaim.rst:225
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/features/modelclaim.rst:226
+msgid "``modelName``"
+msgstr "``modelName``"
+
+#: ../../source/features/modelclaim.rst:227
+#: ../../source/features/modelclaim.rst:239
+#: ../../source/features/modelclaim.rst:243
+#: ../../source/features/modelclaim.rst:246
+msgid "No"
+msgstr "否"
+
+#: ../../source/features/modelclaim.rst:228
+msgid ""
+"Served model identifier used in OpenAI-compatible requests. Defaults to "
+"the ModelClaim object name."
+msgstr "OpenAI 兼容请求中使用的服务模型标识符。默认为 ModelClaim 对象名。"
+
+#: ../../source/features/modelclaim.rst:230
+msgid "``podSelector``"
+msgstr "``podSelector``"
+
+#: ../../source/features/modelclaim.rst:231
+#: ../../source/features/modelclaim.rst:235
+msgid "Yes"
+msgstr "是"
+
+#: ../../source/features/modelclaim.rst:232
+msgid ""
+"Selects eligible warm-pool Pods. Candidates must also have the enabled "
+"pool label."
+msgstr "选择符合条件的热池 Pod。候选 Pod 还必须带有启用池标签。"
+
+#: ../../source/features/modelclaim.rst:234
+msgid "``artifactURL``"
+msgstr "``artifactURL``"
+
+#: ../../source/features/modelclaim.rst:236
+msgid ""
+"Model artifact location, such as ``huggingface://``, ``s3://``, or "
+"``gcs://``."
+msgstr "模型制品位置，例如 ``huggingface://`` 、``s3://`` 或 ``gcs://`` 。"
+
+#: ../../source/features/modelclaim.rst:238
+msgid "``engine``"
+msgstr "``engine``"
+
+#: ../../source/features/modelclaim.rst:240
+msgid ""
+"``vllm`` or ``sglang``. Defaults to ``vllm``. SGLang requires a "
+"compatible custom runtime image."
+msgstr "``vllm`` 或 ``sglang`` 。默认为 ``vllm`` 。SGLang 需要兼容的自定义 runtime 镜像。"
+
+#: ../../source/features/modelclaim.rst:242
+msgid "``replicas``"
+msgstr "``replicas``"
+
+#: ../../source/features/modelclaim.rst:244
+msgid "Defaults to 1. The current API only accepts 1."
+msgstr "默认为 1。当前 API 只接受 1。"
+
+#: ../../source/features/modelclaim.rst:245
+msgid "``engineConfig.args``"
+msgstr "``engineConfig.args``"
+
+#: ../../source/features/modelclaim.rst:247
+msgid ""
+"Engine CLI flags mapped to string values. Use an empty string for a "
+"boolean flag."
+msgstr "映射为字符串值的引擎 CLI 标志。布尔标志使用空字符串。"
+
+#: ../../source/features/modelclaim.rst:250
+msgid "For example:"
+msgstr "例如："
+
+#: ../../source/features/modelclaim.rst:259
+msgid ""
+"Do not set ``--gpu-memory-utilization``. kvcached owns elastic KV-cache "
+"allocation, and the ModelClaim path rejects that flag. Data parallelism "
+"is not supported; ``--data-parallel-size`` must remain 1."
+msgstr ""
+"不要设置 ``--gpu-memory-utilization`` 。弹性 KV cache 分配由 kvcached 负责，ModelClaim "
+"路径会拒绝该标志。不支持数据并行；``--data-parallel-size`` 必须保持为 1。"
+
+#: ../../source/features/modelclaim.rst:264
+msgid "Configure TP and PP pools"
+msgstr "配置 TP 和 PP 池"
+
+#: ../../source/features/modelclaim.rst:266
+msgid "ModelClaim uses a deliberately simple fixed-topology rule for vLLM:"
+msgstr "ModelClaim 对 vLLM 使用刻意简化的固定拓扑规则："
+
+#: ../../source/features/modelclaim.rst:273
+msgid ""
+"For a TP=2 model, create a separate pool whose Pods each request two "
+"GPUs, then use:"
+msgstr "对于 TP=2 的模型，创建独立池，其中每个 Pod 申请两块 GPU，然后使用："
+
+#: ../../source/features/modelclaim.rst:283
+msgid ""
+"Do not use one four-GPU pool to mix TP=1, TP=2, and TP=4 claims. Create "
+"one topology-homogeneous pool per shape. Automatic request-driven KV "
+"policy and idle sleep are currently limited to single-GPU runtime Pods, "
+"even though the fixed TP/PP activation path is supported."
+msgstr ""
+"不要用一个四 GPU 池混放 TP=1、TP=2 和 TP=4 的 claim。每种形态创建一个拓扑同构"
+"池。尽管已支持固定 TP/PP 激活路径，按请求驱动的自动 KV 策略和空闲 sleep 目前"
+"仍仅限单 GPU runtime Pod。"
+
+#: ../../source/features/modelclaim.rst:289
+msgid "Inspect actual runtime state"
+msgstr "查看实际 runtime 状态"
+
+#: ../../source/features/modelclaim.rst:291
+msgid "ModelClaim status summarizes the lifecycle:"
+msgstr "ModelClaim status 汇总生命周期："
+
+#: ../../source/features/modelclaim.rst:297
+msgid "Status"
+msgstr "状态"
+
+#: ../../source/features/modelclaim.rst:298
+msgid "Meaning"
+msgstr "含义"
+
+#: ../../source/features/modelclaim.rst:299
+msgid "``Pending`` / ``Scheduling``"
+msgstr "``Pending`` / ``Scheduling``"
+
+#: ../../source/features/modelclaim.rst:300
+msgid "The claim is new or the controller is selecting a compatible Pod."
+msgstr "claim 新建，或控制器正在选择兼容 Pod。"
+
+#: ../../source/features/modelclaim.rst:301
+msgid "``Loading`` / ``Activating``"
+msgstr "``Loading`` / ``Activating``"
+
+#: ../../source/features/modelclaim.rst:302
+msgid ""
+"The runtime is downloading or starting the engine. It remains non-"
+"routable with port 0."
+msgstr "runtime 正在下载或启动引擎。此时端口为 0，仍不可路由。"
+
+#: ../../source/features/modelclaim.rst:304
+msgid "``Active``"
+msgstr "``Active``"
+
+#: ../../source/features/modelclaim.rst:305
+msgid ""
+"The runtime reports the engine alive and ready; the gateway has a real "
+"per-engine port."
+msgstr "runtime 报告引擎存活且就绪；网关已有真实的按引擎端口。"
+
+#: ../../source/features/modelclaim.rst:307
+msgid "``Sleeping``"
+msgstr "``Sleeping``"
+
+#: ../../source/features/modelclaim.rst:308
+msgid ""
+"The engine remains resident but is intentionally non-routable. A request "
+"can trigger a wake."
+msgstr "引擎仍驻留，但有意不可路由。请求可以触发唤醒。"
+
+#: ../../source/features/modelclaim.rst:310
+msgid "``Failed``"
+msgstr "``Failed``"
+
+#: ../../source/features/modelclaim.rst:311
+msgid "Activation or local restart recovery reached a terminal failure."
+msgstr "激活或本地重启恢复已到达终态失败。"
+
+#: ../../source/features/modelclaim.rst:313
+msgid "Inspect claim status and the routing annotation:"
+msgstr "查看 claim 状态和路由注解："
+
+#: ../../source/features/modelclaim.rst:325
+msgid "An annotation has this form:"
+msgstr "注解格式如下："
+
+#: ../../source/features/modelclaim.rst:331
+msgid ""
+"``port: 0`` means the model is known but not currently routable. It is "
+"used while the engine is activating, restarting, sleeping, or failed."
+msgstr ""
+"``port: 0`` 表示模型已知但当前不可路由。引擎处于激活、重启、sleep 或失败时"
+"会使用该值。"
+
+#: ../../source/features/modelclaim.rst:334
+msgid "For detailed engine and memory state, port-forward the runtime API:"
+msgstr "要查看详细的引擎和内存状态，请对 runtime API 做 port-forward："
+
+#: ../../source/features/modelclaim.rst:342
+msgid ""
+"The snapshot includes per-engine port, IPC name, phase, liveness, "
+"readiness, restart count, last error, KV usage and capacity, best-effort "
+"HBM peak, request activity, and cached-artifact markers."
+msgstr ""
+"snapshot 包含按引擎的端口、IPC 名称、阶段、存活、就绪、重启次数、最近错误、"
+"KV 用量与容量、尽力而为的 HBM 峰值、请求活动，以及已缓存制品标记。"
+
+#: ../../source/features/modelclaim.rst:347
+msgid "Send inference requests"
+msgstr "发送推理请求"
+
+#: ../../source/features/modelclaim.rst:349
+msgid "Find the Envoy Service by its ownership labels and start a port-forward:"
+msgstr "通过归属标签找到 Envoy Service，并启动 port-forward："
+
+#: ../../source/features/modelclaim.rst:360
+msgid "Send an OpenAI-compatible request using ``spec.modelName``:"
+msgstr "使用 ``spec.modelName`` 发送 OpenAI 兼容请求："
+
+#: ../../source/features/modelclaim.rst:373
+msgid "Enable automatic KV and sleep policy"
+msgstr "启用自动 KV 与 sleep 策略"
+
+#: ../../source/features/modelclaim.rst:375
+msgid ""
+"Policy is optional and is configured as one strict JSON annotation on the"
+" warm pool Deployment. It does not add fields to ModelClaim:"
+msgstr ""
+"策略是可选的，以一条严格 JSON 注解配置在热池 Deployment 上。它不会给 "
+"ModelClaim 增加字段："
+
+#: ../../source/features/modelclaim.rst:384
+msgid "The fields mean:"
+msgstr "各字段含义："
+
+#: ../../source/features/modelclaim.rst:386
+msgid "``reclaim.capacityBytes``"
+msgstr "``reclaim.capacityBytes``"
+
+#: ../../source/features/modelclaim.rst:387
+msgid ""
+"Total KV capacity that the policy may distribute on each eligible single-"
+"GPU runtime. This is not total GPU HBM. Choose it only after accounting "
+"for model weights, engine overhead, and headroom."
+msgstr ""
+"策略可在每个符合条件的单 GPU runtime 上分配的总 KV 容量。这不是 GPU 总 HBM。"
+"请在计入模型权重、引擎开销和预留空间后再选择该值。"
+
+#: ../../source/features/modelclaim.rst:391
+msgid "``reclaim.guaranteedFloorPercent``"
+msgstr "``reclaim.guaranteedFloorPercent``"
+
+#: ../../source/features/modelclaim.rst:392
+msgid ""
+"Per-model minimum as a percentage of the configured capacity. The policy "
+"also protects currently used and preallocated KV pages. If protected "
+"usage already exceeds the total capacity, no new plan is applied."
+msgstr ""
+"每个模型的下限，按已配置容量的百分比计。策略还会保护当前已用和预分配的 KV "
+"页。若受保护用量已超过总容量，则不会应用新计划。"
+
+#: ../../source/features/modelclaim.rst:396
+msgid "``lifecycle.sleepAfterSeconds``"
+msgstr "``lifecycle.sleepAfterSeconds``"
+
+#: ../../source/features/modelclaim.rst:397
+msgid ""
+"How long a vLLM engine must have complete, initialized, and idle request "
+"observations before sleep level 1 is applied."
+msgstr ""
+"在应用 sleep level 1 之前，vLLM 引擎必须持续多长时间处于请求观测已完成、已初始"
+"化且空闲。"
+
+#: ../../source/features/modelclaim.rst:400
+msgid ""
+"The controller distributes remaining KV capacity among active models "
+"using bounded inflight requests and completion deltas. A configured limit"
+" is a kvcached capacity ceiling, not an immediate physical HBM allocation"
+" and not an OOM guarantee."
+msgstr ""
+"控制器使用有界的进行中请求和完成增量，在活跃模型之间分配剩余 KV 容量。配置的"
+"限制是 kvcached 容量上限，不是立即的物理 HBM 分配，也不是 OOM 保证。"
+
+#: ../../source/features/modelclaim.rst:405
+msgid ""
+"The JSON parser rejects unknown fields. An invalid policy is disabled and"
+" reported with an ``InvalidPoolPolicy`` Event:"
+msgstr "JSON 解析器会拒绝未知字段。无效策略会被禁用，并以 ``InvalidPoolPolicy`` Event 报告："
+
+#: ../../source/features/modelclaim.rst:414
+msgid "Sleeping request behavior"
+msgstr "Sleep 状态下的请求行为"
+
+#: ../../source/features/modelclaim.rst:416
+msgid ""
+"The gateway does not hold or replay a request while a model wakes. When a"
+" binding is sleeping, the gateway starts one deduplicated asynchronous "
+"wake and returns:"
+msgstr ""
+"模型唤醒期间，网关不会持有或重放请求。当绑定处于 sleep 时，网关会启动一次去重"
+"的异步唤醒并返回："
+
+#: ../../source/features/modelclaim.rst:425
+msgid ""
+"The client or an outer gateway must retry. While the engine is waking, "
+"later requests can continue to receive 503. The controller restores the "
+"real port only after the runtime reports the engine active and ready."
+msgstr ""
+"客户端或外层网关必须重试。引擎唤醒期间，后续请求仍可能收到 503。仅当 runtime "
+"报告引擎处于 active 且就绪后，控制器才会恢复真实端口。"
+
+#: ../../source/features/modelclaim.rst:429
+msgid ""
+"An activating model also returns 503 with ``Retry-After``. A terminally "
+"failed model returns 503 without ``Retry-After``."
+msgstr ""
+"正在激活的模型也会返回带 ``Retry-After`` 的 503。终态失败的模型返回不带 "
+"``Retry-After`` 的 503。"
+
+#: ../../source/features/modelclaim.rst:433
+msgid "Runtime reliability"
+msgstr "Runtime 可靠性"
+
+#: ../../source/features/modelclaim.rst:435
+msgid ""
+"Each ModelClaim engine has an independent process group and supervisor. "
+"An engine crash is removed from routing and restarted with exponential "
+"backoff; other engines in the Pod are not restarted. After five local "
+"restarts, the engine remains ``Failed`` with its error visible in the "
+"runtime snapshot."
+msgstr ""
+"每个 ModelClaim 引擎都有独立的进程组和 supervisor。引擎崩溃后会从路由中移除，并以指数退避重启；Pod 中其他引擎不会重启。本地重启五次后，引擎保持 "
+"``Failed`` ，错误可在 runtime snapshot 中查看。"
+
+#: ../../source/features/modelclaim.rst:440
+msgid ""
+"The kvcached runtime image uses ``tini`` and a small restart loop around "
+"the AIBrix agent. If only the agent process crashes, child engines stay "
+"alive. The new agent reads ``/var/run/aibrix/engines.json``, verifies the"
+" PID start time and health endpoint, and re-adopts valid engines without "
+"changing their port or IPC name."
+msgstr ""
+"kvcached runtime 镜像对 AIBrix agent 使用 ``tini`` 和一个小型重启循环。若仅 agent 进程崩溃，子引擎仍保持存活。新 "
+"agent 读取 ``/var/run/aibrix/engines.json`` ，校验 PID 启动时间和健康检查端点，并重新接管有效引擎，不改变其端口或 "
+"IPC 名称。"
+
+#: ../../source/features/modelclaim.rst:446
+msgid ""
+"This recovery does not cross a Pod restart. If the Pod disappears, the "
+"controller removes the stale instance and can activate the claim on "
+"another compatible Pod. There is no live migration or transparent "
+"preservation of in-flight requests."
+msgstr ""
+"该恢复不能跨过 Pod 重启。若 Pod 消失，控制器会移除过期实例，并可在另一个兼容 "
+"Pod 上激活该 claim。没有热迁移，也不会透明保留进行中请求。"
+
+#: ../../source/features/modelclaim.rst:452
+msgid "Observability"
+msgstr "可观测性"
+
+#: ../../source/features/modelclaim.rst:454
+msgid ""
+"The sample metrics Service is selected by "
+"``observability/monitor/service_monitor_modelclaim_runtime.yaml``. Import"
+" ``observability/grafana/AIBrix_ModelClaim_Runtime_Dashboard.json`` for "
+"the current dashboard."
+msgstr ""
+"示例 metrics Service 由 "
+"``observability/monitor/service_monitor_modelclaim_runtime.yaml`` 选择。导入 "
+"``observability/grafana/AIBrix_ModelClaim_Runtime_Dashboard.json`` 以使用当前"
+"仪表盘。"
+
+#: ../../source/features/modelclaim.rst:459
+msgid "Controller metrics include:"
+msgstr "控制器指标包括："
+
+#: ../../source/features/modelclaim.rst:461
+msgid "``aibrix_modelclaim_desired_replicas``;"
+msgstr "``aibrix_modelclaim_desired_replicas`` ；"
+
+#: ../../source/features/modelclaim.rst:462
+msgid "``aibrix_modelclaim_ready_replicas``;"
+msgstr "``aibrix_modelclaim_ready_replicas`` ；"
+
+#: ../../source/features/modelclaim.rst:463
+msgid "``aibrix_modelclaim_activating``;"
+msgstr "``aibrix_modelclaim_activating`` ；"
+
+#: ../../source/features/modelclaim.rst:464
+#, python-brace-format
+msgid "``aibrix_modelclaim_activation_total{result}``;"
+msgstr "``aibrix_modelclaim_activation_total{result}`` ；"
+
+#: ../../source/features/modelclaim.rst:465
+msgid "``aibrix_modelclaim_pool_policy_valid``."
+msgstr "``aibrix_modelclaim_pool_policy_valid`` 。"
+
+#: ../../source/features/modelclaim.rst:467
+msgid "Runtime metrics include:"
+msgstr "Runtime 指标包括："
+
+#: ../../source/features/modelclaim.rst:469
+msgid "``aibrix:modelclaim_models_resident``;"
+msgstr "``aibrix:modelclaim_models_resident`` ；"
+
+#: ../../source/features/modelclaim.rst:470
+#, python-brace-format
+msgid "``aibrix:modelclaim_kv_used_bytes{model}``;"
+msgstr "``aibrix:modelclaim_kv_used_bytes{model}`` ；"
+
+#: ../../source/features/modelclaim.rst:471
+#, python-brace-format
+msgid "``aibrix:modelclaim_kv_total_bytes{model}``;"
+msgstr "``aibrix:modelclaim_kv_total_bytes{model}`` ；"
+
+#: ../../source/features/modelclaim.rst:472
+#, python-brace-format
+msgid "``aibrix:modelclaim_hbm_peak_bytes{model}``."
+msgstr "``aibrix:modelclaim_hbm_peak_bytes{model}`` 。"
+
+#: ../../source/features/modelclaim.rst:474
+msgid ""
+"HBM attribution is best effort and is used for observation and placement "
+"ranking. It is not a hard admission or reservation signal."
+msgstr "HBM 归因是尽力而为的，用于观测和放置排序。它不是硬准入或预留信号。"
+
+#: ../../source/features/modelclaim.rst:478
+msgid "Troubleshooting"
+msgstr "故障排查"
+
+#: ../../source/features/modelclaim.rst:480
+msgid "Claim remains ``Scheduling`` with zero candidates"
+msgstr "Claim 一直处于 ``Scheduling`` 且候选为零"
+
+#: ../../source/features/modelclaim.rst:481
+msgid ""
+"Confirm that the Pod is Running, has a Pod IP, matches ``podSelector``, "
+"and has ``pool.aibrix.ai/enabled: \"true\"``. For vLLM, confirm that TP "
+"times PP exactly matches the Pod-visible GPU count."
+msgstr ""
+"确认 Pod 处于 Running、有 Pod IP、匹配 ``podSelector`` ，且带有 ``pool.aibrix.ai/enabled: "
+"\"true\"`` 。对于 vLLM，确认 TP 乘以 PP 恰好等于 Pod 可见 GPU 数量。"
+
+#: ../../source/features/modelclaim.rst:485
+msgid "Claim remains ``Activating``"
+msgstr "Claim 一直处于 ``Activating``"
+
+#: ../../source/features/modelclaim.rst:486
+msgid ""
+"Inspect the runtime snapshot and engine logs. Weight download, CUDA graph"
+" initialization, or engine compilation may take time. The controller "
+"intentionally keeps the route at port 0 until ``/health`` succeeds."
+msgstr ""
+"检查 runtime snapshot 和引擎日志。权重下载、CUDA graph 初始化或引擎编译可能"
+"耗时。在 ``/health`` 成功之前，控制器会有意把路由保持在端口 0。"
+
+#: ../../source/features/modelclaim.rst:490
+msgid "Activation rejects ``--gpu-memory-utilization``"
+msgstr "激活拒绝 ``--gpu-memory-utilization``"
+
+#: ../../source/features/modelclaim.rst:491
+msgid ""
+"Remove the flag. The kvcached framework replaces the engine's fixed KV-"
+"memory fraction in this deployment path."
+msgstr "移除该标志。在此部署路径中，kvcached 框架会替代引擎固定的 KV 内存比例。"
+
+#: ../../source/features/modelclaim.rst:494
+msgid "Policy does not change KV limits"
+msgstr "策略没有改变 KV 限制"
+
+#: ../../source/features/modelclaim.rst:495
+msgid ""
+"Automatic policy requires exactly one visible accelerator, valid request "
+"metrics with matching model labels, and at least one observed active "
+"model. It does not shrink when observations are incomplete or protected "
+"KV usage exceeds the configured capacity."
+msgstr ""
+"自动策略要求恰好有一个可见加速器、带匹配模型标签的有效请求指标，以及至少一个"
+"观测到的活跃模型。观测不完整，或受保护 KV 用量超过配置容量时，它不会收缩。"
+
+#: ../../source/features/modelclaim.rst:500
+msgid "Model never enters automatic sleep"
+msgstr "模型从不进入自动 sleep"
+
+#: ../../source/features/modelclaim.rst:501
+msgid ""
+"Automatic idle sleep currently applies only to vLLM. Check that request "
+"activity is initialized and observable and that no request is running or "
+"waiting."
+msgstr ""
+"自动空闲 sleep 目前仅适用于 vLLM。检查请求活动已初始化且可观测，并且没有请求"
+"正在运行或等待。"
+
+#: ../../source/features/modelclaim.rst:505
+msgid "Requests return 503"
+msgstr "请求返回 503"
+
+#: ../../source/features/modelclaim.rst:506
+msgid ""
+"Inspect the routing annotation and ModelClaim status. A sleeping or "
+"activating model is retryable; a failed model requires operator "
+"attention."
+msgstr ""
+"检查路由注解和 ModelClaim 状态。处于 sleep 或激活中的模型可重试；失败模型需要"
+"运维介入。"
+
+#: ../../source/features/modelclaim.rst:509
+msgid "Agent restarted but engines also disappeared"
+msgstr "Agent 重启后引擎也消失了"
+
+#: ../../source/features/modelclaim.rst:510
+msgid ""
+"Check that the container uses ``build/container/Dockerfile.kvcached-"
+"runtime`` and its tini supervisor, and that the engine registry is "
+"mounted at ``/var/run/aibrix``. A full Pod or container restart does not "
+"preserve engine processes."
+msgstr ""
+"确认容器使用 ``build/container/Dockerfile.kvcached-runtime`` 及其 tini supervisor，并且引擎注册表挂载在 "
+"``/var/run/aibrix`` 。完整的 Pod 或容器重启不会保留引擎进程。"
+
+#: ../../source/features/modelclaim.rst:516
+msgid "Cleanup"
+msgstr "清理"
+
+#: ../../source/features/modelclaim.rst:518
+msgid ""
+"Delete claims before the warm pool so the finalizer can stop their "
+"engines and remove routing annotations:"
+msgstr "先删除 claim 再删除热池，以便 finalizer 能停止其引擎并移除路由注解："
+
+#: ../../source/features/modelclaim.rst:527
+msgid "Validation guides"
+msgstr "验证指南"
+
+#: ../../source/features/modelclaim.rst:529
+msgid ""
+"Use the `ModelClaim manual GPU validation runbook <https://github.com"
+"/vllm-project/aibrix/blob/main/docs/modelclaim/manual-validation-"
+"runbook.md>`_ for the full minikube and real-GPU acceptance procedure. A "
+"`Chinese version <https://github.com/vllm-"
+"project/aibrix/blob/main/docs/modelclaim/manual-validation-runbook-"
+"zh.md>`_ is also available. To validate kvcached and vLLM sleep "
+"independently of the AIBrix control plane, use the `mechanism guide "
+"<https://github.com/vllm-project/aibrix/blob/main/docs/modelclaim"
+"/kvcached-vllm-sleep-test-guide.md>`_."
+msgstr ""
+"完整的 minikube 与真实 GPU 验收流程见 `ModelClaim manual GPU validation runbook <https://github.com/vllm-project/aibrix/blob/main/docs/modelclaim/manual-validation-runbook.md>`_ "
+"。也提供 `中文版本 <https://github.com/vllm-project/aibrix/blob/main/docs/modelclaim/manual-validation-runbook-zh.md>`_ "
+"。若要在不依赖 AIBrix 控制面的情况下验证 kvcached 和 vLLM sleep，请使用 `mechanism guide <https://github.com/vllm-project/aibrix/blob/main/docs/modelclaim/kvcached-vllm-sleep-test-guide.md>`_ "
+"。"
+
+#: ../../source/features/modelclaim.rst:537
+msgid "Upstream references:"
+msgstr "上游参考："
+
+#: ../../source/features/modelclaim.rst:539
+msgid "`kvcached <https://github.com/ovg-project/kvcached>`_;"
+msgstr "`kvcached <https://github.com/ovg-project/kvcached>`_ ；"
+
+#: ../../source/features/modelclaim.rst:540
+msgid "`vLLM Sleep Mode <https://docs.vllm.ai/en/stable/features/sleep_mode/>`_;"
+msgstr "`vLLM Sleep Mode <https://docs.vllm.ai/en/stable/features/sleep_mode/>`_ ；"
+
+#: ../../source/features/modelclaim.rst:541
+msgid ""
+"`Prism: Cost-Efficient Multi-LLM Serving via GPU Memory Ballooning "
+"<https://arxiv.org/abs/2505.04021>`_."
+msgstr ""
+"`Prism: Cost-Efficient Multi-LLM Serving via GPU Memory Ballooning <https://arxiv.org/abs/2505.04021>`_ "
+"。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/multi-engine.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/multi-engine.po
@@ -1,0 +1,960 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/multi-engine.rst:5
+msgid "Multi-Engine Support"
+msgstr "多引擎支持"
+
+#: ../../source/features/multi-engine.rst:7
+msgid ""
+"The AIBrix system now supports **multi-engine scheduling**, allowing "
+"developers to deploy and serve multiple engines (e.g., different LLMs or "
+"engine backends) under a single AIBrix instance. This enables flexible "
+"routing of incoming requests to different engines based on model name, "
+"scheduling policies, or performance characteristics."
+msgstr ""
+"AIBrix 现已支持 **多引擎调度** ，可在同一个 AIBrix 实例下部署并服务多个引擎（例如不同 LLM 或引擎后端）。从而能按模型名、调度策略或性能特征，将入站请求灵活路由到不同引擎。"
+
+#: ../../source/features/multi-engine.rst:10
+msgid "Key Features"
+msgstr "主要特性"
+
+#: ../../source/features/multi-engine.rst:12
+msgid ""
+"Support other engines beyond vLLM (e.g., SGLang, xLLM, TRT-LLM) in a "
+"single deployment."
+msgstr "在同一部署中支持 vLLM 以外的引擎（例如 SGLang、xLLM、TRT-LLM）。"
+
+#: ../../source/features/multi-engine.rst:13
+msgid ""
+"Configure engine by adding `model.aibrix.ai/engine` as label in the "
+"deployment YAML file."
+msgstr "在 deployment YAML 中添加 `model.aibrix.ai/engine` 标签以配置引擎。"
+
+#: ../../source/features/multi-engine.rst:14
+msgid "Support for interpreting metrics from different engine types."
+msgstr "支持解析不同类型引擎的指标。"
+
+#: ../../source/features/multi-engine.rst:17
+msgid "Motivation"
+msgstr "动机"
+
+#: ../../source/features/multi-engine.rst:19
+msgid ""
+"Prior to this feature, AIBrix supports vLLM only while serving models. "
+"This limited flexibility in experimenting with or comparing different "
+"engines within the same workload or benchmarking scenario."
+msgstr ""
+"在此功能之前，AIBrix 服务模型时仅支持 vLLM。这限制了在同一工作负载或基准测试"
+"场景中试验或比较不同引擎的灵活性。"
+
+#: ../../source/features/multi-engine.rst:21
+msgid "With multi-engine support, AIBrix enables:"
+msgstr "有了多引擎支持，AIBrix 可以："
+
+#: ../../source/features/multi-engine.rst:23
+msgid ""
+"**Side-by-side comparisons** of latency, throughput, and behavior across "
+"engines."
+msgstr "**并排比较** 不同引擎的延迟、吞吐和行为。"
+
+#: ../../source/features/multi-engine.rst:24
+msgid ""
+"**Deployment flexibility**, supporting model sharding or migration "
+"strategies."
+msgstr "**部署灵活性** ，支持模型分片或迁移策略。"
+
+#: ../../source/features/multi-engine.rst:25
+msgid "**Metrics Adaptation** to interpret metrics from different engine types."
+msgstr "**指标适配** ，以解析不同类型引擎的指标。"
+
+#: ../../source/features/multi-engine.rst:28
+msgid "System Overview"
+msgstr "系统概览"
+
+#: ../../source/features/multi-engine.rst:30
+msgid ""
+"Incoming requests will use the deployment label to determine correct ways"
+" of interpreting metrics retrieved from Prometheus API, which are later "
+"used by the `Router` to delegate execution. To configure a specific "
+"engine, apply the following labels in the deployment YAML file:"
+msgstr ""
+"入站请求会使用 deployment 标签，决定如何正确解析从 Prometheus API 获取的指标，"
+"随后由 `Router` 用于委派执行。要配置特定引擎，请在 deployment YAML 中应用以下"
+"标签："
+
+#: ../../source/features/multi-engine.rst:40
+msgid ""
+"AIBrix will use the `model.aibrix.ai/engine` label to determine which "
+"engine to use for the deployment and search for correct format of metrics"
+" to retrieve from all metrics read from Prometheus."
+msgstr ""
+"AIBrix 会使用 `model.aibrix.ai/engine` 标签确定该 deployment 使用的引擎，并在"
+"从 Prometheus 读取的全部指标中查找正确格式以获取指标。"
+
+#: ../../source/features/multi-engine.rst:42
+msgid "Supported engine label values: ``vllm``, ``sglang``, ``xllm``, ``trtllm``."
+msgstr "支持的引擎标签值：``vllm`` 、``sglang`` 、``xllm`` 、``trtllm`` 。"
+
+#: ../../source/features/multi-engine.rst:45
+msgid "How it works"
+msgstr "工作原理"
+
+#: ../../source/features/multi-engine.rst:47
+msgid ""
+"The AIBrix cache watches pods that carry ``model.aibrix.ai/name`` and "
+"reads ``model.aibrix.ai/engine`` from the same pod. Every metric AIBrix "
+"uses internally has one abstract name (for example "
+"``num_requests_waiting``) and a per-engine mapping to the name the engine"
+" actually exports. The mapping lives in `pkg/metrics/metrics.go "
+"<https://github.com/vllm-"
+"project/aibrix/blob/main/pkg/metrics/metrics.go>`_ and is reproduced in "
+"the table below."
+msgstr ""
+"AIBrix cache 会监视带有 ``model.aibrix.ai/name`` 的 Pod，并从同一 Pod 读取 ``model.aibrix.ai/engine`` "
+"。AIBrix 内部使用的每个指标都有一个抽象名称（例如 ``num_requests_waiting`` ），以及按引擎映射到该引擎实际导出的名称。映射位于 "
+"`pkg/metrics/metrics.go <https://github.com/vllm-project/aibrix/blob/main/pkg/metrics/metrics.go>`_ "
+"，并在下表中复现。"
+
+#: ../../source/features/multi-engine.rst:53
+msgid ""
+"Metrics are scraped from each pod on the port given by ``model.aibrix.ai"
+"/metric-port``, or port ``8000`` when the label is absent, at "
+"``/metrics`` (``/prometheus/metrics`` for ``trtllm``). Requests are "
+"forwarded to ``model.aibrix.ai/port``."
+msgstr ""
+"指标从每个 Pod 上由 ``model.aibrix.ai/metric-port`` 指定的端口抓取；若无该标签则使用端口 ``8000`` "
+"，路径为 ``/metrics`` （``trtllm`` 为 ``/prometheus/metrics`` ）。请求转发到 ``model.aibrix.ai/port`` "
+"。"
+
+#: ../../source/features/multi-engine.rst:56
+msgid ""
+"Routing policies ask for abstract names. When the engine has no mapping "
+"for a metric a policy needs, most policies (``least-request``, ``least-"
+"kv-cache``, ``least-latency``, ``least-busy-time``, ``least-gpu-cache``, "
+"``least-util``, ``throughput``) fall back to a random pod for that "
+"request. The SLO family (``slo-least-load``, ``slo-pack-load``, ``slo-"
+"least-load-pulling``) returns an error instead, which surfaces to the "
+"client as HTTP 503."
+msgstr ""
+"路由策略按抽象名称请求指标。当引擎没有策略所需指标的映射时，大多数策略（``least-request`` 、``least-kv-cache`` "
+"、``least-latency`` 、``least-busy-time`` 、``least-gpu-cache`` 、``least-util`` "
+"、``throughput`` ）会对该请求回退到随机 Pod。SLO 系列（``slo-least-load`` 、``slo-pack-load`` "
+"、``slo-least-load-pulling`` ）则返回错误，对客户端表现为 HTTP 503。"
+
+#: ../../source/features/multi-engine.rst:63
+msgid ""
+"The optional :doc:`runtime` sidecar is a separate mechanism: it re-"
+"exports engine metrics in a standardized shape on its own port. The "
+"engine label works without it."
+msgstr ""
+"可选的 :doc:`runtime` sidecar 是另一套机制：它在自己的端口上以标准化形态重新"
+"导出引擎指标。引擎标签不依赖它也能工作。"
+
+#: ../../source/features/multi-engine.rst:67
+msgid "Configuration reference"
+msgstr "配置参考"
+
+#: ../../source/features/multi-engine.rst:69
+msgid ""
+"Everything is configured with pod labels. Set them on the pod template of"
+" the ``Deployment`` (or of the ``StormService`` role) rather than on the "
+"workload object itself."
+msgstr ""
+"全部通过 Pod 标签配置。请把它们设在 ``Deployment`` （或 ``StormService`` 角色）的 Pod 模板上，而不是工作负载对象本身。"
+
+#: ../../source/features/multi-engine.rst:76
+msgid "Label"
+msgstr "标签"
+
+#: ../../source/features/multi-engine.rst:77
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/features/multi-engine.rst:78
+msgid "Meaning"
+msgstr "含义"
+
+#: ../../source/features/multi-engine.rst:79
+msgid "``model.aibrix.ai/name``"
+msgstr "``model.aibrix.ai/name``"
+
+#: ../../source/features/multi-engine.rst:80
+msgid "required"
+msgstr "必需"
+
+#: ../../source/features/multi-engine.rst:81
+msgid "Model name used in requests and for pod discovery."
+msgstr "请求中使用以及用于 Pod 发现的模型名。"
+
+#: ../../source/features/multi-engine.rst:82
+msgid "``model.aibrix.ai/engine``"
+msgstr "``model.aibrix.ai/engine``"
+
+#: ../../source/features/multi-engine.rst:83
+msgid "``vllm``"
+msgstr "``vllm``"
+
+#: ../../source/features/multi-engine.rst:84
+msgid ""
+"Engine type. One of ``vllm``, ``sglang``, ``xllm``, ``trtllm``. Selects "
+"the metric mapping."
+msgstr "引擎类型。取值为 ``vllm`` 、``sglang`` 、``xllm`` 、``trtllm`` 之一。用于选择指标映射。"
+
+#: ../../source/features/multi-engine.rst:86
+msgid "``model.aibrix.ai/port``"
+msgstr "``model.aibrix.ai/port``"
+
+#: ../../source/features/multi-engine.rst:87
+#: ../../source/features/multi-engine.rst:90
+msgid "``8000``"
+msgstr "``8000``"
+
+#: ../../source/features/multi-engine.rst:88
+msgid "Port the engine serves requests on."
+msgstr "引擎提供请求服务的端口。"
+
+#: ../../source/features/multi-engine.rst:89
+msgid "``model.aibrix.ai/metric-port``"
+msgstr "``model.aibrix.ai/metric-port``"
+
+#: ../../source/features/multi-engine.rst:91
+msgid ""
+"Port the engine exposes ``/metrics`` on, if different from the serving "
+"port."
+msgstr "引擎暴露 ``/metrics`` 的端口（若与服务端口不同）。"
+
+#: ../../source/features/multi-engine.rst:94
+msgid "Supported Metrics"
+msgstr "支持的指标"
+
+#: ../../source/features/multi-engine.rst:96
+msgid ""
+"We only support limited number of metrics from different engines and we "
+"will continuously add more metrics. For routing algorithms implemented "
+"through `routing policy API <https://github.com/vllm-"
+"project/aibrix/tree/main/pkg/plugins/gateway/algorithms>`_, make sure you"
+" use metrics that is supported by your target engine. Most existing "
+"AIBrix routing policies fall back to the default (i.e., random) policy if"
+" they fail to fetch a target metric; see *How it works* above for the "
+"exceptions."
+msgstr ""
+"目前仅支持各引擎的有限指标，后续会持续增加。对于通过 `routing policy API "
+"<https://github.com/vllm-project/aibrix/tree/main/pkg/plugins/gateway"
+"/algorithms>`_ 实现的路由算法，请确保使用目标引擎支持的指标。大多数现有 "
+"AIBrix 路由策略在获取目标指标失败时会回退到默认（即随机）策略；例外情况见上文"
+" *工作原理*。"
+
+#: ../../source/features/multi-engine.rst:102
+msgid "AIBrix metric"
+msgstr "AIBrix 指标"
+
+#: ../../source/features/multi-engine.rst:103
+msgid "vLLM"
+msgstr "vLLM"
+
+#: ../../source/features/multi-engine.rst:104
+msgid "SGLang"
+msgstr "SGLang"
+
+#: ../../source/features/multi-engine.rst:105
+msgid "xLLM"
+msgstr "xLLM"
+
+#: ../../source/features/multi-engine.rst:106
+msgid "TRT-LLM"
+msgstr "TRT-LLM"
+
+#: ../../source/features/multi-engine.rst:107
+msgid "``num_requests_running``"
+msgstr "``num_requests_running``"
+
+#: ../../source/features/multi-engine.rst:108
+msgid "``vllm:num_requests_running``"
+msgstr "``vllm:num_requests_running``"
+
+#: ../../source/features/multi-engine.rst:109
+msgid "``sglang:num_running_reqs``"
+msgstr "``sglang:num_running_reqs``"
+
+#: ../../source/features/multi-engine.rst:110
+#: ../../source/features/multi-engine.rst:111
+#: ../../source/features/multi-engine.rst:115
+#: ../../source/features/multi-engine.rst:116
+#: ../../source/features/multi-engine.rst:120
+#: ../../source/features/multi-engine.rst:121
+#: ../../source/features/multi-engine.rst:124
+#: ../../source/features/multi-engine.rst:125
+#: ../../source/features/multi-engine.rst:126
+#: ../../source/features/multi-engine.rst:129
+#: ../../source/features/multi-engine.rst:130
+#: ../../source/features/multi-engine.rst:131
+#: ../../source/features/multi-engine.rst:134
+#: ../../source/features/multi-engine.rst:135
+#: ../../source/features/multi-engine.rst:136
+#: ../../source/features/multi-engine.rst:140
+#: ../../source/features/multi-engine.rst:143
+#: ../../source/features/multi-engine.rst:145
+#: ../../source/features/multi-engine.rst:146
+#: ../../source/features/multi-engine.rst:148
+#: ../../source/features/multi-engine.rst:150
+#: ../../source/features/multi-engine.rst:151
+#: ../../source/features/multi-engine.rst:155
+#: ../../source/features/multi-engine.rst:159
+#: ../../source/features/multi-engine.rst:160
+#: ../../source/features/multi-engine.rst:164
+#: ../../source/features/multi-engine.rst:165
+#: ../../source/features/multi-engine.rst:166
+#: ../../source/features/multi-engine.rst:168
+#: ../../source/features/multi-engine.rst:170
+#: ../../source/features/multi-engine.rst:171
+#: ../../source/features/multi-engine.rst:174
+#: ../../source/features/multi-engine.rst:175
+#: ../../source/features/multi-engine.rst:176
+#: ../../source/features/multi-engine.rst:179
+#: ../../source/features/multi-engine.rst:180
+#: ../../source/features/multi-engine.rst:181
+#: ../../source/features/multi-engine.rst:184
+#: ../../source/features/multi-engine.rst:185
+#: ../../source/features/multi-engine.rst:186
+#: ../../source/features/multi-engine.rst:189
+#: ../../source/features/multi-engine.rst:190
+#: ../../source/features/multi-engine.rst:191
+#: ../../source/features/multi-engine.rst:194
+#: ../../source/features/multi-engine.rst:195
+#: ../../source/features/multi-engine.rst:196
+#: ../../source/features/multi-engine.rst:199
+#: ../../source/features/multi-engine.rst:200
+#: ../../source/features/multi-engine.rst:201
+#: ../../source/features/multi-engine.rst:204
+#: ../../source/features/multi-engine.rst:205
+#: ../../source/features/multi-engine.rst:206
+#: ../../source/features/multi-engine.rst:209
+#: ../../source/features/multi-engine.rst:210
+#: ../../source/features/multi-engine.rst:211
+#: ../../source/features/multi-engine.rst:215
+#: ../../source/features/multi-engine.rst:220
+#: ../../source/features/multi-engine.rst:225
+#: ../../source/features/multi-engine.rst:229
+#: ../../source/features/multi-engine.rst:230
+#: ../../source/features/multi-engine.rst:231
+#: ../../source/features/multi-engine.rst:234
+#: ../../source/features/multi-engine.rst:235
+#: ../../source/features/multi-engine.rst:236
+#: ../../source/features/multi-engine.rst:239
+#: ../../source/features/multi-engine.rst:240
+#: ../../source/features/multi-engine.rst:241
+#: ../../source/features/multi-engine.rst:246
+#: ../../source/features/multi-engine.rst:248
+#: ../../source/features/multi-engine.rst:249
+#: ../../source/features/multi-engine.rst:251
+#: ../../source/features/multi-engine.rst:254
+#: ../../source/features/multi-engine.rst:255
+#: ../../source/features/multi-engine.rst:256
+#: ../../source/features/multi-engine.rst:263
+#: ../../source/features/multi-engine.rst:264
+#: ../../source/features/multi-engine.rst:265
+#: ../../source/features/multi-engine.rst:269
+#: ../../source/features/multi-engine.rst:270
+#: ../../source/features/multi-engine.rst:271
+#: ../../source/features/multi-engine.rst:274
+#: ../../source/features/multi-engine.rst:275
+#: ../../source/features/multi-engine.rst:276
+#: ../../source/features/multi-engine.rst:279
+#: ../../source/features/multi-engine.rst:280
+#: ../../source/features/multi-engine.rst:281
+#: ../../source/features/multi-engine.rst:284
+#: ../../source/features/multi-engine.rst:285
+#: ../../source/features/multi-engine.rst:286
+#: ../../source/features/multi-engine.rst:289
+#: ../../source/features/multi-engine.rst:290
+#: ../../source/features/multi-engine.rst:291
+#: ../../source/features/multi-engine.rst:294
+#: ../../source/features/multi-engine.rst:295
+#: ../../source/features/multi-engine.rst:296
+#: ../../source/features/multi-engine.rst:299
+#: ../../source/features/multi-engine.rst:300
+#: ../../source/features/multi-engine.rst:301
+#: ../../source/features/multi-engine.rst:304
+#: ../../source/features/multi-engine.rst:305
+#: ../../source/features/multi-engine.rst:306
+#: ../../source/features/multi-engine.rst:309
+#: ../../source/features/multi-engine.rst:310
+#: ../../source/features/multi-engine.rst:311
+#: ../../source/features/multi-engine.rst:314
+#: ../../source/features/multi-engine.rst:315
+#: ../../source/features/multi-engine.rst:316
+#: ../../source/features/multi-engine.rst:319
+#: ../../source/features/multi-engine.rst:320
+#: ../../source/features/multi-engine.rst:321
+#: ../../source/features/multi-engine.rst:325
+#: ../../source/features/multi-engine.rst:326
+#: ../../source/features/multi-engine.rst:329
+#: ../../source/features/multi-engine.rst:330
+#: ../../source/features/multi-engine.rst:331
+#: ../../source/features/multi-engine.rst:334
+#: ../../source/features/multi-engine.rst:335
+#: ../../source/features/multi-engine.rst:336
+#: ../../source/features/multi-engine.rst:339
+#: ../../source/features/multi-engine.rst:340
+#: ../../source/features/multi-engine.rst:341
+msgid "N/A"
+msgstr "N/A"
+
+#: ../../source/features/multi-engine.rst:112
+msgid "``num_requests_waiting``"
+msgstr "``num_requests_waiting``"
+
+#: ../../source/features/multi-engine.rst:113
+msgid "``vllm:num_requests_waiting``"
+msgstr "``vllm:num_requests_waiting``"
+
+#: ../../source/features/multi-engine.rst:114
+msgid "``sglang:num_queue_reqs``"
+msgstr "``sglang:num_queue_reqs``"
+
+#: ../../source/features/multi-engine.rst:117
+msgid "``num_requests_swapped``"
+msgstr "``num_requests_swapped``"
+
+#: ../../source/features/multi-engine.rst:118
+msgid "``vllm:num_requests_swapped``"
+msgstr "``vllm:num_requests_swapped``"
+
+#: ../../source/features/multi-engine.rst:119
+msgid "``sglang:num_retracted_reqs``"
+msgstr "``sglang:num_retracted_reqs``"
+
+#: ../../source/features/multi-engine.rst:122
+msgid "``engine_sleep_state``"
+msgstr "``engine_sleep_state``"
+
+#: ../../source/features/multi-engine.rst:123
+msgid "``vllm:engine_sleep_state``"
+msgstr "``vllm:engine_sleep_state``"
+
+#: ../../source/features/multi-engine.rst:127
+msgid "``http_requests_total``"
+msgstr "``http_requests_total``"
+
+#: ../../source/features/multi-engine.rst:128
+msgid "``vllm:http_requests_total``"
+msgstr "``vllm:http_requests_total``"
+
+#: ../../source/features/multi-engine.rst:132
+msgid "``num_preemptions_total``"
+msgstr "``num_preemptions_total``"
+
+#: ../../source/features/multi-engine.rst:133
+msgid "``vllm:num_preemptions_total``"
+msgstr "``vllm:num_preemptions_total``"
+
+#: ../../source/features/multi-engine.rst:137
+msgid "``request_success_total``"
+msgstr "``request_success_total``"
+
+#: ../../source/features/multi-engine.rst:138
+msgid "``vllm:num_requests_success_total``"
+msgstr "``vllm:num_requests_success_total``"
+
+#: ../../source/features/multi-engine.rst:139
+msgid "``sglang:num_requests_total``"
+msgstr "``sglang:num_requests_total``"
+
+#: ../../source/features/multi-engine.rst:141
+msgid "``trtllm_request_success_total``"
+msgstr "``trtllm_request_success_total``"
+
+#: ../../source/features/multi-engine.rst:142
+msgid "``num_prefill_prealloc_queue_reqs``"
+msgstr "``num_prefill_prealloc_queue_reqs``"
+
+#: ../../source/features/multi-engine.rst:144
+msgid "``sglang:num_prefill_prealloc_queue_reqs``"
+msgstr "``sglang:num_prefill_prealloc_queue_reqs``"
+
+#: ../../source/features/multi-engine.rst:147
+msgid "``num_decode_prealloc_queue_reqs``"
+msgstr "``num_decode_prealloc_queue_reqs``"
+
+#: ../../source/features/multi-engine.rst:149
+msgid "``sglang:num_decode_prealloc_queue_reqs``"
+msgstr "``sglang:num_decode_prealloc_queue_reqs``"
+
+#: ../../source/features/multi-engine.rst:152
+msgid "``e2e_request_latency_seconds``"
+msgstr "``e2e_request_latency_seconds``"
+
+#: ../../source/features/multi-engine.rst:153
+msgid "``vllm:e2e_request_latency_seconds``"
+msgstr "``vllm:e2e_request_latency_seconds``"
+
+#: ../../source/features/multi-engine.rst:154
+msgid "``sglang:e2e_request_latency_seconds``"
+msgstr "``sglang:e2e_request_latency_seconds``"
+
+#: ../../source/features/multi-engine.rst:156
+msgid "``trtllm_e2e_request_latency_seconds``"
+msgstr "``trtllm_e2e_request_latency_seconds``"
+
+#: ../../source/features/multi-engine.rst:157
+msgid "``request_queue_time_seconds``"
+msgstr "``request_queue_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:158
+msgid "``vllm:request_queue_time_seconds``"
+msgstr "``vllm:request_queue_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:161
+msgid "``trtllm_request_queue_time_seconds``"
+msgstr "``trtllm_request_queue_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:162
+msgid "``request_inference_time_seconds``"
+msgstr "``request_inference_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:163
+msgid "``vllm:request_inference_time_seconds``"
+msgstr "``vllm:request_inference_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:167
+msgid "``per_stage_req_latency_seconds``"
+msgstr "``per_stage_req_latency_seconds``"
+
+#: ../../source/features/multi-engine.rst:169
+msgid "``sglang:per_stage_req_latency_seconds``"
+msgstr "``sglang:per_stage_req_latency_seconds``"
+
+#: ../../source/features/multi-engine.rst:172
+#: ../../source/features/multi-engine.rst:173
+msgid "``http_request_duration_seconds``"
+msgstr "``http_request_duration_seconds``"
+
+#: ../../source/features/multi-engine.rst:177
+#: ../../source/features/multi-engine.rst:178
+msgid "``http_request_duration_highr_seconds``"
+msgstr "``http_request_duration_highr_seconds``"
+
+#: ../../source/features/multi-engine.rst:182
+msgid "``prompt_tokens_total``"
+msgstr "``prompt_tokens_total``"
+
+#: ../../source/features/multi-engine.rst:183
+msgid "``vllm:prompt_tokens_total``"
+msgstr "``vllm:prompt_tokens_total``"
+
+#: ../../source/features/multi-engine.rst:187
+msgid "``request_prompt_tokens``"
+msgstr "``request_prompt_tokens``"
+
+#: ../../source/features/multi-engine.rst:188
+msgid "``vllm:request_prompt_tokens``"
+msgstr "``vllm:request_prompt_tokens``"
+
+#: ../../source/features/multi-engine.rst:192
+msgid "``generation_tokens_total``"
+msgstr "``generation_tokens_total``"
+
+#: ../../source/features/multi-engine.rst:193
+msgid "``vllm:generation_tokens_total``"
+msgstr "``vllm:generation_tokens_total``"
+
+#: ../../source/features/multi-engine.rst:197
+msgid "``request_generation_tokens``"
+msgstr "``request_generation_tokens``"
+
+#: ../../source/features/multi-engine.rst:198
+msgid "``vllm:request_generation_tokens``"
+msgstr "``vllm:request_generation_tokens``"
+
+#: ../../source/features/multi-engine.rst:202
+msgid "``request_max_num_generation_tokens``"
+msgstr "``request_max_num_generation_tokens``"
+
+#: ../../source/features/multi-engine.rst:203
+msgid "``vllm:request_max_num_generation_tokens``"
+msgstr "``vllm:request_max_num_generation_tokens``"
+
+#: ../../source/features/multi-engine.rst:207
+msgid "``iteration_tokens_total``"
+msgstr "``iteration_tokens_total``"
+
+#: ../../source/features/multi-engine.rst:208
+msgid "``vllm:iteration_tokens_total``"
+msgstr "``vllm:iteration_tokens_total``"
+
+#: ../../source/features/multi-engine.rst:212
+msgid "``time_to_first_token_seconds``"
+msgstr "``time_to_first_token_seconds``"
+
+#: ../../source/features/multi-engine.rst:213
+msgid "``vllm:time_to_first_token_seconds``"
+msgstr "``vllm:time_to_first_token_seconds``"
+
+#: ../../source/features/multi-engine.rst:214
+msgid "``sglang:time_to_first_token_seconds``"
+msgstr "``sglang:time_to_first_token_seconds``"
+
+#: ../../source/features/multi-engine.rst:216
+msgid "``trtllm_time_to_first_token_seconds``"
+msgstr "``trtllm_time_to_first_token_seconds``"
+
+#: ../../source/features/multi-engine.rst:217
+msgid "``time_per_output_token_seconds``"
+msgstr "``time_per_output_token_seconds``"
+
+#: ../../source/features/multi-engine.rst:218
+msgid "``vllm:time_per_output_token_seconds``"
+msgstr "``vllm:time_per_output_token_seconds``"
+
+#: ../../source/features/multi-engine.rst:219
+#: ../../source/features/multi-engine.rst:224
+msgid "``sglang:inter_token_latency_seconds``"
+msgstr "``sglang:inter_token_latency_seconds``"
+
+#: ../../source/features/multi-engine.rst:221
+#: ../../source/features/multi-engine.rst:226
+msgid "``trtllm_time_per_output_token_seconds``"
+msgstr "``trtllm_time_per_output_token_seconds``"
+
+#: ../../source/features/multi-engine.rst:222
+msgid "``inter_token_latency_seconds``"
+msgstr "``inter_token_latency_seconds``"
+
+#: ../../source/features/multi-engine.rst:223
+msgid "``vllm:inter_token_latency_seconds``"
+msgstr "``vllm:inter_token_latency_seconds``"
+
+#: ../../source/features/multi-engine.rst:227
+msgid "``request_decode_time_seconds``"
+msgstr "``request_decode_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:228
+msgid "``vllm:request_decode_time_seconds``"
+msgstr "``vllm:request_decode_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:232
+msgid "``request_prefill_time_seconds``"
+msgstr "``request_prefill_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:233
+msgid "``vllm:request_prefill_time_seconds``"
+msgstr "``vllm:request_prefill_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:237
+msgid "``request_time_per_output_token_seconds``"
+msgstr "``request_time_per_output_token_seconds``"
+
+#: ../../source/features/multi-engine.rst:238
+msgid "``vllm:request_time_per_output_token_seconds``"
+msgstr "``vllm:request_time_per_output_token_seconds``"
+
+#: ../../source/features/multi-engine.rst:242
+msgid "``gpu_cache_usage_perc``"
+msgstr "``gpu_cache_usage_perc``"
+
+#: ../../source/features/multi-engine.rst:243
+msgid "``vllm:gpu_cache_usage_perc``"
+msgstr "``vllm:gpu_cache_usage_perc``"
+
+#: ../../source/features/multi-engine.rst:244
+#: ../../source/features/multi-engine.rst:259
+msgid "``sglang:token_usage``"
+msgstr "``sglang:token_usage``"
+
+#: ../../source/features/multi-engine.rst:245
+#: ../../source/features/multi-engine.rst:260
+msgid "``kv_cache_utilization``"
+msgstr "``kv_cache_utilization``"
+
+#: ../../source/features/multi-engine.rst:247
+#: ../../source/features/multi-engine.rst:250
+msgid "``engine_utilization``"
+msgstr "``engine_utilization``"
+
+#: ../../source/features/multi-engine.rst:252
+msgid "``cpu_cache_usage_perc``"
+msgstr "``cpu_cache_usage_perc``"
+
+#: ../../source/features/multi-engine.rst:253
+msgid "``vllm:cpu_cache_usage_perc``"
+msgstr "``vllm:cpu_cache_usage_perc``"
+
+#: ../../source/features/multi-engine.rst:257
+msgid "``kv_cache_usage_perc``"
+msgstr "``kv_cache_usage_perc``"
+
+#: ../../source/features/multi-engine.rst:258
+msgid "``vllm:kv_cache_usage_perc``"
+msgstr "``vllm:kv_cache_usage_perc``"
+
+#: ../../source/features/multi-engine.rst:261
+msgid "``trtllm_kv_cache_utilization``"
+msgstr "``trtllm_kv_cache_utilization``"
+
+#: ../../source/features/multi-engine.rst:262
+msgid "``kv_cache_hit_rate``"
+msgstr "``kv_cache_hit_rate``"
+
+#: ../../source/features/multi-engine.rst:266
+msgid "``trtllm_kv_cache_hit_rate``"
+msgstr "``trtllm_kv_cache_hit_rate``"
+
+#: ../../source/features/multi-engine.rst:267
+msgid "``prefix_cache_queries_total``"
+msgstr "``prefix_cache_queries_total``"
+
+#: ../../source/features/multi-engine.rst:268
+msgid "``vllm:prefix_cache_queries_total``"
+msgstr "``vllm:prefix_cache_queries_total``"
+
+#: ../../source/features/multi-engine.rst:272
+msgid "``prefix_cache_hits_total``"
+msgstr "``prefix_cache_hits_total``"
+
+#: ../../source/features/multi-engine.rst:273
+msgid "``vllm:prefix_cache_hits_total``"
+msgstr "``vllm:prefix_cache_hits_total``"
+
+#: ../../source/features/multi-engine.rst:277
+msgid "``external_prefix_cache_queries_total``"
+msgstr "``external_prefix_cache_queries_total``"
+
+#: ../../source/features/multi-engine.rst:278
+msgid "``vllm:external_prefix_cache_queries_total``"
+msgstr "``vllm:external_prefix_cache_queries_total``"
+
+#: ../../source/features/multi-engine.rst:282
+msgid "``external_prefix_cache_hits_total``"
+msgstr "``external_prefix_cache_hits_total``"
+
+#: ../../source/features/multi-engine.rst:283
+msgid "``vllm:external_prefix_cache_hits_total``"
+msgstr "``vllm:external_prefix_cache_hits_total``"
+
+#: ../../source/features/multi-engine.rst:287
+msgid "``nixl_xfer_time_seconds``"
+msgstr "``nixl_xfer_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:288
+msgid "``vllm:nixl_xfer_time_seconds``"
+msgstr "``vllm:nixl_xfer_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:292
+msgid "``nixl_post_time_seconds``"
+msgstr "``nixl_post_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:293
+msgid "``vllm:nixl_post_time_seconds``"
+msgstr "``vllm:nixl_post_time_seconds``"
+
+#: ../../source/features/multi-engine.rst:297
+msgid "``nixl_bytes_transferred``"
+msgstr "``nixl_bytes_transferred``"
+
+#: ../../source/features/multi-engine.rst:298
+msgid "``vllm:nixl_bytes_transferred``"
+msgstr "``vllm:nixl_bytes_transferred``"
+
+#: ../../source/features/multi-engine.rst:302
+msgid "``nixl_num_descriptors``"
+msgstr "``nixl_num_descriptors``"
+
+#: ../../source/features/multi-engine.rst:303
+msgid "``vllm:nixl_num_descriptors``"
+msgstr "``vllm:nixl_num_descriptors``"
+
+#: ../../source/features/multi-engine.rst:307
+msgid "``nixl_num_failed_transfers_total``"
+msgstr "``nixl_num_failed_transfers_total``"
+
+#: ../../source/features/multi-engine.rst:308
+msgid "``vllm:nixl_num_failed_transfers``"
+msgstr "``vllm:nixl_num_failed_transfers``"
+
+#: ../../source/features/multi-engine.rst:312
+msgid "``nixl_num_failed_notifications_total``"
+msgstr "``nixl_num_failed_notifications_total``"
+
+#: ../../source/features/multi-engine.rst:313
+msgid "``vllm:nixl_num_failed_notifications``"
+msgstr "``vllm:nixl_num_failed_notifications``"
+
+#: ../../source/features/multi-engine.rst:317
+msgid "``avg_prompt_throughput_toks_per_s``"
+msgstr "``avg_prompt_throughput_toks_per_s``"
+
+#: ../../source/features/multi-engine.rst:318
+msgid "``vllm:avg_prompt_throughput_toks_per_s``"
+msgstr "``vllm:avg_prompt_throughput_toks_per_s``"
+
+#: ../../source/features/multi-engine.rst:322
+msgid "``avg_generation_throughput_toks_per_s``"
+msgstr "``avg_generation_throughput_toks_per_s``"
+
+#: ../../source/features/multi-engine.rst:323
+msgid "``vllm:avg_generation_throughput_toks_per_s``"
+msgstr "``vllm:avg_generation_throughput_toks_per_s``"
+
+#: ../../source/features/multi-engine.rst:324
+msgid "``sglang:gen_throughput``"
+msgstr "``sglang:gen_throughput``"
+
+#: ../../source/features/multi-engine.rst:327
+msgid "``max_lora``"
+msgstr "``max_lora``"
+
+#: ../../source/features/multi-engine.rst:328
+#: ../../source/features/multi-engine.rst:333
+#: ../../source/features/multi-engine.rst:338
+msgid "``vllm:lora_requests_info``"
+msgstr "``vllm:lora_requests_info``"
+
+#: ../../source/features/multi-engine.rst:332
+msgid "``running_lora_adapters``"
+msgstr "``running_lora_adapters``"
+
+#: ../../source/features/multi-engine.rst:337
+msgid "``waiting_lora_adapters``"
+msgstr "``waiting_lora_adapters``"
+
+#: ../../source/features/multi-engine.rst:343
+msgid ""
+"The SGLang entries for ``gpu_cache_usage_perc`` and "
+"``kv_cache_usage_perc`` map to ``sglang:token_usage`` [1]_."
+msgstr ""
+"SGLang 的 ``gpu_cache_usage_perc`` 和 ``kv_cache_usage_perc`` 映射到 "
+"``sglang:token_usage`` [1]_。"
+
+#: ../../source/features/multi-engine.rst:345
+msgid ""
+"`https://github.com/sgl-project/sglang/issues/5979 <https://github.com"
+"/sgl-project/sglang/issues/5979>`_"
+msgstr ""
+"`https://github.com/sgl-project/sglang/issues/5979 <https://github.com"
+"/sgl-project/sglang/issues/5979>`_"
+
+#: ../../source/features/multi-engine.rst:348
+msgid "TRT-LLM Quickstart"
+msgstr "TRT-LLM 快速开始"
+
+#: ../../source/features/multi-engine.rst:350
+msgid ""
+"To use TRT-LLM as the inference engine, set the ``model.aibrix.ai/engine:"
+" trtllm`` label on your deployment. TRT-LLM must be configured to expose "
+"performance metrics by enabling ``return_perf_metrics: true``, "
+"``enable_iter_perf_stats: true``, and ``enable_iter_req_stats: true`` in "
+"its server config."
+msgstr ""
+"要将 TRT-LLM 用作推理引擎，请在 deployment 上设置 ``model.aibrix.ai/engine: trtllm`` 标签。TRT-LLM "
+"必须在其 server config 中启用 ``return_perf_metrics: true`` 、``enable_iter_perf_stats: "
+"true`` 和 ``enable_iter_req_stats: true`` ，以暴露性能指标。"
+
+#: ../../source/features/multi-engine.rst:352
+msgid "Sample configurations are available at:"
+msgstr "示例配置见："
+
+#: ../../source/features/multi-engine.rst:354
+msgid ""
+"`samples/quickstart/tensorrt/tensor-rt.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/quickstart/tensorrt/tensor-rt.yaml>`_ — "
+"standard single-instance deployment"
+msgstr ""
+"`samples/quickstart/tensorrt/tensor-rt.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/quickstart/tensorrt/tensor-rt.yaml>`_ — "
+"标准单实例部署"
+
+#: ../../source/features/multi-engine.rst:355
+msgid ""
+"`samples/quickstart/tensorrt/tensor-rt-pd.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/quickstart/tensorrt/tensor-rt-pd.yaml>`_"
+" — prefill/decode disaggregated deployment using StormService"
+msgstr ""
+"`samples/quickstart/tensorrt/tensor-rt-pd.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/quickstart/tensorrt/tensor-rt-pd.yaml>`_"
+" — 使用 StormService 的 Prefill/Decode 分离部署"
+
+#: ../../source/features/multi-engine.rst:357
+msgid "Example deployment label configuration for TRT-LLM:"
+msgstr "TRT-LLM 的 deployment 标签配置示例："
+
+#: ../../source/features/multi-engine.rst:367
+msgid "TRT-LLM Limitations"
+msgstr "TRT-LLM 限制"
+
+#: ../../source/features/multi-engine.rst:369
+msgid ""
+"**No queue-depth metrics**: TRT-LLM does not expose "
+"``num_requests_running`` or ``num_requests_waiting``. Routing policies "
+"that rely on queue depth (e.g., least-request) will fall back to random "
+"routing."
+msgstr ""
+"**无队列深度指标** ：TRT-LLM 不暴露 ``num_requests_running`` 或 ``num_requests_waiting`` "
+"。依赖队列深度的路由策略（例如 least-request）会回退到随机路由。"
+
+#: ../../source/features/multi-engine.rst:370
+msgid ""
+"**Metrics require explicit config**: Performance metrics are only emitted"
+" when ``return_perf_metrics: true``, ``enable_iter_perf_stats: true``, "
+"and ``enable_iter_req_stats: true`` are set in the TRT-LLM server "
+"configuration."
+msgstr ""
+"**指标需要显式配置** ：仅当 TRT-LLM server 配置中设置 ``return_perf_metrics: true`` 、``enable_iter_perf_stats: "
+"true`` 和 ``enable_iter_req_stats: true`` 时才会发出性能指标。"
+
+#: ../../source/features/multi-engine.rst:373
+msgid "Adding New Engines"
+msgstr "添加新引擎"
+
+#: ../../source/features/multi-engine.rst:375
+msgid "To support a new engine or metrics type:"
+msgstr "要支持新引擎或指标类型："
+
+#: ../../source/features/multi-engine.rst:377
+msgid ""
+"Adding engine type to metrics name mapping at "
+"`aibrix/pkg/metrics/metrics.go`."
+msgstr "在 `aibrix/pkg/metrics/metrics.go` 中添加引擎类型到指标名的映射。"
+
+#: ../../source/features/multi-engine.rst:378
+msgid ""
+"Adding engine name to `model.aibrix.ai/engine` label in the deployment "
+"YAML file."
+msgstr "在 deployment YAML 的 `model.aibrix.ai/engine` 标签中添加引擎名。"
+
+#: ../../source/features/multi-engine.rst:380
+msgid "For more details, see the `cache_metrics.go` and `metrics.go` in:"
+msgstr "更多细节见以下路径中的 `cache_metrics.go` 和 `metrics.go` ："
+
+#: ../../source/features/multi-engine.rst:382
+msgid ""
+"`aibrix/pkg/cache/cache_metrics.go <https://github.com/vllm-"
+"project/aibrix/blob/main/pkg/cache/cache_metrics.go>`_"
+msgstr ""
+"`aibrix/pkg/cache/cache_metrics.go <https://github.com/vllm-"
+"project/aibrix/blob/main/pkg/cache/cache_metrics.go>`_"
+
+#: ../../source/features/multi-engine.rst:383
+msgid ""
+"`aibrix/pkg/metrics/metrics.go <https://github.com/vllm-"
+"project/aibrix/blob/main/pkg/metrics/metrics.go>`_"
+msgstr ""
+"`aibrix/pkg/metrics/metrics.go <https://github.com/vllm-"
+"project/aibrix/blob/main/pkg/metrics/metrics.go>`_"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/multi-node-inference.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/multi-node-inference.po
@@ -1,0 +1,736 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/multi-node-inference.rst:5
+msgid "Multi-Node Inference"
+msgstr "多节点推理"
+
+#: ../../source/features/multi-node-inference.rst:7
+msgid ""
+"Distributed inference splits and processes an LLM across multiple nodes "
+"or devices. This approach is needed for large models that exceed the "
+"memory capacity of a single machine."
+msgstr ""
+"分布式推理将 LLM 拆分到多个节点或设备上处理。当大模型超出单机内存容量时，就需要"
+"这种方式。"
+
+#: ../../source/features/multi-node-inference.rst:10
+msgid "AIBrix provides two orchestration paths for multi-node inference:"
+msgstr "AIBrix 为多节点推理提供两条编排路径："
+
+#: ../../source/features/multi-node-inference.rst:12
+msgid ""
+"Ray-based Orchestration (``RayClusterFleet`` / ``RayClusterReplicaSet``):"
+" Uses KubeRay for intra-application worker placement and coordination, "
+"with Kubernetes managing replica scaling and rollouts."
+msgstr ""
+"基于 Ray 的编排（``RayClusterFleet`` / ``RayClusterReplicaSet`` ）：用 KubeRay 做应用内 "
+"worker 放置与协调，由 Kubernetes 管理副本扩缩容和滚动发布。"
+
+#: ../../source/features/multi-node-inference.rst:13
+msgid ""
+"Native PodSet Orchestration (``StormService``): Kubernetes-native multi-"
+"role and multi-node grouping via ``podGroupSize`` without requiring "
+"KubeRay."
+msgstr ""
+"原生 PodSet 编排（``StormService`` ）：通过 ``podGroupSize`` 做 Kubernetes 原生的多角色、多节点分组，无需 "
+"KubeRay。"
+
+#: ../../source/features/multi-node-inference.rst:18
+msgid "On this page"
+msgstr "本页内容"
+
+#: ../../source/features/multi-node-inference.rst:21
+msgid "Choosing an Orchestration Abstraction"
+msgstr "选择编排抽象"
+
+#: ../../source/features/multi-node-inference.rst:23
+msgid ""
+"Operators can pick the abstraction matching their deployment topology and"
+" infrastructure setup:"
+msgstr "运维人员可按部署拓扑和基础设施选择对应抽象："
+
+#: ../../source/features/multi-node-inference.rst:29
+msgid "Abstraction"
+msgstr "抽象"
+
+#: ../../source/features/multi-node-inference.rst:30
+msgid "Infrastructure Requirement"
+msgstr "基础设施要求"
+
+#: ../../source/features/multi-node-inference.rst:31
+msgid "Best Suited For"
+msgstr "最适合"
+
+#: ../../source/features/multi-node-inference.rst:32
+msgid "RayClusterFleet"
+msgstr "RayClusterFleet"
+
+#: ../../source/features/multi-node-inference.rst:33
+msgid "KubeRay operator installed"
+msgstr "已安装 KubeRay operator"
+
+#: ../../source/features/multi-node-inference.rst:34
+msgid ""
+"Standard multi-node vLLM deployments where Ray handles process placement "
+"and worker coordination."
+msgstr "标准多节点 vLLM 部署，由 Ray 负责进程放置和 worker 协调。"
+
+#: ../../source/features/multi-node-inference.rst:35
+msgid "StormService"
+msgstr "StormService"
+
+#: ../../source/features/multi-node-inference.rst:36
+msgid "Native Kubernetes (no KubeRay required)"
+msgstr "原生 Kubernetes（无需 KubeRay）"
+
+#: ../../source/features/multi-node-inference.rst:37
+msgid ""
+"Prefill-Decode (PD) disaggregated setups, custom multi-role "
+"architectures, or direct engine-native distributed backends (like SGLang "
+"or vLLM with MPI/NCCL and RDMA networking)."
+msgstr ""
+"Prefill/Decode 分离（PD）部署、自定义多角色架构，或引擎原生分布式后端（例如 "
+"SGLang，或带 MPI/NCCL 与 RDMA 网络的 vLLM）。"
+
+#: ../../source/features/multi-node-inference.rst:41
+msgid "KubeRay Orchestration (RayClusterFleet)"
+msgstr "KubeRay 编排（RayClusterFleet）"
+
+#: ../../source/features/multi-node-inference.rst:43
+msgid ""
+"In distributed computing, managing multi-node inference requires "
+"coordination at two layers: fine-grained task execution inside the "
+"cluster, and standard operational management from Kubernetes."
+msgstr ""
+"在分布式计算中，管理多节点推理需要两层协调：集群内细粒度任务执行，以及 "
+"Kubernetes 侧的标准运维管理。"
+
+#: ../../source/features/multi-node-inference.rst:45
+msgid ""
+"Ray handles intra-application task scheduling and worker communication "
+"well, but relies on external systems for cluster lifecycle operations. "
+"Kubernetes excels at container scheduling, autoscaling, and rolling "
+"updates."
+msgstr ""
+"Ray 擅长应用内任务调度和 worker 通信，但集群生命周期操作依赖外部系统。"
+"Kubernetes 擅长容器调度、自动扩缩容和滚动更新。"
+
+#: ../../source/features/multi-node-inference.rst:47
+msgid ""
+"AIBrix combines both: Ray handles internal distributed computation, while"
+" Kubernetes manages replica lifecycle and environment setup."
+msgstr ""
+"AIBrix 将两者结合：Ray 负责内部分布式计算，Kubernetes 管理副本生命周期和环境"
+"配置。"
+
+#: ../../source/features/multi-node-inference.rst:49
+msgid ""
+"Two key APIs manage Ray clusters: ``RayClusterReplicaSet`` and "
+"``RayClusterFleet``. These mirror Kubernetes ``ReplicaSet`` and "
+"``Deployment`` patterns. In most cases, ``RayClusterFleet`` is the "
+"primary resource to configure."
+msgstr ""
+"管理 Ray 集群的两个关键 API 是 ``RayClusterReplicaSet`` 和 ``RayClusterFleet`` 。它们对应 "
+"Kubernetes 的 ``ReplicaSet`` 和 ``Deployment`` 模式。大多数情况下，主要配置 ``RayClusterFleet`` "
+"。"
+
+#: ../../source/features/multi-node-inference.rst:52
+msgid "mix-grain-orchestration"
+msgstr "mix-grain-orchestration"
+
+#: ../../source/features/multi-node-inference.rst:57
+msgid ""
+"Ray Framework Focus: Ray handles intra-application orchestration. Each "
+"application instance corresponds to a single Ray cluster."
+msgstr "Ray 框架职责：Ray 负责应用内编排。每个应用实例对应一个 Ray 集群。"
+
+#: ../../source/features/multi-node-inference.rst:58
+msgid ""
+"Kubernetes Layer: Kubernetes operates at the outer layer, handling Ray "
+"cluster creation, autoscaling, and rolling updates."
+msgstr "Kubernetes 层：Kubernetes 在外层运作，负责 Ray 集群创建、自动扩缩容和滚动更新。"
+
+#: ../../source/features/multi-node-inference.rst:59
+msgid ""
+"Service Encapsulation: Services map to Ray clusters representing "
+"application instances rather than single pods."
+msgstr "服务封装：Service 映射到代表应用实例的 Ray 集群，而不是单个 Pod。"
+
+#: ../../source/features/multi-node-inference.rst:62
+msgid "We already submitted our ideas to the KubeRay community."
+msgstr "我们已将相关想法提交给 KubeRay 社区。"
+
+#: ../../source/features/multi-node-inference.rst:66
+msgid "How it works"
+msgstr "工作原理"
+
+#: ../../source/features/multi-node-inference.rst:85
+msgid "The layers, from the outside in:"
+msgstr "各层由外到内："
+
+#: ../../source/features/multi-node-inference.rst:87
+msgid ""
+"``RayClusterFleet`` carries the rollout semantics of a ``Deployment``: a "
+"rolling update or recreate strategy, revision history, ``paused``, "
+"``minReadySeconds`` and a progress deadline. Every change to "
+"``spec.template`` produces a new ``RayClusterReplicaSet`` and the fleet "
+"shifts replicas between old and new sets according to ``strategy``."
+msgstr ""
+"``RayClusterFleet`` 具备 ``Deployment`` 的发布语义：滚动更新或 recreate 策略、修订历史、``paused`` "
+"、``minReadySeconds`` 以及进度超时。每次更改 ``spec.template`` 都会产生新的 ``RayClusterReplicaSet`` "
+"，fleet 再按 ``strategy`` 在新旧集合之间迁移副本。"
+
+#: ../../source/features/multi-node-inference.rst:91
+msgid ""
+"``RayClusterReplicaSet`` keeps a fixed number of KubeRay ``RayCluster`` "
+"objects running and replaces any that disappear."
+msgstr ""
+"``RayClusterReplicaSet`` 保持固定数量的 KubeRay ``RayCluster`` 对象运行，并替换"
+"任何消失的对象。"
+
+#: ../../source/features/multi-node-inference.rst:93
+msgid ""
+"``RayCluster`` is KubeRay's resource. Its spec comes from "
+"``spec.template.spec`` of the fleet, with only the fleet-name label added"
+" to the head and worker pod templates, so anything KubeRay supports "
+"(``rayVersion``, ``headGroupSpec``, ``workerGroupSpecs``, "
+"``rayStartParams``) is available."
+msgstr ""
+"``RayCluster`` 是 KubeRay 的资源。其 spec 来自 fleet 的 ``spec.template.spec`` ，仅会在 "
+"head 和 worker Pod 模板上添加 fleet-name 标签，因此 KubeRay 支持的内容（``rayVersion`` 、``headGroupSpec`` "
+"、``workerGroupSpecs`` 、``rayStartParams`` ）都可用。"
+
+#: ../../source/features/multi-node-inference.rst:97
+msgid ""
+"The engine runs on the **head pod** with Ray as its distributed executor "
+"(``--distributed-executor-backend ray`` for vLLM). Worker pods only run "
+"``ray start`` and contribute their GPUs to the Ray cluster."
+msgstr ""
+"引擎运行在 **head Pod** 上，以 Ray 作为分布式执行器（vLLM 使用 ``--distributed-executor-backend "
+"ray`` ）。Worker Pod 只运行 ``ray start`` ，并把 GPU 贡献给 Ray 集群。"
+
+#: ../../source/features/multi-node-inference.rst:101
+msgid ""
+"**Readiness.** A Ray cluster counts as ready only when KubeRay reports "
+"both the ``RayClusterProvisioned`` and ``HeadPodReady`` conditions as "
+"``True`` and every desired worker is ready. Those conditions are produced"
+" by KubeRay's ``RayClusterStatusConditions`` feature gate, which the "
+"AIBrix installation instructions enable. Without the gate the fleet can "
+"never report ready replicas."
+msgstr ""
+"**就绪。** 仅当 KubeRay 将 ``RayClusterProvisioned`` 和 ``HeadPodReady`` 条件都报告为 "
+"``True`` ，且每个期望 worker 都就绪时，Ray 集群才计为就绪。这些条件由 KubeRay 的 ``RayClusterStatusConditions`` "
+"feature gate 产生，AIBrix 安装说明会启用它。没有该 gate 时，fleet 永远无法报告就绪副本。"
+
+#: ../../source/features/multi-node-inference.rst:107
+msgid ""
+"**Routing.** The gateway discovers model pods by the "
+"``model.aibrix.ai/name`` label, but it ignores pods labelled ``ray.io"
+"/node-type: worker``. Requests are therefore routed to head pods only. "
+"The fleet controller stamps every pod with ``orchestration.aibrix.ai"
+"/raycluster-fleet-name`` so that metrics and routing state can be mapped "
+"back to the fleet that owns the pod."
+msgstr ""
+"**路由。** 网关通过 ``model.aibrix.ai/name`` 标签发现模型 Pod，但会忽略带 ``ray.io/node-type: "
+"worker`` 的 Pod。因此请求只路由到 head Pod。fleet 控制器会给每个 Pod 打上 ``orchestration.aibrix.ai/raycluster-fleet-name`` "
+"，以便将指标和路由状态映射回拥有该 Pod 的 fleet。"
+
+#: ../../source/features/multi-node-inference.rst:114
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/features/multi-node-inference.rst:116
+msgid ""
+"The KubeRay operator. It is optional for the rest of AIBrix and only "
+"needed for ``RayClusterFleet`` and ``RayClusterReplicaSet``. Install it "
+"with the Helm command in "
+":doc:`../getting_started/installation/installation`; that command pins a "
+"patched operator image and turns on the ``RayClusterStatusConditions`` "
+"feature gate that readiness depends on."
+msgstr ""
+"KubeRay operator。对 AIBrix 其余部分是可选的，仅 ``RayClusterFleet`` 和 "
+"``RayClusterReplicaSet`` 需要。使用 :doc:`../getting_started/installation"
+"/installation` 中的 Helm 命令安装；该命令会固定打过补丁的 operator 镜像，并打开"
+"就绪依赖的 ``RayClusterStatusConditions`` feature gate。"
+
+#: ../../source/features/multi-node-inference.rst:120
+msgid "GPU nodes for the head pod and each worker pod."
+msgstr "head Pod 和每个 worker Pod 所需的 GPU 节点。"
+
+#: ../../source/features/multi-node-inference.rst:121
+msgid ""
+"An engine image that contains Ray. Official vLLM images from v0.6.6 "
+"onward work out of the box; for older versions see `Container Image "
+"Requirements`_ below."
+msgstr ""
+"包含 Ray 的引擎镜像。v0.6.6 及之后的官方 vLLM 镜像开箱即用；更早版本见下文 `Container Image Requirements`_ "
+"。"
+
+#: ../../source/features/multi-node-inference.rst:125
+msgid "Configuration reference"
+msgstr "配置参考"
+
+#: ../../source/features/multi-node-inference.rst:127
+msgid "Both resources live in the ``orchestration.aibrix.ai/v1alpha1`` API group."
+msgstr "这两个资源都位于 ``orchestration.aibrix.ai/v1alpha1`` API 组。"
+
+#: ../../source/features/multi-node-inference.rst:129
+msgid "**RayClusterFleet spec**"
+msgstr "**RayClusterFleet spec**"
+
+#: ../../source/features/multi-node-inference.rst:135
+msgid "Field"
+msgstr "字段"
+
+#: ../../source/features/multi-node-inference.rst:136
+msgid "Type"
+msgstr "类型"
+
+#: ../../source/features/multi-node-inference.rst:137
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/features/multi-node-inference.rst:138
+msgid "``replicas``"
+msgstr "``replicas``"
+
+#: ../../source/features/multi-node-inference.rst:139
+#: ../../source/features/multi-node-inference.rst:153
+#: ../../source/features/multi-node-inference.rst:156
+#: ../../source/features/multi-node-inference.rst:162
+msgid "int32"
+msgstr "int32"
+
+#: ../../source/features/multi-node-inference.rst:140
+msgid "Number of Ray clusters to run. Defaults to 1."
+msgstr "要运行的 Ray 集群数量。默认为 1。"
+
+#: ../../source/features/multi-node-inference.rst:141
+msgid "``selector``"
+msgstr "``selector``"
+
+#: ../../source/features/multi-node-inference.rst:142
+msgid "LabelSelector"
+msgstr "LabelSelector"
+
+#: ../../source/features/multi-node-inference.rst:143
+msgid "Must match the labels in ``template.metadata.labels``. Required."
+msgstr "必须匹配 ``template.metadata.labels`` 中的标签。必需。"
+
+#: ../../source/features/multi-node-inference.rst:144
+msgid "``template``"
+msgstr "``template``"
+
+#: ../../source/features/multi-node-inference.rst:145
+msgid "RayClusterTemplateSpec"
+msgstr "RayClusterTemplateSpec"
+
+#: ../../source/features/multi-node-inference.rst:146
+msgid ""
+"``metadata`` and ``spec`` for each Ray cluster. ``spec`` is a KubeRay "
+"``RayClusterSpec`` and is passed through, with the fleet-name label added"
+" to the pod templates."
+msgstr ""
+"每个 Ray 集群的 ``metadata`` 和 ``spec`` 。``spec`` 是 KubeRay 的 ``RayClusterSpec`` "
+"，会原样透传，并在 Pod 模板上添加 fleet-name 标签。"
+
+#: ../../source/features/multi-node-inference.rst:148
+msgid "``strategy``"
+msgstr "``strategy``"
+
+#: ../../source/features/multi-node-inference.rst:149
+msgid "DeploymentStrategy"
+msgstr "DeploymentStrategy"
+
+#: ../../source/features/multi-node-inference.rst:150
+msgid ""
+"``Recreate`` or ``RollingUpdate`` with ``maxSurge`` and "
+"``maxUnavailable``, same semantics as a ``Deployment``."
+msgstr ""
+"``Recreate`` 或带 ``maxSurge`` 和 ``maxUnavailable`` 的 ``RollingUpdate`` ，语义与 "
+"``Deployment`` 相同。"
+
+#: ../../source/features/multi-node-inference.rst:152
+msgid "``minReadySeconds``"
+msgstr "``minReadySeconds``"
+
+#: ../../source/features/multi-node-inference.rst:154
+msgid "How long a Ray cluster must stay ready before it counts as available."
+msgstr "Ray 集群必须保持就绪多久才计为可用。"
+
+#: ../../source/features/multi-node-inference.rst:155
+msgid "``revisionHistoryLimit``"
+msgstr "``revisionHistoryLimit``"
+
+#: ../../source/features/multi-node-inference.rst:157
+msgid "Number of old ``RayClusterReplicaSet`` objects to keep for rollback."
+msgstr "为回滚保留的旧 ``RayClusterReplicaSet`` 对象数量。"
+
+#: ../../source/features/multi-node-inference.rst:158
+msgid "``paused``"
+msgstr "``paused``"
+
+#: ../../source/features/multi-node-inference.rst:159
+msgid "bool"
+msgstr "bool"
+
+#: ../../source/features/multi-node-inference.rst:160
+msgid "Stop the controller from acting on template changes."
+msgstr "阻止控制器对模板变更采取行动。"
+
+#: ../../source/features/multi-node-inference.rst:161
+msgid "``progressDeadlineSeconds``"
+msgstr "``progressDeadlineSeconds``"
+
+#: ../../source/features/multi-node-inference.rst:163
+msgid ""
+"Seconds after which a stalled rollout is reported as failed in "
+"``status.conditions``."
+msgstr "停滞的发布在多少秒后会在 ``status.conditions`` 中报告为失败。"
+
+#: ../../source/features/multi-node-inference.rst:165
+msgid ""
+"**RayClusterFleet status** reports ``replicas``, ``updatedReplicas``, "
+"``readyReplicas``, ``availableReplicas``, ``unavailableReplicas``, "
+"``observedGeneration``, ``conditions`` and ``scalingTargetSelector``. The"
+" fleet exposes the Kubernetes ``scale`` subresource, so ``kubectl scale "
+"rayclusterfleet <name> --replicas=N`` works, and a :doc:`PodAutoscaler "
+"<autoscaling/autoscaling>` can use ``kind: RayClusterFleet`` as its "
+"``scaleTargetRef``."
+msgstr ""
+"**RayClusterFleet status** 报告 ``replicas`` 、``updatedReplicas`` 、``readyReplicas`` "
+"、``availableReplicas`` 、``unavailableReplicas`` 、``observedGeneration`` "
+"、``conditions`` 和 ``scalingTargetSelector`` 。fleet 暴露 Kubernetes ``scale`` "
+"子资源，因此 ``kubectl scale rayclusterfleet <name> --replicas=N`` 可用，:doc:`PodAutoscaler "
+"<autoscaling/autoscaling>` 也可以把 ``kind: RayClusterFleet`` 用作 ``scaleTargetRef`` "
+"。"
+
+#: ../../source/features/multi-node-inference.rst:171
+msgid ""
+"**RayClusterReplicaSet spec** is the subset a ``ReplicaSet`` would have: "
+"``replicas``, ``selector``, ``template`` and ``minReadySeconds``. You "
+"normally never create one directly."
+msgstr ""
+"**RayClusterReplicaSet spec** 是 ``ReplicaSet`` 会有的子集：``replicas`` 、``selector`` "
+"、``template`` 和 ``minReadySeconds`` 。通常不必直接创建它。"
+
+#: ../../source/features/multi-node-inference.rst:174
+msgid "**Labels and annotations that matter**"
+msgstr "**相关标签和注解**"
+
+#: ../../source/features/multi-node-inference.rst:180
+msgid "Key"
+msgstr "键"
+
+#: ../../source/features/multi-node-inference.rst:181
+msgid "Purpose"
+msgstr "用途"
+
+#: ../../source/features/multi-node-inference.rst:182
+msgid "``model.aibrix.ai/name`` (label)"
+msgstr "``model.aibrix.ai/name`` （标签）"
+
+#: ../../source/features/multi-node-inference.rst:183
+msgid ""
+"Set it on the head and worker pod templates. The gateway discovers the "
+"model's pods through this label. (The ``PodAutoscaler`` uses the fleet's "
+"scale selector instead.)"
+msgstr ""
+"设在 head 和 worker Pod 模板上。网关通过该标签发现模型的 Pod。（``PodAutoscaler`` "
+"改用 fleet 的 scale selector。）"
+
+#: ../../source/features/multi-node-inference.rst:185
+msgid ""
+"``ray.io/overwrite-container-cmd: \"true\"`` (annotation on the Ray "
+"cluster template)"
+msgstr "``ray.io/overwrite-container-cmd: \"true\"`` （Ray 集群模板上的注解）"
+
+#: ../../source/features/multi-node-inference.rst:186
+msgid ""
+"Tells KubeRay to respect the container ``command`` and ``args`` you wrote"
+" instead of generating its own ``ray start`` command. KubeRay still "
+"injects the generated command into the env var "
+"``KUBERAY_GEN_RAY_START_CMD`` so you can run it yourself, which is what "
+"the sample does. The generated variable does not include ``ulimit``, so "
+"set that in your own command."
+msgstr ""
+"告诉 KubeRay 使用你写的容器 ``command`` 和 ``args`` ，而不是生成自己的 ``ray start`` 命令。KubeRay "
+"仍会把生成的命令注入环境变量 ``KUBERAY_GEN_RAY_START_CMD`` ，以便你自行运行，示例就是这样做的。生成的变量不含 ``ulimit`` "
+"，请在自己的命令中设置。"
+
+#: ../../source/features/multi-node-inference.rst:191
+msgid "``ray.io/node-type`` (label, set by KubeRay)"
+msgstr "``ray.io/node-type`` （标签，由 KubeRay 设置）"
+
+#: ../../source/features/multi-node-inference.rst:192
+msgid "``head`` or ``worker``. The gateway skips ``worker`` pods when routing."
+msgstr "``head`` 或 ``worker`` 。网关路由时会跳过 ``worker`` Pod。"
+
+#: ../../source/features/multi-node-inference.rst:193
+msgid ""
+"``orchestration.aibrix.ai/raycluster-fleet-name`` (label, set by the "
+"fleet controller)"
+msgstr "``orchestration.aibrix.ai/raycluster-fleet-name`` （标签，由 fleet 控制器设置）"
+
+#: ../../source/features/multi-node-inference.rst:194
+msgid "Maps a pod back to its fleet. Do not set it yourself."
+msgstr "将 Pod 映射回其 fleet。不要自行设置。"
+
+#: ../../source/features/multi-node-inference.rst:196
+msgid ""
+"**Parallelism sizing.** With the Ray executor, the engine's tensor-"
+"parallel size must equal the number of GPUs in the whole Ray cluster "
+"(head plus workers). The sample below runs ``--tensor-parallel-size 2`` "
+"on a head pod with one GPU and one worker pod with one GPU."
+msgstr ""
+"**并行度规模。** 使用 Ray 执行器时，引擎的 tensor-parallel size 必须等于整个 Ray 集群（head 加 worker）的 "
+"GPU 数量。下面的示例在带 1 块 GPU 的 head Pod 和带 1 块 GPU 的 worker Pod 上运行 ``--tensor-parallel-size "
+"2`` 。"
+
+#: ../../source/features/multi-node-inference.rst:201
+msgid "RayClusterFleet Example"
+msgstr "RayClusterFleet 示例"
+
+#: ../../source/features/multi-node-inference.rst:203
+msgid ""
+"Below is a ``RayClusterFleet`` example deploying a two-node distributed "
+"inference cluster:"
+msgstr "下面是部署两节点分布式推理集群的 ``RayClusterFleet`` 示例："
+
+#: ../../source/features/multi-node-inference.rst:208
+msgid "What the sample is doing, section by section:"
+msgstr "示例各部分在做什么："
+
+#: ../../source/features/multi-node-inference.rst:210
+msgid ""
+"The **head container** raises the file-descriptor limit, installs the Ray"
+" dashboard dependencies, runs the KubeRay-generated ``ray start`` command"
+" in the background, waits until the Ray dashboard on port 8265 answers, "
+"and only then launches ``vllm serve`` with ``--distributed-executor-"
+"backend ray``. Waiting for the dashboard matters: vLLM connects to the "
+"Ray cluster at startup and fails if the head is not up yet."
+msgstr ""
+"**head 容器** 提高文件描述符限制，安装 Ray dashboard 依赖，在后台运行 KubeRay 生成的 ``ray start`` "
+"命令，等到端口 8265 上的 Ray dashboard 响应后，才用 ``--distributed-executor-backend ray`` "
+"启动 ``vllm serve`` 。等待 dashboard 很重要：vLLM 在启动时连接 Ray 集群，如果 head 尚未就绪就会失败。"
+
+#: ../../source/features/multi-node-inference.rst:215
+msgid ""
+"The **worker container** runs the generated ``ray start`` command with "
+"its own pod IP and then blocks with ``tail -f /dev/null``. A ``preStop`` "
+"hook calls ``ray stop`` so the node leaves the cluster cleanly."
+msgstr ""
+"**worker 容器** 用自己的 Pod IP 运行生成的 ``ray start`` 命令，然后用 ``tail -f /dev/null`` "
+"阻塞。``preStop`` hook 会调用 ``ray stop`` ，以便节点干净地离开集群。"
+
+#: ../../source/features/multi-node-inference.rst:218
+msgid ""
+"The **AI Runtime sidecar** on the head pod exposes standardized metrics "
+"on port 8080 and provides the liveness and readiness probes for the pod. "
+"See :doc:`runtime`."
+msgstr ""
+"head Pod 上的 **AI Runtime sidecar** 在端口 8080 暴露标准化指标，并为该 Pod 提供存活和就绪探针。见 "
+":doc:`runtime` 。"
+
+#: ../../source/features/multi-node-inference.rst:220
+msgid ""
+"The **Service** selects pods by ``model.aibrix.ai/name`` and carries the "
+"``prometheus-discovery: \"true\"`` label so metrics are scraped."
+msgstr ""
+"**Service** 按 ``model.aibrix.ai/name`` 选择 Pod，并带有 ``prometheus-"
+"discovery: \"true\"`` 标签以便抓取指标。"
+
+#: ../../source/features/multi-node-inference.rst:222
+msgid ""
+"The **HTTPRoute** attaches the model to the AIBrix gateway by matching "
+"the ``model`` header. This is the same route shape used for single-pod "
+"deployments; see :doc:`../production/gateway`."
+msgstr ""
+"**HTTPRoute** 通过匹配 ``model`` 头把模型挂到 AIBrix 网关。这与单 Pod 部署使用的路由形态相同；见 :doc:`../production/gateway` "
+"。"
+
+#: ../../source/features/multi-node-inference.rst:227
+msgid "Verify the deployment"
+msgstr "验证部署"
+
+#: ../../source/features/multi-node-inference.rst:240
+msgid ""
+"The fleet CRD defines no extra printer columns, so compare the counts "
+"directly:"
+msgstr "fleet CRD 没有定义额外打印列，因此直接比较计数："
+
+#: ../../source/features/multi-node-inference.rst:247
+msgid ""
+"The fleet is healthy when both numbers match. Then send a request through"
+" the gateway exactly as you would for a single-pod model:"
+msgstr "两个数字一致时 fleet 健康。然后像单 Pod 模型一样通过网关发送请求："
+
+#: ../../source/features/multi-node-inference.rst:260
+msgid "Troubleshooting"
+msgstr "故障排查"
+
+#: ../../source/features/multi-node-inference.rst:262
+msgid ""
+"**The fleet never reports ready replicas.** Run ``kubectl describe "
+"raycluster <name>`` and look at ``Status.Conditions``. AIBrix requires "
+"``RayClusterProvisioned`` and ``HeadPodReady`` to be ``True``. If those "
+"conditions are absent entirely, the KubeRay operator was installed "
+"without the ``RayClusterStatusConditions`` feature gate; reinstall it "
+"with the command from the installation guide."
+msgstr ""
+"**fleet 从不报告就绪副本。** 运行 ``kubectl describe raycluster <name>`` 并查看 ``Status.Conditions`` "
+"。AIBrix 要求 ``RayClusterProvisioned`` 和 ``HeadPodReady`` 为 ``True`` 。若这些条件完全不存在，说明安装 "
+"KubeRay operator 时未打开 ``RayClusterStatusConditions`` feature gate；请用安装指南中的命令重新安装。"
+
+#: ../../source/features/multi-node-inference.rst:268
+msgid ""
+"**Head pod restarts, or vLLM exits with a Ray connection error.** The "
+"engine started before the Ray head was up. Keep the dashboard wait loop "
+"from the sample in front of ``vllm serve``. Also confirm ``rayVersion`` "
+"in the template matches the Ray version inside the image; a mismatch "
+"prevents workers from joining."
+msgstr ""
+"**Head Pod 重启，或 vLLM 因 Ray 连接错误退出。** 引擎在 Ray head 就绪前就启动了。"
+"请把示例中的 dashboard 等待循环放在 ``vllm serve`` 之前。同时确认模板中的 "
+"``rayVersion`` 与镜像内的 Ray 版本一致；不匹配会阻止 worker 加入。"
+
+#: ../../source/features/multi-node-inference.rst:273
+msgid ""
+"**Worker pods stay Pending.** Each worker requests a GPU. Check node "
+"capacity with ``kubectl describe node`` and confirm the "
+"``nvidia.com/gpu`` request in ``workerGroupSpecs`` can be satisfied."
+msgstr ""
+"**Worker Pod 一直 Pending。** 每个 worker 都会申请 GPU。用 ``kubectl describe "
+"node`` 检查节点容量，并确认 ``workerGroupSpecs`` 中的 ``nvidia.com/gpu`` 请求"
+"能被满足。"
+
+#: ../../source/features/multi-node-inference.rst:277
+msgid ""
+"**The gateway returns an error for the model although the pods are "
+"Running.** The gateway only routes to head pods that carry "
+"``model.aibrix.ai/name`` and are Ready. Check that the label is on the "
+"head pod template (not only on the fleet) and that the readiness probe on"
+" the runtime sidecar (port 8080, ``/ready``) is passing."
+msgstr ""
+"**Pod 已 Running，但网关对该模型返回错误。** 网关只路由到带 ``model.aibrix.ai/name`` 且 Ready "
+"的 head Pod。确认标签在 head Pod 模板上（不只在 fleet 上），并且 runtime sidecar 的就绪探针（端口 8080，``/ready`` "
+"）通过。"
+
+#: ../../source/features/multi-node-inference.rst:283
+msgid "Native PodSet Orchestration (StormService)"
+msgstr "原生 PodSet 编排（StormService）"
+
+#: ../../source/features/multi-node-inference.rst:285
+msgid ""
+"For deployments that do not run KubeRay, or for disaggregated "
+"architectures requiring explicit role separation (such as separate "
+"Prefill and Decode roles), AIBrix provides native multi-node grouping via"
+" ``StormService``."
+msgstr ""
+"对于不运行 KubeRay 的部署，或需要显式角色分离的分离式架构（例如独立的 Prefill "
+"和 Decode 角色），AIBrix 通过 ``StormService`` 提供原生多节点分组。"
+
+#: ../../source/features/multi-node-inference.rst:287
+msgid ""
+"Using ``podGroupSize`` within a role template, ``StormService`` allocates"
+" multiple synchronized pods for each replica instance and injects "
+"deterministic distributed environment variables (such as "
+"``$POD_GROUP_INDEX`` and ``$PODSET_NAME``). This enables engine-native "
+"Tensor Parallelism (TP) across multiple nodes."
+msgstr ""
+"在角色模板中使用 ``podGroupSize`` 时，``StormService`` 会为每个副本实例分配多个同步 Pod，并注入确定性的分布式环境变量（例如 "
+"``$POD_GROUP_INDEX`` 和 ``$PODSET_NAME`` ）。从而支持跨多节点的引擎原生张量并行（TP）。"
+
+#: ../../source/features/multi-node-inference.rst:289
+msgid "Key capabilities:"
+msgstr "主要能力："
+
+#: ../../source/features/multi-node-inference.rst:291
+msgid ""
+"No external dependencies: Runs directly on Kubernetes without installing "
+"KubeRay."
+msgstr "无外部依赖：直接运行在 Kubernetes 上，无需安装 KubeRay。"
+
+#: ../../source/features/multi-node-inference.rst:292
+msgid ""
+"Multi-Role and Disaggregation support: Allows defining separate roles "
+"(such as routing, prefill, and decode) with distinct resource profiles "
+"and pod group sizes within a single service definition."
+msgstr ""
+"多角色与分离支持：允许在单个服务定义中为不同角色（例如 routing、prefill、decode）"
+"配置不同的资源规格和 Pod 组大小。"
+
+#: ../../source/features/multi-node-inference.rst:293
+#, python-brace-format
+msgid ""
+"Deterministic rank and discovery: Pods within a group discover peers via "
+"predictable headless service DNS entries (such as "
+"``${PODSET_NAME}-0.${STORM_SERVICE_NAME}``)."
+msgstr ""
+"确定性 rank 与发现：组内 Pod 通过可预测的无头 Service DNS 条目发现对端（例如 ``${PODSET_NAME}-0.${STORM_SERVICE_NAME}`` "
+"）。"
+
+#: ../../source/features/multi-node-inference.rst:296
+msgid "StormService Multi-Node TP Sample"
+msgstr "StormService 多节点 TP 示例"
+
+#: ../../source/features/multi-node-inference.rst:298
+msgid ""
+"Below is a complete multi-node Tensor Parallelism example with "
+"Prefill/Decode disaggregation (2-node prefill and 2-node decode with "
+"``podGroupSize: 2`` and ``--nnodes 2 --tp-size 2``):"
+msgstr ""
+"下面是带 Prefill/Decode 分离的完整多节点张量并行示例（2 节点 prefill 和 2 节点 decode，使用 ``podGroupSize: "
+"2`` 和 ``--nnodes 2 --tp-size 2`` ）："
+
+#: ../../source/features/multi-node-inference.rst:305
+msgid "Container Image Requirements"
+msgstr "容器镜像要求"
+
+#: ../../source/features/multi-node-inference.rst:309
+msgid ""
+"Starting from v0.6.6, essential packages to run distributed inference "
+"with the official vLLM container image distribution are included out of "
+"the box. If you use earlier versions, follow the guidance below to build "
+"a compatible image."
+msgstr ""
+"从 v0.6.6 起，官方 vLLM 容器镜像已开箱包含运行分布式推理所需的关键软件包。若使用"
+"更早版本，请按下面的指引构建兼容镜像。"
+
+#: ../../source/features/multi-node-inference.rst:312
+msgid "If you are using an earlier vLLM version, you have two options:"
+msgstr "若使用更早的 vLLM 版本，有两种选择："
+
+#: ../../source/features/multi-node-inference.rst:314
+msgid "Use our built image ``aibrix/vllm-openai:v0.6.1.post2-distributed``."
+msgstr "使用我们构建的镜像 ``aibrix/vllm-openai:v0.6.1.post2-distributed`` 。"
+
+#: ../../source/features/multi-node-inference.rst:315
+msgid "Build your own image following these steps:"
+msgstr "按以下步骤构建自己的镜像："
+
+#: ../../source/features/multi-node-inference.rst:330
+msgid ":doc:`pd-disaggregation`"
+msgstr ":doc:`pd-disaggregation`"
+
+#: ../../source/features/multi-node-inference.rst:331
+msgid "The complete guide to prefill/decode disaggregation with ``StormService``."
+msgstr "使用 ``StormService`` 做 Prefill/Decode 分离的完整指南。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/pd-disaggregation.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/pd-disaggregation.po
@@ -1,0 +1,1508 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/pd-disaggregation.rst:5
+msgid "Prefill-Decode Disaggregation (PD)"
+msgstr "Prefill/Decode 分离（PD）"
+
+#: ../../source/features/pd-disaggregation.rst:7
+msgid ""
+"Modern LLM inference workloads are rarely uniform. Some requests contain "
+"long prompts that benefit from specialized execution pipelines, while "
+"others are short and interactive. Designing infrastructure that "
+"efficiently handles both types of requests can be challenging."
+msgstr ""
+"现代 LLM 推理负载很少是均一的。有些请求包含长 prompt，适合专用执行流水线；另一些"
+"则短且交互式。要设计能高效处理这两类请求的基础设施并不容易。"
+
+#: ../../source/features/pd-disaggregation.rst:9
+msgid ""
+"AIBrix addresses this with intelligent routing across different types of "
+"inference pods within the same deployment. Instead of forcing operators "
+"to choose one architecture or maintain separate deployments, AIBrix runs "
+"both approaches together and automatically decides which pod should "
+"handle each request."
+msgstr ""
+"AIBrix 通过在同一部署内对不同类型推理 Pod 做智能路由来解决这个问题。不必强迫运维"
+"只选一种架构或维护多套部署，AIBrix 可以同时运行两种方式，并自动决定每个请求由哪个"
+" Pod 处理。"
+
+#: ../../source/features/pd-disaggregation.rst:11
+msgid ""
+"LLM inference has two distinct phases. **Prefill** processes the entire "
+"input prompt in one shot — it is compute-intensive and fast. **Decode** "
+"generates output tokens one at a time — it is memory-bandwidth-bound and "
+"slow. In a standard deployment, both phases run on the same GPU, causing "
+"them to compete for resources."
+msgstr ""
+"LLM 推理有两个不同阶段。**Prefill** 一次性处理整个输入 prompt，计算密集且快。"
+"**Decode** 逐个生成输出 token，受内存带宽限制且慢。标准部署中两个阶段跑在同一块 "
+"GPU 上，会互相争抢资源。"
+
+#: ../../source/features/pd-disaggregation.rst:13
+msgid ""
+"**PD disaggregation** separates these phases onto dedicated pods, so each"
+" can be sized, tuned, and scaled independently. The result is higher GPU "
+"utilization and lower latency at scale."
+msgstr ""
+"**Prefill/Decode 分离** 把这两个阶段放到专用 Pod 上，从而可以独立定容、调参和"
+"扩缩容。结果是规模化时更高的 GPU 利用率和更低的延迟。"
+
+#: ../../source/features/pd-disaggregation.rst:15
+msgid ""
+"**Standard inference pods** run both phases end-to-end on a single GPU. "
+"They handle short interactive requests efficiently and absorb overflow "
+"traffic when PD resources are busy."
+msgstr ""
+"**标准推理 Pod** 在单块 GPU 上端到端运行两个阶段。它们能高效处理短交互请求，并在 "
+"PD 资源繁忙时吸收溢出流量。"
+
+#: ../../source/features/pd-disaggregation.rst:20
+msgid "On this page"
+msgstr "本页内容"
+
+#: ../../source/features/pd-disaggregation.rst:23
+msgid "Intelligent Routing Across Pod Types"
+msgstr "跨 Pod 类型的智能路由"
+
+#: ../../source/features/pd-disaggregation.rst:25
+msgid "Each pod type serves a different role:"
+msgstr "每种 Pod 承担不同角色："
+
+#: ../../source/features/pd-disaggregation.rst:27
+msgid ""
+"**Prefill/Decode pods** — Designed for workloads where separating prefill"
+" and decode stages improves efficiency. Particularly effective for long "
+"prompts or workloads dominated by heavy prompt processing."
+msgstr ""
+"**Prefill/Decode Pod** — 面向分离 prefill 与 decode 阶段能提升效率的负载。对长 "
+"prompt 或以重度 prompt 处理为主的负载尤其有效。"
+
+#: ../../source/features/pd-disaggregation.rst:28
+msgid ""
+"**Standard inference pods** — Execute the entire request lifecycle within"
+" a single process. Well suited for short prompts and interactive "
+"requests, and act as a safety valve when PD resources are saturated."
+msgstr ""
+"**标准推理 Pod** — 在单个进程内执行完整请求生命周期。适合短 prompt 和交互请求，"
+"并在 PD 资源饱和时充当安全阀。"
+
+#: ../../source/features/pd-disaggregation.rst:30
+msgid ""
+"The AIBrix gateway continuously evaluates system conditions and routes "
+"each request to the best available pod:"
+msgstr "AIBrix 网关持续评估系统状况，并把每个请求路由到当前最佳可用 Pod："
+
+#: ../../source/features/pd-disaggregation.rst:52
+msgid ""
+"The routing decision incorporates several signals: current pod load, "
+"queue depth, pod availability, and scoring logic used to rank candidate "
+"pods. This allows AIBrix to distribute traffic efficiently while "
+"maintaining stable latency."
+msgstr ""
+"路由决策会综合多个信号：当前 Pod 负载、队列深度、Pod 可用性，以及用于给候选 Pod "
+"排序的打分逻辑。从而在保持延迟稳定的同时高效分发流量。"
+
+#: ../../source/features/pd-disaggregation.rst:54
+msgid "**Key benefits:**"
+msgstr "**主要收益：**"
+
+#: ../../source/features/pd-disaggregation.rst:56
+msgid ""
+"**Optimized handling of mixed workloads** — Long prompts are routed to "
+"prefill/decode pods; short requests are handled efficiently by standard "
+"inference pods."
+msgstr ""
+"**优化混合负载处理** — 长 prompt 路由到 Prefill/Decode Pod；短请求由标准推理 "
+"Pod 高效处理。"
+
+#: ../../source/features/pd-disaggregation.rst:57
+msgid ""
+"**Graceful handling of traffic spikes** — Standard inference pods absorb "
+"overflow traffic when PD resources are saturated."
+msgstr "**平稳应对流量尖峰** — PD 资源饱和时，标准推理 Pod 吸收溢出流量。"
+
+#: ../../source/features/pd-disaggregation.rst:58
+msgid ""
+"**Single deployment architecture** — Run multiple execution models for "
+"the same model without managing separate clusters."
+msgstr "**单一部署架构** — 为同一模型运行多种执行模式，无需管理独立集群。"
+
+#: ../../source/features/pd-disaggregation.rst:59
+msgid ""
+"**Dynamic routing decisions** — Traffic is distributed based on real-time"
+" system conditions instead of static configuration."
+msgstr "**动态路由决策** — 按实时系统状况分发流量，而不是静态配置。"
+
+#: ../../source/features/pd-disaggregation.rst:60
+msgid ""
+"**Improved GPU utilization** — Requests are balanced across available "
+"pods to maximize throughput and efficiency."
+msgstr "**更高 GPU 利用率** — 在可用 Pod 之间均衡请求，以最大化吞吐和效率。"
+
+#: ../../source/features/pd-disaggregation.rst:64
+msgid "How PD Disaggregation Works"
+msgstr "Prefill/Decode 分离如何工作"
+
+#: ../../source/features/pd-disaggregation.rst:85
+msgid ""
+"The gateway routes the request to a **prefill pod**, which processes the "
+"prompt and computes the KV cache."
+msgstr "网关把请求路由到 **prefill Pod** ，由其处理 prompt 并计算 KV cache。"
+
+#: ../../source/features/pd-disaggregation.rst:86
+msgid ""
+"The KV cache is transferred to a **decode pod** via a high-speed "
+"interconnect (SHFS for GPU, NIXL for Neuron)."
+msgstr "KV cache 通过高速互联传到 **decode Pod** （GPU 用 SHFS，Neuron 用 NIXL）。"
+
+#: ../../source/features/pd-disaggregation.rst:87
+msgid "The decode pod streams the generated tokens back to the client."
+msgstr "decode Pod 将生成的 token 流式返回给客户端。"
+
+#: ../../source/features/pd-disaggregation.rst:89
+msgid ""
+"If no complete prefill/decode pair is available for the request's prompt "
+"length — for example the prompt is outside all configured buckets, or the"
+" matching roleset is incomplete because a decode pod is down — the "
+"request falls back to a **standard inference pod** (``combined: true``) "
+"that runs both phases locally, when one is configured and its prompt-"
+"length range matches."
+msgstr ""
+"若该请求的 prompt 长度没有完整的 prefill/decode 配对可用——例如 prompt 超出所有已配置分桶，或匹配的 roleset "
+"因 decode Pod 宕机而不完整——则在已配置且 prompt 长度范围匹配时，请求会回退到本地同时运行两个阶段的 **标准推理 Pod** "
+"（``combined: true`` ）。"
+
+#: ../../source/features/pd-disaggregation.rst:93
+msgid "Supported Engines"
+msgstr "支持的引擎"
+
+#: ../../source/features/pd-disaggregation.rst:99
+msgid "Engine"
+msgstr "引擎"
+
+#: ../../source/features/pd-disaggregation.rst:100
+msgid "Label value"
+msgstr "标签值"
+
+#: ../../source/features/pd-disaggregation.rst:101
+msgid "Notes"
+msgstr "说明"
+
+#: ../../source/features/pd-disaggregation.rst:102
+msgid "vLLM"
+msgstr "vLLM"
+
+#: ../../source/features/pd-disaggregation.rst:103
+msgid "``vllm``"
+msgstr "``vllm``"
+
+#: ../../source/features/pd-disaggregation.rst:104
+msgid "Default. No extra labels required."
+msgstr "默认。无需额外标签。"
+
+#: ../../source/features/pd-disaggregation.rst:105
+msgid "SGLang"
+msgstr "SGLang"
+
+#: ../../source/features/pd-disaggregation.rst:106
+msgid "``sglang``"
+msgstr "``sglang``"
+
+#: ../../source/features/pd-disaggregation.rst:107
+msgid ""
+"Requires ``model.aibrix.ai/sglang-bootstrap-port`` annotation (default: "
+"``8998``)."
+msgstr "需要 ``model.aibrix.ai/sglang-bootstrap-port`` 注解（默认：``8998`` ）。"
+
+#: ../../source/features/pd-disaggregation.rst:108
+msgid "TensorRT-LLM"
+msgstr "TensorRT-LLM"
+
+#: ../../source/features/pd-disaggregation.rst:109
+msgid "``trtllm``"
+msgstr "``trtllm``"
+
+#: ../../source/features/pd-disaggregation.rst:110
+msgid "Uses NIXL KV transfer backend (``AIBRIX_KV_CONNECTOR_TYPE=nixl``)."
+msgstr "使用 NIXL KV 传输后端（``AIBRIX_KV_CONNECTOR_TYPE=nixl`` ）。"
+
+#: ../../source/features/pd-disaggregation.rst:112
+msgid "Set the engine on each pod with the ``model.aibrix.ai/engine`` label."
+msgstr "在每个 Pod 上用 ``model.aibrix.ai/engine`` 标签设置引擎。"
+
+#: ../../source/features/pd-disaggregation.rst:116
+msgid "Step 1 — Label Your Pods"
+msgstr "步骤 1 — 给 Pod 打标签"
+
+#: ../../source/features/pd-disaggregation.rst:118
+msgid "The gateway identifies the role of each pod using two labels:"
+msgstr "网关用两个标签识别每个 Pod 的角色："
+
+#: ../../source/features/pd-disaggregation.rst:124
+msgid "Label"
+msgstr "标签"
+
+#: ../../source/features/pd-disaggregation.rst:125
+msgid "Value"
+msgstr "值"
+
+#: ../../source/features/pd-disaggregation.rst:126
+msgid "Purpose"
+msgstr "用途"
+
+#: ../../source/features/pd-disaggregation.rst:127
+msgid "``role-name``"
+msgstr "``role-name``"
+
+#: ../../source/features/pd-disaggregation.rst:128
+msgid "``prefill``, ``decode``, or another value (e.g. ``all``)"
+msgstr "``prefill`` 、``decode`` ，或其他值（例如 ``all`` ）"
+
+#: ../../source/features/pd-disaggregation.rst:129
+msgid ""
+"Tells the gateway which phase this pod handles. Standard inference pods "
+"use a role other than ``prefill``/``decode`` (or omit ``role-name``) and "
+"set ``combined: true`` in ``routingConfig``."
+msgstr ""
+"告诉网关该 Pod 处理哪个阶段。标准推理 Pod 使用 ``prefill``/``decode`` 以外的角色（或省略 ``role-name`` "
+"），并在 ``routingConfig`` 中设置 ``combined: true`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:130
+msgid "``roleset-name``"
+msgstr "``roleset-name``"
+
+#: ../../source/features/pd-disaggregation.rst:131
+msgid "any string (e.g. ``group-0``)"
+msgstr "任意字符串（例如 ``group-0`` ）"
+
+#: ../../source/features/pd-disaggregation.rst:132
+msgid ""
+"Groups a prefill pod and a decode pod into a **pair**. The gateway only "
+"uses pairs where both prefill and decode pods are present."
+msgstr "把一个 prefill Pod 和一个 decode Pod 组成 **配对** 。网关只使用 prefill 和 decode 都存在的配对。"
+
+#: ../../source/features/pd-disaggregation.rst:134
+msgid "A prefill pod template looks like this:"
+msgstr "prefill Pod 模板如下："
+
+#: ../../source/features/pd-disaggregation.rst:146
+msgid "A decode pod template looks like this:"
+msgstr "decode Pod 模板如下："
+
+#: ../../source/features/pd-disaggregation.rst:159
+msgid ""
+"Both pods in a pair must share the same ``roleset-name``. If a roleset "
+"has only a prefill pod or only a decode pod, the gateway skips that "
+"entire roleset."
+msgstr ""
+"同一配对中的两个 Pod 必须共享相同的 ``roleset-name`` 。若某个 roleset 只有 prefill Pod 或只有 decode "
+"Pod，网关会跳过整个 roleset。"
+
+#: ../../source/features/pd-disaggregation.rst:163
+msgid "Step 2 — Enable PD Routing"
+msgstr "步骤 2 — 启用 PD 路由"
+
+#: ../../source/features/pd-disaggregation.rst:165
+msgid ""
+"Set ``routing-strategy: pd`` on individual requests, or configure it as "
+"the default via the model config annotation (recommended for production):"
+msgstr "在单个请求上设置 ``routing-strategy: pd`` ，或通过模型配置注解设为默认（生产环境建议后者）："
+
+#: ../../source/features/pd-disaggregation.rst:175
+msgid ""
+"To make ``pd`` the default for a model, add the config annotation to the "
+"pod template (see `Config Profiles <gateway-plugins.html#config-"
+"profiles>`_ in the Gateway Routing guide):"
+msgstr ""
+"要把 ``pd`` 设为某模型的默认策略，请在 Pod 模板上添加配置注解（见网关路由指南中的 `Config Profiles <gateway-plugins.html#config-profiles>`_ "
+"）："
+
+#: ../../source/features/pd-disaggregation.rst:187
+msgid ""
+"To prevent clients from overriding ``pd`` with a ``routing-strategy`` "
+"header (e.g. ``random``), pin it model-wide with "
+"``lockedRoutingStrategy``:"
+msgstr ""
+"若要防止客户端用 ``routing-strategy`` 头（例如 ``random`` ）覆盖 ``pd`` ，请用 ``lockedRoutingStrategy`` "
+"在模型范围内锁定："
+
+#: ../../source/features/pd-disaggregation.rst:204
+msgid "Step 3 — Add Standard Inference Pods (Optional)"
+msgstr "步骤 3 — 添加标准推理 Pod（可选）"
+
+#: ../../source/features/pd-disaggregation.rst:207
+msgid ""
+"Standard inference pods are entirely optional. A pure prefill/decode "
+"deployment works without them. Think of them as a power-up: they unlock a"
+" second execution path that the gateway can exploit to absorb overflow, "
+"handle workloads outside your configured prompt-length buckets, and "
+"smooth out traffic spikes — all without spinning up a separate deployment"
+" or changing a single line of client code."
+msgstr ""
+"标准推理 Pod 完全可选。纯 Prefill/Decode 部署没有它们也能工作。可以把它们看作增强："
+"它们解锁第二条执行路径，网关可用它吸收溢出、处理超出已配置 prompt 长度分桶的负载，"
+"并平滑流量尖峰——无需另起一套部署，也不必改一行客户端代码。"
+
+#: ../../source/features/pd-disaggregation.rst:209
+msgid ""
+"Adding standard inference pods turns a rigid two-tier pipeline into a "
+"self-healing, adaptive system. When PD capacity is saturated or a request"
+" falls outside the bucket ranges you've configured, the gateway "
+"automatically falls back to a standard inference pod and keeps the "
+"request moving rather than rejecting it or queueing indefinitely. The "
+"result is higher effective throughput, more consistent tail latency, and "
+"a gentler on-ramp for teams migrating incrementally from a standard "
+"deployment to full PD disaggregation."
+msgstr ""
+"加入标准推理 Pod 后，刚性的两层流水线会变成可自愈、自适应的系统。当 PD 容量饱和，"
+"或请求落在已配置分桶范围之外时，网关会自动回退到标准推理 Pod，让请求继续前进，而不是"
+"拒绝或无限排队。结果是更高的有效吞吐、更稳定的尾延迟，以及从标准部署逐步迁移到完整 "
+"Prefill/Decode 分离时更平缓的过渡。"
+
+#: ../../source/features/pd-disaggregation.rst:211
+msgid ""
+"Standard inference pods run both prefill and decode on a single GPU. They"
+" serve as overflow capacity when:"
+msgstr "标准推理 Pod 在单块 GPU 上同时运行 prefill 和 decode。在以下情况作为溢出容量："
+
+#: ../../source/features/pd-disaggregation.rst:213
+msgid "The request's prompt length falls outside all configured PD buckets."
+msgstr "请求的 prompt 长度超出所有已配置的 PD 分桶。"
+
+#: ../../source/features/pd-disaggregation.rst:214
+msgid ""
+"The matching PD roleset is incomplete (for example, a decode pod is "
+"unavailable)."
+msgstr "匹配的 PD roleset 不完整（例如 decode Pod 不可用）。"
+
+#: ../../source/features/pd-disaggregation.rst:215
+msgid ""
+"All prefill/decode pairs are at capacity (load-imbalance routing may "
+"select a combined pod)."
+msgstr "所有 prefill/decode 配对都已满载（负载不均衡路由可能选择 combined Pod）。"
+
+#: ../../source/features/pd-disaggregation.rst:216
+msgid ""
+"You want a gradual migration path (run standard inference pods alongside "
+"disaggregated pairs)."
+msgstr "需要渐进迁移路径（标准推理 Pod 与分离配对并行运行）。"
+
+#: ../../source/features/pd-disaggregation.rst:218
+msgid ""
+"**To configure a standard inference pod**, set ``combined: true`` in the "
+"pod's ``routingConfig`` annotation and enable prompt-length bucketing on "
+"the gateway:"
+msgstr ""
+"**要配置标准推理 Pod** ，请在该 Pod 的 ``routingConfig`` 注解中设置 ``combined: true`` ，并在网关上启用 "
+"prompt 长度分桶："
+
+#: ../../source/features/pd-disaggregation.rst:239
+msgid ""
+"Enable prompt-length bucketing on the gateway plugin (add to its "
+"environment):"
+msgstr "在网关插件上启用 prompt 长度分桶（加入其环境变量）："
+
+#: ../../source/features/pd-disaggregation.rst:248
+msgid ""
+"With bucketing enabled, the gateway considers a standard inference pod as"
+" a candidate only when the request's prompt length falls within the pod's"
+" configured range (see below). Without a range configured, a standard "
+"inference pod accepts any prompt length."
+msgstr ""
+"启用分桶后，仅当请求的 prompt 长度落在该 Pod 配置范围内时，网关才会把标准推理 Pod "
+"视为候选（见下文）。未配置范围时，标准推理 Pod 接受任意 prompt 长度。"
+
+#: ../../source/features/pd-disaggregation.rst:252
+msgid "Prompt-Length Bucketing"
+msgstr "Prompt 长度分桶"
+
+#: ../../source/features/pd-disaggregation.rst:254
+msgid ""
+"Bucketing lets you assign different pods to different prompt-length "
+"ranges. This is useful when:"
+msgstr "分桶可以把不同 Pod 分配给不同 prompt 长度范围。适用于："
+
+#: ../../source/features/pd-disaggregation.rst:256
+msgid "Short prompts are compute-cheap and can share a pod."
+msgstr "短 prompt 计算开销小，可以共享一个 Pod。"
+
+#: ../../source/features/pd-disaggregation.rst:257
+msgid "Long prompts need dedicated resources."
+msgstr "长 prompt 需要专用资源。"
+
+#: ../../source/features/pd-disaggregation.rst:258
+msgid ""
+"You want to prevent long-prompt requests from starving short-prompt "
+"traffic."
+msgstr "希望避免长 prompt 请求饿死短 prompt 流量。"
+
+#: ../../source/features/pd-disaggregation.rst:260
+msgid "Configure the range in the pod's ``routingConfig``:"
+msgstr "在 Pod 的 ``routingConfig`` 中配置范围："
+
+#: ../../source/features/pd-disaggregation.rst:282
+msgid "Field (inside ``routingConfig``)"
+msgstr "字段（位于 ``routingConfig`` 内）"
+
+#: ../../source/features/pd-disaggregation.rst:283
+#: ../../source/features/pd-disaggregation.rst:415
+#: ../../source/features/pd-disaggregation.rst:488
+#: ../../source/features/pd-disaggregation.rst:651
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/features/pd-disaggregation.rst:284
+msgid "``promptLenBucketMinLength``"
+msgstr "``promptLenBucketMinLength``"
+
+#: ../../source/features/pd-disaggregation.rst:285
+msgid "Minimum prompt token length (inclusive) this pod handles. Default: ``0``."
+msgstr "该 Pod 处理的最小 prompt token 长度（含）。默认：``0`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:286
+msgid "``promptLenBucketMaxLength``"
+msgstr "``promptLenBucketMaxLength``"
+
+#: ../../source/features/pd-disaggregation.rst:287
+msgid ""
+"Maximum prompt token length (inclusive) this pod handles. Default: "
+"unlimited. Set to ``0`` for unlimited."
+msgstr "该 Pod 处理的最大 prompt token 长度（含）。默认不限。设为 ``0`` 表示不限。"
+
+#: ../../source/features/pd-disaggregation.rst:288
+msgid "``combined``"
+msgstr "``combined``"
+
+#: ../../source/features/pd-disaggregation.rst:289
+msgid ""
+"``true`` = this pod is a standard inference pod (runs both prefill and "
+"decode). Default: ``false``."
+msgstr "``true`` = 该 Pod 是标准推理 Pod（同时运行 prefill 和 decode）。默认：``false`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:290
+msgid "``prefillScorePolicy``"
+msgstr "``prefillScorePolicy``"
+
+#: ../../source/features/pd-disaggregation.rst:291
+msgid ""
+"How to score prefill pods. ``prefix_cache`` (default), ``least_request``,"
+" ``conductor``, ``token_load``, or ``hybrid_cache_load``."
+msgstr ""
+"如何给 prefill Pod 打分。``prefix_cache`` （默认）、``least_request`` 、``conductor`` "
+"、``token_load`` 或 ``hybrid_cache_load`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:292
+msgid "``decodeScorePolicy``"
+msgstr "``decodeScorePolicy``"
+
+#: ../../source/features/pd-disaggregation.rst:293
+msgid ""
+"How to score decode pods. ``load_balancing`` (default), "
+"``least_request``, or ``conductor``."
+msgstr "如何给 decode Pod 打分。``load_balancing`` （默认）、``least_request`` 或 ``conductor`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:296
+msgid ""
+"Bucketing only takes effect when ``AIBRIX_PROMPT_LENGTH_BUCKETING=true`` "
+"is set on the gateway plugin."
+msgstr "仅当网关插件设置 ``AIBRIX_PROMPT_LENGTH_BUCKETING=true`` 时，分桶才会生效。"
+
+#: ../../source/features/pd-disaggregation.rst:300
+msgid "Conductor Scoring Policy"
+msgstr "Conductor 打分策略"
+
+#: ../../source/features/pd-disaggregation.rst:302
+msgid ""
+"The ``conductor`` scoring policy selects pods by estimating latency for "
+"both prefill and decode phases, combining real-time metrics with workload"
+" characteristics."
+msgstr ""
+"``conductor`` 打分策略通过估计 prefill 和 decode 两个阶段的延迟来选择 Pod，并把"
+"实时指标与负载特征结合起来。"
+
+#: ../../source/features/pd-disaggregation.rst:304
+msgid "**Prefill Scoring**"
+msgstr "**Prefill 打分**"
+
+#: ../../source/features/pd-disaggregation.rst:306
+msgid "Estimates Time To First Token (TTFT) by considering:"
+msgstr "通过以下因素估计 Time To First Token（TTFT）："
+
+#: ../../source/features/pd-disaggregation.rst:308
+msgid "**Queue time** — Time waiting behind currently running requests"
+msgstr "**排队时间** — 排在当前正在运行请求之后的等待时间"
+
+#: ../../source/features/pd-disaggregation.rst:309
+msgid "**Prefix time** — Time to process tokens already in the KV prefix cache"
+msgstr "**前缀时间** — 处理已在 KV prefix cache 中的 token 所需时间"
+
+#: ../../source/features/pd-disaggregation.rst:310
+msgid ""
+"**Prefill time** — Time to compute tokens that do not match the cache "
+"(accounts for attention complexity)"
+msgstr "**Prefill 时间** — 计算未命中 cache 的 token 所需时间（计入 attention 复杂度）"
+
+#: ../../source/features/pd-disaggregation.rst:312
+msgid "**Decode Scoring**"
+msgstr "**Decode 打分**"
+
+#: ../../source/features/pd-disaggregation.rst:314
+msgid "Estimates Time Between Tokens (TBT) by considering:"
+msgstr "通过以下因素估计 Time Between Tokens（TBT）："
+
+#: ../../source/features/pd-disaggregation.rst:316
+msgid "**Current throughput** — Derived from real-time generation metrics"
+msgstr "**当前吞吐** — 由实时生成指标推导"
+
+#: ../../source/features/pd-disaggregation.rst:317
+msgid "**Batch scaling** — TBT increases as batch size grows"
+msgstr "**批处理放大** — 批大小增大时 TBT 上升"
+
+#: ../../source/features/pd-disaggregation.rst:318
+msgid "**GPU pressure** — Applies a penalty when cache usage exceeds 90%"
+msgstr "**GPU 压力** — cache 使用率超过 90% 时施加惩罚"
+
+#: ../../source/features/pd-disaggregation.rst:320
+#: ../../source/features/pd-disaggregation.rst:388
+#: ../../source/features/pd-disaggregation.rst:463
+msgid "**Configuration**"
+msgstr "**配置**"
+
+#: ../../source/features/pd-disaggregation.rst:322
+msgid "Enable conductor via the routing config:"
+msgstr "通过路由配置启用 conductor："
+
+#: ../../source/features/pd-disaggregation.rst:340
+msgid ""
+"Or set gateway-wide via ``AIBRIX_PREFILL_SCORE_POLICY`` and "
+"``AIBRIX_DECODE_SCORE_POLICY``."
+msgstr ""
+"或通过 ``AIBRIX_PREFILL_SCORE_POLICY`` 和 ``AIBRIX_DECODE_SCORE_POLICY`` 做网关"
+"范围设置。"
+
+#: ../../source/features/pd-disaggregation.rst:342
+msgid "**When to use conductor:**"
+msgstr "**何时使用 conductor：**"
+
+#: ../../source/features/pd-disaggregation.rst:344
+msgid "You want routing based on predicted latency rather than just request count"
+msgstr "希望基于预测延迟而不仅仅是请求数来路由"
+
+#: ../../source/features/pd-disaggregation.rst:345
+msgid "Your workload has variable prompt lengths and mixed cache-hit patterns"
+msgstr "负载的 prompt 长度多变，且 cache 命中模式混合"
+
+#: ../../source/features/pd-disaggregation.rst:346
+msgid "You need to account for GPU memory pressure in decode routing"
+msgstr "需要在 decode 路由中考虑 GPU 内存压力"
+
+#: ../../source/features/pd-disaggregation.rst:352
+msgid "Token Load Scoring Policy"
+msgstr "Token Load 打分策略"
+
+#: ../../source/features/pd-disaggregation.rst:354
+msgid ""
+"The ``token_load`` prefill scoring policy spreads prefill work by prompt "
+"size instead of by request count. ``least_request`` treats a 100-token "
+"prompt and a 30,000-token prompt as the same unit of load, so a pod that "
+"drew a few long prompts keeps receiving new requests until its count "
+"catches up with its neighbours. Under a mix of short and long prompts "
+"this shows up as a long TTFT tail on the pods that hold the long prompts."
+" ``token_load`` charges each request by its estimated prompt tokens, so "
+"one long prompt counts as much as many short ones."
+msgstr ""
+"``token_load`` prefill 打分策略按 prompt 大小而不是请求数来分摊 prefill 工作。"
+"``least_request`` 把 100 token 的 prompt 和 30,000 token 的 prompt 视为同一单位"
+"负载，因此拿到几个长 prompt 的 Pod 会继续接收新请求，直到其计数赶上邻居。在短长 "
+"prompt 混合时，这会表现为持有长 prompt 的 Pod 出现较长的 TTFT 尾部。``token_load`` "
+"按估计的 prompt token 向每个请求计费，因此一个长 prompt 等价于多个短 prompt。"
+
+#: ../../source/features/pd-disaggregation.rst:356
+msgid "**Scoring**"
+msgstr "**打分**"
+
+#: ../../source/features/pd-disaggregation.rst:358
+msgid ""
+"The router keeps two per-pod counters and scores each prefill pod as "
+"(lower is better):"
+msgstr "路由器为每个 Pod 维护两个计数器，并按以下方式给每个 prefill Pod 打分（越低越好）："
+
+#: ../../source/features/pd-disaggregation.rst:364
+msgid ""
+"``active_tokens`` — prompt tokens of the prefill requests the pod is "
+"computing right now."
+msgstr "``active_tokens`` — 该 Pod 当前正在计算的 prefill 请求的 prompt token。"
+
+#: ../../source/features/pd-disaggregation.rst:365
+msgid ""
+"``kv_tokens`` — prompt tokens whose KV cache is still resident on the pod"
+" because the decode pod has not finished with the request yet. Weighted "
+"by ``kv_weight`` (``AIBRIX_TOKEN_LOAD_KV_WEIGHT``, default ``0.3``) since"
+" resident KV costs the pod less than active compute."
+msgstr ""
+"``kv_tokens`` — 因 decode Pod 尚未完成请求而仍驻留在该 Pod 上的 KV cache 对应的 prompt token。按 "
+"``kv_weight`` （``AIBRIX_TOKEN_LOAD_KV_WEIGHT`` ，默认 ``0.3`` ）加权，因为驻留 KV 对该 "
+"Pod 的代价低于活跃计算。"
+
+#: ../../source/features/pd-disaggregation.rst:367
+msgid ""
+"Each request is charged ``request_cost + new_tokens``, where "
+"``request_cost`` (``AIBRIX_TOKEN_LOAD_REQUEST_COST``, default ``3500``) "
+"models the fixed scheduling and KV-transfer work that does not scale with"
+" prompt length, and ``new_tokens`` is the part of the prompt the pod "
+"actually has to compute. ``prompt_tokens`` is estimated as one token per "
+"four bytes of request body; ``new_tokens`` is derived from it by the "
+"first rule that applies:"
+msgstr ""
+"每个请求计费为 ``request_cost + new_tokens`` ，其中 ``request_cost`` （``AIBRIX_TOKEN_LOAD_REQUEST_COST`` "
+"，默认 ``3500`` ）建模不随 prompt 长度变化的固定调度和 KV 传输开销，``new_tokens`` 是该 Pod 实际必须计算的 "
+"prompt 部分。``prompt_tokens`` 按请求体每四字节一个 token 估计；``new_tokens`` 按第一条适用规则从中推导："
+
+#: ../../source/features/pd-disaggregation.rst:369
+msgid ""
+"**Session delta.** If the request carries an ``x-aibrix-session-key`` "
+"header (the caller-owned opaque key also used by ``session-affinity`` "
+"routing; not the gateway-issued ``x-session-id``) and the gateway has "
+"seen a shorter prompt for that key (and model) recently, the charge is "
+"the growth since that prompt. Each turn of a chat resends the whole "
+"history, but an engine that still holds the conversation's KV cache only "
+"computes the new turn: charging the whole prompt again would make a long "
+"conversation look several times more expensive than it is. The rule "
+"assumes the earlier turns are reachable from whichever prefill pod is "
+"selected, through a shared or tiered KV store, sticky routing or the "
+"pod's own prefix cache; if your prefill pods only have a local prefix "
+"cache and the router may move a conversation between them, do not send "
+"the key, or set ``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS=0`` to turn the "
+"rule off, and rely on rule 2. The last prompt size of a key is kept for "
+"``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS`` (default ``1800``); keys longer"
+" than 256 bytes are ignored, and at most "
+"``AIBRIX_TOKEN_LOAD_MAX_SESSIONS`` (default ``100000``) keys are "
+"remembered at once, so a client cannot grow the table without bound. Once"
+" the table is full, new keys are charged by rules 2 and 3 until the "
+"janitor forgets idle ones."
+msgstr ""
+"**会话增量。** 若请求带有 ``x-aibrix-session-key`` 头（调用方持有的不透明键，也用于 ``session-affinity`` "
+"路由；不是网关签发的 ``x-session-id`` ），且网关最近见过该键（及模型）对应的更短 prompt，则计费为相对该 prompt "
+"的增量。多轮对话每一轮都会重发完整历史，但若引擎仍持有对话的 KV cache，则只需计算新一轮：若再次对整个 prompt 计费，长对话会显得比实际贵数倍。该规则假设先前轮次可从所选任意 "
+"prefill Pod 到达，途径共享或分层 KV 存储、粘性路由或 Pod 自身的 prefix cache；若 prefill Pod 只有本地 "
+"prefix cache，且路由器可能在它们之间迁移对话，请不要发送该键，或设置 ``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS=0`` "
+"关闭该规则，并依赖规则 2。某个键的上次 prompt 大小会保留 ``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS`` "
+"（默认 ``1800`` ）秒；超过 256 字节的键会被忽略，同时最多记住 ``AIBRIX_TOKEN_LOAD_MAX_SESSIONS`` "
+"（默认 ``100000`` ）个键，因此客户端无法无界扩大该表。表满后，新键按规则 2 和 3 计费，直到清理器忘记空闲项。"
+
+#: ../../source/features/pd-disaggregation.rst:370
+msgid ""
+"**Prefix match.** If the scoring policy looked the prompt up in the "
+"prefix cache (``hybrid_cache_load``), the charge is ``prompt_tokens × (1 "
+"− match_percent / 100)``."
+msgstr ""
+"**前缀匹配。** 若打分策略在 prefix cache 中查找了该 prompt（``hybrid_cache_load`` ），则计费为 "
+"``prompt_tokens × (1 − match_percent / 100)`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:371
+msgid ""
+"**Whole prompt.** Otherwise the whole prompt is charged. ``token_load`` "
+"itself does not consult the prefix cache, so without a session header "
+"this is what it charges."
+msgstr ""
+"**整个 prompt。** 否则对整个 prompt 计费。``token_load`` 本身不查询 prefix cache，"
+"因此没有会话头时就按这种方式计费。"
+
+#: ../../source/features/pd-disaggregation.rst:373
+msgid "**Charge lifecycle**"
+msgstr "**计费生命周期**"
+
+#: ../../source/features/pd-disaggregation.rst:375
+msgid ""
+"The request is charged to the selected prefill pod in the same critical "
+"section as the selection itself, so concurrent selections see each "
+"other's charges."
+msgstr ""
+"请求会在与选择本身相同的临界区内计入所选 prefill Pod，因此并发选择能看到彼此的计费。"
+
+#: ../../source/features/pd-disaggregation.rst:376
+msgid ""
+"When the prefill HTTP call returns, the ``active_tokens`` part is "
+"released; ``kv_tokens`` stays."
+msgstr "prefill HTTP 调用返回后，释放 ``active_tokens`` 部分；``kv_tokens`` 保留。"
+
+#: ../../source/features/pd-disaggregation.rst:377
+msgid ""
+"When the request completes (or the prefill call fails), the ``kv_tokens``"
+" part is released too."
+msgstr "请求完成（或 prefill 调用失败）时，``kv_tokens`` 部分也会释放。"
+
+#: ../../source/features/pd-disaggregation.rst:379
+msgid ""
+"A charge whose release never arrives is force-released after "
+"``AIBRIX_TOKEN_LOAD_TTL_SECONDS`` (default ``3600``) with a warning log, "
+"so a leaked entry cannot pin load on a pod indefinitely. Releases are "
+"idempotent and the counters never go below zero. The same janitor, which "
+"runs once a minute, drops the counters and metric series of any pod that "
+"has been at zero load and untouched for a whole minute, so prefill pods "
+"that come and go under autoscaling or rollouts do not accumulate on the "
+"gateway; the next charge re-creates the pod from zero."
+msgstr ""
+"若某次计费始终未收到释放，会在 ``AIBRIX_TOKEN_LOAD_TTL_SECONDS`` （默认 ``3600`` ）秒后强制释放并打警告日志，以免泄漏项无限占用某个 "
+"Pod 的负载。释放是幂等的，计数器不会低于零。同一清理器每分钟运行一次，会丢掉已连续一整分钟处于零负载且未被触及的 Pod 的计数器和指标序列，因此自动扩缩容或滚动发布中来去的 "
+"prefill Pod 不会在网关上堆积；下一次计费会从零重新创建该 Pod。"
+
+#: ../../source/features/pd-disaggregation.rst:381
+msgid "**Metrics**"
+msgstr "**指标**"
+
+#: ../../source/features/pd-disaggregation.rst:383
+msgid ""
+"The gateway exports the two counters per prefill pod as gauges labelled "
+"by ``pod_name``:"
+msgstr "网关按每个 prefill Pod 导出这两个计数器，作为带 ``pod_name`` 标签的 gauge："
+
+#: ../../source/features/pd-disaggregation.rst:385
+msgid "``pd_token_load_active_tokens``"
+msgstr "``pd_token_load_active_tokens``"
+
+#: ../../source/features/pd-disaggregation.rst:386
+msgid "``pd_token_load_kv_tokens``"
+msgstr "``pd_token_load_kv_tokens``"
+
+#: ../../source/features/pd-disaggregation.rst:390
+msgid "Enable ``token_load`` via the routing config:"
+msgstr "通过路由配置启用 ``token_load`` ："
+
+#: ../../source/features/pd-disaggregation.rst:407
+msgid ""
+"Or set gateway-wide via ``AIBRIX_PREFILL_SCORE_POLICY=token_load``. The "
+"tunables are gateway-wide environment variables:"
+msgstr ""
+"或通过 ``AIBRIX_PREFILL_SCORE_POLICY=token_load`` 做网关范围设置。可调参数是网关"
+"范围环境变量："
+
+#: ../../source/features/pd-disaggregation.rst:413
+#: ../../source/features/pd-disaggregation.rst:486
+#: ../../source/features/pd-disaggregation.rst:649
+msgid "Variable"
+msgstr "变量"
+
+#: ../../source/features/pd-disaggregation.rst:414
+#: ../../source/features/pd-disaggregation.rst:487
+#: ../../source/features/pd-disaggregation.rst:650
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/features/pd-disaggregation.rst:416
+#: ../../source/features/pd-disaggregation.rst:661
+msgid "``AIBRIX_TOKEN_LOAD_KV_WEIGHT``"
+msgstr "``AIBRIX_TOKEN_LOAD_KV_WEIGHT``"
+
+#: ../../source/features/pd-disaggregation.rst:417
+#: ../../source/features/pd-disaggregation.rst:662
+msgid "``0.3``"
+msgstr "``0.3``"
+
+#: ../../source/features/pd-disaggregation.rst:418
+msgid "Weight of resident KV tokens in the score."
+msgstr "驻留 KV token 在分数中的权重。"
+
+#: ../../source/features/pd-disaggregation.rst:419
+#: ../../source/features/pd-disaggregation.rst:664
+msgid "``AIBRIX_TOKEN_LOAD_REQUEST_COST``"
+msgstr "``AIBRIX_TOKEN_LOAD_REQUEST_COST``"
+
+#: ../../source/features/pd-disaggregation.rst:420
+#: ../../source/features/pd-disaggregation.rst:665
+msgid "``3500``"
+msgstr "``3500``"
+
+#: ../../source/features/pd-disaggregation.rst:421
+msgid "Fixed per-request cost added to every charge, in tokens."
+msgstr "每次计费都加上的固定每请求成本，单位为 token。"
+
+#: ../../source/features/pd-disaggregation.rst:422
+#: ../../source/features/pd-disaggregation.rst:667
+msgid "``AIBRIX_TOKEN_LOAD_TTL_SECONDS``"
+msgstr "``AIBRIX_TOKEN_LOAD_TTL_SECONDS``"
+
+#: ../../source/features/pd-disaggregation.rst:423
+#: ../../source/features/pd-disaggregation.rst:668
+msgid "``3600``"
+msgstr "``3600``"
+
+#: ../../source/features/pd-disaggregation.rst:424
+msgid "Maximum age of an outstanding charge before it is force-released."
+msgstr "未完成计费在强制释放前的最大存活时间。"
+
+#: ../../source/features/pd-disaggregation.rst:425
+#: ../../source/features/pd-disaggregation.rst:670
+msgid "``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS``"
+msgstr "``AIBRIX_TOKEN_LOAD_SESSION_TTL_SECONDS``"
+
+#: ../../source/features/pd-disaggregation.rst:426
+#: ../../source/features/pd-disaggregation.rst:671
+msgid "``1800``"
+msgstr "``1800``"
+
+#: ../../source/features/pd-disaggregation.rst:427
+msgid ""
+"How long the last prompt size of a session is remembered for the session-"
+"delta charge. ``0`` turns the session-delta rule off."
+msgstr "为会话增量计费记住会话上次 prompt 大小的时长。``0`` 关闭会话增量规则。"
+
+#: ../../source/features/pd-disaggregation.rst:428
+#: ../../source/features/pd-disaggregation.rst:673
+msgid "``AIBRIX_TOKEN_LOAD_MAX_SESSIONS``"
+msgstr "``AIBRIX_TOKEN_LOAD_MAX_SESSIONS``"
+
+#: ../../source/features/pd-disaggregation.rst:429
+#: ../../source/features/pd-disaggregation.rst:674
+msgid "``100000``"
+msgstr "``100000``"
+
+#: ../../source/features/pd-disaggregation.rst:430
+msgid ""
+"Maximum number of sessions remembered at once; new sessions beyond it are"
+" charged without a delta."
+msgstr "同时记住的最大会话数；超出后的新会话不计增量。"
+
+#: ../../source/features/pd-disaggregation.rst:432
+msgid "**When to use token_load:**"
+msgstr "**何时使用 token_load：**"
+
+#: ../../source/features/pd-disaggregation.rst:434
+msgid ""
+"Your prompt lengths vary widely (for example agentic or RAG traffic mixed"
+" with short chat) and you see a TTFT tail on some prefill pods under "
+"``least_request``"
+msgstr ""
+"prompt 长度差异很大（例如 agentic 或 RAG 流量与短对话混合），且在 ``least_request`` "
+"下部分 prefill Pod 出现 TTFT 尾部"
+
+#: ../../source/features/pd-disaggregation.rst:435
+msgid ""
+"Prefix-cache locality matters less than balancing prefill compute, or "
+"your prefix cache hit rate is low"
+msgstr "prefix cache 局部性不如均衡 prefill 计算重要，或 prefix cache 命中率较低"
+
+#: ../../source/features/pd-disaggregation.rst:437
+msgid ""
+"If prefix-cache locality does matter, use :ref:`hybrid_cache_load <pd-"
+"hybrid-cache-load-policy>` instead, which keeps this ledger and adds the "
+"cache lookup on top."
+msgstr ""
+"若 prefix cache 局部性确实重要，请改用 :ref:`hybrid_cache_load <pd-hybrid-cache-load-policy>` "
+"，它保留该账本并叠加 cache 查找。"
+
+#: ../../source/features/pd-disaggregation.rst:442
+msgid "Hybrid Cache-Load Scoring Policy"
+msgstr "Hybrid Cache-Load 打分策略"
+
+#: ../../source/features/pd-disaggregation.rst:444
+msgid ""
+"``hybrid_cache_load`` combines the prefix-cache lookup of "
+"``prefix_cache`` with the token ledger of ``token_load``. "
+"``prefix_cache`` always prefers the pod that holds the prompt's prefix, "
+"even when that pod is buried under long prompts and an idle neighbour "
+"would answer sooner; ``token_load`` ignores the cache and recomputes "
+"prefixes another pod already holds. The hybrid policy lets the cache "
+"decide between idle pods and the load decide between busy ones."
+msgstr ""
+"``hybrid_cache_load`` 把 ``prefix_cache`` 的 prefix cache 查找与 ``token_load`` "
+"的 token 账本结合起来。``prefix_cache`` 总是偏好持有该 prompt 前缀的 Pod，即使该 "
+"Pod 被长 prompt 压住、空闲邻居会更快应答；``token_load`` 忽略 cache，并重新计算"
+"另一 Pod 已持有的前缀。混合策略让 cache 在空闲 Pod 之间做决定，让负载在繁忙 Pod "
+"之间做决定。"
+
+#: ../../source/features/pd-disaggregation.rst:453
+msgid ""
+"where ``load = active_tokens + kv_weight × kv_tokens`` is the same ledger"
+" ``token_load`` reads and ``factor`` is "
+"``AIBRIX_HYBRID_CACHE_LOAD_FACTOR`` (default ``0.5``). Lower is better."
+msgstr ""
+"其中 ``load = active_tokens + kv_weight × kv_tokens`` 与 ``token_load`` 读取的账本相同，``factor`` "
+"为 ``AIBRIX_HYBRID_CACHE_LOAD_FACTOR`` （默认 ``0.5`` ）。越低越好。"
+
+#: ../../source/features/pd-disaggregation.rst:455
+msgid ""
+"On idle pods every score is a bare discount below 1, so the pod with the "
+"best prefix match wins outright."
+msgstr "在空闲 Pod 上，每个分数都是低于 1 的纯折扣，因此前缀匹配最好的 Pod 直接胜出。"
+
+#: ../../source/features/pd-disaggregation.rst:456
+msgid ""
+"On busy pods the match only discounts the load. With the default factor a"
+" full match halves a pod's load, so a pod holding the prefix loses once "
+"it carries more than twice the load of an idle neighbour."
+msgstr ""
+"在繁忙 Pod 上，匹配只对负载打折。默认 factor 下，完全匹配会把 Pod 负载减半，因此"
+"持有前缀的 Pod 一旦负载超过空闲邻居的两倍就会落败。"
+
+#: ../../source/features/pd-disaggregation.rst:457
+msgid ""
+"The square keeps small matches from moving the decision: a 30 % match "
+"discounts by 4.5 %, a 70 % match by 24.5 %."
+msgstr "平方项避免小匹配左右决策：30% 匹配只打 4.5% 折扣，70% 匹配打 24.5% 折扣。"
+
+#: ../../source/features/pd-disaggregation.rst:459
+#, python-format
+msgid ""
+"**Minimum match.** Prompts that share only a system prompt or a few "
+"template tokens would otherwise all attract to the pod that served the "
+"first of them. ``AIBRIX_MIN_MATCH_PCT`` (default ``0``, i.e. off) treats "
+"any match below the threshold as no match, both in the score and in the "
+"``new_tokens`` charge. A value between ``30`` and ``60`` is a reasonable "
+"starting point when your system prompt is a small part of a typical "
+"request. The same variable also applies to ``prefix_cache`` scoring "
+"(there is no ``new_tokens`` charge there), where the effect is larger: "
+"its cache term spans ``10.0`` against a load term of ``1.0``, so without "
+"a threshold a 1 % incidental match outweighs the whole load range and the"
+" pod that served the first of a burst of cold prompts attracts the rest "
+"of the burst."
+msgstr ""
+"**最小匹配。** 若多个 prompt 只共享 system prompt 或少量模板 token，否则它们会全部被吸引到处理了其中第一个的 "
+"Pod。``AIBRIX_MIN_MATCH_PCT`` （默认 ``0`` ，即关闭）会把低于阈值的匹配视为无匹配，同时作用于分数和 ``new_tokens`` "
+"计费。当 system prompt 只占典型请求的一小部分时，``30`` 到 ``60`` 是合理起点。同一变量也适用于 ``prefix_cache`` "
+"打分（那里没有 ``new_tokens`` 计费），影响更大：其 cache 项跨度为 ``10.0`` ，负载项为 ``1.0`` ，因此没有阈值时，1 "
+"% incidental 匹配就会压过整个负载范围，处理了一波冷 prompt 中第一个的 Pod 会把该波后续请求都吸走。"
+
+#: ../../source/features/pd-disaggregation.rst:461
+msgid ""
+"The charge lifecycle, the metrics and the ``AIBRIX_TOKEN_LOAD_*`` "
+"tunables are those of :ref:`token_load <pd-token-load-policy>`; the "
+"prefix-match rule of the ``new_tokens`` estimate applies, so a pod that "
+"already holds most of the prompt is charged only for the rest. Like "
+"``prefix_cache``, the policy needs a tokenizer "
+"(``AIBRIX_PREFIX_CACHE_TOKENIZER_TYPE``) and warms the prefix index with "
+"the selected pod after each request."
+msgstr ""
+"计费生命周期、指标和 ``AIBRIX_TOKEN_LOAD_*`` 可调参数与 :ref:`token_load <pd-token-load-policy>` "
+"相同；``new_tokens`` 估计的前缀匹配规则适用，因此已持有大部分 prompt 的 Pod 只对剩余部分计费。与 ``prefix_cache`` "
+"一样，该策略需要 tokenizer（``AIBRIX_PREFIX_CACHE_TOKENIZER_TYPE`` ），并在每次请求后用所选 Pod "
+"预热 prefix 索引。"
+
+#: ../../source/features/pd-disaggregation.rst:480
+msgid "Or set gateway-wide via ``AIBRIX_PREFILL_SCORE_POLICY=hybrid_cache_load``."
+msgstr "或通过 ``AIBRIX_PREFILL_SCORE_POLICY=hybrid_cache_load`` 做网关范围设置。"
+
+#: ../../source/features/pd-disaggregation.rst:489
+#: ../../source/features/pd-disaggregation.rst:676
+msgid "``AIBRIX_HYBRID_CACHE_LOAD_FACTOR``"
+msgstr "``AIBRIX_HYBRID_CACHE_LOAD_FACTOR``"
+
+#: ../../source/features/pd-disaggregation.rst:490
+#: ../../source/features/pd-disaggregation.rst:677
+msgid "``0.5``"
+msgstr "``0.5``"
+
+#: ../../source/features/pd-disaggregation.rst:491
+msgid ""
+"Discount a full prefix match applies to a pod's load, ``0`` to ``1``. "
+"Higher values favour cache affinity over balance; at ``1`` a fully "
+"matched pod scores ``0`` and always wins."
+msgstr ""
+"完全前缀匹配对 Pod 负载应用的折扣，``0`` 到 ``1`` 。值越高越偏向 cache 亲和而非均衡；为 ``1`` 时完全匹配的 Pod "
+"得分为 ``0`` 并总是胜出。"
+
+#: ../../source/features/pd-disaggregation.rst:492
+#: ../../source/features/pd-disaggregation.rst:679
+msgid "``AIBRIX_MIN_MATCH_PCT``"
+msgstr "``AIBRIX_MIN_MATCH_PCT``"
+
+#: ../../source/features/pd-disaggregation.rst:493
+#: ../../source/features/pd-disaggregation.rst:680
+#: ../../source/features/pd-disaggregation.rst:707
+msgid "``0``"
+msgstr "``0``"
+
+#: ../../source/features/pd-disaggregation.rst:494
+msgid ""
+"Prefix-match percentage below which a match is ignored, ``0`` to ``100``."
+" ``0`` disables the threshold. Also honoured by ``prefix_cache``."
+msgstr "低于该百分比的前缀匹配会被忽略，``0`` 到 ``100`` 。``0`` 关闭阈值。``prefix_cache`` 也会遵守。"
+
+#: ../../source/features/pd-disaggregation.rst:496
+msgid "**When to use hybrid_cache_load:**"
+msgstr "**何时使用 hybrid_cache_load：**"
+
+#: ../../source/features/pd-disaggregation.rst:498
+msgid ""
+"Multi-turn or shared-prefix traffic where prefix-cache hits are worth "
+"chasing, but prompt lengths vary enough that ``prefix_cache`` leaves some"
+" pods with a TTFT tail"
+msgstr ""
+"多轮或共享前缀流量中，prefix cache 命中值得追逐，但 prompt 长度变化大到 "
+"``prefix_cache`` 会让部分 Pod 出现 TTFT 尾部"
+
+#: ../../source/features/pd-disaggregation.rst:499
+msgid ""
+"You already run ``token_load`` and want cache affinity back without "
+"giving up the load balance"
+msgstr "已经在跑 ``token_load`` ，希望找回 cache 亲和且不放弃负载均衡"
+
+#: ../../source/features/pd-disaggregation.rst:503
+msgid "Complete Example"
+msgstr "完整示例"
+
+#: ../../source/features/pd-disaggregation.rst:505
+msgid ""
+"This example shows a three-tier setup: prefill + decode pods for short "
+"prompts, and standard inference pods for long prompts or overflow."
+msgstr ""
+"该示例展示三层设置：短 prompt 用 prefill + decode Pod，长 prompt 或溢出用标准推理 "
+"Pod。"
+
+#: ../../source/features/pd-disaggregation.rst:507
+msgid "**Prefill pod** (short prompts: 0–2048 tokens):"
+msgstr "**Prefill Pod** （短 prompt：0–2048 token）："
+
+#: ../../source/features/pd-disaggregation.rst:532
+msgid "**Decode pod** (paired with the prefill pod above):"
+msgstr "**Decode Pod** （与上面的 prefill Pod 配对）："
+
+#: ../../source/features/pd-disaggregation.rst:557
+msgid "**Standard inference pod** (long prompts: 2048+ tokens, and overflow):"
+msgstr "**标准推理 Pod** （长 prompt：2048+ token，以及溢出）："
+
+#: ../../source/features/pd-disaggregation.rst:580
+msgid "**Gateway plugin** (enable bucketing):"
+msgstr "**网关插件** （启用分桶）："
+
+#: ../../source/features/pd-disaggregation.rst:591
+msgid "Pod Selection Algorithm"
+msgstr "Pod 选择算法"
+
+#: ../../source/features/pd-disaggregation.rst:593
+msgid ""
+"Once pods are partitioned into prefill, decode, and combined slices, the "
+"gateway selects the best target through a cascade of checks. Bucketing "
+"(when ``AIBRIX_PROMPT_LENGTH_BUCKETING=true``) runs first; load-imbalance"
+" and scoring steps run only when a PD pair is still in play."
+msgstr ""
+"Pod 被划分为 prefill、decode 和 combined 切片后，网关通过级联检查选择最佳目标。分桶（当 ``AIBRIX_PROMPT_LENGTH_BUCKETING=true`` "
+"）最先运行；仅当 PD 配对仍在候选中时，才运行负载不均衡和打分步骤。"
+
+#: ../../source/features/pd-disaggregation.rst:595
+msgid "**Step 0 — Prompt-length bucketing (optional)**"
+msgstr "**步骤 0 — Prompt 长度分桶（可选）**"
+
+#: ../../source/features/pd-disaggregation.rst:597
+msgid ""
+"When bucketing is enabled, each roleset contributes to the bucket-"
+"filtered pool only when **both** its prefill and decode pods declare a "
+"range that includes the request's prompt length. Incomplete rolesets "
+"(missing decode or prefill) are skipped. If no complete bucket-matched "
+"pair exists — including when a decode pod is down in the matching bucket "
+"— the gateway routes to a ``combined: true`` pod whose range includes the"
+" prompt, or returns an error if none is available. When a bucket match "
+"exists but PD pods are heavily loaded while a combined pod is idle, "
+"``shouldPickCombined()`` may select the combined pod instead."
+msgstr ""
+"启用分桶时，仅当 roleset 的 prefill 和 decode Pod **都** 声明了包含该请求 prompt "
+"长度的范围时，该 roleset 才会进入分桶过滤池。不完整的 roleset（缺少 decode 或 "
+"prefill）会被跳过。若不存在完整的分桶匹配配对——包括匹配分桶中 decode Pod 宕机——"
+"网关会路由到范围包含该 prompt 的 ``combined: true`` Pod；若没有可用则返回错误。"
+"当分桶匹配存在，但 PD Pod 负载很重而 combined Pod 空闲时，``shouldPickCombined()`` "
+"可能改选 combined Pod。"
+
+#: ../../source/features/pd-disaggregation.rst:599
+msgid "**Step 1 — Prefill load-imbalance fast path**"
+msgstr "**步骤 1 — Prefill 负载不均衡快速路径**"
+
+#: ../../source/features/pd-disaggregation.rst:601
+msgid ""
+"If the difference between the maximum and minimum number of outstanding "
+"prefill requests across prefill pods exceeds "
+"``AIBRIX_PREFILL_LOAD_IMBALANCE_MIN_SPREAD``, the gateway routes the "
+"prefill phase to the single least-loaded prefill pod and aligns the "
+"decode candidates to the same roleset."
+msgstr ""
+"若各 prefill Pod 上未完成 prefill 请求数的最大值与最小值之差超过 ``AIBRIX_PREFILL_LOAD_IMBALANCE_MIN_SPREAD`` "
+"，网关会把 prefill 阶段路由到负载最低的单个 prefill Pod，并把 decode 候选对齐到同一 roleset。"
+
+#: ../../source/features/pd-disaggregation.rst:603
+msgid "**Step 2 — Decode load-imbalance fast path**"
+msgstr "**步骤 2 — Decode 负载不均衡快速路径**"
+
+#: ../../source/features/pd-disaggregation.rst:605
+msgid ""
+"Three ordered checks run against decode pods. The first that fires "
+"selects a single decode pod and aligns the prefill candidates to its "
+"roleset. Steps 1 and 2 are independent: both can fire on the same request"
+" if both sides are imbalanced."
+msgstr ""
+"对 decode Pod 按顺序做三次检查。最先触发的一次会选出单个 decode Pod，并把 prefill "
+"候选对齐到其 roleset。步骤 1 和 2 相互独立：若两侧都不均衡，同一请求上两者都可以触发。"
+
+#: ../../source/features/pd-disaggregation.rst:607
+msgid ""
+"*Request count spread* — If ``max(running + pending) − min`` across "
+"metric-bearing pods ≥ ``AIBRIX_DECODE_LOAD_IMBALANCE_MIN_SPREAD``, route "
+"to the least-loaded pod. Pods without ``RealtimeNumRequestsRunning`` are "
+"excluded from the spread to avoid thundering-herd on freshly restarted "
+"pods; their pending-decode count is still tracked for the scoring step."
+msgstr ""
+"*请求数差* — 若带指标 Pod 上 ``max(running + pending) − min`` ≥ ``AIBRIX_DECODE_LOAD_IMBALANCE_MIN_SPREAD`` "
+"，则路由到负载最低的 Pod。没有 ``RealtimeNumRequestsRunning`` 的 Pod 不参与该差值计算，以免刚重启的 Pod "
+"被惊群；其 pending-decode 计数仍会在打分步骤中跟踪。"
+
+#: ../../source/features/pd-disaggregation.rst:609
+msgid ""
+"*Throughput spread* — If ``max(throughput) − min`` across metric-bearing "
+"pods > ``AIBRIX_DECODE_THROUGHPUT_IMBALANCE_MIN_SPREAD``, route to the "
+"lowest-throughput pod."
+msgstr ""
+"*吞吐差* — 若带指标 Pod 上 ``max(throughput) − min`` > ``AIBRIX_DECODE_THROUGHPUT_IMBALANCE_MIN_SPREAD`` "
+"，则路由到吞吐最低的 Pod。"
+
+#: ../../source/features/pd-disaggregation.rst:611
+msgid ""
+"*Drain-rate score* — If all pods report a positive ``drain_rate``, score "
+"each pod as ``effective_running_reqs / drain_rate``. If ``max_score / "
+"min_score`` exceeds ``AIBRIX_DECODE_SCORE_RATIO_THRESHOLD``, route to the"
+" pod with the lowest score (fastest estimated queue drain)."
+msgstr ""
+"*排空速率分数* — 若所有 Pod 都报告正的 ``drain_rate`` ，则每个 Pod 打分为 ``effective_running_reqs "
+"/ drain_rate`` 。若 ``max_score / min_score`` 超过 ``AIBRIX_DECODE_SCORE_RATIO_THRESHOLD`` "
+"，则路由到分数最低的 Pod（估计队列排空最快）。"
+
+#: ../../source/features/pd-disaggregation.rst:613
+msgid "**Step 3 — Prefill scoring**"
+msgstr "**步骤 3 — Prefill 打分**"
+
+#: ../../source/features/pd-disaggregation.rst:615
+msgid ""
+"Each prefill pod is scored by the selected policy. Pods with a request "
+"count more than ``N`` standard deviations above the mean are skipped (``N"
+" = AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR``). The lowest-scoring "
+"pod per roleset is kept as the roleset's prefill candidate."
+msgstr ""
+"每个 prefill Pod 按所选策略打分。请求数高于均值超过 ``N`` 个标准差的 Pod 会被跳过（``N = AIBRIX_PREFIX_CACHE_STANDARD_DEVIATION_FACTOR`` "
+"）。每个 roleset 保留分数最低的 Pod 作为该 roleset 的 prefill 候选。"
+
+#: ../../source/features/pd-disaggregation.rst:617
+msgid ""
+"``prefix_cache`` (default): ``score = (100 − prefix_match_percent) × 0.1 "
+"+ req_count / max_req_count`` — lower score means more cache hits and "
+"less load. Matches below ``AIBRIX_MIN_MATCH_PCT`` count as ``0``."
+msgstr ""
+"``prefix_cache`` （默认）：``score = (100 − prefix_match_percent) × 0.1 + req_count "
+"/ max_req_count`` — 分数越低表示 cache 命中越多、负载越低。低于 ``AIBRIX_MIN_MATCH_PCT`` 的匹配计为 "
+"``0`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:618
+msgid "``least_request``: ``score = req_count``."
+msgstr "``least_request`` ：``score = req_count`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:619
+msgid ""
+"``token_load``: ``score = active_tokens + kv_weight × kv_tokens`` — the "
+"token-weighted load the router has charged to the pod; see :ref:`Token "
+"Load Scoring Policy <pd-token-load-policy>`."
+msgstr ""
+"``token_load`` ：``score = active_tokens + kv_weight × kv_tokens`` — 路由器已计入该 "
+"Pod 的按 token 加权负载；见 :ref:`Token Load Scoring Policy <pd-token-load-policy>` "
+"。"
+
+#: ../../source/features/pd-disaggregation.rst:620
+msgid ""
+"``hybrid_cache_load``: ``score = load × (1 − (prefix_match_percent / "
+"100)² × factor)``, or just the discount when the pod is idle — cache "
+"affinity decides between idle pods, load between busy ones; see "
+":ref:`Hybrid Cache-Load Scoring Policy <pd-hybrid-cache-load-policy>`."
+msgstr ""
+"``hybrid_cache_load`` ：``score = load × (1 − (prefix_match_percent / 100)² "
+"× factor)`` ，Pod 空闲时则仅为折扣——空闲 Pod 之间由 cache 亲和决定，繁忙 Pod 之间由负载决定；见 :ref:`Hybrid "
+"Cache-Load Scoring Policy <pd-hybrid-cache-load-policy>` 。"
+
+#: ../../source/features/pd-disaggregation.rst:622
+msgid "**Step 4 — Decode scoring**"
+msgstr "**步骤 4 — Decode 打分**"
+
+#: ../../source/features/pd-disaggregation.rst:624
+msgid ""
+"Each decode pod is scored by the selected policy. Pods without "
+"``RealtimeNumRequestsRunning`` receive a cold-start score (``1.0 + "
+"pending_decode_count``) when at least one sibling pod already has "
+"metrics, so they compete fairly without attracting all traffic "
+"immediately."
+msgstr ""
+"每个 decode Pod 按所选策略打分。没有 ``RealtimeNumRequestsRunning`` 的 Pod，在至少一个兄弟 Pod "
+"已有指标时，会得到冷启动分数（``1.0 + pending_decode_count`` ），从而能公平竞争，又不会立刻吸走全部流量。"
+
+#: ../../source/features/pd-disaggregation.rst:626
+msgid ""
+"``load_balancing`` (default): ``score = (w_run × norm_reqs + w_thru × (1 "
+"− norm_throughput)) / norm_free_gpu``, where norms are relative to the "
+"batch maximum; lower is better."
+msgstr ""
+"``load_balancing`` （默认）：``score = (w_run × norm_reqs + w_thru × (1 − norm_throughput)) "
+"/ norm_free_gpu`` ，其中归一化相对本批最大值；越低越好。"
+
+#: ../../source/features/pd-disaggregation.rst:627
+msgid "``least_request``: ``score = running_reqs + pending_decode_count``."
+msgstr "``least_request`` ：``score = running_reqs + pending_decode_count`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:629
+msgid "**Step 5 — Final pair selection**"
+msgstr "**步骤 5 — 最终配对选择**"
+
+#: ../../source/features/pd-disaggregation.rst:631
+msgid ""
+"For each roleset with both a prefill and decode candidate, the gateway "
+"computes:"
+msgstr "对同时有 prefill 和 decode 候选的每个 roleset，网关计算："
+
+#: ../../source/features/pd-disaggregation.rst:637
+msgid ""
+"The roleset with the lowest combined score wins. The selected prefill and"
+" decode pods always come from the same roleset."
+msgstr "综合分数最低的 roleset 胜出。所选 prefill 和 decode Pod 始终来自同一 roleset。"
+
+#: ../../source/features/pd-disaggregation.rst:641
+msgid "Environment Variables"
+msgstr "环境变量"
+
+#: ../../source/features/pd-disaggregation.rst:643
+msgid "These are set on the **gateway plugin** deployment."
+msgstr "这些变量设置在 **网关插件** 的 deployment 上。"
+
+#: ../../source/features/pd-disaggregation.rst:652
+msgid "``AIBRIX_PROMPT_LENGTH_BUCKETING``"
+msgstr "``AIBRIX_PROMPT_LENGTH_BUCKETING``"
+
+#: ../../source/features/pd-disaggregation.rst:653
+msgid "``false``"
+msgstr "``false``"
+
+#: ../../source/features/pd-disaggregation.rst:654
+msgid ""
+"Enable prompt-length bucket matching for prefill, decode, and standard "
+"inference pods."
+msgstr "为 prefill、decode 和标准推理 Pod 启用 prompt 长度分桶匹配。"
+
+#: ../../source/features/pd-disaggregation.rst:655
+msgid "``AIBRIX_PREFILL_REQUEST_TIMEOUT``"
+msgstr "``AIBRIX_PREFILL_REQUEST_TIMEOUT``"
+
+#: ../../source/features/pd-disaggregation.rst:656
+msgid "``30``"
+msgstr "``30``"
+
+#: ../../source/features/pd-disaggregation.rst:657
+msgid "Seconds before a prefill request to a prefill pod times out."
+msgstr "发往 prefill Pod 的 prefill 请求超时秒数。"
+
+#: ../../source/features/pd-disaggregation.rst:658
+msgid "``AIBRIX_PREFILL_SCORE_POLICY``"
+msgstr "``AIBRIX_PREFILL_SCORE_POLICY``"
+
+#: ../../source/features/pd-disaggregation.rst:659
+msgid "``prefix_cache``"
+msgstr "``prefix_cache``"
+
+#: ../../source/features/pd-disaggregation.rst:660
+msgid ""
+"Default scoring policy for selecting prefill pods. ``prefix_cache``, "
+"``least_request``, ``conductor``, ``token_load``, or "
+"``hybrid_cache_load``."
+msgstr ""
+"选择 prefill Pod 的默认打分策略。``prefix_cache`` 、``least_request`` 、``conductor`` "
+"、``token_load`` 或 ``hybrid_cache_load`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:663
+msgid ""
+"``token_load`` and ``hybrid_cache_load``. Weight of resident KV tokens in"
+" the prefill score. Must be positive."
+msgstr "``token_load`` 和 ``hybrid_cache_load`` 。驻留 KV token 在 prefill 分数中的权重。必须为正。"
+
+#: ../../source/features/pd-disaggregation.rst:666
+msgid ""
+"``token_load`` and ``hybrid_cache_load``. Fixed per-request cost, in "
+"tokens, added to every prefill charge. Must be positive."
+msgstr ""
+"``token_load`` 和 ``hybrid_cache_load`` 。每次 prefill 计费都加上的固定每请求成本，单位为 token。必须为正。"
+
+#: ../../source/features/pd-disaggregation.rst:669
+msgid ""
+"``token_load`` and ``hybrid_cache_load``. Charges older than this are "
+"force-released and logged; must exceed the longest legitimate request. "
+"Must be positive."
+msgstr "``token_load`` 和 ``hybrid_cache_load`` 。超过该时长的计费会被强制释放并记录日志；必须大于最长合法请求。必须为正。"
+
+#: ../../source/features/pd-disaggregation.rst:672
+msgid ""
+"``token_load`` and ``hybrid_cache_load``. How long the last prompt size "
+"of an ``x-aibrix-session-key`` session is remembered for the session-"
+"delta charge. ``0`` turns the session-delta rule off; otherwise must be "
+"positive."
+msgstr ""
+"``token_load`` 和 ``hybrid_cache_load`` 。为会话增量计费记住 ``x-aibrix-session-key`` "
+"会话上次 prompt 大小的时长。``0`` 关闭会话增量规则；否则必须为正。"
+
+#: ../../source/features/pd-disaggregation.rst:675
+msgid ""
+"``token_load`` and ``hybrid_cache_load``. Maximum number of sessions "
+"remembered at once for the session-delta charge. Must be positive."
+msgstr "``token_load`` 和 ``hybrid_cache_load`` 。会话增量计费同时记住的最大会话数。必须为正。"
+
+#: ../../source/features/pd-disaggregation.rst:678
+msgid ""
+"``hybrid_cache_load`` only. Discount a full prefix match applies to a "
+"pod's token load, ``0`` to ``1``. ``1`` makes a fully matched pod always "
+"win; ``0`` turns the discount off."
+msgstr ""
+"仅 ``hybrid_cache_load`` 。完全前缀匹配对 Pod token 负载应用的折扣，``0`` 到 ``1`` 。``1`` "
+"使完全匹配的 Pod 总是胜出；``0`` 关闭折扣。"
+
+#: ../../source/features/pd-disaggregation.rst:681
+msgid ""
+"``prefix_cache`` and ``hybrid_cache_load``. Prefix matches below this "
+"percentage are ignored, ``0`` to ``100``. ``0`` disables the threshold."
+msgstr ""
+"``prefix_cache`` 和 ``hybrid_cache_load`` 。低于该百分比的前缀匹配会被忽略，``0`` 到 ``100`` "
+"。``0`` 关闭阈值。"
+
+#: ../../source/features/pd-disaggregation.rst:682
+msgid "``AIBRIX_DECODE_SCORE_POLICY``"
+msgstr "``AIBRIX_DECODE_SCORE_POLICY``"
+
+#: ../../source/features/pd-disaggregation.rst:683
+msgid "``load_balancing``"
+msgstr "``load_balancing``"
+
+#: ../../source/features/pd-disaggregation.rst:684
+msgid ""
+"Default scoring policy for selecting decode pods. ``load_balancing``, "
+"``least_request``, or ``conductor``."
+msgstr "选择 decode Pod 的默认打分策略。``load_balancing`` 、``least_request`` 或 ``conductor`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:685
+msgid "``AIBRIX_KV_CONNECTOR_TYPE``"
+msgstr "``AIBRIX_KV_CONNECTOR_TYPE``"
+
+#: ../../source/features/pd-disaggregation.rst:686
+msgid "``shfs``"
+msgstr "``shfs``"
+
+#: ../../source/features/pd-disaggregation.rst:687
+msgid ""
+"KV transfer backend. ``shfs`` for GPU (SHFS/KVCacheManager), ``nixl`` for"
+" Neuron (TensorRT-LLM)."
+msgstr "KV 传输后端。GPU 用 ``shfs`` （SHFS/KVCacheManager），Neuron 用 ``nixl`` （TensorRT-LLM）。"
+
+#: ../../source/features/pd-disaggregation.rst:688
+msgid "``AIBRIX_PREFILL_LOAD_IMBALANCE_MIN_SPREAD``"
+msgstr "``AIBRIX_PREFILL_LOAD_IMBALANCE_MIN_SPREAD``"
+
+#: ../../source/features/pd-disaggregation.rst:689
+#: ../../source/features/pd-disaggregation.rst:692
+msgid "``16``"
+msgstr "``16``"
+
+#: ../../source/features/pd-disaggregation.rst:690
+msgid ""
+"Minimum request-count spread between prefill pods before load-imbalance "
+"routing kicks in."
+msgstr "prefill Pod 之间触发负载不均衡路由所需的最小请求数差。"
+
+#: ../../source/features/pd-disaggregation.rst:691
+msgid "``AIBRIX_DECODE_LOAD_IMBALANCE_MIN_SPREAD``"
+msgstr "``AIBRIX_DECODE_LOAD_IMBALANCE_MIN_SPREAD``"
+
+#: ../../source/features/pd-disaggregation.rst:693
+msgid ""
+"Minimum ``(max − min)`` running request count spread between decode pods "
+"before request-count load-imbalance routing kicks in."
+msgstr "decode Pod 之间触发按请求数的负载不均衡路由所需的最小 ``(max − min)`` 运行请求数差。"
+
+#: ../../source/features/pd-disaggregation.rst:694
+msgid "``AIBRIX_DECODE_THROUGHPUT_IMBALANCE_MIN_SPREAD``"
+msgstr "``AIBRIX_DECODE_THROUGHPUT_IMBALANCE_MIN_SPREAD``"
+
+#: ../../source/features/pd-disaggregation.rst:695
+msgid "``2048``"
+msgstr "``2048``"
+
+#: ../../source/features/pd-disaggregation.rst:696
+msgid ""
+"Minimum ``(max − min)`` token throughput spread (tok/s) between decode "
+"pods before throughput-based load-imbalance routing kicks in."
+msgstr "decode Pod 之间触发按吞吐的负载不均衡路由所需的最小 ``(max − min)`` token 吞吐差（tok/s）。"
+
+#: ../../source/features/pd-disaggregation.rst:697
+msgid "``AIBRIX_DECODE_SCORE_RATIO_THRESHOLD``"
+msgstr "``AIBRIX_DECODE_SCORE_RATIO_THRESHOLD``"
+
+#: ../../source/features/pd-disaggregation.rst:698
+msgid "``1.5``"
+msgstr "``1.5``"
+
+#: ../../source/features/pd-disaggregation.rst:699
+msgid ""
+"``max_drain_score / min_drain_score`` ratio above which the drain-rate "
+"routing fast path is triggered. Score for each pod is "
+"``effective_running_reqs / drain_rate``."
+msgstr ""
+"触发排空速率路由快速路径的 ``max_drain_score / min_drain_score`` 比值。每个 Pod 的分数为 ``effective_running_reqs "
+"/ drain_rate`` 。"
+
+#: ../../source/features/pd-disaggregation.rst:700
+msgid "``AIBRIX_DECODE_LB_WEIGHT_RUNNING``"
+msgstr "``AIBRIX_DECODE_LB_WEIGHT_RUNNING``"
+
+#: ../../source/features/pd-disaggregation.rst:701
+#: ../../source/features/pd-disaggregation.rst:704
+msgid "``1.0``"
+msgstr "``1.0``"
+
+#: ../../source/features/pd-disaggregation.rst:702
+msgid ""
+"Weight applied to the normalized running-request term in the "
+"``load_balancing`` decode score numerator."
+msgstr "``load_balancing`` decode 分数分子中，归一化运行请求项的权重。"
+
+#: ../../source/features/pd-disaggregation.rst:703
+msgid "``AIBRIX_DECODE_LB_WEIGHT_THROUGHPUT``"
+msgstr "``AIBRIX_DECODE_LB_WEIGHT_THROUGHPUT``"
+
+#: ../../source/features/pd-disaggregation.rst:705
+msgid ""
+"Weight applied to the normalized inverse-throughput term in the "
+"``load_balancing`` decode score numerator."
+msgstr "``load_balancing`` decode 分数分子中，归一化逆吞吐项的权重。"
+
+#: ../../source/features/pd-disaggregation.rst:706
+msgid "``AIBRIX_TRT_MACHINE_ID``"
+msgstr "``AIBRIX_TRT_MACHINE_ID``"
+
+#: ../../source/features/pd-disaggregation.rst:708
+msgid ""
+"10-bit machine ID used in Snowflake-style ``disagg_request_id`` "
+"generation for TensorRT-LLM (valid range: ``[0, 1024)``)."
+msgstr ""
+"用于 TensorRT-LLM 的 Snowflake 风格 ``disagg_request_id`` 生成的 10 位机器 ID（有效范围：``[0, "
+"1024)`` ）。"
+
+#: ../../source/features/pd-disaggregation.rst:712
+msgid ":doc:`../designs/aibrix-stormservice`"
+msgstr ":doc:`../designs/aibrix-stormservice`"
+
+#: ../../source/features/pd-disaggregation.rst:713
+msgid "StormService, the orchestration layer behind PD disaggregation."
+msgstr "StormService，Prefill/Decode 分离背后的编排层。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/runtime.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/runtime.po
@@ -1,0 +1,980 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/runtime.rst:5
+msgid "AI Engine Runtime"
+msgstr "AI Engine Runtime"
+
+#: ../../source/features/runtime.rst:8
+msgid "Overview"
+msgstr "概述"
+
+#: ../../source/features/runtime.rst:10
+msgid ""
+"The AI Engine Runtime is a small HTTP service that runs next to the "
+"inference engine, usually as a sidecar container in the same pod. It "
+"gives the AIBrix control plane one stable API for things that otherwise "
+"differ from engine to engine:"
+msgstr ""
+"AI Engine Runtime 是一个小型 HTTP 服务，与推理引擎一起运行，通常作为同一 Pod "
+"中的 sidecar 容器。它为 AIBrix 控制面提供统一 API，用于处理各引擎之间原本不一致的能力："
+
+#: ../../source/features/runtime.rst:14
+msgid ""
+"**Metric standardization**: it scrapes the engine's ``/metrics`` and re-"
+"exports them on its own port with a consistent naming, so the autoscaler "
+"and the gateway can read one shape."
+msgstr "**指标标准化** ：抓取引擎的 ``/metrics`` ，并在自身端口上以统一命名重新导出，以便自动扩缩容器和网关读取同一格式。"
+
+#: ../../source/features/runtime.rst:16
+msgid ""
+"**Model and adapter management**: it downloads model weights from "
+"HuggingFace, S3 or TOS and loads or unloads LoRA adapters on the engine. "
+"The :doc:`lora-dynamic-loading` controller calls these endpoints."
+msgstr ""
+"**模型与适配器管理** ：从 Hugging Face、S3 或 TOS 下载模型权重，并在引擎上加载或卸载 LoRA 适配器。:doc:`lora-dynamic-loading` "
+"控制器会调用这些接口。"
+
+#: ../../source/features/runtime.rst:19
+msgid ""
+"**Runtime model lifecycle**: an experimental set of endpoints used by "
+":doc:`modelclaim` to start, sleep, wake and deactivate engine processes "
+"in a shared pod."
+msgstr "**Runtime 模型生命周期** ：一组实验性接口，供 :doc:`modelclaim` 在共享 Pod 中启动、休眠、唤醒和停用引擎进程。"
+
+#: ../../source/features/runtime.rst:22
+msgid ""
+"The runtime does not proxy inference traffic: Envoy forwards requests "
+"straight to the engine container. The only contact the gateway has with "
+"the runtime is the wake call it makes for a sleeping ModelClaim engine. "
+"Most deployments do not need the runtime. Install it when you use dynamic"
+" LoRA loading or ModelClaim."
+msgstr ""
+"Runtime 不代理推理流量：Envoy 将请求直接转发到引擎容器。网关与 runtime 的唯一交互，"
+"是对处于休眠状态的 ModelClaim 引擎发起唤醒调用。大多数部署不需要 runtime。"
+"仅在使用动态 LoRA 加载或 ModelClaim 时安装。"
+
+#: ../../source/features/runtime.rst:28
+msgid "How it works"
+msgstr "工作原理"
+
+#: ../../source/features/runtime.rst:41
+msgid ""
+"The runtime listens on port ``8080`` and reaches the engine through "
+"``INFERENCE_ENGINE_ENDPOINT`` (``http://localhost:8000`` by default)."
+msgstr ""
+"Runtime 监听 ``8080`` 端口，并通过 ``INFERENCE_ENGINE_ENDPOINT`` （默认 ``http://localhost:8000`` "
+"）访问引擎。"
+
+#: ../../source/features/runtime.rst:43
+msgid ""
+"The controller manager flag ``--enable-runtime-sidecar`` only affects the"
+" ModelAdapter (LoRA) controller. With it on, that controller uses the "
+"runtime API on ``8080`` when a container named ``aibrix-runtime`` is "
+"present and the engine's own API on ``8000`` otherwise; with it off (the "
+"default) it always calls the engine. The ModelClaim controller and the "
+"gateway's wake path always use the runtime on ``8080``, regardless of the"
+" flag."
+msgstr ""
+"控制器管理器标志 ``--enable-runtime-sidecar`` 仅影响 ModelAdapter（LoRA）控制器。"
+"开启后，若存在名为 ``aibrix-runtime`` 的容器，该控制器使用 ``8080`` 上的 runtime "
+"API，否则使用引擎自身 ``8000`` 上的 API；关闭时（默认）始终调用引擎。"
+"ModelClaim 控制器和网关的唤醒路径始终使用 ``8080`` 上的 runtime，与该标志无关。"
+
+#: ../../source/features/runtime.rst:48
+msgid ""
+"Metrics are collected on each scrape: the runtime fetches the engine's "
+"metrics page, applies the standardization rules for ``INFERENCE_ENGINE`` "
+"and serves the result. Rule sets for ``sglang`` and ``trtllm`` exist in "
+"the code, but the runtime only starts with ``INFERENCE_ENGINE=vllm``: the"
+" engine client it initialises at startup rejects every other value."
+msgstr ""
+"每次抓取都会收集指标：runtime 拉取引擎的指标页，按 ``INFERENCE_ENGINE`` 应用标准化规则"
+"并提供结果。代码中存在 ``sglang`` 和 ``trtllm`` 的规则集，但 runtime 仅在 "
+"``INFERENCE_ENGINE=vllm`` 时启动：启动时初始化的引擎客户端会拒绝其他所有值。"
+
+#: ../../source/features/runtime.rst:53
+msgid ""
+"The model management API (``/v1/lora_adapter/*``, ``/v1/models``) is "
+"implemented for vLLM 0.6.1 and later. Other engines are not supported by "
+"those endpoints yet."
+msgstr ""
+"模型管理 API（``/v1/lora_adapter/*`` 、``/v1/models`` ）面向 vLLM 0.6.1 及更高版本实现。其他引擎暂不支持这些接口。"
+
+#: ../../source/features/runtime.rst:57
+msgid "Installation"
+msgstr "安装"
+
+#: ../../source/features/runtime.rst:59
+msgid ""
+"AIBrix Runtime can be injected into your workloads automatically using "
+"webhook-based sidecar injection (recommended) or manually added to your "
+"deployment manifests."
+msgstr ""
+"可使用基于 webhook 的 sidecar 注入（推荐）自动将 AIBrix Runtime 注入工作负载，"
+"或手动添加到部署清单。"
+
+#: ../../source/features/runtime.rst:62
+msgid "Automatic Sidecar Injection (Recommended)"
+msgstr "自动 Sidecar 注入（推荐）"
+
+#: ../../source/features/runtime.rst:64
+msgid ""
+"The easiest way to enable the runtime is through automatic sidecar "
+"injection. Simply add an annotation to your Deployment or StormService:"
+msgstr ""
+"启用 runtime 最简单的方式是自动 sidecar 注入。只需在 Deployment 或 StormService "
+"上添加注解："
+
+#: ../../source/features/runtime.rst:82
+msgid ""
+"The webhook will automatically inject the ``aibrix-runtime`` sidecar "
+"container into your pods."
+msgstr "Webhook 会自动将 ``aibrix-runtime`` sidecar 容器注入 Pod。"
+
+#: ../../source/features/runtime.rst:84
+msgid "What gets injected, so you know what to expect in the pod spec:"
+msgstr "注入内容如下，便于了解 Pod spec 中会出现什么："
+
+#: ../../source/features/runtime.rst:86
+msgid ""
+"a container named ``aibrix-runtime`` running ``aibrix_runtime --port "
+"8080`` from image ``aibrix/runtime:v0.5.0`` unless overridden by the "
+"image annotation below;"
+msgstr ""
+"名为 ``aibrix-runtime`` 的容器，运行 ``aibrix_runtime --port 8080`` ，镜像为 ``aibrix/runtime:v0.5.0`` "
+"，除非被下方的镜像注解覆盖；"
+
+#: ../../source/features/runtime.rst:88
+msgid ""
+"``INFERENCE_ENGINE`` taken from the ``model.aibrix.ai/engine`` annotation"
+" on the workload when set, otherwise inferred from the engine container's"
+" image name (``vllm``, ``sglang``, ``tgi``, ``triton``, ``llamacpp``, "
+"else ``unknown``), and "
+"``INFERENCE_ENGINE_ENDPOINT=http://localhost:8000``. Only ``vllm`` yields"
+" a runtime that starts, so inject it only into vLLM workloads;"
+msgstr ""
+"``INFERENCE_ENGINE`` 取自工作负载上的 ``model.aibrix.ai/engine`` 注解（若已设置），否则从引擎容器镜像名推断（``vllm`` "
+"、``sglang`` 、``tgi`` 、``triton`` 、``llamacpp`` ，否则为 ``unknown`` ），以及 ``INFERENCE_ENGINE_ENDPOINT=http://localhost:8000`` "
+"。只有 ``vllm`` 能让 runtime 成功启动，因此仅注入到 vLLM 工作负载；"
+
+#: ../../source/features/runtime.rst:93
+msgid ""
+"a container port named ``metrics`` on ``8080``, a liveness probe on "
+"``/healthz`` and a readiness probe on ``/ready``;"
+msgstr "名为 ``metrics`` 的容器端口 ``8080`` ，存活探针 ``/healthz`` ，就绪探针 ``/ready`` ；"
+
+#: ../../source/features/runtime.rst:95
+msgid ""
+"a volume ``adapter-storage`` mounted at ``/tmp/aibrix/adapters`` for "
+"downloaded adapters;"
+msgstr "卷 ``adapter-storage`` ，挂载到 ``/tmp/aibrix/adapters`` ，用于已下载的适配器；"
+
+#: ../../source/features/runtime.rst:96
+msgid ""
+"resource requests of ``100m`` CPU and ``256Mi`` memory, limits of "
+"``500m`` and ``512Mi``."
+msgstr "资源请求为 ``100m`` CPU 和 ``256Mi`` 内存，限制为 ``500m`` 和 ``512Mi`` 。"
+
+#: ../../source/features/runtime.rst:98
+msgid ""
+"The webhook is registered for ``Deployment`` and ``StormService`` objects"
+" with ``failurePolicy: Ignore``, so a webhook outage never blocks "
+"workload creation; it only means the sidecar is not added."
+msgstr ""
+"Webhook 注册在 ``Deployment`` 和 ``StormService`` 对象上，``failurePolicy: Ignore`` "
+"，因此 webhook 故障不会阻止工作负载创建，只是不会添加 sidecar。"
+
+#: ../../source/features/runtime.rst:102
+msgid "**For StormService**"
+msgstr "**StormService**"
+
+#: ../../source/features/runtime.rst:104
+msgid "Sidecar injection also works with StormService custom resources:"
+msgstr "Sidecar 注入同样适用于 StormService 自定义资源："
+
+#: ../../source/features/runtime.rst:126
+msgid "The runtime sidecar will be injected into each role's pod template."
+msgstr "Runtime sidecar 会注入到每个角色的 Pod 模板中。"
+
+#: ../../source/features/runtime.rst:128
+msgid "**Customize Runtime Image**"
+msgstr "**自定义 Runtime 镜像**"
+
+#: ../../source/features/runtime.rst:130
+msgid "You can specify a custom runtime image using an annotation:"
+msgstr "可通过注解指定自定义 runtime 镜像："
+
+#: ../../source/features/runtime.rst:144
+msgid "**Enable Global Runtime Flag**"
+msgstr "**启用全局 Runtime 标志**"
+
+#: ../../source/features/runtime.rst:146
+msgid ""
+"To enable the controller to use the runtime sidecar API, set the global "
+"flag when starting the controller manager:"
+msgstr "要让控制器使用 runtime sidecar API，在启动控制器管理器时设置全局标志："
+
+#: ../../source/features/runtime.rst:153
+msgid "The runtime detection logic works as follows:"
+msgstr "Runtime 检测逻辑如下："
+
+#: ../../source/features/runtime.rst:155
+msgid ""
+"**EnableRuntimeSidecar = false**: Controller always uses direct engine "
+"API (port 8000), even if sidecar is injected"
+msgstr "**EnableRuntimeSidecar = false** ：控制器始终使用引擎直连 API（端口 8000），即使已注入 sidecar"
+
+#: ../../source/features/runtime.rst:156
+msgid ""
+"**EnableRuntimeSidecar = true**: Controller detects if pod has ``aibrix-"
+"runtime`` container:"
+msgstr "**EnableRuntimeSidecar = true** ：控制器检测 Pod 是否有 ``aibrix-runtime`` 容器："
+
+#: ../../source/features/runtime.rst:158
+msgid "Sidecar present → Uses runtime API (port 8080)"
+msgstr "存在 sidecar → 使用 runtime API（端口 8080）"
+
+#: ../../source/features/runtime.rst:159
+msgid "Sidecar absent → Fallback to direct engine API (port 8000)"
+msgstr "不存在 sidecar → 回退到引擎直连 API（端口 8000）"
+
+#: ../../source/features/runtime.rst:161
+msgid ""
+"This design ensures functionality works with or without the runtime "
+"sidecar, providing maximum flexibility."
+msgstr "该设计确保有无 runtime sidecar 都能工作，提供最大灵活性。"
+
+#: ../../source/features/runtime.rst:164
+msgid "Manual Sidecar Installation"
+msgstr "手动安装 Sidecar"
+
+#: ../../source/features/runtime.rst:166
+msgid ""
+"If you prefer manual control, you can add the runtime sidecar directly to"
+" your deployment YAML:"
+msgstr "如需手动控制，可将 runtime sidecar 直接添加到部署 YAML："
+
+#: ../../source/features/runtime.rst:199
+msgid "Standalone Installation"
+msgstr "独立安装"
+
+#: ../../source/features/runtime.rst:201
+msgid ""
+"If you like to use the runtime for other cases outside of Kubernetes, you"
+" can install it by the following command."
+msgstr "若要在 Kubernetes 之外使用 runtime，可执行以下命令安装。"
+
+#: ../../source/features/runtime.rst:205
+msgid "``python3 -m pip install aibrix``"
+msgstr "``python3 -m pip install aibrix``"
+
+#: ../../source/features/runtime.rst:207
+msgid "If you want to use nightly version, you can install from code."
+msgstr "若要使用 nightly 版本，可从源码安装。"
+
+#: ../../source/features/runtime.rst:209
+msgid "``cd $AIBRIX_HOME/python/aibrix && python3 -m pip install -e .``"
+msgstr "``cd $AIBRIX_HOME/python/aibrix && python3 -m pip install -e .``"
+
+#: ../../source/features/runtime.rst:213
+msgid "Metric Standardization"
+msgstr "指标标准化"
+
+#: ../../source/features/runtime.rst:215
+msgid ""
+"Different inference engines will expose different metrics, and AI Runtime"
+" will standardize them."
+msgstr "不同推理引擎会暴露不同指标，AI Runtime 会将其标准化。"
+
+#: ../../source/features/runtime.rst:217
+msgid ""
+"Define the information related to the inference engine side in the "
+"container environment variables. For example, if ``vLLM`` provides "
+"metrics services on ``http://localhost:8000/metrics``, launch the AI "
+"Runtime Server by the following command:"
+msgstr ""
+"在容器环境变量中定义推理引擎相关信息。例如，若 ``vLLM`` 在 "
+"``http://localhost:8000/metrics`` 提供指标服务，可用以下命令启动 AI Runtime Server："
+
+#: ../../source/features/runtime.rst:224
+msgid ""
+"The runtime serves the result on ``http://localhost:8080/metrics``. Every"
+" metric the engine exposes is passed through unchanged, and for the "
+"metrics that have a standardization rule the runtime additionally emits a"
+" copy under an engine-neutral ``aibrix:`` name. The SGLang and TRT-LLM "
+"columns below describe rule sets present in the code; they cannot be "
+"selected today because the runtime only starts with "
+"``INFERENCE_ENGINE=vllm``."
+msgstr ""
+"Runtime 在 ``http://localhost:8080/metrics`` 提供结果。引擎暴露的每条指标都会原样透传；"
+"对有标准化规则的指标，runtime 还会额外以引擎无关的 ``aibrix:`` 名称输出一份副本。"
+"下表中 SGLang 和 TRT-LLM 列描述的是代码中已有的规则集；目前无法选用，因为 runtime 仅在 "
+"``INFERENCE_ENGINE=vllm`` 时启动。"
+
+#: ../../source/features/runtime.rst:234
+msgid "Standard name"
+msgstr "标准名称"
+
+#: ../../source/features/runtime.rst:235
+msgid "vLLM source"
+msgstr "vLLM 来源"
+
+#: ../../source/features/runtime.rst:236
+msgid "SGLang source"
+msgstr "SGLang 来源"
+
+#: ../../source/features/runtime.rst:237
+msgid "TRT-LLM source"
+msgstr "TRT-LLM 来源"
+
+#: ../../source/features/runtime.rst:238
+msgid "``aibrix:queue_size``"
+msgstr "``aibrix:queue_size``"
+
+#: ../../source/features/runtime.rst:239
+msgid "``vllm:num_requests_waiting``"
+msgstr "``vllm:num_requests_waiting``"
+
+#: ../../source/features/runtime.rst:240
+msgid "``sglang:num_queue_reqs``"
+msgstr "``sglang:num_queue_reqs``"
+
+#: ../../source/features/runtime.rst:241 ../../source/features/runtime.rst:244
+#: ../../source/features/runtime.rst:245 ../../source/features/runtime.rst:248
+#: ../../source/features/runtime.rst:251 ../../source/features/runtime.rst:253
+#: ../../source/features/runtime.rst:257 ../../source/features/runtime.rst:261
+#: ../../source/features/runtime.rst:263 ../../source/features/runtime.rst:265
+#: ../../source/features/runtime.rst:280 ../../source/features/runtime.rst:283
+#: ../../source/features/runtime.rst:285 ../../source/features/runtime.rst:287
+#: ../../source/features/runtime.rst:288
+msgid "N/A"
+msgstr "N/A"
+
+#: ../../source/features/runtime.rst:242
+msgid "``aibrix:gpu_cache_usage_perc``"
+msgstr "``aibrix:gpu_cache_usage_perc``"
+
+#: ../../source/features/runtime.rst:243
+msgid "``vllm:gpu_cache_usage_perc``"
+msgstr "``vllm:gpu_cache_usage_perc``"
+
+#: ../../source/features/runtime.rst:246
+msgid "``aibrix:kv_cache_usage_perc``"
+msgstr "``aibrix:kv_cache_usage_perc``"
+
+#: ../../source/features/runtime.rst:247
+msgid "``vllm:kv_cache_usage_perc``"
+msgstr "``vllm:kv_cache_usage_perc``"
+
+#: ../../source/features/runtime.rst:249
+msgid "``kv_cache_utilization``"
+msgstr "``kv_cache_utilization``"
+
+#: ../../source/features/runtime.rst:250
+msgid "``aibrix:token_usage``"
+msgstr "``aibrix:token_usage``"
+
+#: ../../source/features/runtime.rst:252
+msgid "``sglang:token_usage``"
+msgstr "``sglang:token_usage``"
+
+#: ../../source/features/runtime.rst:254
+msgid "``aibrix:prompt_tokens_total``"
+msgstr "``aibrix:prompt_tokens_total``"
+
+#: ../../source/features/runtime.rst:255
+msgid "``vllm:prompt_tokens_total``"
+msgstr "``vllm:prompt_tokens_total``"
+
+#: ../../source/features/runtime.rst:256
+msgid "``sglang:prompt_tokens_total``"
+msgstr "``sglang:prompt_tokens_total``"
+
+#: ../../source/features/runtime.rst:258
+msgid "``aibrix:generation_tokens_total``"
+msgstr "``aibrix:generation_tokens_total``"
+
+#: ../../source/features/runtime.rst:259
+msgid "``vllm:generation_tokens_total``"
+msgstr "``vllm:generation_tokens_total``"
+
+#: ../../source/features/runtime.rst:260
+msgid "``sglang:generation_tokens_total``"
+msgstr "``sglang:generation_tokens_total``"
+
+#: ../../source/features/runtime.rst:262
+msgid "``aibrix:generation_throughput``"
+msgstr "``aibrix:generation_throughput``"
+
+#: ../../source/features/runtime.rst:264
+msgid "``sglang:gen_throughput``"
+msgstr "``sglang:gen_throughput``"
+
+#: ../../source/features/runtime.rst:266
+msgid "``aibrix:time_to_first_token_seconds``"
+msgstr "``aibrix:time_to_first_token_seconds``"
+
+#: ../../source/features/runtime.rst:267
+msgid "``vllm:time_to_first_token_seconds``"
+msgstr "``vllm:time_to_first_token_seconds``"
+
+#: ../../source/features/runtime.rst:268
+msgid "``sglang:time_to_first_token_seconds``"
+msgstr "``sglang:time_to_first_token_seconds``"
+
+#: ../../source/features/runtime.rst:269
+msgid "``time_to_first_token_seconds``"
+msgstr "``time_to_first_token_seconds``"
+
+#: ../../source/features/runtime.rst:270
+msgid "``aibrix:time_per_output_token_seconds``"
+msgstr "``aibrix:time_per_output_token_seconds``"
+
+#: ../../source/features/runtime.rst:271
+msgid "``vllm:time_per_output_token_seconds``"
+msgstr "``vllm:time_per_output_token_seconds``"
+
+#: ../../source/features/runtime.rst:272
+msgid "``sglang:time_per_output_token_seconds``"
+msgstr "``sglang:time_per_output_token_seconds``"
+
+#: ../../source/features/runtime.rst:273
+msgid "``time_per_output_token_seconds``"
+msgstr "``time_per_output_token_seconds``"
+
+#: ../../source/features/runtime.rst:274
+msgid "``aibrix:e2e_request_latency_seconds``"
+msgstr "``aibrix:e2e_request_latency_seconds``"
+
+#: ../../source/features/runtime.rst:275
+msgid "``vllm:e2e_request_latency_seconds``"
+msgstr "``vllm:e2e_request_latency_seconds``"
+
+#: ../../source/features/runtime.rst:276
+msgid "``sglang:e2e_request_latency_seconds``"
+msgstr "``sglang:e2e_request_latency_seconds``"
+
+#: ../../source/features/runtime.rst:277
+msgid "``e2e_request_latency_seconds``"
+msgstr "``e2e_request_latency_seconds``"
+
+#: ../../source/features/runtime.rst:278
+msgid "``aibrix:request_success_total``"
+msgstr "``aibrix:request_success_total``"
+
+#: ../../source/features/runtime.rst:279
+msgid "``vllm:request_success_total``"
+msgstr "``vllm:request_success_total``"
+
+#: ../../source/features/runtime.rst:281
+msgid "``request_success_total``"
+msgstr "``request_success_total``"
+
+#: ../../source/features/runtime.rst:282
+msgid "``aibrix:cache_hit_rate``"
+msgstr "``aibrix:cache_hit_rate``"
+
+#: ../../source/features/runtime.rst:284
+msgid "``sglang:cache_hit_rate``"
+msgstr "``sglang:cache_hit_rate``"
+
+#: ../../source/features/runtime.rst:286
+msgid "``aibrix:kv_cache_hit_rate``"
+msgstr "``aibrix:kv_cache_hit_rate``"
+
+#: ../../source/features/runtime.rst:289
+msgid "``kv_cache_hit_rate``"
+msgstr "``kv_cache_hit_rate``"
+
+#: ../../source/features/runtime.rst:291
+msgid ""
+"Set ``METRICS_RAW_PASSTHROUGH_MODE=1`` (or "
+"``METRICS_ENABLE_TRANSFORMATION=0``) to skip the copies and serve the "
+"engine's metrics exactly as they are. If a rule fails on a scrape, the "
+"runtime logs the error and falls back to raw passthrough for that scrape "
+"rather than dropping metrics. A sample of the vLLM output as served by "
+"the runtime:"
+msgstr ""
+"设置 ``METRICS_RAW_PASSTHROUGH_MODE=1`` （或 ``METRICS_ENABLE_TRANSFORMATION=0`` "
+"）可跳过副本，完全按引擎原始指标提供。若某次抓取时规则失败，runtime 会记录错误，并在该次抓取回退到原始透传，而不是丢弃指标。以下是 runtime "
+"提供的 vLLM 输出示例："
+
+#: ../../source/features/runtime.rst:358
+msgid ""
+"The sample above was captured before the ``aibrix:`` names were "
+"introduced and shows only the pass-through metrics. Current versions also"
+" emit the standardized copies listed in the table."
+msgstr ""
+"上述示例采集于引入 ``aibrix:`` 名称之前，仅展示透传指标。当前版本还会输出表中列出的标准化副本。"
+
+#: ../../source/features/runtime.rst:364
+msgid "Model Downloading"
+msgstr "模型下载"
+
+#: ../../source/features/runtime.rst:366
+msgid ""
+"The AI Engine Runtime supports downloading models from multiple remote "
+"sources, including HuggingFace, S3, and TOS. This is extremely useful "
+"when the control plane needs to interact with the pod to dynamically load"
+" new models."
+msgstr ""
+"AI Engine Runtime 支持从多个远程源下载模型，包括 Hugging Face、S3 和 TOS。"
+"当控制面需要与 Pod 交互以动态加载新模型时，这非常有用。"
+
+#: ../../source/features/runtime.rst:371
+msgid "Download From HuggingFace"
+msgstr "从 Hugging Face 下载"
+
+#: ../../source/features/runtime.rst:372
+msgid ""
+"First Define the necessary environment variables for the HuggingFace "
+"model."
+msgstr "首先为 Hugging Face 模型定义必要的环境变量。"
+
+#: ../../source/features/runtime.rst:383
+msgid "Then use AI Engine Runtime to download the model from HuggingFace:"
+msgstr "然后使用 AI Engine Runtime 从 Hugging Face 下载模型："
+
+#: ../../source/features/runtime.rst:393
+msgid "Download From S3"
+msgstr "从 S3 下载"
+
+#: ../../source/features/runtime.rst:394
+msgid "First Define the necessary environment variables for the S3 model."
+msgstr "首先为 S3 模型定义必要的环境变量。"
+
+#: ../../source/features/runtime.rst:408
+msgid "Then use AI Runtime to download the model from AWS S3:"
+msgstr "然后使用 AI Runtime 从 AWS S3 下载模型："
+
+#: ../../source/features/runtime.rst:418
+msgid "Download From TOS"
+msgstr "从 TOS 下载"
+
+#: ../../source/features/runtime.rst:419
+msgid "First Define the necessary environment variables for the TOS model."
+msgstr "首先为 TOS 模型定义必要的环境变量。"
+
+#: ../../source/features/runtime.rst:433
+msgid "Then use AI Runtime to download the model from TOS:"
+msgstr "然后使用 AI Runtime 从 TOS 下载模型："
+
+#: ../../source/features/runtime.rst:443
+msgid "Model Configuration API"
+msgstr "模型配置 API"
+
+#: ../../source/features/runtime.rst:446
+msgid ""
+"this needs the engine to starts with `--enable-lora` and env `export "
+"VLLM_ALLOW_RUNTIME_LORA_UPDATING=true` enabled. You can check "
+"`Dynamically serving LoRA Adapters "
+"<https://docs.vllm.ai/en/latest/features/lora.html#dynamically-serving-"
+"lora-adapters>`_ for more details."
+msgstr ""
+"这需要引擎以 `--enable-lora` 启动，并启用环境变量 `export VLLM_ALLOW_RUNTIME_LORA_UPDATING=true` "
+"。更多细节见 `Dynamically serving LoRA Adapters <https://docs.vllm.ai/en/latest/features/lora.html#dynamically-serving-lora-adapters>`_ "
+"。"
+
+#: ../../source/features/runtime.rst:450
+msgid ""
+"Let's assume you already have a base model and runtime deployed and you "
+"want to load a LoRA adapter to it."
+msgstr "假设你已部署基础模型和 runtime，并希望向其加载 LoRA 适配器。"
+
+#: ../../source/features/runtime.rst:558
+msgid "Configuration reference"
+msgstr "配置参考"
+
+#: ../../source/features/runtime.rst:560
+msgid ""
+"**Command line.** ``aibrix_runtime`` accepts ``--host`` (default "
+"``0.0.0.0``), ``--port`` (default ``8080``) and ``--enable-fastapi-docs``"
+" to serve the OpenAPI schema and Swagger UI."
+msgstr ""
+"**命令行。** ``aibrix_runtime`` 接受 ``--host`` （默认 ``0.0.0.0`` ）、``--port`` （默认 "
+"``8080`` ）以及 ``--enable-fastapi-docs`` （用于提供 OpenAPI schema 和 Swagger UI）。"
+
+#: ../../source/features/runtime.rst:563
+msgid "**Environment variables**"
+msgstr "**环境变量**"
+
+#: ../../source/features/runtime.rst:569
+msgid "Variable"
+msgstr "变量"
+
+#: ../../source/features/runtime.rst:570
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/features/runtime.rst:571 ../../source/features/runtime.rst:630
+msgid "Meaning"
+msgstr "含义"
+
+#: ../../source/features/runtime.rst:572
+msgid "``INFERENCE_ENGINE``"
+msgstr "``INFERENCE_ENGINE``"
+
+#: ../../source/features/runtime.rst:573
+msgid "``vllm``"
+msgstr "``vllm``"
+
+#: ../../source/features/runtime.rst:574
+msgid ""
+"Engine type. Must be ``vllm``; the runtime fails to start with any other "
+"value."
+msgstr "引擎类型。必须为 ``vllm`` ；其他值会导致 runtime 启动失败。"
+
+#: ../../source/features/runtime.rst:575
+msgid "``INFERENCE_ENGINE_VERSION``"
+msgstr "``INFERENCE_ENGINE_VERSION``"
+
+#: ../../source/features/runtime.rst:576
+msgid "``0.6.1``"
+msgstr "``0.6.1``"
+
+#: ../../source/features/runtime.rst:577
+msgid ""
+"Engine version. For vLLM, versions from ``0.6.1`` enable the LoRA "
+"endpoints."
+msgstr "引擎版本。对于 vLLM，``0.6.1`` 起启用 LoRA 接口。"
+
+#: ../../source/features/runtime.rst:578
+msgid "``INFERENCE_ENGINE_ENDPOINT``"
+msgstr "``INFERENCE_ENGINE_ENDPOINT``"
+
+#: ../../source/features/runtime.rst:579
+msgid "``http://localhost:8000``"
+msgstr "``http://localhost:8000``"
+
+#: ../../source/features/runtime.rst:580
+msgid "Base URL of the engine."
+msgstr "引擎的基础 URL。"
+
+#: ../../source/features/runtime.rst:581
+msgid "``METRIC_SCRAPE_PATH``"
+msgstr "``METRIC_SCRAPE_PATH``"
+
+#: ../../source/features/runtime.rst:582
+msgid "``/metrics``"
+msgstr "``/metrics``"
+
+#: ../../source/features/runtime.rst:583
+msgid "Path scraped on the engine."
+msgstr "在引擎上抓取的路径。"
+
+#: ../../source/features/runtime.rst:584
+msgid "``METRICS_ENABLE_TRANSFORMATION``"
+msgstr "``METRICS_ENABLE_TRANSFORMATION``"
+
+#: ../../source/features/runtime.rst:585 ../../source/features/runtime.rst:609
+msgid "``1``"
+msgstr "``1``"
+
+#: ../../source/features/runtime.rst:586
+msgid "Apply standardization rules. ``0`` forces raw passthrough."
+msgstr "应用标准化规则。``0`` 强制原始透传。"
+
+#: ../../source/features/runtime.rst:587
+msgid "``METRICS_RAW_PASSTHROUGH_MODE``"
+msgstr "``METRICS_RAW_PASSTHROUGH_MODE``"
+
+#: ../../source/features/runtime.rst:588 ../../source/features/runtime.rst:606
+msgid "``0``"
+msgstr "``0``"
+
+#: ../../source/features/runtime.rst:589
+msgid "Serve the engine's metrics unchanged."
+msgstr "原样提供引擎指标。"
+
+#: ../../source/features/runtime.rst:590
+msgid "``PROMETHEUS_MULTIPROC_DIR``"
+msgstr "``PROMETHEUS_MULTIPROC_DIR``"
+
+#: ../../source/features/runtime.rst:591
+msgid "``/tmp/aibrix/metrics/``"
+msgstr "``/tmp/aibrix/metrics/``"
+
+#: ../../source/features/runtime.rst:592
+msgid "Scratch directory for the Prometheus client."
+msgstr "Prometheus 客户端的临时目录。"
+
+#: ../../source/features/runtime.rst:593
+msgid "``DOWNLOADER_LOCAL_DIR``"
+msgstr "``DOWNLOADER_LOCAL_DIR``"
+
+#: ../../source/features/runtime.rst:594
+msgid "``/tmp/aibrix/models/``"
+msgstr "``/tmp/aibrix/models/``"
+
+#: ../../source/features/runtime.rst:595
+msgid "Where models are downloaded when a request does not name a directory."
+msgstr "请求未指定目录时，模型的下载位置。"
+
+#: ../../source/features/runtime.rst:596
+msgid "``DOWNLOADER_NUM_THREADS``"
+msgstr "``DOWNLOADER_NUM_THREADS``"
+
+#: ../../source/features/runtime.rst:597
+msgid "``32``"
+msgstr "``32``"
+
+#: ../../source/features/runtime.rst:598
+msgid "Parallel download threads."
+msgstr "并行下载线程数。"
+
+#: ../../source/features/runtime.rst:599
+msgid "``DOWNLOADER_ALLOW_FILE_SUFFIX``"
+msgstr "``DOWNLOADER_ALLOW_FILE_SUFFIX``"
+
+#: ../../source/features/runtime.rst:600
+msgid "*(all files)*"
+msgstr "*（所有文件）*"
+
+#: ../../source/features/runtime.rst:601
+msgid "Comma-separated suffixes to fetch, for example ``json, safetensors``."
+msgstr "要获取的后缀，逗号分隔，例如 ``json, safetensors`` 。"
+
+#: ../../source/features/runtime.rst:602
+msgid "``DOWNLOADER_PART_THRESHOLD`` / ``DOWNLOADER_PART_CHUNKSIZE``"
+msgstr "``DOWNLOADER_PART_THRESHOLD`` / ``DOWNLOADER_PART_CHUNKSIZE``"
+
+#: ../../source/features/runtime.rst:603
+msgid "``67108864``"
+msgstr "``67108864``"
+
+#: ../../source/features/runtime.rst:604
+msgid "Size in bytes above which a file is fetched in parts, and the part size."
+msgstr "超过该字节数的文件按分片获取，以及分片大小。"
+
+#: ../../source/features/runtime.rst:605
+msgid "``DOWNLOADER_FORCE_DOWNLOAD``"
+msgstr "``DOWNLOADER_FORCE_DOWNLOAD``"
+
+#: ../../source/features/runtime.rst:607
+msgid "Re-download even if the files already exist locally."
+msgstr "即使本地已存在文件也重新下载。"
+
+#: ../../source/features/runtime.rst:608
+msgid "``DOWNLOADER_CHECK_FILE_EXIST``"
+msgstr "``DOWNLOADER_CHECK_FILE_EXIST``"
+
+#: ../../source/features/runtime.rst:610
+msgid "Skip files that already exist locally."
+msgstr "跳过本地已存在的文件。"
+
+#: ../../source/features/runtime.rst:611
+msgid "``HF_TOKEN``, ``HF_ENDPOINT``, ``HF_REVISION``"
+msgstr "``HF_TOKEN`` 、``HF_ENDPOINT`` 、``HF_REVISION``"
+
+#: ../../source/features/runtime.rst:612 ../../source/features/runtime.rst:615
+#: ../../source/features/runtime.rst:619
+msgid "*(unset)*"
+msgstr "*（未设置）*"
+
+#: ../../source/features/runtime.rst:613
+msgid "HuggingFace credentials, mirror endpoint and revision."
+msgstr "Hugging Face 凭证、镜像端点和修订版本。"
+
+#: ../../source/features/runtime.rst:614
+msgid ""
+"``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, ``AWS_ENDPOINT_URL``, "
+"``AWS_REGION``"
+msgstr ""
+"``AWS_ACCESS_KEY_ID`` 、``AWS_SECRET_ACCESS_KEY`` 、``AWS_ENDPOINT_URL`` 、``AWS_REGION``"
+
+#: ../../source/features/runtime.rst:616
+msgid ""
+"S3 credentials and endpoint. ``DOWNLOADER_S3_MAX_IO_QUEUE`` (``100``) and"
+" ``DOWNLOADER_S3_IO_CHUNKSIZE`` (``16777216``) tune the transfer."
+msgstr ""
+"S3 凭证和端点。``DOWNLOADER_S3_MAX_IO_QUEUE`` （``100`` ）和 ``DOWNLOADER_S3_IO_CHUNKSIZE`` "
+"（``16777216`` ）用于调节传输。"
+
+#: ../../source/features/runtime.rst:618
+msgid "``TOS_ACCESS_KEY``, ``TOS_SECRET_KEY``, ``TOS_ENDPOINT``, ``TOS_REGION``"
+msgstr "``TOS_ACCESS_KEY`` 、``TOS_SECRET_KEY`` 、``TOS_ENDPOINT`` 、``TOS_REGION``"
+
+#: ../../source/features/runtime.rst:620
+msgid ""
+"TOS credentials and endpoint. ``DOWNLOADER_TOS_VERSION`` (``v2``) selects"
+" the client API and ``TOS_ENABLE_CRC`` enables checksums."
+msgstr ""
+"TOS 凭证和端点。``DOWNLOADER_TOS_VERSION`` （``v2`` ）选择客户端 API，``TOS_ENABLE_CRC`` "
+"启用校验和。"
+
+#: ../../source/features/runtime.rst:623
+msgid "**Annotations and flags**"
+msgstr "**注解与标志**"
+
+#: ../../source/features/runtime.rst:629
+msgid "Setting"
+msgstr "设置"
+
+#: ../../source/features/runtime.rst:631
+msgid "``model.aibrix.ai/sidecar-injection: \"true\"`` (annotation)"
+msgstr "``model.aibrix.ai/sidecar-injection: \"true\"`` （注解）"
+
+#: ../../source/features/runtime.rst:632
+msgid ""
+"Ask the webhook to inject the runtime into a ``Deployment`` or "
+"``StormService``."
+msgstr "请求 webhook 将 runtime 注入 ``Deployment`` 或 ``StormService`` 。"
+
+#: ../../source/features/runtime.rst:633
+msgid "``model.aibrix.ai/sidecar-runtime-image`` (annotation)"
+msgstr "``model.aibrix.ai/sidecar-runtime-image`` （注解）"
+
+#: ../../source/features/runtime.rst:634
+msgid "Runtime image to inject instead of the default."
+msgstr "要注入的 runtime 镜像，替代默认值。"
+
+#: ../../source/features/runtime.rst:635
+msgid "``--enable-runtime-sidecar`` (controller manager flag, default ``false``)"
+msgstr "``--enable-runtime-sidecar`` （控制器管理器标志，默认 ``false`` ）"
+
+#: ../../source/features/runtime.rst:636
+msgid ""
+"Let controllers use the runtime API when the ``aibrix-runtime`` container"
+" is present."
+msgstr "当存在 ``aibrix-runtime`` 容器时，允许控制器使用 runtime API。"
+
+#: ../../source/features/runtime.rst:639
+msgid "HTTP API reference"
+msgstr "HTTP API 参考"
+
+#: ../../source/features/runtime.rst:641
+msgid "All endpoints are served on the runtime port (``8080`` by default)."
+msgstr "所有接口均在 runtime 端口上提供（默认 ``8080`` ）。"
+
+#: ../../source/features/runtime.rst:647
+msgid "Endpoint"
+msgstr "接口"
+
+#: ../../source/features/runtime.rst:648
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/features/runtime.rst:649
+msgid "``GET /healthz``"
+msgstr "``GET /healthz``"
+
+#: ../../source/features/runtime.rst:650
+msgid "Liveness. Always ``200`` once the process is up."
+msgstr "存活检查。进程启动后始终返回 ``200`` 。"
+
+#: ../../source/features/runtime.rst:651
+msgid "``GET /ready``"
+msgstr "``GET /ready``"
+
+#: ../../source/features/runtime.rst:652
+msgid "Readiness. Used as the pod readiness probe when injected."
+msgstr "就绪检查。注入时用作 Pod 就绪探针。"
+
+#: ../../source/features/runtime.rst:653
+msgid "``GET /metrics``"
+msgstr "``GET /metrics``"
+
+#: ../../source/features/runtime.rst:654
+msgid "Standardized engine metrics in Prometheus format."
+msgstr "Prometheus 格式的标准化引擎指标。"
+
+#: ../../source/features/runtime.rst:655
+msgid "``POST /v1/lora_adapter/load``"
+msgstr "``POST /v1/lora_adapter/load``"
+
+#: ../../source/features/runtime.rst:656
+#, python-brace-format
+msgid ""
+"Body ``{\"lora_name\": ..., \"lora_path\": ...}``. Loads an adapter on "
+"the engine. ``lora_path`` is passed to the engine unchanged, so it must "
+"be a path the engine can open. A second body form, ``{\"lora_name\": ...,"
+" \"artifact_url\": ...}``, makes the runtime download the artifact first;"
+" this is what the ModelAdapter controller sends."
+msgstr ""
+"请求体 ``{\"lora_name\": ..., \"lora_path\": ...}`` 。在引擎上加载适配器。``lora_path`` "
+"原样传给引擎，因此必须是引擎能打开的路径。第二种请求体形式 ``{\"lora_name\": ..., \"artifact_url\": ...}`` "
+"会先由 runtime 下载产物；这是 ModelAdapter 控制器发送的格式。"
+
+#: ../../source/features/runtime.rst:660
+msgid "``POST /v1/lora_adapter/unload``"
+msgstr "``POST /v1/lora_adapter/unload``"
+
+#: ../../source/features/runtime.rst:661
+#, python-brace-format
+msgid "Body ``{\"lora_name\": ...}``."
+msgstr "请求体 ``{\"lora_name\": ...}`` 。"
+
+#: ../../source/features/runtime.rst:662
+msgid "``GET /v1/models``"
+msgstr "``GET /v1/models``"
+
+#: ../../source/features/runtime.rst:663
+msgid "Models currently served by the engine, proxied from the engine."
+msgstr "引擎当前服务的模型，从引擎代理而来。"
+
+#: ../../source/features/runtime.rst:664
+msgid "``POST /v1/model/download``"
+msgstr "``POST /v1/model/download``"
+
+#: ../../source/features/runtime.rst:665
+#, python-brace-format
+msgid ""
+"Body ``{\"model_uri\": ..., \"local_dir\": ..., \"model_name\": ..., "
+"\"download_extra_config\": {...}}``. Only ``model_uri`` is required."
+msgstr ""
+"请求体 ``{\"model_uri\": ..., \"local_dir\": ..., \"model_name\": ..., \"download_extra_config\": "
+"{...}}`` 。仅 ``model_uri`` 为必填。"
+
+#: ../../source/features/runtime.rst:667
+msgid "``GET /v1/model/list``"
+msgstr "``GET /v1/model/list``"
+
+#: ../../source/features/runtime.rst:668
+#, python-brace-format
+msgid ""
+"Lists models present in a local directory. Takes an optional JSON body "
+"``{\"local_dir\": ...}`` (a body, not a query parameter, even though the "
+"method is GET); without it the runtime's default download directory is "
+"listed."
+msgstr ""
+"列出本地目录中的模型。接受可选 JSON 请求体 ``{\"local_dir\": ...}`` （尽管方法是 GET，这是请求体而非查询参数）；未提供时列出 "
+"runtime 的默认下载目录。"
+
+#: ../../source/features/runtime.rst:671
+msgid "``/v1/runtime/models/*`` and ``GET /v1/runtime/snapshot``"
+msgstr "``/v1/runtime/models/*`` 和 ``GET /v1/runtime/snapshot``"
+
+#: ../../source/features/runtime.rst:672
+msgid ""
+"Experimental engine lifecycle endpoints (``activate``, ``deactivate``, "
+"``sleep``, ``wake``, ``kv-limit``) used by :doc:`modelclaim`. Not "
+"intended for direct use."
+msgstr ""
+"实验性引擎生命周期接口（``activate`` 、``deactivate`` 、``sleep`` 、``wake`` 、``kv-limit`` "
+"），供 :doc:`modelclaim` 使用。不打算直接调用。"
+
+#: ../../source/features/runtime.rst:677
+msgid ":doc:`../designs/aibrix-engine-runtime`"
+msgstr ":doc:`../designs/aibrix-engine-runtime`"
+
+#: ../../source/features/runtime.rst:678
+msgid "Internal design of the AI Runtime sidecar."
+msgstr "AI Runtime sidecar 的内部设计。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/semantic-router.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/semantic-router.po
@@ -1,0 +1,926 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/semantic-router.rst:5
+msgid "vLLM Semantic Router"
+msgstr "vLLM Semantic Router"
+
+#: ../../source/features/semantic-router.rst:7
+msgid ""
+"Imagine you're building an AI assistant that handles everything — math "
+"homework, legal questions, creative writing, and medical queries. You "
+"*could* run a single large model for all of it. But what if you could "
+"automatically send math and physics questions to a reasoning-optimized "
+"model, and route everyday conversational queries to a faster, lighter "
+"model — all transparently, with no changes to how your clients make "
+"requests?"
+msgstr ""
+"假设你正在构建一个处理各类请求的 AI 助手——数学作业、法律问题、创意写作和医疗咨询。"
+"你*可以*用单个大模型处理全部请求。但如果能自动把数学和物理问题发给针对推理优化的模型，"
+"把日常对话发给更快、更轻的模型——且对客户端请求方式完全透明、无需改动呢？"
+
+#: ../../source/features/semantic-router.rst:9
+msgid ""
+"That's exactly what the **vLLM Semantic Router** does. It sits in front "
+"of your model fleet and classifies each incoming prompt by topic and "
+"intent, then forwards it to the best-fit model with the right "
+"configuration. Clients always call the same endpoint with the same API — "
+"the router handles the rest."
+msgstr ""
+"这正是 **vLLM Semantic Router** 所做的事。它位于模型集群前方，按主题和意图对每条"
+"入站 prompt 分类，再转发到最匹配的模型并带上合适配置。客户端始终用同一接口和同一 "
+"API 调用——其余由路由器处理。"
+
+#: ../../source/features/semantic-router.rst:11
+msgid ""
+"This guide walks you through deploying the semantic router with AIBrix "
+"and Envoy Gateway, using a concrete example that routes between "
+"``qwen3-8b`` (for STEM and reasoning tasks) and ``llama3-8b-instruct`` "
+"(for business, legal, and general queries)."
+msgstr ""
+"本指南介绍如何在 AIBrix 和 Envoy Gateway 上部署语义路由器，并用一个具体示例在 ``qwen3-8b`` （STEM 与推理任务）和 "
+"``llama3-8b-instruct`` （商务、法律与通用查询）之间路由。"
+
+#: ../../source/features/semantic-router.rst:14
+msgid ""
+"All sample manifests referenced in this guide live under `samples"
+"/semantic-router/ <https://github.com/vllm-"
+"project/aibrix/tree/main/samples/semantic-router>`_ in the AIBrix "
+"repository."
+msgstr ""
+"本指南引用的全部示例清单位于 AIBrix 仓库的 `samples/semantic-router/ <https://github.com/vllm-project/aibrix/tree/main/samples/semantic-router>`_ "
+"。"
+
+#: ../../source/features/semantic-router.rst:19
+msgid "How It Works"
+msgstr "工作原理"
+
+#: ../../source/features/semantic-router.rst:21
+msgid ""
+"The router integrates as an `Envoy External Processor (ext_proc) "
+"<https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_proc_filter>`_"
+" — a gRPC sidecar that Envoy consults before forwarding each request. "
+"Here's the full request path:"
+msgstr ""
+"路由器以 `Envoy External Processor (ext_proc) "
+"<https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_proc_filter>`_"
+" 方式集成——这是一个 gRPC sidecar，Envoy 在转发每个请求前会向其咨询。完整请求路径如下："
+
+#: ../../source/features/semantic-router.rst:39
+msgid "**What the router does for each request:**"
+msgstr "**路由器对每个请求执行的操作：**"
+
+#: ../../source/features/semantic-router.rst:41
+msgid "Receives the full buffered request body from Envoy over gRPC."
+msgstr "通过 gRPC 从 Envoy 接收完整缓冲的请求体。"
+
+#: ../../source/features/semantic-router.rst:42
+msgid "Extracts the user's message content."
+msgstr "提取用户消息内容。"
+
+#: ../../source/features/semantic-router.rst:43
+msgid ""
+"Runs an **embedding-based domain classifier** (or a fast **keyword "
+"scanner** for explicit signals like \"think step by step\")."
+msgstr "运行**基于 embedding 的领域分类器** （或对 \"think step by step\" 这类显式信号使用快速**关键词扫描器** ）。"
+
+#: ../../source/features/semantic-router.rst:44
+msgid "Selects the highest-priority matching decision."
+msgstr "选择优先级最高的匹配决策。"
+
+#: ../../source/features/semantic-router.rst:45
+msgid ""
+"Rewrites the request — replacing the ``model`` field, injecting a system "
+"prompt, and optionally enabling reasoning mode."
+msgstr "改写请求——替换 ``model`` 字段、注入系统提示词，并可选择启用推理模式。"
+
+#: ../../source/features/semantic-router.rst:46
+msgid ""
+"Returns the mutated request to Envoy, which forwards it to the selected "
+"backend."
+msgstr "将改写后的请求返回给 Envoy，再由其转发到所选后端。"
+
+#: ../../source/features/semantic-router.rst:48
+msgid ""
+"The client always uses ``\"model\": \"MoM\"`` (Model of Models). The "
+"router replaces this with the real backend model name. No client changes "
+"are needed."
+msgstr "客户端始终使用 ``\"model\": \"MoM\"`` （Model of Models）。路由器将其替换为真实后端模型名。无需改动客户端。"
+
+#: ../../source/features/semantic-router.rst:53
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/features/semantic-router.rst:55
+msgid "Before you begin, make sure you have:"
+msgstr "开始前请确认具备："
+
+#: ../../source/features/semantic-router.rst:57
+msgid ""
+"A running Kubernetes cluster with `AIBrix installed <https://github.com"
+"/vllm-project/aibrix>`_ (includes Envoy Gateway)."
+msgstr ""
+"已运行的 Kubernetes 集群，并已 `安装 AIBrix <https://github.com/vllm-project/aibrix>`_ "
+"（包含 Envoy Gateway）。"
+
+#: ../../source/features/semantic-router.rst:58
+msgid "``kubectl`` configured to talk to your cluster."
+msgstr "已配置 ``kubectl`` 以访问集群。"
+
+#: ../../source/features/semantic-router.rst:59
+msgid "GPU nodes available for model serving."
+msgstr "可用于模型服务的 GPU 节点。"
+
+#: ../../source/features/semantic-router.rst:60
+msgid "A Hugging Face account and API token (for downloading model weights)."
+msgstr "Hugging Face 账号和 API token（用于下载模型权重）。"
+
+#: ../../source/features/semantic-router.rst:61
+msgid ""
+"Model weights pre-staged on your nodes at ``/data01/models/``, or access "
+"to pull them from HuggingFace."
+msgstr "模型权重已预置在节点的 ``/data01/models/`` ，或可从 Hugging Face 拉取。"
+
+#: ../../source/features/semantic-router.rst:64
+msgid ""
+"The sample uses ``qwen3-8b`` and ``llama3-8b-instruct``. Each model "
+"requires one GPU with at least 48 GB of GPU memory."
+msgstr "示例使用 ``qwen3-8b`` 和 ``llama3-8b-instruct`` 。每个模型需要一块至少 48 GB 显存的 GPU。"
+
+#: ../../source/features/semantic-router.rst:69
+msgid "Step 1 — Create the Namespace and Credentials"
+msgstr "步骤 1 — 创建命名空间和凭证"
+
+#: ../../source/features/semantic-router.rst:71
+msgid ""
+"Create a dedicated namespace for the semantic router, then store your "
+"Hugging Face token as a Kubernetes secret (used by the router to download"
+" its embedding model):"
+msgstr ""
+"为语义路由器创建专用命名空间，然后将 Hugging Face token 存为 Kubernetes secret"
+"（路由器用于下载其 embedding 模型）："
+
+#: ../../source/features/semantic-router.rst:85
+msgid "Step 2 — Deploy the Backend Model Services"
+msgstr "步骤 2 — 部署后端模型服务"
+
+#: ../../source/features/semantic-router.rst:87
+msgid ""
+"The router needs the actual model servers to be running before it can "
+"forward requests. Deploy both backends:"
+msgstr "路由器转发请求前，实际模型服务必须已在运行。部署两个后端："
+
+#: ../../source/features/semantic-router.rst:94
+msgid ""
+"Each manifest creates a ``Deployment`` (3 replicas) and a ``Service`` in "
+"the ``default`` namespace. The AIBrix controller automatically creates an"
+" ``HTTPRoute`` for each model so Envoy Gateway can discover them."
+msgstr ""
+"每个清单在 ``default`` 命名空间中创建一个 ``Deployment`` （3 个副本）和一个 ``Service`` 。AIBrix "
+"控制器会为每个模型自动创建 ``HTTPRoute`` ，以便 Envoy Gateway 发现它们。"
+
+#: ../../source/features/semantic-router.rst:96
+msgid "Wait until both deployments are ready before proceeding:"
+msgstr "继续之前请等待两个部署都就绪："
+
+#: ../../source/features/semantic-router.rst:106
+msgid "Step 3 — Deploy the Semantic Router"
+msgstr "步骤 3 — 部署语义路由器"
+
+#: ../../source/features/semantic-router.rst:108
+msgid "Apply the router's ConfigMap (routing rules) and the router Deployment:"
+msgstr "应用路由器的 ConfigMap（路由规则）和路由器 Deployment："
+
+#: ../../source/features/semantic-router.rst:115
+msgid ""
+"The router container (``ghcr.io/vllm-project/semantic-"
+"router/extproc:latest``) downloads its embedding model at startup — allow"
+" up to **60 seconds** for this. You can watch progress with:"
+msgstr ""
+"路由器容器（``ghcr.io/vllm-project/semantic-router/extproc:latest`` ）在启动时下载 embedding "
+"模型——请预留最多 **60 秒** 。可用以下方式查看进度："
+
+#: ../../source/features/semantic-router.rst:121
+msgid "The router exposes three ports:"
+msgstr "路由器暴露三个端口："
+
+#: ../../source/features/semantic-router.rst:127
+msgid "Port"
+msgstr "端口"
+
+#: ../../source/features/semantic-router.rst:128
+msgid "Protocol"
+msgstr "协议"
+
+#: ../../source/features/semantic-router.rst:129
+msgid "Purpose"
+msgstr "用途"
+
+#: ../../source/features/semantic-router.rst:130
+msgid "``50051``"
+msgstr "``50051``"
+
+#: ../../source/features/semantic-router.rst:131
+msgid "gRPC"
+msgstr "gRPC"
+
+#: ../../source/features/semantic-router.rst:132
+msgid "ext_proc interface — receives requests from Envoy"
+msgstr "ext_proc 接口——接收来自 Envoy 的请求"
+
+#: ../../source/features/semantic-router.rst:133
+msgid "``8080``"
+msgstr "``8080``"
+
+#: ../../source/features/semantic-router.rst:134
+#: ../../source/features/semantic-router.rst:137
+msgid "HTTP"
+msgstr "HTTP"
+
+#: ../../source/features/semantic-router.rst:135
+msgid "Classification REST API (useful for debugging)"
+msgstr "分类 REST API（便于调试）"
+
+#: ../../source/features/semantic-router.rst:136
+msgid "``9190``"
+msgstr "``9190``"
+
+#: ../../source/features/semantic-router.rst:138
+msgid "Prometheus metrics"
+msgstr "Prometheus 指标"
+
+#: ../../source/features/semantic-router.rst:143
+msgid "Step 4 — Wire the Router into Envoy Gateway"
+msgstr "步骤 4 — 将路由器接入 Envoy Gateway"
+
+#: ../../source/features/semantic-router.rst:145
+msgid ""
+"Apply the Gateway API resources that register the semantic router as an "
+"ext_proc filter on the Envoy listener:"
+msgstr "应用 Gateway API 资源，将语义路由器注册为 Envoy 监听器上的 ext_proc 过滤器："
+
+#: ../../source/features/semantic-router.rst:151
+msgid "This applies an ``EnvoyPatchPolicy`` with two JSON patches:"
+msgstr "这会应用带两个 JSON patch 的 ``EnvoyPatchPolicy`` ："
+
+#: ../../source/features/semantic-router.rst:153
+msgid ""
+"**Patch 1** adds the ``semantic-router-extproc`` HTTP filter to Envoy's "
+"filter chain. It uses ``BUFFERED`` body mode so Envoy accumulates the "
+"complete request body before handing it to the router — no streaming "
+"complexity."
+msgstr ""
+"**Patch 1** 将 ``semantic-router-extproc`` HTTP 过滤器加入 Envoy 的过滤器链。"
+"它使用 ``BUFFERED`` body 模式，使 Envoy 在把请求交给路由器前累积完整请求体——"
+"无需处理流式复杂性。"
+
+#: ../../source/features/semantic-router.rst:155
+msgid ""
+"**Patch 2** registers the router as an upstream cluster (``STRICT_DNS``, "
+"HTTP/2 for gRPC) so Envoy knows how to reach it at ``semantic-router"
+".vllm-semantic-router-system.svc.cluster.local:50051``."
+msgstr ""
+"**Patch 2** 将路由器注册为上游集群（``STRICT_DNS`` ，gRPC 使用 HTTP/2），以便 Envoy 能访问 ``semantic-router.vllm-semantic-router-system.svc.cluster.local:50051`` "
+"。"
+
+#: ../../source/features/semantic-router.rst:157
+msgid "Verify the patch was accepted:"
+msgstr "确认 patch 已被接受："
+
+#: ../../source/features/semantic-router.rst:163
+msgid "Look for ``Status: True`` under ``Conditions``."
+msgstr "在 ``Conditions`` 下查找 ``Status: True`` 。"
+
+#: ../../source/features/semantic-router.rst:168
+msgid "Step 5 — Access the Gateway"
+msgstr "步骤 5 — 访问网关"
+
+#: ../../source/features/semantic-router.rst:170
+msgid "Port-forward the Envoy service to test locally:"
+msgstr "将 Envoy 服务端口转发到本地以便测试："
+
+#: ../../source/features/semantic-router.rst:180
+msgid "In production, use the LoadBalancer external IP instead:"
+msgstr "生产环境请改用 LoadBalancer 外部 IP："
+
+#: ../../source/features/semantic-router.rst:191
+msgid "Step 6 — Test Semantic Routing"
+msgstr "步骤 6 — 测试语义路由"
+
+#: ../../source/features/semantic-router.rst:193
+msgid ""
+"All requests use the virtual model name ``\"MoM\"`` (Model of Models). "
+"The router transparently selects the right backend."
+msgstr "所有请求使用虚拟模型名 ``\"MoM\"`` （Model of Models）。路由器透明地选择正确后端。"
+
+#: ../../source/features/semantic-router.rst:195
+msgid "**Math question → routed to qwen3-8b (reasoning enabled)**"
+msgstr "**数学问题 → 路由到 qwen3-8b（启用推理）**"
+
+#: ../../source/features/semantic-router.rst:209
+msgid ""
+"The router classifies this as the ``math`` domain, selects ``qwen3-8b``, "
+"injects a mathematics expert system prompt, and enables chain-of-thought "
+"reasoning (``chat_template_kwargs.enable_thinking: true``)."
+msgstr ""
+"路由器将其分类为 ``math`` 领域，选择 ``qwen3-8b`` ，注入数学专家系统提示词，并启用思维链推理（``chat_template_kwargs.enable_thinking: "
+"true`` ）。"
+
+#: ../../source/features/semantic-router.rst:211
+msgid "**Business question → routed to llama3-8b-instruct (standard mode)**"
+msgstr "**商务问题 → 路由到 llama3-8b-instruct（标准模式）**"
+
+#: ../../source/features/semantic-router.rst:225
+msgid "**Explicit reasoning trigger → overrides domain classification**"
+msgstr "**显式推理触发 → 覆盖领域分类**"
+
+#: ../../source/features/semantic-router.rst:227
+msgid ""
+"If the user explicitly asks for step-by-step thinking, the ``thinking`` "
+"keyword rule fires (priority 15, highest in the config) regardless of the"
+" detected domain:"
+msgstr ""
+"若用户明确要求逐步思考，无论检测到的领域是什么，``thinking`` 关键词规则都会触发"
+"（优先级 15，配置中最高）："
+
+#: ../../source/features/semantic-router.rst:241
+msgid ""
+"Even though this is a business query, \"walk me through\" matches the "
+"``thinking`` keyword set, so it routes to ``qwen3-8b`` with reasoning "
+"enabled."
+msgstr ""
+"尽管这是商务查询，\"walk me through\" 匹配 ``thinking`` 关键词集，因此路由到 "
+"``qwen3-8b`` 并启用推理。"
+
+#: ../../source/features/semantic-router.rst:246
+msgid "Routing Rules Reference"
+msgstr "路由规则参考"
+
+#: ../../source/features/semantic-router.rst:248
+msgid ""
+"The complete routing table for the sample (15 rules, defined in "
+"`semantic-router-configmap.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/semantic-router/semantic-router-"
+"configmap.yaml>`_):"
+msgstr ""
+"示例的完整路由表（15 条规则，定义于 `semantic-router-configmap.yaml <https://github.com/vllm-project/aibrix/blob/main/samples/semantic-router/semantic-router-configmap.yaml>`_ "
+"）："
+
+#: ../../source/features/semantic-router.rst:254
+msgid "Domain / Keyword"
+msgstr "领域 / 关键词"
+
+#: ../../source/features/semantic-router.rst:255
+msgid "Match Type"
+msgstr "匹配类型"
+
+#: ../../source/features/semantic-router.rst:256
+msgid "Model"
+msgstr "模型"
+
+#: ../../source/features/semantic-router.rst:257
+msgid "Reasoning"
+msgstr "推理"
+
+#: ../../source/features/semantic-router.rst:258
+msgid "Priority"
+msgstr "优先级"
+
+#: ../../source/features/semantic-router.rst:259
+msgid ""
+"``thinking`` (keywords: *step by step, think step, chain of thought, "
+"reason through, show your work, walk me through*)"
+msgstr ""
+"``thinking`` （关键词：*step by step, think step, chain of thought, reason through, "
+"show your work, walk me through*）"
+
+#: ../../source/features/semantic-router.rst:260
+msgid "keyword"
+msgstr "keyword"
+
+#: ../../source/features/semantic-router.rst:261
+#: ../../source/features/semantic-router.rst:266
+#: ../../source/features/semantic-router.rst:271
+#: ../../source/features/semantic-router.rst:276
+#: ../../source/features/semantic-router.rst:281
+#: ../../source/features/semantic-router.rst:286
+#: ../../source/features/semantic-router.rst:291
+msgid "``qwen3-8b``"
+msgstr "``qwen3-8b``"
+
+#: ../../source/features/semantic-router.rst:262
+#: ../../source/features/semantic-router.rst:267
+#: ../../source/features/semantic-router.rst:272
+#: ../../source/features/semantic-router.rst:277
+#: ../../source/features/semantic-router.rst:282
+#: ../../source/features/semantic-router.rst:287
+#: ../../source/features/semantic-router.rst:292
+msgid "on"
+msgstr "on"
+
+#: ../../source/features/semantic-router.rst:263
+msgid "15"
+msgstr "15"
+
+#: ../../source/features/semantic-router.rst:264
+msgid "``math``"
+msgstr "``math``"
+
+#: ../../source/features/semantic-router.rst:265
+#: ../../source/features/semantic-router.rst:270
+#: ../../source/features/semantic-router.rst:275
+#: ../../source/features/semantic-router.rst:280
+#: ../../source/features/semantic-router.rst:285
+#: ../../source/features/semantic-router.rst:290
+#: ../../source/features/semantic-router.rst:295
+#: ../../source/features/semantic-router.rst:300
+#: ../../source/features/semantic-router.rst:305
+#: ../../source/features/semantic-router.rst:310
+#: ../../source/features/semantic-router.rst:315
+#: ../../source/features/semantic-router.rst:320
+#: ../../source/features/semantic-router.rst:325
+#: ../../source/features/semantic-router.rst:330
+msgid "domain"
+msgstr "domain"
+
+#: ../../source/features/semantic-router.rst:268
+#: ../../source/features/semantic-router.rst:273
+#: ../../source/features/semantic-router.rst:278
+#: ../../source/features/semantic-router.rst:283
+#: ../../source/features/semantic-router.rst:288
+#: ../../source/features/semantic-router.rst:293
+#: ../../source/features/semantic-router.rst:298
+#: ../../source/features/semantic-router.rst:303
+#: ../../source/features/semantic-router.rst:308
+#: ../../source/features/semantic-router.rst:313
+#: ../../source/features/semantic-router.rst:318
+#: ../../source/features/semantic-router.rst:323
+#: ../../source/features/semantic-router.rst:328
+msgid "10"
+msgstr "10"
+
+#: ../../source/features/semantic-router.rst:269
+msgid "``physics``"
+msgstr "``physics``"
+
+#: ../../source/features/semantic-router.rst:274
+msgid "``computer science``"
+msgstr "``computer science``"
+
+#: ../../source/features/semantic-router.rst:279
+msgid "``biology``"
+msgstr "``biology``"
+
+#: ../../source/features/semantic-router.rst:284
+msgid "``chemistry``"
+msgstr "``chemistry``"
+
+#: ../../source/features/semantic-router.rst:289
+msgid "``engineering``"
+msgstr "``engineering``"
+
+#: ../../source/features/semantic-router.rst:294
+msgid "``business``"
+msgstr "``business``"
+
+#: ../../source/features/semantic-router.rst:296
+#: ../../source/features/semantic-router.rst:301
+#: ../../source/features/semantic-router.rst:306
+#: ../../source/features/semantic-router.rst:311
+#: ../../source/features/semantic-router.rst:316
+#: ../../source/features/semantic-router.rst:321
+#: ../../source/features/semantic-router.rst:326
+#: ../../source/features/semantic-router.rst:331
+msgid "``llama3-8b-instruct``"
+msgstr "``llama3-8b-instruct``"
+
+#: ../../source/features/semantic-router.rst:297
+#: ../../source/features/semantic-router.rst:302
+#: ../../source/features/semantic-router.rst:307
+#: ../../source/features/semantic-router.rst:312
+#: ../../source/features/semantic-router.rst:317
+#: ../../source/features/semantic-router.rst:322
+#: ../../source/features/semantic-router.rst:327
+#: ../../source/features/semantic-router.rst:332
+msgid "off"
+msgstr "off"
+
+#: ../../source/features/semantic-router.rst:299
+msgid "``law``"
+msgstr "``law``"
+
+#: ../../source/features/semantic-router.rst:304
+msgid "``psychology``"
+msgstr "``psychology``"
+
+#: ../../source/features/semantic-router.rst:309
+msgid "``health``"
+msgstr "``health``"
+
+#: ../../source/features/semantic-router.rst:314
+msgid "``economics``"
+msgstr "``economics``"
+
+#: ../../source/features/semantic-router.rst:319
+msgid "``history``"
+msgstr "``history``"
+
+#: ../../source/features/semantic-router.rst:324
+msgid "``philosophy``"
+msgstr "``philosophy``"
+
+#: ../../source/features/semantic-router.rst:329
+msgid "``other`` (catch-all)"
+msgstr "``other`` （兜底）"
+
+#: ../../source/features/semantic-router.rst:333
+msgid "5"
+msgstr "5"
+
+#: ../../source/features/semantic-router.rst:335
+msgid ""
+"Higher priority rules are evaluated first. The ``thinking`` keyword rule "
+"(priority 15) always overrides domain rules (priority 10)."
+msgstr ""
+"优先级更高的规则先评估。``thinking`` 关键词规则（优先级 15）始终覆盖领域规则"
+"（优先级 10）。"
+
+#: ../../source/features/semantic-router.rst:340
+msgid "Understanding the Configuration"
+msgstr "理解配置"
+
+#: ../../source/features/semantic-router.rst:342
+msgid ""
+"All routing behavior is controlled by `semantic-router-configmap.yaml "
+"<https://github.com/vllm-project/aibrix/blob/main/samples/semantic-router"
+"/semantic-router-configmap.yaml>`_. Here's how the key pieces fit "
+"together."
+msgstr ""
+"全部路由行为由 `semantic-router-configmap.yaml "
+"<https://github.com/vllm-project/aibrix/blob/main/samples/semantic-router"
+"/semantic-router-configmap.yaml>`_ 控制。以下是各关键部分如何配合。"
+
+#: ../../source/features/semantic-router.rst:345
+msgid "Decision Structure"
+msgstr "决策结构"
+
+#: ../../source/features/semantic-router.rst:347
+msgid "Each routing decision looks like this:"
+msgstr "每条路由决策如下："
+
+#: ../../source/features/semantic-router.rst:372
+msgid "Rule Types"
+msgstr "规则类型"
+
+#: ../../source/features/semantic-router.rst:378
+msgid "Type"
+msgstr "类型"
+
+#: ../../source/features/semantic-router.rst:379
+msgid "How it matches"
+msgstr "匹配方式"
+
+#: ../../source/features/semantic-router.rst:380
+msgid "``domain``"
+msgstr "``domain``"
+
+#: ../../source/features/semantic-router.rst:381
+msgid ""
+"Embedding-based cosine similarity between the prompt and a named domain "
+"label. The router picks the domain whose embedding is closest to the "
+"prompt."
+msgstr ""
+"prompt 与命名领域标签之间基于 embedding 的余弦相似度。路由器选择 embedding 最接近 "
+"prompt 的领域。"
+
+#: ../../source/features/semantic-router.rst:382
+msgid "``keyword``"
+msgstr "``keyword``"
+
+#: ../../source/features/semantic-router.rst:383
+msgid ""
+"Fast exact substring search (case-insensitive by default). Matches if any"
+" keyword in the set appears anywhere in the prompt."
+msgstr ""
+"快速精确子串搜索（默认不区分大小写）。集合中任一关键词出现在 prompt 任意位置即匹配。"
+
+#: ../../source/features/semantic-router.rst:386
+msgid "Priority Strategy"
+msgstr "优先级策略"
+
+#: ../../source/features/semantic-router.rst:388
+msgid "With ``strategy: priority`` (the default):"
+msgstr "使用 ``strategy: priority`` （默认）时："
+
+#: ../../source/features/semantic-router.rst:390
+msgid "All decisions whose rules match the prompt are collected."
+msgstr "收集规则匹配该 prompt 的全部决策。"
+
+#: ../../source/features/semantic-router.rst:391
+msgid "The decision with the **highest ``priority`` value** wins."
+msgstr "**``priority`` 值最高** 的决策胜出。"
+
+#: ../../source/features/semantic-router.rst:392
+msgid "Ties are broken by **declaration order** in the YAML — first wins."
+msgstr "平局按 YAML 中的**声明顺序** 打破——先声明者胜出。"
+
+#: ../../source/features/semantic-router.rst:395
+msgid "Signals Catalog"
+msgstr "信号目录"
+
+#: ../../source/features/semantic-router.rst:397
+msgid ""
+"Every domain or keyword set used in rules must be declared under "
+"``routing.signals``:"
+msgstr "规则中使用的每个领域或关键词集必须在 ``routing.signals`` 下声明："
+
+#: ../../source/features/semantic-router.rst:421
+msgid "Model Reasoning Activation"
+msgstr "模型推理激活"
+
+#: ../../source/features/semantic-router.rst:423
+msgid ""
+"The ``use_reasoning: true/false`` flag on a ``modelRef`` controls whether"
+" the router injects reasoning-activation parameters into the forwarded "
+"request. Different model families use different parameters."
+msgstr ""
+"``modelRef`` 上的 ``use_reasoning: true/false`` 标志控制路由器是否向转发请求注入"
+"推理激活参数。不同模型族使用不同参数。"
+
+#: ../../source/features/semantic-router.rst:426
+msgid "Reasoning Families"
+msgstr "推理族"
+
+#: ../../source/features/semantic-router.rst:428
+msgid "Defined under ``providers.defaults.reasoning_families``:"
+msgstr "定义在 ``providers.defaults.reasoning_families`` 下："
+
+#: ../../source/features/semantic-router.rst:447
+msgid "Assigning a Reasoning Family to a Model"
+msgstr "为模型指定推理族"
+
+#: ../../source/features/semantic-router.rst:466
+msgid ""
+"When ``use_reasoning: true`` fires for ``qwen3-8b``, the router adds to "
+"the outbound request body:"
+msgstr "当 ``qwen3-8b`` 触发 ``use_reasoning: true`` 时，路由器向出站请求体添加："
+
+#: ../../source/features/semantic-router.rst:476
+msgid ""
+"vLLM reads this field and activates Qwen3's built-in chain-of-thought "
+"path."
+msgstr "vLLM 读取该字段并激活 Qwen3 内置的思维链路径。"
+
+#: ../../source/features/semantic-router.rst:481
+msgid "Plugins"
+msgstr "插件"
+
+#: ../../source/features/semantic-router.rst:483
+msgid "Plugins are applied in declaration order after a decision is selected."
+msgstr "选定决策后，插件按声明顺序应用。"
+
+#: ../../source/features/semantic-router.rst:486
+msgid "System Prompt Plugin"
+msgstr "系统提示词插件"
+
+#: ../../source/features/semantic-router.rst:488
+msgid "Injects or replaces the system message in ``messages[]``:"
+msgstr "注入或替换 ``messages[]`` 中的系统消息："
+
+#: ../../source/features/semantic-router.rst:503
+msgid "Mode"
+msgstr "模式"
+
+#: ../../source/features/semantic-router.rst:504
+msgid "Behaviour"
+msgstr "行为"
+
+#: ../../source/features/semantic-router.rst:505
+msgid "``replace``"
+msgstr "``replace``"
+
+#: ../../source/features/semantic-router.rst:506
+msgid "Removes any existing system message and prepends a new one."
+msgstr "移除已有系统消息并在开头插入新的系统消息。"
+
+#: ../../source/features/semantic-router.rst:507
+msgid "``prepend``"
+msgstr "``prepend``"
+
+#: ../../source/features/semantic-router.rst:508
+msgid "Inserts before existing system messages."
+msgstr "插入到已有系统消息之前。"
+
+#: ../../source/features/semantic-router.rst:509
+msgid "``append``"
+msgstr "``append``"
+
+#: ../../source/features/semantic-router.rst:510
+msgid "Inserts after existing system messages."
+msgstr "插入到已有系统消息之后。"
+
+#: ../../source/features/semantic-router.rst:513
+msgid "Semantic Cache Plugin"
+msgstr "语义缓存插件"
+
+#: ../../source/features/semantic-router.rst:515
+msgid ""
+"Caches responses by prompt embedding similarity. On a cache hit the "
+"router short-circuits the backend call and returns the cached response "
+"directly — great for frequently repeated queries:"
+msgstr ""
+"按 prompt embedding 相似度缓存响应。命中缓存时，路由器短路后端调用并直接返回缓存响应——"
+"适合频繁重复的查询："
+
+#: ../../source/features/semantic-router.rst:525
+msgid ""
+"Global cache settings (TTL, max entries, eviction) are configured under "
+"``global.stores.semantic_cache``:"
+msgstr "全局缓存设置（TTL、最大条目数、驱逐）配置在 ``global.stores.semantic_cache`` 下："
+
+#: ../../source/features/semantic-router.rst:541
+msgid ""
+"The semantic cache is particularly valuable for domains like ``health`` "
+"(threshold 0.95 — very strict) and ``other`` (threshold 0.75 — more "
+"permissive), where many users ask similar questions with slightly "
+"different wording."
+msgstr ""
+"语义缓存在 ``health`` （阈值 0.95——非常严格）和 ``other`` （阈值 0.75——更宽松）这类领域尤其有用，许多用户会用略有不同的措辞提出相似问题。"
+
+#: ../../source/features/semantic-router.rst:546
+msgid "Adding a New Route"
+msgstr "添加新路由"
+
+#: ../../source/features/semantic-router.rst:548
+msgid ""
+"Adding a new topic (e.g., \"cybersecurity\") takes three steps and a "
+"config reload:"
+msgstr "添加新主题（例如 \"cybersecurity\"）需要三步并重新加载配置："
+
+#: ../../source/features/semantic-router.rst:550
+msgid "**1. Declare the domain** under ``routing.signals.domains``:"
+msgstr "**1. 声明领域** ，写在 ``routing.signals.domains`` 下："
+
+#: ../../source/features/semantic-router.rst:556
+msgid "**2. Add the decision** under ``routing.decisions``:"
+msgstr "**2. 添加决策** ，写在 ``routing.decisions`` 下："
+
+#: ../../source/features/semantic-router.rst:578
+msgid "**3. Apply and reload**:"
+msgstr "**3. 应用并重新加载：**"
+
+#: ../../source/features/semantic-router.rst:590
+msgid "Observability"
+msgstr "可观测性"
+
+#: ../../source/features/semantic-router.rst:592
+msgid ""
+"The router exposes Prometheus metrics on port ``9190``. To scrape them "
+"locally:"
+msgstr "路由器在端口 ``9190`` 暴露 Prometheus 指标。要在本地抓取："
+
+#: ../../source/features/semantic-router.rst:599
+msgid ""
+"Then open ``http://localhost:9190/metrics`` in your browser or point "
+"Prometheus at it."
+msgstr "然后在浏览器中打开 ``http://localhost:9190/metrics`` ，或让 Prometheus 指向它。"
+
+#: ../../source/features/semantic-router.rst:601
+msgid ""
+"To enable distributed tracing (OpenTelemetry / Jaeger), set the following"
+" in the ConfigMap:"
+msgstr "要启用分布式追踪（OpenTelemetry / Jaeger），在 ConfigMap 中设置："
+
+#: ../../source/features/semantic-router.rst:618
+msgid "Troubleshooting"
+msgstr "故障排查"
+
+#: ../../source/features/semantic-router.rst:620
+msgid "**Router pod is slow to start**"
+msgstr "**路由器 Pod 启动较慢**"
+
+#: ../../source/features/semantic-router.rst:622
+msgid ""
+"The embedding model download can take up to 60 seconds. The startup probe"
+" retries for up to 60 minutes (``failureThreshold: 360``), so the pod "
+"will eventually become ready. Watch the logs:"
+msgstr ""
+"embedding 模型下载最多可能需要 60 秒。启动探针最多重试 60 分钟（``failureThreshold: 360`` ），因此 "
+"Pod 最终会就绪。查看日志："
+
+#: ../../source/features/semantic-router.rst:628
+msgid "**Envoy can't reach the router**"
+msgstr "**Envoy 无法访问路由器**"
+
+#: ../../source/features/semantic-router.rst:630
+msgid "Verify the EnvoyPatchPolicy was accepted:"
+msgstr "确认 EnvoyPatchPolicy 已被接受："
+
+#: ../../source/features/semantic-router.rst:636
+msgid "Check that the router Service is reachable:"
+msgstr "检查路由器 Service 是否可达："
+
+#: ../../source/features/semantic-router.rst:642
+msgid "**All requests go to the fallback model**"
+msgstr "**所有请求都落到兜底模型**"
+
+#: ../../source/features/semantic-router.rst:644
+msgid ""
+"The ``other_decision`` (priority 5) catches any prompt that doesn't match"
+" a known domain. Check whether the domain embeddings are loaded by "
+"querying the classification API directly:"
+msgstr "``other_decision`` （优先级 5）捕获任何未匹配已知领域的 prompt。可直接查询分类 API，确认领域 embedding 是否已加载："
+
+#: ../../source/features/semantic-router.rst:654
+msgid "**Config changes aren't taking effect**"
+msgstr "**配置变更未生效**"
+
+#: ../../source/features/semantic-router.rst:656
+msgid ""
+"The router reads config at startup. After applying a new ConfigMap, "
+"rolling-restart the deployment:"
+msgstr "路由器在启动时读取配置。应用新 ConfigMap 后，滚动重启 Deployment："
+
+#: ../../source/features/semantic-router.rst:665
+msgid "Sample Files"
+msgstr "示例文件"
+
+#: ../../source/features/semantic-router.rst:667
+msgid "All manifests for this example are in the AIBrix repository:"
+msgstr "本示例的全部清单位于 AIBrix 仓库："
+
+#: ../../source/features/semantic-router.rst:669
+msgid ""
+"`samples/semantic-router/README.md <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/semantic-router/README.md>`_ — quick-"
+"start guide"
+msgstr ""
+"`samples/semantic-router/README.md <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/semantic-router/README.md>`_ — 快速入门"
+
+#: ../../source/features/semantic-router.rst:670
+msgid ""
+"`samples/semantic-router/DESIGN.md <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/semantic-router/DESIGN.md>`_ — deep-dive"
+" architecture reference"
+msgstr ""
+"`samples/semantic-router/DESIGN.md <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/semantic-router/DESIGN.md>`_ — 架构深入参考"
+
+#: ../../source/features/semantic-router.rst:671
+msgid ""
+"`samples/semantic-router/semantic-router-configmap.yaml "
+"<https://github.com/vllm-project/aibrix/blob/main/samples/semantic-router"
+"/semantic-router-configmap.yaml>`_ — full routing configuration with all "
+"15 rules"
+msgstr ""
+"`samples/semantic-router/semantic-router-configmap.yaml "
+"<https://github.com/vllm-project/aibrix/blob/main/samples/semantic-router"
+"/semantic-router-configmap.yaml>`_ — 包含全部 15 条规则的完整路由配置"
+
+#: ../../source/features/semantic-router.rst:672
+msgid ""
+"`samples/semantic-router/semantic-router.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/semantic-router/semantic-router.yaml>`_ "
+"— router Deployment, Services, and RBAC"
+msgstr ""
+"`samples/semantic-router/semantic-router.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/semantic-router/semantic-router.yaml>`_ "
+"— 路由器 Deployment、Service 和 RBAC"
+
+#: ../../source/features/semantic-router.rst:673
+msgid ""
+"`samples/semantic-router/gwapi-resources.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/semantic-router/gwapi-resources.yaml>`_ "
+"— EnvoyPatchPolicy that wires the router into the gateway"
+msgstr ""
+"`samples/semantic-router/gwapi-resources.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/semantic-router/gwapi-resources.yaml>`_ "
+"— 将路由器接入网关的 EnvoyPatchPolicy"
+
+#: ../../source/features/semantic-router.rst:674
+msgid ""
+"`samples/semantic-router/models/ <https://github.com/vllm-"
+"project/aibrix/tree/main/samples/semantic-router/models>`_ — model "
+"Deployment and Service manifests"
+msgstr ""
+"`samples/semantic-router/models/ <https://github.com/vllm-"
+"project/aibrix/tree/main/samples/semantic-router/models>`_ — 模型 Deployment "
+"和 Service 清单"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/features/vllm-omni.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/features/vllm-omni.po
@@ -1,0 +1,448 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/features/vllm-omni.rst:5
+msgid "vLLM-Omni Multi-Modal Serving"
+msgstr "vLLM-Omni 多模态服务"
+
+#: ../../source/features/vllm-omni.rst:7
+msgid ""
+"`vLLM-Omni <https://docs.vllm.ai/projects/vllm-omni/en/stable/>`_ extends"
+" vLLM's OpenAI-compatible serving to non-text modalities — image "
+"generation/editing, speech and general audio, and video generation — "
+"behind the same ``vllm serve`` entrypoint you already use for LLMs. "
+"AIBrix's gateway understands these endpoints natively: it routes requests"
+" to the right backend pods and, for video generation specifically, keeps "
+"track of which pod owns each in-progress job so follow-up calls land back"
+" on it."
+msgstr ""
+"`vLLM-Omni <https://docs.vllm.ai/projects/vllm-omni/en/stable/>`_ 将 vLLM "
+"的 OpenAI 兼容服务扩展到非文本模态——图像生成/编辑、语音与通用音频、以及视频生成——"
+"仍使用你已用于 LLM 的同一 ``vllm serve`` 入口。AIBrix 网关原生识别这些接口："
+"它将请求路由到正确的后端 Pod；对于视频生成，还会跟踪每个进行中任务由哪个 Pod 持有，"
+"以便后续调用回到同一 Pod。"
+
+#: ../../source/features/vllm-omni.rst:9
+msgid ""
+"This guide walks through deploying a vLLM-Omni video generation model — "
+"`Wan-AI/Wan2.1-VACE-1.3B-diffusers <https://huggingface.co/Wan-"
+"AI/Wan2.1-VACE-1.3B-diffusers>`_ — and driving it through AIBrix's "
+"gateway, both synchronously and as an async job you poll and download."
+msgstr ""
+"本指南介绍如何部署 vLLM-Omni 视频生成模型 `Wan-AI/Wan2.1-VACE-1.3B-diffusers <https://huggingface.co/Wan-AI/Wan2.1-VACE-1.3B-diffusers>`_ "
+"，并通过 AIBrix 网关调用：既支持同步生成，也支持异步任务轮询与下载。"
+
+#: ../../source/features/vllm-omni.rst:12
+msgid ""
+"The sample manifest referenced in this guide lives at "
+"`samples/vllm_omni/wan2.1-vace-1.3b.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/vllm_omni/wan2.1-vace-1.3b.yaml>`_ in "
+"the AIBrix repository. A text+audio example (`Qwen/Qwen2.5-Omni-7B "
+"<https://huggingface.co/Qwen/Qwen2.5-Omni-7B>`_) is also available at "
+"`samples/vllm_omni/qwen2-5-omni-7b.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/vllm_omni/qwen2-5-omni-7b.yaml>`_."
+msgstr ""
+"本指南引用的示例清单位于 AIBrix 仓库的 `samples/vllm_omni/wan2.1-vace-1.3b.yaml <https://github.com/vllm-project/aibrix/blob/main/samples/vllm_omni/wan2.1-vace-1.3b.yaml>`_ "
+"。文本+音频示例（`Qwen/Qwen2.5-Omni-7B <https://huggingface.co/Qwen/Qwen2.5-Omni-7B>`_ "
+"）见 `samples/vllm_omni/qwen2-5-omni-7b.yaml <https://github.com/vllm-project/aibrix/blob/main/samples/vllm_omni/qwen2-5-omni-7b.yaml>`_ "
+"。"
+
+#: ../../source/features/vllm-omni.rst:17
+msgid "How It Works"
+msgstr "工作原理"
+
+#: ../../source/features/vllm-omni.rst:19
+msgid ""
+"A vLLM-Omni pod is started the same way as any other model in AIBrix — a "
+"``Deployment`` labeled with ``model.aibrix.ai/name`` and a matching "
+"``Service`` — with one difference: passing ``--omni`` to ``vllm serve``. "
+"That flag auto-detects the model's task from its architecture and exposes"
+" the matching OpenAI-compatible endpoint (``/v1/images/generations``, "
+"``/v1/audio/speech``, ``/v1/videos``, ...)."
+msgstr ""
+"vLLM-Omni Pod 的启动方式与 AIBrix 中其他模型相同：带 ``model.aibrix.ai/name`` 标签的 ``Deployment`` "
+"以及对应的 ``Service`` 。区别是向 ``vllm serve`` 传入 ``--omni`` 。该标志根据模型架构自动识别任务，并暴露对应的 "
+"OpenAI 兼容接口（``/v1/images/generations`` 、``/v1/audio/speech`` 、``/v1/videos`` "
+"等）。"
+
+#: ../../source/features/vllm-omni.rst:21
+msgid ""
+"The stock gateway already matches ``/v1/videos`` on the reserved "
+"HTTPRoute (so requests reach ext_proc before a ``model`` header exists) "
+"and uses 600s Envoy / ext_proc / model-HTTPRoute timeouts so synchronous "
+"generation can finish. If you installed an older AIBrix release, add a "
+"PathPrefix ``/v1/videos`` match to ``aibrix-reserved-router`` and set "
+"``AIBRIX_GATEWAY_TIMEOUT_SECONDS=600`` on the controller-manager."
+msgstr ""
+"默认网关已在保留 HTTPRoute 上匹配 ``/v1/videos`` （因此请求在尚无 ``model`` 头时即可到达 ext_proc），并将 "
+"Envoy / ext_proc / 模型 HTTPRoute 超时设为 600s，以便同步生成能够完成。若安装的是较旧的 AIBrix 版本，请为 "
+"``aibrix-reserved-router`` 添加 PathPrefix ``/v1/videos`` 匹配，并在 controller-manager "
+"上设置 ``AIBRIX_GATEWAY_TIMEOUT_SECONDS=600`` 。"
+
+#: ../../source/features/vllm-omni.rst:23
+msgid ""
+"Video generation needs a bit more from the gateway than a stateless chat "
+"completion does. Because a generated video is written to local disk on "
+"whichever pod created it, the gateway has to remember that pod-to-job "
+"mapping and route follow-up calls back to the exact same pod:"
+msgstr ""
+"视频生成对网关的要求高于无状态 chat completion。生成的视频写在创建它的 Pod "
+"本地磁盘上，因此网关必须记住 Pod 与任务的映射，并将后续调用路由回同一 Pod："
+
+#: ../../source/features/vllm-omni.rst:38
+msgid ""
+"This mapping is kept in-memory per gateway replica and, when the gateway "
+"is configured with Redis, written through to Redis too — so a job created"
+" via one gateway replica can still be polled or fetched through a "
+"different replica. An unknown, expired, or no-longer-live video ID "
+"returns ``404`` rather than routing nowhere."
+msgstr ""
+"该映射保存在每个网关副本的内存中；若网关配置了 Redis，还会写入 Redis。因此通过一个网关副本创建的任务，仍可通过另一个副本轮询或获取。未知、过期或所属 "
+"Pod 已不存活的视频 ID 返回 ``404`` ，而不是路由到空处。"
+
+#: ../../source/features/vllm-omni.rst:40
+msgid ""
+"``POST /v1/videos/sync`` and image/audio endpoints don't need any of "
+"this: they're a single request/response, so ordinary model-based routing "
+"is enough."
+msgstr ""
+"``POST /v1/videos/sync`` 以及图像/音频接口不需要上述机制：它们是单次请求/响应，"
+"普通的基于模型路由即可。"
+
+#: ../../source/features/vllm-omni.rst:45
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/features/vllm-omni.rst:47
+msgid "Before you begin, make sure you have:"
+msgstr "开始前请确认具备："
+
+#: ../../source/features/vllm-omni.rst:49
+msgid ""
+"A running Kubernetes cluster with `AIBrix installed <https://github.com"
+"/vllm-project/aibrix>`_ (includes Envoy Gateway)."
+msgstr ""
+"已运行的 Kubernetes 集群，并已 `安装 AIBrix <https://github.com/vllm-project/aibrix>`_ "
+"（包含 Envoy Gateway）。"
+
+#: ../../source/features/vllm-omni.rst:50
+msgid "``kubectl`` configured to talk to your cluster."
+msgstr "已配置 ``kubectl`` 以访问集群。"
+
+#: ../../source/features/vllm-omni.rst:51
+msgid ""
+"A GPU node (one GPU is enough for the 1.3B-parameter Wan model used "
+"below)."
+msgstr "一个 GPU 节点（下方使用的 1.3B 参数 Wan 模型一块 GPU 即可）。"
+
+#: ../../source/features/vllm-omni.rst:52
+msgid "``jq`` and ``curl`` for the examples below."
+msgstr "运行下方示例所需的 ``jq`` 和 ``curl`` 。"
+
+#: ../../source/features/vllm-omni.rst:57
+msgid "Step 1 — Deploy the Video Generation Model"
+msgstr "步骤 1 — 部署视频生成模型"
+
+#: ../../source/features/vllm-omni.rst:62
+msgid ""
+"Apply it and wait for the pod to become ready. The model is loaded from "
+"the host path ``/data00/models/Wan2.1-VACE-1.3B-diffusers`` (mounted at "
+"``/models``), so the weights must already be present on the node:"
+msgstr ""
+"应用清单并等待 Pod 就绪。模型从主机路径 ``/data00/models/Wan2.1-VACE-1.3B-diffusers`` 加载（挂载到 "
+"``/models`` ），因此权重必须已存在于该节点："
+
+#: ../../source/features/vllm-omni.rst:70
+msgid ""
+"To serve a different vLLM-Omni model (a different video model, or an "
+"image/audio one like ``qwen2-5-omni-7b.yaml``), swap the container's "
+"``vllm serve <model>`` argument, ``--served-model-name``, and the "
+"``model.aibrix.ai/name``/Service name — the request shape stays the same "
+"as long as the model belongs to the same task family. See vLLM-Omni's "
+"`supported models list <https://docs.vllm.ai/projects/vllm-"
+"omni/en/stable/>`_."
+msgstr ""
+"若要服务其他 vLLM-Omni 模型（其他视频模型，或 ``qwen2-5-omni-7b.yaml`` 这类图像/音频模型），替换容器的 ``vllm "
+"serve <model>`` 参数、``--served-model-name`` ，以及 ``model.aibrix.ai/name``/Service "
+"名称。只要模型属于同一任务族，请求形态保持不变。参见 vLLM-Omni 的 `支持模型列表 <https://docs.vllm.ai/projects/vllm-omni/en/stable/>`_ "
+"。"
+
+#: ../../source/features/vllm-omni.rst:75
+msgid "Step 2 — Access the Gateway"
+msgstr "步骤 2 — 访问网关"
+
+#: ../../source/features/vllm-omni.rst:77
+msgid "Port-forward the Envoy service to test locally:"
+msgstr "将 Envoy 服务端口转发到本地以便测试："
+
+#: ../../source/features/vllm-omni.rst:89
+msgid "In production, use the LoadBalancer external IP instead:"
+msgstr "生产环境请改用 LoadBalancer 外部 IP："
+
+#: ../../source/features/vllm-omni.rst:102
+msgid "Step 3 — Generate a Video Synchronously"
+msgstr "步骤 3 — 同步生成视频"
+
+#: ../../source/features/vllm-omni.rst:104
+msgid ""
+"``POST /v1/videos/sync`` blocks until generation completes and returns "
+"the raw MP4 bytes directly. Both video endpoints take ``multipart/form-"
+"data`` — do **not** set ``-H \"Content-Type: application/json\"``."
+msgstr ""
+"``POST /v1/videos/sync`` 会阻塞直到生成完成，并直接返回原始 MP4 字节。两个视频接口均接受 ``multipart/form-data``——**不要** "
+"设置 ``-H \"Content-Type: application/json\"`` 。"
+
+#: ../../source/features/vllm-omni.rst:124
+msgid ""
+"**Image-to-video**: VACE also supports using a reference image as the "
+"starting frame — pass it via ``input_reference``:"
+msgstr "**图生视频** ：VACE 也支持将参考图像作为起始帧——通过 ``input_reference`` 传入："
+
+#: ../../source/features/vllm-omni.rst:141
+msgid "Step 4 — Generate a Video Asynchronously"
+msgstr "步骤 4 — 异步生成视频"
+
+#: ../../source/features/vllm-omni.rst:143
+msgid ""
+"For longer generations, ``POST /v1/videos`` returns immediately with a "
+"job ID while generation continues in the background — poll for status and"
+" fetch the result once it's done."
+msgstr ""
+"对于更长的生成，``POST /v1/videos`` 立即返回任务 ID，生成在后台继续。"
+"轮询状态，完成后获取结果。"
+
+#: ../../source/features/vllm-omni.rst:145
+msgid "**Submit the job:**"
+msgstr "**提交任务：**"
+
+#: ../../source/features/vllm-omni.rst:165
+msgid ""
+"The raw response (before extracting ``.id``) looks like this. The same "
+"shape is returned by the poll step below, with ``status``, ``progress``, "
+"and ``completed_at`` updated as generation proceeds:"
+msgstr ""
+"提取 ``.id`` 之前的原始响应如下。下方轮询步骤返回相同结构，``status`` 、``progress`` 和 ``completed_at`` "
+"会随生成进度更新："
+
+#: ../../source/features/vllm-omni.rst:192
+msgid ""
+"**Poll status** until it reports ``completed`` or ``failed``. This "
+"request is transparently pinned to the pod that created the job, "
+"regardless of which pod would normally be picked by the gateway's routing"
+" policy:"
+msgstr ""
+"**轮询状态** ，直到报告 ``completed`` 或 ``failed`` 。该请求会透明地固定到创建任务的 Pod，而不论网关路由策略通常会选中哪个 "
+"Pod："
+
+#: ../../source/features/vllm-omni.rst:198
+msgid "**Download the result** once ``completed``:"
+msgstr "状态为 ``completed`` 后**下载结果** ："
+
+#: ../../source/features/vllm-omni.rst:204
+msgid ""
+"**List all jobs for a model** instead of polling one by ID (``model`` is "
+"required):"
+msgstr "**列出某模型的全部任务** ，而不是按 ID 轮询单个任务（``model`` 必填）："
+
+#: ../../source/features/vllm-omni.rst:210
+msgid "**Delete a job** once you no longer need it:"
+msgstr "不再需要时**删除任务** ："
+
+#: ../../source/features/vllm-omni.rst:219
+msgid "Endpoint Reference"
+msgstr "接口参考"
+
+#: ../../source/features/vllm-omni.rst:225
+msgid "Endpoint"
+msgstr "接口"
+
+#: ../../source/features/vllm-omni.rst:226
+msgid "Method"
+msgstr "方法"
+
+#: ../../source/features/vllm-omni.rst:227
+msgid "Behavior"
+msgstr "行为"
+
+#: ../../source/features/vllm-omni.rst:228
+#: ../../source/features/vllm-omni.rst:231
+msgid "``/v1/videos``"
+msgstr "``/v1/videos``"
+
+#: ../../source/features/vllm-omni.rst:229
+#: ../../source/features/vllm-omni.rst:235
+msgid "POST"
+msgstr "POST"
+
+#: ../../source/features/vllm-omni.rst:230
+msgid "Create an async video generation job. Returns a job ID immediately."
+msgstr "创建异步视频生成任务。立即返回任务 ID。"
+
+#: ../../source/features/vllm-omni.rst:232
+#: ../../source/features/vllm-omni.rst:238
+#: ../../source/features/vllm-omni.rst:241
+msgid "GET"
+msgstr "GET"
+
+#: ../../source/features/vllm-omni.rst:233
+msgid ""
+"List jobs for a model. Requires a ``model`` query parameter; fans out "
+"across every ready pod for that model."
+msgstr ""
+"列出某模型的任务。需要 ``model`` 查询参数；会扇出到该模型的每个就绪 Pod。"
+
+#: ../../source/features/vllm-omni.rst:234
+msgid "``/v1/videos/sync``"
+msgstr "``/v1/videos/sync``"
+
+#: ../../source/features/vllm-omni.rst:236
+msgid ""
+"Create a job and block until it completes; returns the video bytes "
+"directly."
+msgstr "创建任务并阻塞直到完成；直接返回视频字节。"
+
+#: ../../source/features/vllm-omni.rst:237
+#: ../../source/features/vllm-omni.rst:243
+#, python-brace-format
+msgid "``/v1/videos/{id}``"
+msgstr "``/v1/videos/{id}``"
+
+#: ../../source/features/vllm-omni.rst:239
+msgid "Poll a job's status. Pinned to the pod that created it."
+msgstr "轮询任务状态。固定到创建该任务的 Pod。"
+
+#: ../../source/features/vllm-omni.rst:240
+#, python-brace-format
+msgid "``/v1/videos/{id}/content``"
+msgstr "``/v1/videos/{id}/content``"
+
+#: ../../source/features/vllm-omni.rst:242
+msgid "Download the completed video. Pinned to the pod that created it."
+msgstr "下载已完成的视频。固定到创建该任务的 Pod。"
+
+#: ../../source/features/vllm-omni.rst:244
+msgid "DELETE"
+msgstr "DELETE"
+
+#: ../../source/features/vllm-omni.rst:245
+msgid ""
+"Delete a job and its stored video. Pinned to the pod that created it; the"
+" mapping is evicted after a 2xx or 404 response so a failed delete can "
+"still be retried."
+msgstr ""
+"删除任务及其存储的视频。固定到创建该任务的 Pod；在 2xx 或 404 响应后驱逐映射，"
+"因此删除失败仍可重试。"
+
+#: ../../source/features/vllm-omni.rst:250
+msgid "Troubleshooting"
+msgstr "故障排查"
+
+#: ../../source/features/vllm-omni.rst:252
+msgid "**``GET``/``DELETE`` on a video ID returns 404**"
+msgstr "**对视频 ID 执行 ``GET``/``DELETE`` 返回 404**"
+
+#: ../../source/features/vllm-omni.rst:254
+msgid ""
+"The job ID is unknown to the gateway, has passed its retention window, or"
+" its owning pod is no longer ready (e.g. it was rescheduled). Once a pod "
+"is gone, the video it generated is gone with it — resubmit the job."
+msgstr ""
+"网关不认识该任务 ID、已超过保留窗口，或其所属 Pod 不再就绪（例如被重新调度）。"
+"Pod 消失后，它生成的视频一并消失——请重新提交任务。"
+
+#: ../../source/features/vllm-omni.rst:256
+msgid "**``POST /v1/videos/sync`` returns 504 / ext_proc timeout**"
+msgstr "**``POST /v1/videos/sync`` 返回 504 / ext_proc 超时**"
+
+#: ../../source/features/vllm-omni.rst:258
+msgid ""
+"Synchronous generation can take several minutes. Current AIBrix defaults "
+"are 600s for the reserved-router ext_proc ``messageTimeout``, the "
+"ORIGINAL_DST route, and model HTTPRoutes "
+"(``AIBRIX_GATEWAY_TIMEOUT_SECONDS``). Older installs used 60s/120s and "
+"will abort first; raise those three timeouts to at least 600s."
+msgstr ""
+"同步生成可能需要数分钟。当前 AIBrix 默认将保留路由的 ext_proc ``messageTimeout`` 、ORIGINAL_DST "
+"路由以及模型 HTTPRoute 设为 600s（``AIBRIX_GATEWAY_TIMEOUT_SECONDS`` ）。旧安装使用 60s/120s，会先超时中止；请将这三处超时至少提高到 "
+"600s。"
+
+#: ../../source/features/vllm-omni.rst:260
+msgid "**``GET /v1/videos`` (list) returns 400**"
+msgstr "**``GET /v1/videos`` （列表）返回 400**"
+
+#: ../../source/features/vllm-omni.rst:262
+msgid ""
+"The ``model`` query parameter is required — the gateway needs it to know "
+"which pods to fan out to: ``curl -s \"$BASE/v1/videos?model=wan21-vace-"
+"13b\"``."
+msgstr ""
+"``model`` 查询参数为必填——网关需要它来确定扇出到哪些 Pod：``curl -s \"$BASE/v1/videos?model=wan21-vace-13b\"`` "
+"。"
+
+#: ../../source/features/vllm-omni.rst:264
+msgid "**Job created on one gateway replica can't be found via another**"
+msgstr "**在一个网关副本上创建的任务无法通过另一个副本找到**"
+
+#: ../../source/features/vllm-omni.rst:266
+msgid ""
+"This cross-replica lookup relies on AIBrix's gateway being configured "
+"with Redis. Without Redis, the video-job-to-pod mapping only lives in the"
+" replica that handled the ``POST /v1/videos`` call."
+msgstr ""
+"跨副本查找依赖 AIBrix 网关配置 Redis。没有 Redis 时，视频任务到 Pod 的映射"
+"只存在于处理 ``POST /v1/videos`` 的那个副本中。"
+
+#: ../../source/features/vllm-omni.rst:268
+msgid "**Pod takes a long time to become ready**"
+msgstr "**Pod 就绪耗时很长**"
+
+#: ../../source/features/vllm-omni.rst:270
+msgid ""
+"Confirm the weights exist on the node at ``/data00/models/Wan2.1-VACE-1"
+".3B-diffusers``. Loading a video diffusion model into GPU memory can "
+"still take a few minutes. Watch progress with:"
+msgstr ""
+"确认节点上存在权重 ``/data00/models/Wan2.1-VACE-1.3B-diffusers`` 。将视频扩散模型加载到 GPU "
+"内存仍可能需要几分钟。可用以下方式查看进度："
+
+#: ../../source/features/vllm-omni.rst:279
+msgid "Sample Files"
+msgstr "示例文件"
+
+#: ../../source/features/vllm-omni.rst:281
+msgid ""
+"`samples/vllm_omni/wan2.1-vace-1.3b.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/vllm_omni/wan2.1-vace-1.3b.yaml>`_ — "
+"Deployment and Service for the video generation example used in this "
+"guide"
+msgstr ""
+"`samples/vllm_omni/wan2.1-vace-1.3b.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/vllm_omni/wan2.1-vace-1.3b.yaml>`_ — "
+"本指南视频生成示例所用的 Deployment 和 Service"
+
+#: ../../source/features/vllm-omni.rst:282
+msgid ""
+"`samples/vllm_omni/qwen2-5-omni-7b.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/vllm_omni/qwen2-5-omni-7b.yaml>`_ — "
+"text+audio vLLM-Omni example"
+msgstr ""
+"`samples/vllm_omni/qwen2-5-omni-7b.yaml <https://github.com/vllm-"
+"project/aibrix/blob/main/samples/vllm_omni/qwen2-5-omni-7b.yaml>`_ — "
+"文本+音频 vLLM-Omni 示例"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/advanced-k8s-examples.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/advanced-k8s-examples.po
@@ -1,0 +1,91 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:5
+msgid "Advanced Kubernetes Examples"
+msgstr "高级 Kubernetes 示例"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:8
+msgid "Introduction"
+msgstr "简介"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:9
+msgid ""
+"This documentation demonstrates advanced deployment patterns with AIBrix "
+"on Kubernetes, featuring persistent model caching and optimized resource "
+"configuration."
+msgstr ""
+"本文展示在 Kubernetes 上使用 AIBrix 的高级部署模式，包括持久化模型缓存和优化的资源配置。"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:12
+msgid "Persistent Volume Claim Optimization"
+msgstr "PersistentVolumeClaim 优化"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:13
+msgid ""
+"The following example shows how to: - Create isolated namespace with "
+"security policies - Deploy vLLM model with PVC for HuggingFace cache - "
+"Configure liveness/readiness probes - Set up monitoring annotations"
+msgstr ""
+"以下示例展示如何： - 创建带安全策略的隔离命名空间 - 使用 PVC 部署带 HuggingFace 缓存的 "
+"vLLM 模型 - 配置存活/就绪探针 - 设置监控注解"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:164
+msgid "Key Features"
+msgstr "主要特性"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:165
+msgid ""
+"**PVC Caching** - 30Gi persistent storage for HuggingFace models at "
+"`/root/.cache/huggingface`"
+msgstr ""
+"**PVC 缓存** - 在 `/root/.cache/huggingface` 为 HuggingFace 模型提供 30Gi 持久存储"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:166
+msgid "**Resource Limits** - Explicit GPU/CPU/Memory allocations"
+msgstr "**资源限制** - 显式分配 GPU/CPU/内存"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:167
+msgid "**Health Monitoring** - Multi-stage probes with failure thresholds"
+msgstr "**健康监控** - 带失败阈值的多阶段探针"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:168
+msgid "**Metrics Integration** - Prometheus annotations for service discovery"
+msgstr "**指标集成** - 用于服务发现的 Prometheus 注解"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:171
+msgid "Usage Notes"
+msgstr "使用说明"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:172
+msgid "Model name labels must match across Deployment/Service"
+msgstr "Deployment/Service 中的模型名称标签必须一致"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:173
+msgid "PVC storage class should match cluster configuration"
+msgstr "PVC 的 storage class 应与集群配置匹配"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:174
+msgid "Adjust `max-model-len` according to actual model requirements"
+msgstr "根据实际模型需求调整 `max-model-len`"
+
+#: ../../source/getting_started/advanced-k8s-examples.rst:175
+msgid "Probe delays accommodate model loading time (30s initial delay)"
+msgstr "探针延迟需覆盖模型加载时间（初始延迟 30s）"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/container-images.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/container-images.po
@@ -1,0 +1,358 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/container-images.rst:5
+msgid "AIBrix Container Images"
+msgstr "AIBrix 容器镜像"
+
+#: ../../source/getting_started/container-images.rst:8
+msgid "Overview"
+msgstr "概述"
+
+#: ../../source/getting_started/container-images.rst:10
+msgid ""
+"AIBrix provides enhanced container images for **vLLM** and **SGLang** "
+"that include additional capabilities for distributed inference and KV "
+"cache disaggregation:"
+msgstr ""
+"AIBrix 为 **vLLM** 和 **SGLang** 提供增强容器镜像，额外支持分布式推理和 "
+"KV cache 分离："
+
+#: ../../source/getting_started/container-images.rst:12
+msgid "**aibrix_kvcache** - Built from source for KV cache disaggregation support"
+msgstr "**aibrix_kvcache** - 从源码构建，用于支持 KV cache 分离"
+
+#: ../../source/getting_started/container-images.rst:13
+msgid ""
+"**nixl + nixl-cu12** - UCX-based high-performance networking libraries "
+"for RDMA"
+msgstr "**nixl + nixl-cu12** - 基于 UCX 的高性能 RDMA 网络库"
+
+#: ../../source/getting_started/container-images.rst:14
+msgid ""
+"**UCX tooling** - Pre-installed debugging and performance testing "
+"utilities"
+msgstr "**UCX tooling** - 预装的调试和性能测试工具"
+
+#: ../../source/getting_started/container-images.rst:17
+msgid "Image Naming Convention"
+msgstr "镜像命名约定"
+
+#: ../../source/getting_started/container-images.rst:19
+msgid ""
+"AIBrix images extend upstream inference engines with additional "
+"capabilities:"
+msgstr "AIBrix 镜像在上游推理引擎之上扩展了额外能力："
+
+#: ../../source/getting_started/container-images.rst:21
+msgid "Upstream vs. AIBrix Images"
+msgstr "上游镜像与 AIBrix 镜像"
+
+#: ../../source/getting_started/container-images.rst:25
+msgid "Upstream Image"
+msgstr "上游镜像"
+
+#: ../../source/getting_started/container-images.rst:26
+msgid "AIBrix Enhanced Image"
+msgstr "AIBrix 增强镜像"
+
+#: ../../source/getting_started/container-images.rst:27
+msgid "Use Case"
+msgstr "用途"
+
+#: ../../source/getting_started/container-images.rst:28
+msgid "``vllm/vllm-openai:v0.10.2``"
+msgstr "``vllm/vllm-openai:v0.10.2``"
+
+#: ../../source/getting_started/container-images.rst:29
+msgid "``aibrix/vllm-openai:v0.10.2-aibrix-v0.5.0-nixl-0.7.1-20251123``"
+msgstr "``aibrix/vllm-openai:v0.10.2-aibrix-v0.5.0-nixl-0.7.1-20251123``"
+
+#: ../../source/getting_started/container-images.rst:30
+msgid "vLLM + KVCache + RDMA"
+msgstr "vLLM + KVCache + RDMA"
+
+#: ../../source/getting_started/container-images.rst:31
+msgid "``lmsysorg/sglang:v0.5.5.post3``"
+msgstr "``lmsysorg/sglang:v0.5.5.post3``"
+
+#: ../../source/getting_started/container-images.rst:32
+msgid "``aibrix/sglang:v0.5.5.post3-aibrix-v0.5.0-nixl-0.7.1-20251123``"
+msgstr "``aibrix/sglang:v0.5.5.post3-aibrix-v0.5.0-nixl-0.7.1-20251123``"
+
+#: ../../source/getting_started/container-images.rst:33
+msgid "SGLang + KVCache + RDMA"
+msgstr "SGLang + KVCache + RDMA"
+
+#: ../../source/getting_started/container-images.rst:36
+msgid "When to Use AIBrix Images"
+msgstr "何时使用 AIBrix 镜像"
+
+#: ../../source/getting_started/container-images.rst:38
+msgid "Use **AIBrix-enhanced images** when you need:"
+msgstr "在需要以下能力时使用 **AIBrix 增强镜像** ："
+
+#: ../../source/getting_started/container-images.rst:40
+msgid "**KV Cache Offloading**: KV cache offload to Host memory or remote storage"
+msgstr "**KV Cache 卸载** ：将 KV cache 卸载到主机内存或远程存储"
+
+#: ../../source/getting_started/container-images.rst:41
+msgid ""
+"**Prefill-Decode Disaggregation**: Separate prefill and decode workloads "
+"via NIXL"
+msgstr "**Prefill-Decode 分离** ：通过 NIXL 将 prefill 与 decode 工作负载分开"
+
+#: ../../source/getting_started/container-images.rst:43
+msgid "Use **upstream images** for:"
+msgstr "在以下场景使用 **上游镜像** ："
+
+#: ../../source/getting_started/container-images.rst:45
+msgid "Standard single-node inference without disaggregation"
+msgstr "无需分离的标准单节点推理"
+
+#: ../../source/getting_started/container-images.rst:46
+msgid "Development and testing without specialized networking"
+msgstr "不需要专用网络的开发和测试"
+
+#: ../../source/getting_started/container-images.rst:49
+msgid "Compatibility Matrix"
+msgstr "兼容性矩阵"
+
+#: ../../source/getting_started/container-images.rst:51
+msgid "The following table shows tested component versions for AIBrix v0.5.0:"
+msgstr "下表列出 AIBrix v0.5.0 已测试的组件版本："
+
+#: ../../source/getting_started/container-images.rst:53
+msgid "Component Versions"
+msgstr "组件版本"
+
+#: ../../source/getting_started/container-images.rst:57
+msgid "Component"
+msgstr "组件"
+
+#: ../../source/getting_started/container-images.rst:58
+msgid "vLLM Image"
+msgstr "vLLM 镜像"
+
+#: ../../source/getting_started/container-images.rst:59
+msgid "SGLang Image"
+msgstr "SGLang 镜像"
+
+#: ../../source/getting_started/container-images.rst:60
+msgid "Notes"
+msgstr "说明"
+
+#: ../../source/getting_started/container-images.rst:61
+msgid "Engine Version"
+msgstr "引擎版本"
+
+#: ../../source/getting_started/container-images.rst:62
+msgid "v0.10.2"
+msgstr "v0.10.2"
+
+#: ../../source/getting_started/container-images.rst:63
+msgid "v0.5.5.post3"
+msgstr "v0.5.5.post3"
+
+#: ../../source/getting_started/container-images.rst:64
+msgid "Stable inference engines"
+msgstr "稳定的推理引擎"
+
+#: ../../source/getting_started/container-images.rst:65
+msgid "CUDA Version"
+msgstr "CUDA 版本"
+
+#: ../../source/getting_started/container-images.rst:66
+msgid "12.8"
+msgstr "12.8"
+
+#: ../../source/getting_started/container-images.rst:67
+msgid "12.9"
+msgstr "12.9"
+
+#: ../../source/getting_started/container-images.rst:68
+msgid "CUDA toolkit version"
+msgstr "CUDA toolkit 版本"
+
+#: ../../source/getting_started/container-images.rst:69
+msgid "PyTorch Version"
+msgstr "PyTorch 版本"
+
+#: ../../source/getting_started/container-images.rst:70
+msgid "2.8"
+msgstr "2.8"
+
+#: ../../source/getting_started/container-images.rst:71
+msgid "2.9"
+msgstr "2.9"
+
+#: ../../source/getting_started/container-images.rst:72
+msgid "Auto-detected from base image"
+msgstr "从基础镜像自动检测"
+
+#: ../../source/getting_started/container-images.rst:73
+msgid "AIBrix KVCache"
+msgstr "AIBrix KVCache"
+
+#: ../../source/getting_started/container-images.rst:74
+#: ../../source/getting_started/container-images.rst:75
+#: ../../source/getting_started/container-images.rst:116
+msgid "v0.5.0"
+msgstr "v0.5.0"
+
+#: ../../source/getting_started/container-images.rst:76
+msgid "KV cache disaggregation support"
+msgstr "KV cache 分离支持"
+
+#: ../../source/getting_started/container-images.rst:77
+msgid "NIXL Version"
+msgstr "NIXL 版本"
+
+#: ../../source/getting_started/container-images.rst:78
+#: ../../source/getting_started/container-images.rst:79
+msgid "0.7.1"
+msgstr "0.7.1"
+
+#: ../../source/getting_started/container-images.rst:80
+msgid "UCX-based RDMA networking"
+msgstr "基于 UCX 的 RDMA 网络"
+
+#: ../../source/getting_started/container-images.rst:81
+msgid "UCX Version"
+msgstr "UCX 版本"
+
+#: ../../source/getting_started/container-images.rst:82
+#: ../../source/getting_started/container-images.rst:83
+msgid "1.19.0"
+msgstr "1.19.0"
+
+#: ../../source/getting_started/container-images.rst:84
+msgid "Unified Communication X"
+msgstr "Unified Communication X"
+
+#: ../../source/getting_started/container-images.rst:87
+msgid ""
+"PyTorch version is automatically extracted from the upstream base image "
+"to ensure compatibility. AIBrix KVCache is built against the exact "
+"PyTorch version from the base image."
+msgstr ""
+"PyTorch 版本会从上游基础镜像自动提取，以确保兼容性。AIBrix KVCache 针对基础镜像中的"
+"精确 PyTorch 版本构建。"
+
+#: ../../source/getting_started/container-images.rst:91
+msgid "Released Images (v0.5.0)"
+msgstr "已发布镜像（v0.5.0）"
+
+#: ../../source/getting_started/container-images.rst:93
+msgid "The following pre-built images are available for immediate use:"
+msgstr "以下预构建镜像可直接使用："
+
+#: ../../source/getting_started/container-images.rst:95
+msgid "**vLLM Image:**"
+msgstr "**vLLM 镜像：**"
+
+#: ../../source/getting_started/container-images.rst:101
+msgid "**SGLang Image:**"
+msgstr "**SGLang 镜像：**"
+
+#: ../../source/getting_started/container-images.rst:108
+msgid "Building Custom Images"
+msgstr "构建自定义镜像"
+
+#: ../../source/getting_started/container-images.rst:110
+msgid ""
+"For detailed build instructions and troubleshooting, see "
+"`build/container/README.md <https://github.com/vllm-"
+"project/aibrix/blob/main/build/container/README.md>`_."
+msgstr ""
+"详细构建说明和故障排查参见 `build/container/README.md <https://github.com/vllm-project/aibrix/blob/main/build/container/README.md>`_ "
+"。"
+
+#: ../../source/getting_started/container-images.rst:113
+msgid "Version History"
+msgstr "版本历史"
+
+#: ../../source/getting_started/container-images.rst:118
+msgid "**vLLM**: v0.10.2 with CUDA 12.8, PyTorch 2.8"
+msgstr "**vLLM** ：v0.10.2，CUDA 12.8，PyTorch 2.8"
+
+#: ../../source/getting_started/container-images.rst:119
+msgid "**SGLang**: v0.5.5.post3 with CUDA 12.9, PyTorch 2.9"
+msgstr "**SGLang** ：v0.5.5.post3，CUDA 12.9，PyTorch 2.9"
+
+#: ../../source/getting_started/container-images.rst:120
+msgid "**AIBrix KVCache**: v0.5.0"
+msgstr "**AIBrix KVCache** ：v0.5.0"
+
+#: ../../source/getting_started/container-images.rst:121
+msgid "**NIXL**: 0.7.1"
+msgstr "**NIXL** ：0.7.1"
+
+#: ../../source/getting_started/container-images.rst:122
+msgid "**UCX**: 1.19.0"
+msgstr "**UCX** ：1.19.0"
+
+#: ../../source/getting_started/container-images.rst:124
+msgid "Features:"
+msgstr "功能："
+
+#: ../../source/getting_started/container-images.rst:126
+msgid "Full KV cache offloading support"
+msgstr "完整的 KV cache 卸载支持"
+
+#: ../../source/getting_started/container-images.rst:127
+msgid "RDMA networking for distributed inference"
+msgstr "用于分布式推理的 RDMA 网络"
+
+#: ../../source/getting_started/container-images.rst:128
+msgid "Prefill-Decode disaggregation support"
+msgstr "Prefill-Decode 分离支持"
+
+#: ../../source/getting_started/container-images.rst:131
+msgid "Troubleshooting"
+msgstr "故障排查"
+
+#: ../../source/getting_started/container-images.rst:134
+msgid "Performance Issues"
+msgstr "性能问题"
+
+#: ../../source/getting_started/container-images.rst:136
+msgid "For RDMA networking issues:"
+msgstr "RDMA 网络问题："
+
+#: ../../source/getting_started/container-images.rst:138
+msgid "Verify RDMA devices are available: ``ibv_devices``"
+msgstr "确认 RDMA 设备可用：``ibv_devices``"
+
+#: ../../source/getting_started/container-images.rst:139
+msgid "Check UCX configuration: ``ucx_info -d``"
+msgstr "检查 UCX 配置：``ucx_info -d``"
+
+#: ../../source/getting_started/container-images.rst:140
+msgid "Test RDMA bandwidth: ``ib_write_bw``"
+msgstr "测试 RDMA 带宽：``ib_write_bw``"
+
+#: ../../source/getting_started/container-images.rst:141
+msgid "Ensure security policies allow RDMA access"
+msgstr "确保安全策略允许 RDMA 访问"
+
+#: ../../source/getting_started/container-images.rst:143
+msgid "For debugging utilities included in the image, run:"
+msgstr "镜像中包含的调试工具可运行："

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/faq.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/faq.po
@@ -1,0 +1,182 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/faq.rst:5
+msgid "FAQ"
+msgstr "常见问题"
+
+#: ../../source/getting_started/faq.rst:8
+msgid "FAQ - Installation"
+msgstr "常见问题 - 安装"
+
+#: ../../source/getting_started/faq.rst:11
+msgid "Failed to delete the AIBrix"
+msgstr "无法删除 AIBrix"
+
+#: ../../source/getting_started/faq.rst:13
+#: ../../source/getting_started/faq.rst:18
+msgid "aibrix-architecture-v1"
+msgstr "aibrix-architecture-v1"
+
+#: ../../source/getting_started/faq.rst:23
+msgid ""
+"In this case, you just need to find the model adapter, edit the object, "
+"and remove the ``finalizer`` pair. the pod would be deleted "
+"automatically."
+msgstr ""
+"此时只需找到 model adapter，编辑该对象并移除 ``finalizer`` 字段，pod 就会自动删除。"
+
+#: ../../source/getting_started/faq.rst:27
+msgid "Gateway error messages"
+msgstr "网关错误信息"
+
+#: ../../source/getting_started/faq.rst:29
+msgid "model does not exist"
+msgstr "model does not exist"
+
+#: ../../source/getting_started/faq.rst:31
+msgid "model-error"
+msgstr "model-error"
+
+#: ../../source/getting_started/faq.rst:36
+msgid "routing strategy is incorrect"
+msgstr "routing strategy is incorrect"
+
+#: ../../source/getting_started/faq.rst:38
+msgid "no ready pods"
+msgstr "no ready pods"
+
+#: ../../source/getting_started/faq.rst:41
+msgid "Gateway ReferenceGrant Issue"
+msgstr "网关 ReferenceGrant 问题"
+
+#: ../../source/getting_started/faq.rst:43
+msgid ""
+"When using multi-node inference with RayClusterFleet (as described in the"
+" :ref:`multi-node inference guide <distributed_inference>`), you might "
+"encounter a 500 error when accessing the model through the Envoy gateway,"
+" while direct access via port-forward works fine."
+msgstr ""
+"使用 RayClusterFleet 进行多节点推理时（参见 :ref:`multi-node inference guide <distributed_inference>` "
+"），通过 Envoy 网关访问模型可能出现 500 错误，而通过 port-forward 直接访问则正常。"
+
+#: ../../source/getting_started/faq.rst:45
+msgid ""
+"This issue occurs because the gateway (in aibrix-system namespace) needs "
+"explicit permission to access services in other namespaces (e.g., default"
+" namespace). To resolve this, you need to create a ReferenceGrant:"
+msgstr ""
+"原因是网关（位于 aibrix-system 命名空间）需要显式权限才能访问其他命名空间中的服务"
+"（例如 default 命名空间）。解决方法是创建 ReferenceGrant："
+
+#: ../../source/getting_started/faq.rst:63
+msgid ""
+"After applying this ReferenceGrant, the gateway should be able to "
+"properly route requests to your model service."
+msgstr "应用该 ReferenceGrant 后，网关应能正确将请求路由到模型服务。"
+
+#: ../../source/getting_started/faq.rst:65
+msgid ""
+"Note: This is typically only needed for multi-node deployments. Simple "
+"model deployments usually work without requiring this additional "
+"configuration."
+msgstr ""
+"注意：这通常只在多节点部署时需要。简单的模型部署一般不需要这项额外配置。"
+
+#: ../../source/getting_started/faq.rst:68
+msgid "Using NodePort or ClusterIP to Expose the Gateway API"
+msgstr "使用 NodePort 或 ClusterIP 暴露网关 API"
+
+#: ../../source/getting_started/faq.rst:70
+msgid ""
+"In the :ref:`quickstart` guide, model endpoints are typically accessed "
+"using either ``kubectl port-forward`` or through a LoadBalancer service. "
+"However, in some environments (e.g., local clusters without external load"
+" balancers), you may prefer to expose the Envoy gateway using a "
+"``NodePort`` service or rely on the default ``ClusterIP`` service type."
+msgstr ""
+"在 :ref:`quickstart` 指南中，模型端点通常通过 ``kubectl port-forward`` 或 "
+"LoadBalancer 服务访问。但在某些环境（例如没有外部负载均衡器的本地集群）中，"
+"你可能更希望用 ``NodePort`` 服务暴露 Envoy 网关，或沿用默认的 ``ClusterIP`` 服务类型。"
+
+#: ../../source/getting_started/faq.rst:73
+msgid ""
+"**Important:** You should not modify the ``svc/envoy-aibrix-system-"
+"aibrix-eg-903790dc`` service directly, since it is managed by the "
+"EnvoyProxy controller. Instead, update the EnvoyProxy configuration to "
+"set the service type."
+msgstr ""
+"**重要：** 不要直接修改 ``svc/envoy-aibrix-system-aibrix-eg-903790dc`` 服务，"
+"因为它由 EnvoyProxy 控制器管理。应更新 EnvoyProxy 配置来设置服务类型。"
+
+#: ../../source/getting_started/faq.rst:76
+msgid "**Option 1**: NodePort (Expose Outside the Cluster)"
+msgstr "**选项 1** ：NodePort（暴露到集群外）"
+
+#: ../../source/getting_started/faq.rst:78
+msgid "Update the spec to ``NodePort``:"
+msgstr "将 spec 更新为 ``NodePort`` ："
+
+#: ../../source/getting_started/faq.rst:91
+msgid "After applying the change, the gateway service will be updated:"
+msgstr "应用更改后，网关服务会更新为："
+
+#: ../../source/getting_started/faq.rst:99
+msgid "You can then regenerate the model endpoint:"
+msgstr "然后可以重新生成模型端点："
+
+#: ../../source/getting_started/faq.rst:107
+msgid ""
+"Your model endpoint is now accessible from outside the cluster via "
+"NodePort."
+msgstr "现在可以通过 NodePort 从集群外访问模型端点。"
+
+#: ../../source/getting_started/faq.rst:109
+msgid "**Option 2**: ClusterIP (Internal Access Only)"
+msgstr "**选项 2** ：ClusterIP（仅集群内访问）"
+
+#: ../../source/getting_started/faq.rst:111
+msgid "By default, the Envoy gateway service type is ``ClusterIP``:"
+msgstr "默认情况下，Envoy 网关服务类型为 ``ClusterIP`` ："
+
+#: ../../source/getting_started/faq.rst:124
+msgid "The gateway service looks like this:"
+msgstr "网关服务类似如下："
+
+#: ../../source/getting_started/faq.rst:132
+msgid ""
+"You can then regenerate the model endpoint (accessible only inside the "
+"cluster):"
+msgstr "然后可以重新生成模型端点（仅集群内可访问）："
+
+#: ../../source/getting_started/faq.rst:140
+msgid ""
+"This endpoint works only within the Kubernetes cluster (e.g., when other "
+"services communicate with the gateway internally)."
+msgstr ""
+"该端点仅在 Kubernetes 集群内可用（例如其他服务在集群内部与网关通信）。"
+
+#: ../../source/getting_started/faq.rst:142
+msgid ""
+"Get more configurations in the `Envoy Gateway docs "
+"<https://gateway.envoyproxy.io/latest/api/extension_types/#kubernetesservicespec>`__."
+msgstr ""
+"更多配置见 `Envoy Gateway docs "
+"<https://gateway.envoyproxy.io/latest/api/extension_types/#kubernetesservicespec>`__。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/aws.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/aws.po
@@ -1,0 +1,270 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/installation/aws.rst:5
+msgid "Amazon Web Services (AWS)"
+msgstr "Amazon Web Services (AWS)"
+
+#: ../../source/getting_started/installation/aws.rst:8
+msgid "Introduction"
+msgstr "简介"
+
+#: ../../source/getting_started/installation/aws.rst:10
+msgid ""
+"An AIBrix cluster can either be deployed using the `AI on EKS "
+"<https://awslabs.github.io/ai-on-eks/>`_ project, which offers a simple "
+"deployment that will create a VPC, EKS cluster, and deploy AIBrix, or "
+"manually step-by-step."
+msgstr ""
+"AIBrix 集群既可以通过 `AI on EKS <https://awslabs.github.io/ai-on-eks/>`_ 项目部署"
+"（该项目提供一键部署，会创建 VPC、EKS 集群并部署 AIBrix），也可以逐步手动部署。"
+
+#: ../../source/getting_started/installation/aws.rst:13
+msgid "AI on EKS"
+msgstr "AI on EKS"
+
+#: ../../source/getting_started/installation/aws.rst:15
+msgid ""
+"`AI on EKS <https://awslabs.github.io/ai-on-eks/>`_ provides a one-line "
+"`deployment <https://awslabs.github.io/ai-on-eks/docs/infra/aibrix>`_ of "
+"AIBrix."
+msgstr ""
+"`AI on EKS <https://awslabs.github.io/ai-on-eks/>`_ 提供一行命令完成 AIBrix `deployment "
+"<https://awslabs.github.io/ai-on-eks/docs/infra/aibrix>`_ 。"
+
+#: ../../source/getting_started/installation/aws.rst:17
+msgid ""
+"This deployment will create a VPC, subnets, EKS environment and deploy "
+"AIBrix."
+msgstr "该部署会创建 VPC、子网、EKS 环境并部署 AIBrix。"
+
+#: ../../source/getting_started/installation/aws.rst:19
+msgid ""
+"AI on EKS also includes `inference charts <https://awslabs.github.io/ai-"
+"on-eks/docs/blueprints/inference/inference-charts>`_ that can deploy "
+"models to be served by AIBrix."
+msgstr ""
+"AI on EKS 还包含 `inference charts <https://awslabs.github.io/ai-on-eks/docs/blueprints/inference/inference-charts>`_ "
+"，可用于部署由 AIBrix 提供服务的模型。"
+
+#: ../../source/getting_started/installation/aws.rst:22
+msgid "Manually"
+msgstr "手动部署"
+
+#: ../../source/getting_started/installation/aws.rst:25
+#: ../../source/getting_started/installation/aws.rst:81
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/getting_started/installation/aws.rst:27
+msgid "`eksctl <https://eksctl.io/installation/>`_"
+msgstr "`eksctl <https://eksctl.io/installation/>`_"
+
+#: ../../source/getting_started/installation/aws.rst:28
+msgid "A quota of at least 1 GPU within your AWS project."
+msgstr "AWS 项目中至少有 1 个 GPU 配额。"
+
+#: ../../source/getting_started/installation/aws.rst:31
+msgid "Steps"
+msgstr "步骤"
+
+#: ../../source/getting_started/installation/aws.rst:33
+msgid "Create an eks cluster:"
+msgstr "创建 EKS 集群："
+
+#: ../../source/getting_started/installation/aws.rst:39
+msgid ""
+"Clone AIBrix code repo ``git clone https://github.com/vllm-"
+"project/aibrix.git``."
+msgstr "克隆 AIBrix 代码仓库 ``git clone https://github.com/vllm-project/aibrix.git`` 。"
+
+#: ../../source/getting_started/installation/aws.rst:40
+msgid "Install AIBrix dependencies, CRDs, and core components:"
+msgstr "安装 AIBrix 依赖、CRD 和核心组件："
+
+#: ../../source/getting_started/installation/aws.rst:47
+msgid "Wait for components to complete running."
+msgstr "等待组件运行完成。"
+
+#: ../../source/getting_started/installation/aws.rst:48
+msgid "Deploy a model by following the instructions in :doc:`../quickstart`."
+msgstr "按照 :doc:`../quickstart` 中的说明部署模型。"
+
+#: ../../source/getting_started/installation/aws.rst:49
+msgid "Once the model is ready and running, you can test it by running:"
+msgstr "模型就绪并运行后，可运行以下命令进行测试："
+
+#: ../../source/getting_started/installation/aws.rst:66
+msgid ""
+"When you are finished testing and no longer want the resources, run "
+"``eksctl delete cluster --name aibrix``."
+msgstr "测试结束且不再需要这些资源时，运行 ``eksctl delete cluster --name aibrix`` 。"
+
+#: ../../source/getting_started/installation/aws.rst:69
+msgid "AWS Neuron (Trainium) with Dynamic Resource Allocation"
+msgstr "AWS Neuron（Trainium）与 Dynamic Resource Allocation"
+
+#: ../../source/getting_started/installation/aws.rst:71
+msgid ""
+"AIBrix supports disaggregated inference (prefill/decode separation) on "
+"AWS Trainium (Trn2 / Trn3) using the ``pd`` routing algorithm. On Neuron,"
+" the KV cache is transferred from prefill to decode over NIXL on the "
+"``LIBFABRIC`` backend, which rides EFA (Elastic Fabric Adapter). This "
+"requires each serving pod to be allocated **both** a set of NeuronCores "
+"**and** EFA devices — and, critically, from the **same PCIe/NUMA group** "
+"so the fabric path between pods is valid. The recommended way to request "
+"them together is Kubernetes **Dynamic Resource Allocation (DRA)**."
+msgstr ""
+"AIBrix 支持在 AWS Trainium（Trn2 / Trn3）上使用 ``pd`` 路由算法进行分离式推理（prefill/decode "
+"分离）。在 Neuron 上，KV cache 通过 NIXL 的 ``LIBFABRIC`` 后端从 prefill 传到 decode，该后端运行在 "
+"EFA（Elastic Fabric Adapter）之上。这要求每个服务 pod **同时** 分配一组 NeuronCores **和** "
+"EFA 设备，并且关键的是它们必须来自**同一 PCIe/NUMA 组** ，才能保证 pod 之间的 fabric 路径有效。推荐用 Kubernetes "
+"**Dynamic Resource Allocation (DRA)** 一并申请这两类资源。"
+
+#: ../../source/getting_started/installation/aws.rst:83
+msgid ""
+"Kubernetes **1.34 or later**, where Dynamic Resource Allocation is GA and"
+" the API group is ``resource.k8s.io/v1`` (a fixed device request is "
+"wrapped in ``exactly:``). On 1.30–1.33 DRA is beta "
+"(``resource.k8s.io/v1beta1``) with a different request schema."
+msgstr ""
+"Kubernetes **1.34 或更高版本** ，此时 Dynamic Resource Allocation 已 GA，API 组为 ``resource.k8s.io/v1`` "
+"（固定设备请求包在 ``exactly:`` 中）。在 1.30–1.33 上 DRA 为 beta（``resource.k8s.io/v1beta1`` "
+"），请求 schema 不同。"
+
+#: ../../source/getting_started/installation/aws.rst:87
+msgid ""
+"An EKS nodegroup of ``trn2.48xlarge`` (or ``trn3-dev1.48xlarge``) with "
+"EFA enabled (``efaEnabled: true`` and ``privateNetworking: true`` in the "
+"eksctl nodegroup config). EFA capacity is typically obtained through an "
+"on-demand capacity reservation (ODCR)."
+msgstr ""
+"启用 EFA 的 ``trn2.48xlarge`` （或 ``trn3-dev1.48xlarge`` ）EKS nodegroup（eksctl "
+"nodegroup 配置中 ``efaEnabled: true`` 且 ``privateNetworking: true`` ）。EFA 容量通常通过按需容量预留（ODCR）获取。"
+
+#: ../../source/getting_started/installation/aws.rst:91
+msgid "Two DRA drivers installed:"
+msgstr "安装两个 DRA 驱动："
+
+#: ../../source/getting_started/installation/aws.rst:93
+msgid ""
+"**Neuron DRA driver** — publishes ``neuron.aws.com`` devices. Install per"
+" the `Neuron DRA guide <https://awsdocs-neuron.readthedocs-"
+"hosted.com/en/latest/containers/neuron-dra.html>`_. Do not also run the "
+"Neuron device plugin on the same cluster."
+msgstr ""
+"**Neuron DRA driver** — 发布 ``neuron.aws.com`` 设备。按 `Neuron DRA guide "
+"<https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/neuron-dra.html>`_ "
+"安装。不要在同一集群上再运行 Neuron device plugin。"
+
+#: ../../source/getting_started/installation/aws.rst:96
+msgid ""
+"**EFA DRA driver** (``aws-dranet``) — publishes "
+"``efa.networking.k8s.aws`` devices. Install per the `Amazon EKS DRA "
+"device-management guide <https://docs.aws.amazon.com/eks/latest/userguide"
+"/device-management-efa.html>`_."
+msgstr ""
+"**EFA DRA driver** （``aws-dranet`` ）— 发布 ``efa.networking.k8s.aws`` 设备。按 "
+"`Amazon EKS DRA device-management guide <https://docs.aws.amazon.com/eks/latest/userguide/device-management-efa.html>`_ "
+"安装。"
+
+#: ../../source/getting_started/installation/aws.rst:100
+msgid "Verify both device classes are discovered:"
+msgstr "确认两类设备均已被发现："
+
+#: ../../source/getting_started/installation/aws.rst:108
+msgid "Allocate Neuron + EFA together with a ResourceClaimTemplate"
+msgstr "用 ResourceClaimTemplate 同时分配 Neuron 和 EFA"
+
+#: ../../source/getting_started/installation/aws.rst:110
+msgid ""
+"A single claim requests both device classes and, via a ``constraints`` "
+"block, pins them to the **same device group** — this is what keeps the "
+"NeuronCores and EFA NICs on the same PCIe/NUMA locality so the "
+"NIXL/LIBFABRIC path between pods is valid. Only the ``48xlarge`` Trn size"
+" is EFA-enabled."
+msgstr ""
+"单个 claim 同时申请两类设备，并通过 ``constraints`` 块将它们固定到**同一设备组**——"
+"这样才能让 NeuronCores 和 EFA NIC 处于同一 PCIe/NUMA 局部性，保证 pod 之间的 "
+"NIXL/LIBFABRIC 路径有效。只有 ``48xlarge`` 规格的 Trainium 实例启用了 EFA。"
+
+#: ../../source/getting_started/installation/aws.rst:115
+msgid ""
+"Two ready-to-use templates are provided in `samples/disaggregation/neuron"
+" <https://github.com/vllm-"
+"project/aibrix/tree/main/samples/disaggregation/neuron>`_:"
+msgstr ""
+"`samples/disaggregation/neuron <https://github.com/vllm-"
+"project/aibrix/tree/main/samples/disaggregation/neuron>`_ 中提供了两份可直接使用的模板："
+
+#: ../../source/getting_started/installation/aws.rst:118
+msgid ""
+"``xl-lnc2-trn2-efa-rct.yaml`` — **half an instance**: 8 NeuronCores + 8 "
+"EFA from one ``devicegroup8``. A ``trn2.48xlarge`` has 16 Neuron devices "
+"in two such groups, so this template carves the node into two 8-device "
+"chunks — one per pod — letting a prefill and a decode pod co-reside on "
+"one node, each with an aligned, mutually-routable Neuron + EFA set."
+msgstr ""
+"``xl-lnc2-trn2-efa-rct.yaml`` — **半个实例** ：来自一个 ``devicegroup8`` 的 8 个 NeuronCores "
+"+ 8 个 EFA。一台 ``trn2.48xlarge`` 有 16 个 Neuron 设备，分成两组，因此该模板把节点切成两块各 8 个设备——每个 "
+"pod 一块——让 prefill 和 decode pod 可以共驻同一节点，且各自拥有对齐、可互路由的 Neuron + EFA 集合。"
+
+#: ../../source/getting_started/installation/aws.rst:123
+msgid ""
+"``xxl-lnc2-trn2-efa-rct.yaml`` — **a full instance**: all 16 NeuronCores "
+"+ 16 EFA aligned on one ``devicegroup16`` (a single pod owns the whole "
+"node)."
+msgstr ""
+"``xxl-lnc2-trn2-efa-rct.yaml`` — **整个实例** ：全部 16 个 NeuronCores + 16 个 EFA "
+"对齐到一个 ``devicegroup16`` （单个 pod 独占整台节点）。"
+
+#: ../../source/getting_started/installation/aws.rst:126
+msgid "The essential shape (see the files for the full manifest):"
+msgstr "核心形态如下（完整清单见文件）："
+
+#: ../../source/getting_started/installation/aws.rst:153
+msgid ""
+"A pod references the template via ``resourceClaims`` and "
+"``resources.claims``. For Trn3, use the ``trn3-dev1.48xlarge`` selector."
+msgstr ""
+"pod 通过 ``resourceClaims`` 和 ``resources.claims`` 引用该模板。对于 Trn3，使用 "
+"``trn3-dev1.48xlarge`` selector。"
+
+#: ../../source/getting_started/installation/aws.rst:158
+msgid ""
+"Validate the fabric before serving — run "
+"``/opt/amazon/efa/bin/fi_pingpong -p efa`` (server) in one pod and "
+"``fi_pingpong -p efa <server-pod-ip>`` (client) in the other. A bandwidth"
+" table confirms EFA works pod-to-pod."
+msgstr ""
+"提供服务前先验证 fabric：在一个 pod 中运行 ``/opt/amazon/efa/bin/fi_pingpong -p efa`` （服务端），在另一个 "
+"pod 中运行 ``fi_pingpong -p efa <server-pod-ip>`` （客户端）。出现带宽表即说明 EFA 在 pod "
+"之间可用。"
+
+#: ../../source/getting_started/installation/aws.rst:162
+msgid ""
+"Once the prefill/decode Deployments are running with these claims and the"
+" ``role-name: prefill|decode`` labels, enable disaggregated routing on "
+"the gateway with ``ROUTING_ALGORITHM=pd`` and deploy a model as in the "
+"steps above."
+msgstr ""
+"当带有这些 claim 以及 ``role-name: prefill|decode`` 标签的 prefill/decode "
+"Deployment 运行起来后，在网关上用 ``ROUTING_ALGORITHM=pd`` 启用分离路由，"
+"并按上文步骤部署模型。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/gcp.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/gcp.po
@@ -1,0 +1,413 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/installation/gcp.rst:5
+msgid "Google Cloud Platform (GCP)"
+msgstr "Google Cloud Platform (GCP)"
+
+#: ../../source/getting_started/installation/gcp.rst:8
+msgid "Introduction"
+msgstr "简介"
+
+#: ../../source/getting_started/installation/gcp.rst:10
+msgid ""
+"This module deploys an AIBrix cluster in its entirety onto a Google "
+"Container Cluster. It is the quickest way to get up and running with "
+"AIBrix. The purpose of this module is to both allow developers to quickly"
+" spin up the stack, and allow for the team to test on the Google Cloud "
+"Platform."
+msgstr ""
+"该模块将完整的 AIBrix 集群部署到 Google Container Cluster。这是最快让 AIBrix "
+"跑起来的方式。目的是让开发者快速拉起整套栈，也方便团队在 Google Cloud Platform 上测试。"
+
+#: ../../source/getting_started/installation/gcp.rst:13
+msgid ""
+"This module was created to allow users to quickly spin up AIBrix on GCP. "
+"It is not currently built for production deployments. The user is "
+"responsible for any costs incurred by running this module."
+msgstr ""
+"该模块用于在 GCP 上快速拉起 AIBrix，目前并非面向生产部署。运行本模块产生的费用由用户自行承担。"
+
+#: ../../source/getting_started/installation/gcp.rst:14
+msgid ""
+"This module use terraform as the infrastructure as code tool. If you are "
+"looking for other means, feel free to cut an `issue <https://github.com"
+"/vllm-project/aibrix/issues>`_."
+msgstr ""
+"该模块使用 Terraform 作为基础设施即代码工具。如果需要其他方式，欢迎提交 `issue <https://github.com/vllm-project/aibrix/issues>`_ "
+"。"
+
+#: ../../source/getting_started/installation/gcp.rst:17
+msgid "Quickstart"
+msgstr "快速开始"
+
+#: ../../source/getting_started/installation/gcp.rst:20
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/getting_started/installation/gcp.rst:22
+msgid "`GCloud CLI <https://cloud.google.com/sdk/docs/install>`_"
+msgstr "`GCloud CLI <https://cloud.google.com/sdk/docs/install>`_"
+
+#: ../../source/getting_started/installation/gcp.rst:23
+msgid ""
+"A quota of at least 1 GPU within your GCP project. More information can "
+"be found on the topic `here <https://cloud.google.com/compute/resource-"
+"usage#gpu_quota>`_."
+msgstr ""
+"GCP 项目中至少有 1 个 GPU 配额。更多信息见 `here <https://cloud.google.com/compute/resource-usage#gpu_quota>`_ "
+"。"
+
+#: ../../source/getting_started/installation/gcp.rst:24
+msgid ""
+"`Terraform CLI <https://developer.hashicorp.com/terraform/tutorials/aws-"
+"get-started/install-cli>`_"
+msgstr ""
+"`Terraform CLI <https://developer.hashicorp.com/terraform/tutorials/aws-"
+"get-started/install-cli>`_"
+
+#: ../../source/getting_started/installation/gcp.rst:27
+msgid "Steps"
+msgstr "步骤"
+
+#: ../../source/getting_started/installation/gcp.rst:29
+msgid "Change directory to the module location: ``cd /deployment/terraform/gcp``"
+msgstr "切换到模块目录：``cd /deployment/terraform/gcp``"
+
+#: ../../source/getting_started/installation/gcp.rst:30
+msgid ""
+"Run ``gcloud auth application-default login`` to setup credentials to "
+"Google."
+msgstr "运行 ``gcloud auth application-default login`` 配置 Google 凭据。"
+
+#: ../../source/getting_started/installation/gcp.rst:31
+msgid ""
+"Install cluster auth plugin with ``gcloud components install gke-gcloud-"
+"auth-plugin``."
+msgstr "使用 ``gcloud components install gke-gcloud-auth-plugin`` 安装集群认证插件。"
+
+#: ../../source/getting_started/installation/gcp.rst:32
+msgid ""
+"Rename ``terraform.tfvars.example`` to ``terraform.tfvars`` and fill in "
+"the required variables. You can also add any optional overrides here as "
+"well."
+msgstr ""
+"将 ``terraform.tfvars.example`` 重命名为 ``terraform.tfvars`` 并填写必填变量。"
+"也可以在此添加可选覆盖项。"
+
+#: ../../source/getting_started/installation/gcp.rst:33
+msgid "Run ``terraform init`` to initialize the module."
+msgstr "运行 ``terraform init`` 初始化模块。"
+
+#: ../../source/getting_started/installation/gcp.rst:34
+msgid ""
+"Run ``terraform plan`` to see details on the resources created by this "
+"module."
+msgstr "运行 ``terraform plan`` 查看本模块将创建的资源详情。"
+
+#: ../../source/getting_started/installation/gcp.rst:35
+msgid ""
+"When you are satisfied with the plan and want to create the resources, "
+"run ``terraform apply``."
+msgstr "确认计划无误并希望创建资源时，运行 ``terraform apply`` 。"
+
+#: ../../source/getting_started/installation/gcp.rst:38
+msgid ""
+"If you receive ``NodePool aibrix-gpu-nodes was created in the error state"
+" \"ERROR\"`` while running the script, check your quotas for GPUs and the"
+" specific instances you're trying to deploy."
+msgstr ""
+"如果运行脚本时收到 ``NodePool aibrix-gpu-nodes was created in the error state \"ERROR\"`` "
+"，请检查 GPU 配额以及要部署的具体实例规格。"
+
+#: ../../source/getting_started/installation/gcp.rst:40
+msgid ""
+"Wait for module to complete running. It will output a command to receive "
+"the kubernetes config file and a public IP address."
+msgstr "等待模块运行完成。它会输出获取 Kubernetes 配置文件的命令以及一个公网 IP。"
+
+#: ../../source/getting_started/installation/gcp.rst:41
+msgid "Run a command against the public IP:"
+msgstr "对公网 IP 运行命令："
+
+#: ../../source/getting_started/installation/gcp.rst:57
+msgid ""
+"When you are finished testing and no longer want the resources, run "
+"``terraform destroy``."
+msgstr "测试结束且不再需要这些资源时，运行 ``terraform destroy`` 。"
+
+#: ../../source/getting_started/installation/gcp.rst:60
+msgid ""
+"Ensure that you complete this step once you are done trying it out, as "
+"GPUs are expensive."
+msgstr "试用结束后务必完成此步，因为 GPU 费用较高。"
+
+#: ../../source/getting_started/installation/gcp.rst:63
+msgid "Inputs"
+msgstr "输入"
+
+#: ../../source/getting_started/installation/gcp.rst:69
+#: ../../source/getting_started/installation/gcp.rst:132
+#: ../../source/getting_started/installation/gcp.rst:146
+#: ../../source/getting_started/installation/gcp.rst:163
+msgid "Name"
+msgstr "名称"
+
+#: ../../source/getting_started/installation/gcp.rst:70
+#: ../../source/getting_started/installation/gcp.rst:133
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/getting_started/installation/gcp.rst:71
+msgid "Type"
+msgstr "类型"
+
+#: ../../source/getting_started/installation/gcp.rst:72
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/getting_started/installation/gcp.rst:73
+msgid "Required"
+msgstr "必填"
+
+#: ../../source/getting_started/installation/gcp.rst:74
+msgid "aibrix_release_version"
+msgstr "aibrix_release_version"
+
+#: ../../source/getting_started/installation/gcp.rst:75
+msgid "The version of AIBrix to deploy."
+msgstr "要部署的 AIBrix 版本。"
+
+#: ../../source/getting_started/installation/gcp.rst:76
+#: ../../source/getting_started/installation/gcp.rst:81
+#: ../../source/getting_started/installation/gcp.rst:86
+#: ../../source/getting_started/installation/gcp.rst:91
+#: ../../source/getting_started/installation/gcp.rst:106
+#: ../../source/getting_started/installation/gcp.rst:111
+#: ../../source/getting_started/installation/gcp.rst:116
+#: ../../source/getting_started/installation/gcp.rst:121
+msgid "string"
+msgstr "string"
+
+#: ../../source/getting_started/installation/gcp.rst:77
+msgid "\"v0.2.0\""
+msgstr "\"v0.2.0\""
+
+#: ../../source/getting_started/installation/gcp.rst:78
+#: ../../source/getting_started/installation/gcp.rst:83
+#: ../../source/getting_started/installation/gcp.rst:88
+#: ../../source/getting_started/installation/gcp.rst:98
+#: ../../source/getting_started/installation/gcp.rst:103
+#: ../../source/getting_started/installation/gcp.rst:108
+#: ../../source/getting_started/installation/gcp.rst:113
+#: ../../source/getting_started/installation/gcp.rst:118
+msgid "no"
+msgstr "否"
+
+#: ../../source/getting_started/installation/gcp.rst:79
+msgid "cluster_name"
+msgstr "cluster_name"
+
+#: ../../source/getting_started/installation/gcp.rst:80
+msgid "Name of the GKE cluster."
+msgstr "GKE 集群名称。"
+
+#: ../../source/getting_started/installation/gcp.rst:82
+msgid "\"aibrix-inference-cluster\""
+msgstr "\"aibrix-inference-cluster\""
+
+#: ../../source/getting_started/installation/gcp.rst:84
+msgid "cluster_zone"
+msgstr "cluster_zone"
+
+#: ../../source/getting_started/installation/gcp.rst:85
+msgid ""
+"Zone to deploy cluster within. If not provided will be deployed to "
+"default region."
+msgstr "部署集群的可用区。未提供时将部署到默认区域。"
+
+#: ../../source/getting_started/installation/gcp.rst:87
+#: ../../source/getting_started/installation/gcp.rst:117
+msgid "\"\""
+msgstr "\"\""
+
+#: ../../source/getting_started/installation/gcp.rst:89
+msgid "default_region"
+msgstr "default_region"
+
+#: ../../source/getting_started/installation/gcp.rst:90
+msgid "Default region to deploy resources within."
+msgstr "部署资源的默认区域。"
+
+#: ../../source/getting_started/installation/gcp.rst:92
+#: ../../source/getting_started/installation/gcp.rst:122
+#: ../../source/getting_started/installation/gcp.rst:151
+#: ../../source/getting_started/installation/gcp.rst:154
+msgid "n/a"
+msgstr "n/a"
+
+#: ../../source/getting_started/installation/gcp.rst:93
+#: ../../source/getting_started/installation/gcp.rst:123
+msgid "yes"
+msgstr "是"
+
+#: ../../source/getting_started/installation/gcp.rst:94
+msgid "deploy_example_model"
+msgstr "deploy_example_model"
+
+#: ../../source/getting_started/installation/gcp.rst:95
+msgid "Whether to deploy the example model."
+msgstr "是否部署示例模型。"
+
+#: ../../source/getting_started/installation/gcp.rst:96
+msgid "bool"
+msgstr "bool"
+
+#: ../../source/getting_started/installation/gcp.rst:97
+msgid "true"
+msgstr "true"
+
+#: ../../source/getting_started/installation/gcp.rst:99
+msgid "node_pool_machine_count"
+msgstr "node_pool_machine_count"
+
+#: ../../source/getting_started/installation/gcp.rst:100
+msgid "Machine count for the node pool."
+msgstr "节点池机器数量。"
+
+#: ../../source/getting_started/installation/gcp.rst:101
+msgid "number"
+msgstr "number"
+
+#: ../../source/getting_started/installation/gcp.rst:102
+msgid "1"
+msgstr "1"
+
+#: ../../source/getting_started/installation/gcp.rst:104
+msgid "node_pool_machine_type"
+msgstr "node_pool_machine_type"
+
+#: ../../source/getting_started/installation/gcp.rst:105
+msgid "Machine type for the node pool. Must be in the A3, A2, or G2 series."
+msgstr "节点池机器类型。必须是 A3、A2 或 G2 系列。"
+
+#: ../../source/getting_started/installation/gcp.rst:107
+msgid "\"g2-standard-4\""
+msgstr "\"g2-standard-4\""
+
+#: ../../source/getting_started/installation/gcp.rst:109
+msgid "node_pool_name"
+msgstr "node_pool_name"
+
+#: ../../source/getting_started/installation/gcp.rst:110
+msgid "Name of the GPU node pool."
+msgstr "GPU 节点池名称。"
+
+#: ../../source/getting_started/installation/gcp.rst:112
+msgid "\"aibrix-gpu-nodes\""
+msgstr "\"aibrix-gpu-nodes\""
+
+#: ../../source/getting_started/installation/gcp.rst:114
+msgid "node_pool_zone"
+msgstr "node_pool_zone"
+
+#: ../../source/getting_started/installation/gcp.rst:115
+msgid ""
+"Zone to deploy GPU node pool within. If not provided will be deployed to "
+"zone in default region which has capacity for machine type."
+msgstr ""
+"部署 GPU 节点池的可用区。未提供时将部署到默认区域中对该机器类型有容量的可用区。"
+
+#: ../../source/getting_started/installation/gcp.rst:119
+msgid "project_id"
+msgstr "project_id"
+
+#: ../../source/getting_started/installation/gcp.rst:120
+msgid "GCP project to deploy resources within."
+msgstr "部署资源所在的 GCP 项目。"
+
+#: ../../source/getting_started/installation/gcp.rst:126
+msgid "Outputs"
+msgstr "输出"
+
+#: ../../source/getting_started/installation/gcp.rst:134
+msgid "aibrix_service_public_ip"
+msgstr "aibrix_service_public_ip"
+
+#: ../../source/getting_started/installation/gcp.rst:135
+msgid "Public IP address for AIBrix service."
+msgstr "AIBrix 服务的公网 IP。"
+
+#: ../../source/getting_started/installation/gcp.rst:136
+msgid "configure_kubectl_command"
+msgstr "configure_kubectl_command"
+
+#: ../../source/getting_started/installation/gcp.rst:137
+msgid "Command to run which will allow kubectl access."
+msgstr "用于获得 kubectl 访问权限的命令。"
+
+#: ../../source/getting_started/installation/gcp.rst:140
+msgid "Modules"
+msgstr "模块"
+
+#: ../../source/getting_started/installation/gcp.rst:147
+msgid "Source"
+msgstr "来源"
+
+#: ../../source/getting_started/installation/gcp.rst:148
+#: ../../source/getting_started/installation/gcp.rst:164
+msgid "Version"
+msgstr "版本"
+
+#: ../../source/getting_started/installation/gcp.rst:149
+msgid "aibrix"
+msgstr "aibrix"
+
+#: ../../source/getting_started/installation/gcp.rst:150
+msgid "deployment/terraform/kubernetes"
+msgstr "deployment/terraform/kubernetes"
+
+#: ../../source/getting_started/installation/gcp.rst:152
+msgid "cluster"
+msgstr "cluster"
+
+#: ../../source/getting_started/installation/gcp.rst:153
+msgid "deployment/terraform/gcp/cluster"
+msgstr "deployment/terraform/gcp/cluster"
+
+#: ../../source/getting_started/installation/gcp.rst:157
+msgid "Providers"
+msgstr "Provider"
+
+#: ../../source/getting_started/installation/gcp.rst:165
+msgid "google"
+msgstr "google"
+
+#: ../../source/getting_started/installation/gcp.rst:166
+msgid "6.22.0"
+msgstr "6.22.0"
+
+#: ../../source/getting_started/installation/gcp.rst:167
+msgid "kubernetes"
+msgstr "kubernetes"
+
+#: ../../source/getting_started/installation/gcp.rst:168
+msgid "2.36.0"
+msgstr "2.36.0"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/installation.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/installation.po
@@ -1,0 +1,223 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/installation/installation.rst:122
+msgid "Getting Started"
+msgstr "快速开始"
+
+#: ../../source/getting_started/installation/installation.rst:5
+msgid "Installation"
+msgstr "安装"
+
+#: ../../source/getting_started/installation/installation.rst:7
+msgid ""
+"This guide describes how to install AIBrix manifests in different "
+"platforms."
+msgstr "本指南说明如何在不同平台安装 AIBrix 清单。"
+
+#: ../../source/getting_started/installation/installation.rst:9
+msgid ""
+"Currently, AIBrix installation does rely on other cloud specific "
+"features. It's fully compatible with vanilla Kubernetes."
+msgstr ""
+"目前，AIBrix 安装并不依赖其他云平台特定功能，与原生 Kubernetes 完全兼容。"
+
+#: ../../source/getting_started/installation/installation.rst:12
+msgid "Install AIBrix on Cloud Kubernetes Clusters"
+msgstr "在云上的 Kubernetes 集群安装 AIBrix"
+
+#: ../../source/getting_started/installation/installation.rst:15
+msgid ""
+"AIBrix requires `Envoy Gateway <https://gateway.envoyproxy.io/>`_ for "
+"request routing."
+msgstr ""
+"AIBrix 需要 `Envoy Gateway <https://gateway.envoyproxy.io/>`_ 来做请求路由。"
+
+#: ../../source/getting_started/installation/installation.rst:17
+msgid ""
+"`KubeRay <https://github.com/ray-project/kuberay>`_ is **optional** and "
+"only required if you plan to use Ray as your distributed inference "
+"runtime (RayClusterFleet, RayClusterReplicaSet)."
+msgstr ""
+"`KubeRay <https://github.com/ray-project/kuberay>`_ 是 **可选** 的，仅在计划使用 "
+"Ray 作为分布式推理运行时（RayClusterFleet、RayClusterReplicaSet）时才需要。"
+
+#: ../../source/getting_started/installation/installation.rst:19
+msgid ""
+"AIBrix can run without KubeRay - use StormService for both single-node "
+"and multi-node inference workloads. The distributed inference controller "
+"will be automatically skipped if KubeRay CRDs are not detected."
+msgstr ""
+"没有 KubeRay 也可以运行 AIBrix：单节点和多节点推理工作负载都可使用 StormService。"
+"若未检测到 KubeRay CRD，分布式推理控制器会自动跳过。"
+
+#: ../../source/getting_started/installation/installation.rst:23
+msgid "Stable Version"
+msgstr "稳定版"
+
+#: ../../source/getting_started/installation/installation.rst:36
+msgid "Stable Version Using Helm"
+msgstr "使用 Helm 安装稳定版"
+
+#: ../../source/getting_started/installation/installation.rst:39
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/getting_started/installation/installation.rst:41
+msgid "**Envoy Gateway**"
+msgstr "**Envoy Gateway**"
+
+#: ../../source/getting_started/installation/installation.rst:51
+msgid ""
+"If you are experiencing network issues with `docker.io`, you can install "
+"the helm chart from the code repo "
+"https://github.com/envoyproxy/gateway/tree/main/charts/gateway-helm "
+"instead."
+msgstr ""
+"如果访问 `docker.io` 遇到网络问题，可以从代码仓库 "
+"https://github.com/envoyproxy/gateway/tree/main/charts/gateway-helm "
+"安装 Helm chart。"
+
+#: ../../source/getting_started/installation/installation.rst:53
+msgid "**KubeRay operator (Optional)**"
+msgstr "**KubeRay operator（可选）**"
+
+#: ../../source/getting_started/installation/installation.rst:56
+msgid ""
+"Skip this step if you don't need Ray-based distributed inference. AIBrix "
+"will work without KubeRay for StormService-based workloads."
+msgstr ""
+"如果不需要基于 Ray 的分布式推理，可跳过此步。基于 StormService 的工作负载无需 "
+"KubeRay 即可运行 AIBrix。"
+
+#: ../../source/getting_started/installation/installation.rst:76
+msgid "Install AIBrix with Helm"
+msgstr "使用 Helm 安装 AIBrix"
+
+#: ../../source/getting_started/installation/installation.rst:87
+msgid "Upgrade AIBrix with Helm"
+msgstr "使用 Helm 升级 AIBrix"
+
+#: ../../source/getting_started/installation/installation.rst:95
+msgid "Uninstall AIBrix with Helm"
+msgstr "使用 Helm 卸载 AIBrix"
+
+#: ../../source/getting_started/installation/installation.rst:105
+msgid "Nightly Version"
+msgstr "Nightly 版本"
+
+#: ../../source/getting_started/installation/installation.rst:120
+msgid "Install AIBrix in testing Environments"
+msgstr "在测试环境中安装 AIBrix"
+
+#: ../../source/getting_started/installation/installation.rst:135
+msgid "Install Individual AIBrix Components"
+msgstr "安装单个 AIBrix 组件"
+
+#: ../../source/getting_started/installation/installation.rst:139
+msgid "Autoscaler"
+msgstr "Autoscaler"
+
+#: ../../source/getting_started/installation/installation.rst:147
+msgid "Distributed Inference (Ray-based)"
+msgstr "分布式推理（基于 Ray）"
+
+#: ../../source/getting_started/installation/installation.rst:150
+msgid "This requires KubeRay operator to be installed first."
+msgstr "这需要先安装 KubeRay operator。"
+
+#: ../../source/getting_started/installation/installation.rst:158
+msgid "Model Adapter(Lora)"
+msgstr "Model Adapter（LoRA）"
+
+#: ../../source/getting_started/installation/installation.rst:165
+msgid "KV Cache"
+msgstr "KV Cache"
+
+#: ../../source/getting_started/installation/installation.rst:173
+msgid "Disabling Controllers"
+msgstr "禁用控制器"
+
+#: ../../source/getting_started/installation/installation.rst:175
+msgid ""
+"If you install AIBrix with all controllers enabled by default but don't "
+"have KubeRay installed, the distributed inference controller will be "
+"automatically skipped with a log message."
+msgstr ""
+"如果按默认启用全部控制器安装 AIBrix，但未安装 KubeRay，分布式推理控制器会自动跳过，"
+"并输出一条日志。"
+
+#: ../../source/getting_started/installation/installation.rst:177
+msgid ""
+"To explicitly disable specific controllers, use the ``--controllers`` "
+"flag:"
+msgstr "要显式禁用特定控制器，使用 ``--controllers`` 标志："
+
+#: ../../source/getting_started/installation/installation.rst:187
+msgid "Available controllers:"
+msgstr "可用控制器："
+
+#: ../../source/getting_started/installation/installation.rst:189
+msgid "``pod-autoscaler-controller``: HPA/KPA-style autoscaling"
+msgstr "``pod-autoscaler-controller`` ：HPA/KPA 风格的自动扩缩容"
+
+#: ../../source/getting_started/installation/installation.rst:190
+msgid ""
+"``distributed-inference-controller``: Ray-based distributed inference "
+"(requires KubeRay)"
+msgstr "``distributed-inference-controller`` ：基于 Ray 的分布式推理（需要 KubeRay）"
+
+#: ../../source/getting_started/installation/installation.rst:191
+msgid "``model-adapter-controller``: LoRA adapter management"
+msgstr "``model-adapter-controller`` ：LoRA adapter 管理"
+
+#: ../../source/getting_started/installation/installation.rst:192
+msgid ""
+"``kv-cache-controller``: Distributed KV cache server orchestration with "
+"consistent hashing"
+msgstr "``kv-cache-controller`` ：带一致性哈希的分布式 KV cache 服务编排"
+
+#: ../../source/getting_started/installation/installation.rst:193
+msgid ""
+"``stormservice-controller``: Multi-node orchestration with P/D and AFD "
+"support"
+msgstr "``stormservice-controller`` ：支持 P/D 和 AFD 的多节点编排"
+
+#: ../../source/getting_started/installation/installation.rst:195
+msgid "What's next?"
+msgstr "下一步"
+
+#: ../../source/getting_started/installation/installation.rst:198
+msgid ":doc:`../quickstart`: deploy your first model"
+msgstr ":doc:`../quickstart` ：部署第一个模型"
+
+#: ../../source/getting_started/installation/installation.rst:199
+msgid ""
+":doc:`../../production/model-deployment`: production model deployment "
+"guidance"
+msgstr ":doc:`../../production/model-deployment` ：生产环境模型部署指南"
+
+#: ../../source/getting_started/installation/installation.rst:200
+msgid ":doc:`../../production/gateway`: production gateway configuration"
+msgstr ":doc:`../../production/gateway` ：生产环境网关配置"
+
+#: ../../source/getting_started/installation/installation.rst:201
+msgid ":doc:`../../production/observability`: metrics, dashboards, and telemetry"
+msgstr ":doc:`../../production/observability` ：指标、仪表盘和遥测"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/lambda.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/lambda.po
@@ -1,0 +1,339 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/installation/lambda.rst:5
+msgid "Lambda Cloud"
+msgstr "Lambda Cloud"
+
+#: ../../source/getting_started/installation/lambda.rst:7
+msgid ""
+"This guide provides a step-by-step tutorial to deploy AIBrix on a single-"
+"node Lambda instance for testing purposes. The setup includes installing "
+"dependencies, verifying the installation, setting up the cluster, and "
+"deploying AIBrix components."
+msgstr ""
+"本指南逐步说明如何在单节点 Lambda 实例上部署 AIBrix 以供测试。步骤包括安装依赖、"
+"验证安装、搭建集群以及部署 AIBrix 组件。"
+
+#: ../../source/getting_started/installation/lambda.rst:10
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/getting_started/installation/lambda.rst:13
+msgid "1. Get a Lambda Cloud instance"
+msgstr "1. 获取 Lambda Cloud 实例"
+
+#: ../../source/getting_started/installation/lambda.rst:15
+msgid ""
+"You can follow `lambda cloud docs <https://docs.lambdalabs.com/>`_ to "
+"launch an instance."
+msgstr "可按照 `lambda cloud docs <https://docs.lambdalabs.com/>`_ 启动实例。"
+
+#: ../../source/getting_started/installation/lambda.rst:17
+msgid "lambda-cloud-instance"
+msgstr "lambda-cloud-instance"
+
+#: ../../source/getting_started/installation/lambda.rst:22
+msgid ""
+"After launching the instance, you can get the instance's IP address and "
+"ssh into the instance."
+msgstr "启动实例后，可获取实例 IP 并用 ssh 登录。"
+
+#: ../../source/getting_started/installation/lambda.rst:24
+msgid "lambda-cloud-ssh"
+msgstr "lambda-cloud-ssh"
+
+#: ../../source/getting_started/installation/lambda.rst:29
+msgid "You can also enter the Jupyter notebook without managing SSH keys."
+msgstr "也可以不管理 SSH 密钥，直接进入 Jupyter notebook。"
+
+#: ../../source/getting_started/installation/lambda.rst:32
+msgid "2. Clone AIBrix code base"
+msgstr "2. 克隆 AIBrix 代码库"
+
+#: ../../source/getting_started/installation/lambda.rst:34
+msgid "Clone the AIBrix code base to your local machine:"
+msgstr "将 AIBrix 代码库克隆到本机："
+
+#: ../../source/getting_started/installation/lambda.rst:43
+msgid "3. Install Dependencies"
+msgstr "3. 安装依赖"
+
+#: ../../source/getting_started/installation/lambda.rst:45
+msgid ""
+"Run the following script to install the necessary dependencies including "
+"`nvkind`, `minikube`, `kubectl`, `Helm`, `Go`, and the `NVIDIA Container "
+"Toolkit`."
+msgstr ""
+"运行以下脚本安装必要依赖，包括 `nvkind` 、`minikube` 、`kubectl` 、`Helm` 、`Go` 和 `NVIDIA "
+"Container Toolkit` 。"
+
+#: ../../source/getting_started/installation/lambda.rst:51
+#: ../../source/getting_started/installation/lambda.rst:80
+#: ../../source/getting_started/installation/lambda.rst:211
+msgid "**Summary:**"
+msgstr "**摘要：**"
+
+#: ../../source/getting_started/installation/lambda.rst:53
+msgid "Installs required system packages (`jq`, `Go`, `kubectl`, `kind`, `Helm`)"
+msgstr "安装所需系统软件包（`jq` 、`Go` 、`kubectl` 、`kind` 、`Helm` ）"
+
+#: ../../source/getting_started/installation/lambda.rst:54
+msgid ""
+"Installs `nvkind` and `minikube` (custom Kubernetes-in-Docker with GPU "
+"support)"
+msgstr "安装 `nvkind` 和 `minikube` （支持 GPU 的自定义 Kubernetes-in-Docker）"
+
+#: ../../source/getting_started/installation/lambda.rst:55
+msgid "Configures the NVIDIA Container Toolkit"
+msgstr "配置 NVIDIA Container Toolkit"
+
+#: ../../source/getting_started/installation/lambda.rst:56
+msgid "Updates Docker settings for GPU compatibility"
+msgstr "更新 Docker 设置以兼容 GPU"
+
+#: ../../source/getting_started/installation/lambda.rst:63
+msgid "Once completed, restart your terminal or run:"
+msgstr "完成后重启终端，或运行："
+
+#: ../../source/getting_started/installation/lambda.rst:70
+msgid "4. Verify GPU container runtime"
+msgstr "4. 验证 GPU 容器运行时"
+
+#: ../../source/getting_started/installation/lambda.rst:72
+msgid ""
+"The path for the following script assumes that you are in the root "
+"directory of the AIBrix repository."
+msgstr "以下脚本的路径假定当前位于 AIBrix 仓库根目录。"
+
+#: ../../source/getting_started/installation/lambda.rst:74
+msgid ""
+"Run the following script to ensure that the NVIDIA drivers and Docker "
+"integration are correctly configured:"
+msgstr "运行以下脚本，确认 NVIDIA 驱动和 Docker 集成配置正确："
+
+#: ../../source/getting_started/installation/lambda.rst:82
+msgid "Runs `nvidia-smi` to check GPU availability"
+msgstr "运行 `nvidia-smi` 检查 GPU 是否可用"
+
+#: ../../source/getting_started/installation/lambda.rst:83
+msgid "Runs a Docker container with NVIDIA runtime to verify GPU detection"
+msgstr "使用 NVIDIA runtime 运行 Docker 容器，验证能否检测到 GPU"
+
+#: ../../source/getting_started/installation/lambda.rst:84
+msgid "Ensures that GPU devices are accessible within containers"
+msgstr "确认容器内可以访问 GPU 设备"
+
+#: ../../source/getting_started/installation/lambda.rst:86
+msgid "If all checks pass successfully like below, proceed to the next step."
+msgstr "如果如下所示全部检查通过，继续下一步。"
+
+#: ../../source/getting_started/installation/lambda.rst:95
+msgid "Setup Kubernetes Environments"
+msgstr "搭建 Kubernetes 环境"
+
+#: ../../source/getting_started/installation/lambda.rst:97
+msgid "We provide two ways to set up the environment:"
+msgstr "我们提供两种搭建环境的方式："
+
+#: ../../source/getting_started/installation/lambda.rst:99
+msgid ""
+"**Minikube** (Recommended): Minikube is the recommended option for local "
+"testing and development. It provides a stable, single-node Kubernetes "
+"cluster."
+msgstr "**Minikube** （推荐）：Minikube 是本地测试和开发的推荐选项。它提供稳定的单节点 Kubernetes 集群。"
+
+#: ../../source/getting_started/installation/lambda.rst:100
+msgid ""
+"**Kind**: Kind can also be used, but due to the container-based nature of"
+" Kind clusters, we often observe that containers unexpectedly receive "
+"`SIGTERM` signals.(see `issue#683 <https://github.com/vllm-"
+"project/aibrix/issues/683>`_ and `issue#684 <https://github.com/vllm-"
+"project/aibrix/issues/684>`_)."
+msgstr ""
+"**Kind** ：也可以使用 Kind，但由于 Kind 集群基于容器，我们经常观察到容器会意外收到 `SIGTERM` 信号。（参见 `issue#683 "
+"<https://github.com/vllm-project/aibrix/issues/683>`_ 和 `issue#684 <https://github.com/vllm-project/aibrix/issues/684>`_ "
+"）。"
+
+#: ../../source/getting_started/installation/lambda.rst:103
+msgid ""
+"The root cause has not yet been fully determined. Therefore, we recommend"
+" using Minikube whenever possible for a more stable experience."
+msgstr "根因尚未完全确定。因此建议尽可能使用 Minikube，以获得更稳定的体验。"
+
+#: ../../source/getting_started/installation/lambda.rst:107
+msgid "MiniKube"
+msgstr "MiniKube"
+
+#: ../../source/getting_started/installation/lambda.rst:110
+msgid "1. Create a `minikube` Cluster"
+msgstr "1. 创建 `minikube` 集群"
+
+#: ../../source/getting_started/installation/lambda.rst:112
+msgid "First, ensure that your non-root user has `docker` permission:"
+msgstr "首先确认非 root 用户具有 `docker` 权限："
+
+#: ../../source/getting_started/installation/lambda.rst:119
+msgid "Create a Kubernetes cluster using minikube:"
+msgstr "使用 minikube 创建 Kubernetes 集群："
+
+#: ../../source/getting_started/installation/lambda.rst:146
+msgid ""
+"If you meet problems setup the cluster and enable the GPU support, check "
+"`Using NVIDIA GPUs with minikube "
+"<https://minikube.sigs.k8s.io/docs/tutorials/nvidia/>`_ for more details."
+msgstr ""
+"如果搭建集群并启用 GPU 支持时遇到问题，参见 `Using NVIDIA GPUs with minikube <https://minikube.sigs.k8s.io/docs/tutorials/nvidia/>`_ "
+"。"
+
+#: ../../source/getting_started/installation/lambda.rst:147
+msgid ""
+"GPU operator will be automatially installed along with the cluster setup,"
+" we do not need to install it separately."
+msgstr "GPU operator 会随集群搭建自动安装，无需单独安装。"
+
+#: ../../source/getting_started/installation/lambda.rst:150
+msgid "2. Enable LoadBalancer service in minikube"
+msgstr "2. 在 minikube 中启用 LoadBalancer 服务"
+
+#: ../../source/getting_started/installation/lambda.rst:152
+msgid ""
+"Services of type LoadBalancer can be exposed via the `minikube tunnel` "
+"command. It must be run in a separate terminal window to keep the "
+"`LoadBalancer` running. Check `LoadBalancer access "
+"<https://minikube.sigs.k8s.io/docs/handbook/accessing/>`_ for more "
+"details."
+msgstr ""
+"LoadBalancer 类型的服务可通过 `minikube tunnel` 命令暴露。必须在单独的终端窗口中运行，以保持 `LoadBalancer` "
+"可用。详情见 `LoadBalancer access <https://minikube.sigs.k8s.io/docs/handbook/accessing/>`_ "
+"。"
+
+#: ../../source/getting_started/installation/lambda.rst:155
+msgid "Run the tunnel in a separate terminal and do not close this window."
+msgstr "在单独的终端中运行 tunnel，不要关闭该窗口。"
+
+#: ../../source/getting_started/installation/lambda.rst:174
+msgid "3. Delete the minikube cluster"
+msgstr "3. 删除 minikube 集群"
+
+#: ../../source/getting_started/installation/lambda.rst:176
+msgid "Once you've done testing, you can delete the `minikube` cluster:"
+msgstr "测试完成后，可以删除 `minikube` 集群："
+
+#: ../../source/getting_started/installation/lambda.rst:184
+msgid "Kind"
+msgstr "Kind"
+
+#: ../../source/getting_started/installation/lambda.rst:187
+msgid "1. Create a `nvkind` Cluster"
+msgstr "1. 创建 `nvkind` 集群"
+
+#: ../../source/getting_started/installation/lambda.rst:189
+msgid "Create a Kubernetes cluster using nvkind:"
+msgstr "使用 nvkind 创建 Kubernetes 集群："
+
+#: ../../source/getting_started/installation/lambda.rst:195
+msgid ""
+"This will set up a single-node cluster with GPU support. Make sure you "
+"see `Ready` status for the node:"
+msgstr "这将搭建支持 GPU 的单节点集群。确认节点状态为 `Ready` ："
+
+#: ../../source/getting_started/installation/lambda.rst:203
+msgid "2. Setup NVIDIA GPU Operator"
+msgstr "2. 安装 NVIDIA GPU Operator"
+
+#: ../../source/getting_started/installation/lambda.rst:205
+msgid ""
+"Run the following script to install the NVIDIA GPU Operator and configure"
+" the cloud provider:"
+msgstr "运行以下脚本安装 NVIDIA GPU Operator 并配置 cloud provider："
+
+#: ../../source/getting_started/installation/lambda.rst:213
+msgid "Installs the NVIDIA GPU Operator using Helm"
+msgstr "使用 Helm 安装 NVIDIA GPU Operator"
+
+#: ../../source/getting_started/installation/lambda.rst:214
+msgid "Installs the Cloud Provider Kind (`cloud-provider-kind`)"
+msgstr "安装 Cloud Provider Kind（`cloud-provider-kind` ）"
+
+#: ../../source/getting_started/installation/lambda.rst:215
+msgid "Runs `cloud-provider-kind` in the background for cloud integration"
+msgstr "在后台运行 `cloud-provider-kind` 以进行云集成"
+
+#: ../../source/getting_started/installation/lambda.rst:219
+msgid "3. Delete Lambda Kind Cluster"
+msgstr "3. 删除 Lambda Kind 集群"
+
+#: ../../source/getting_started/installation/lambda.rst:221
+msgid "Once you've done testing, you can delete the `nvkind` cluster:"
+msgstr "测试完成后，可以删除 `nvkind` 集群："
+
+#: ../../source/getting_started/installation/lambda.rst:232
+msgid "Install AIBrix"
+msgstr "安装 AIBrix"
+
+#: ../../source/getting_started/installation/lambda.rst:234
+msgid "Once the cluster is up and running, install AIBrix components:"
+msgstr "集群就绪后，安装 AIBrix 组件："
+
+#: ../../source/getting_started/installation/lambda.rst:236
+msgid "**Install dependencies:**"
+msgstr "**安装依赖：**"
+
+#: ../../source/getting_started/installation/lambda.rst:246
+msgid "Verify that the AIBrix components are installed successfully:"
+msgstr "确认 AIBrix 组件安装成功："
+
+#: ../../source/getting_started/installation/lambda.rst:253
+msgid "Now, you can follow :doc:`../quickstart` to deploy your models."
+msgstr "现在可以按照 :doc:`../quickstart` 部署模型。"
+
+#: ../../source/getting_started/installation/lambda.rst:257
+msgid "Conclusion"
+msgstr "小结"
+
+#: ../../source/getting_started/installation/lambda.rst:258
+msgid ""
+"You have successfully deployed AIBrix on a single-node Lambda instance. "
+"This setup allows for efficient testing and debugging of AIBrix "
+"components in a local environment."
+msgstr ""
+"你已在单节点 Lambda 实例上成功部署 AIBrix。该环境便于在本地高效测试和调试 "
+"AIBrix 组件。"
+
+#: ../../source/getting_started/installation/lambda.rst:260
+msgid "If you encounter issues, ensure that:"
+msgstr "如果遇到问题，请确认："
+
+#: ../../source/getting_started/installation/lambda.rst:262
+msgid "The NVIDIA GPU Operator is correctly installed"
+msgstr "NVIDIA GPU Operator 已正确安装"
+
+#: ../../source/getting_started/installation/lambda.rst:263
+msgid "The cluster has GPU resources available (`kubectl describe nodes`)"
+msgstr "集群有可用 GPU 资源（`kubectl describe nodes` ）"
+
+#: ../../source/getting_started/installation/lambda.rst:264
+msgid "Docker and Kubernetes configurations match GPU compatibility requirements"
+msgstr "Docker 和 Kubernetes 配置满足 GPU 兼容性要求"
+
+#: ../../source/getting_started/installation/lambda.rst:266
+msgid "Happy Testing!"
+msgstr "祝测试顺利！"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/local-mode.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/local-mode.po
@@ -1,0 +1,268 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/installation/local-mode.rst:5
+msgid "Local Mode"
+msgstr "本地模式"
+
+#: ../../source/getting_started/installation/local-mode.rst:7
+msgid ""
+"Local mode runs the AIBrix gateway data path on a single machine without "
+"Kubernetes. It starts Envoy and the AIBrix gateway plugin as local "
+"processes and routes traffic to model servers listed in a static endpoint"
+" file."
+msgstr ""
+"本地模式在单台机器上运行 AIBrix 网关数据路径，不需要 Kubernetes。它将 Envoy 和 "
+"AIBrix 网关插件作为本地进程启动，并把流量路由到静态端点文件中列出的模型服务。"
+
+#: ../../source/getting_started/installation/local-mode.rst:11
+msgid ""
+"Use local mode for gateway routing development, quick OpenAI-compatible "
+"request testing, and debugging routing algorithms. Use a Kubernetes "
+"installation when you need controllers, CRDs, autoscaling, model "
+"downloading, runtime sidecars, or the full batch and metadata stack."
+msgstr ""
+"本地模式适用于网关路由开发、快速测试 OpenAI 兼容请求，以及调试路由算法。"
+"如果需要控制器、CRD、自动扩缩容、模型下载、runtime sidecar，或完整的批处理和元数据栈，"
+"请使用 Kubernetes 安装。"
+
+#: ../../source/getting_started/installation/local-mode.rst:17
+msgid "Architecture"
+msgstr "架构"
+
+#: ../../source/getting_started/installation/local-mode.rst:36
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/getting_started/installation/local-mode.rst:38
+msgid "Install these tools on the local machine:"
+msgstr "在本机安装以下工具："
+
+#: ../../source/getting_started/installation/local-mode.rst:40
+msgid "Go 1.22 or newer"
+msgstr "Go 1.22 或更高版本"
+
+#: ../../source/getting_started/installation/local-mode.rst:41
+msgid "Envoy"
+msgstr "Envoy"
+
+#: ../../source/getting_started/installation/local-mode.rst:42
+msgid "one or more OpenAI-compatible model servers, such as vLLM"
+msgstr "一个或多个 OpenAI 兼容的模型服务，例如 vLLM"
+
+#: ../../source/getting_started/installation/local-mode.rst:44
+msgid "On macOS, Envoy can be installed with Homebrew:"
+msgstr "在 macOS 上可用 Homebrew 安装 Envoy："
+
+#: ../../source/getting_started/installation/local-mode.rst:50
+msgid "On Linux, download an Envoy release binary:"
+msgstr "在 Linux 上下载 Envoy 发行版二进制："
+
+#: ../../source/getting_started/installation/local-mode.rst:59
+msgid "Build the local gateway plugin binary from the repository root:"
+msgstr "在仓库根目录构建本地网关插件二进制："
+
+#: ../../source/getting_started/installation/local-mode.rst:65
+msgid "Start a backend model server. This example uses vLLM:"
+msgstr "启动后端模型服务。本例使用 vLLM："
+
+#: ../../source/getting_started/installation/local-mode.rst:72
+msgid "Configure endpoints"
+msgstr "配置端点"
+
+#: ../../source/getting_started/installation/local-mode.rst:74
+msgid ""
+"Local mode reads model endpoints from "
+"``deployment/local/configs/endpoints.yaml``. A minimal configuration "
+"looks like this:"
+msgstr ""
+"本地模式从 ``deployment/local/configs/endpoints.yaml`` 读取模型端点。最小配置如下："
+
+#: ../../source/getting_started/installation/local-mode.rst:85
+msgid "The request model name must match the configured model name."
+msgstr "请求中的模型名称必须与配置的模型名称一致。"
+
+#: ../../source/getting_started/installation/local-mode.rst:87
+msgid ""
+"The same file can also describe prefill and decode role sets for "
+"prefill/decode disaggregation testing:"
+msgstr "同一文件也可描述 prefill 和 decode 角色集，用于 prefill/decode 分离测试："
+
+#: ../../source/getting_started/installation/local-mode.rst:103
+msgid "Run local mode"
+msgstr "运行本地模式"
+
+#: ../../source/getting_started/installation/local-mode.rst:105
+msgid "On Linux, the helper script starts Envoy and the gateway plugin:"
+msgstr "在 Linux 上，辅助脚本会启动 Envoy 和网关插件："
+
+#: ../../source/getting_started/installation/local-mode.rst:112
+msgid "Send a request through Envoy:"
+msgstr "通过 Envoy 发送请求："
+
+#: ../../source/getting_started/installation/local-mode.rst:123
+msgid "Stop the local processes:"
+msgstr "停止本地进程："
+
+#: ../../source/getting_started/installation/local-mode.rst:129
+msgid ""
+"On macOS, or when you want direct process control, start the processes in"
+" separate terminals from the repository root:"
+msgstr ""
+"在 macOS 上，或希望直接控制进程时，从仓库根目录在不同终端中分别启动进程："
+
+#: ../../source/getting_started/installation/local-mode.rst:145
+msgid "Use a custom endpoint or Envoy config with the helper script:"
+msgstr "使用辅助脚本指定自定义端点或 Envoy 配置："
+
+#: ../../source/getting_started/installation/local-mode.rst:155
+msgid "Routing algorithms"
+msgstr "路由算法"
+
+#: ../../source/getting_started/installation/local-mode.rst:157
+msgid "Set ``ROUTING_ALGORITHM`` before starting local mode:"
+msgstr "启动本地模式前设置 ``ROUTING_ALGORITHM`` ："
+
+#: ../../source/getting_started/installation/local-mode.rst:163
+msgid ""
+"Use local mode with the same gateway routing algorithms that are "
+"supported by the gateway plugin, such as random routing, least-request "
+"routing, prefix-cache-aware routing, and prefill/decode routing. For "
+"production gateway configuration and algorithm behavior, see "
+":ref:`gateway`."
+msgstr ""
+"本地模式可使用网关插件支持的同一套路由算法，例如随机路由、least-request 路由、感知前缀缓存的路由，以及 prefill/decode "
+"路由。生产环境网关配置和算法行为参见 :ref:`gateway` 。"
+
+#: ../../source/getting_started/installation/local-mode.rst:169
+msgid "Ports and logs"
+msgstr "端口与日志"
+
+#: ../../source/getting_started/installation/local-mode.rst:174
+msgid "Component"
+msgstr "组件"
+
+#: ../../source/getting_started/installation/local-mode.rst:175
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/getting_started/installation/local-mode.rst:176
+msgid "Purpose"
+msgstr "用途"
+
+#: ../../source/getting_started/installation/local-mode.rst:177
+msgid "Envoy HTTP listener"
+msgstr "Envoy HTTP 监听器"
+
+#: ../../source/getting_started/installation/local-mode.rst:178
+msgid "``localhost:10080``"
+msgstr "``localhost:10080``"
+
+#: ../../source/getting_started/installation/local-mode.rst:179
+msgid "OpenAI-compatible request entry point."
+msgstr "OpenAI 兼容请求入口。"
+
+#: ../../source/getting_started/installation/local-mode.rst:180
+msgid "Envoy admin"
+msgstr "Envoy 管理接口"
+
+#: ../../source/getting_started/installation/local-mode.rst:181
+msgid "``localhost:9901``"
+msgstr "``localhost:9901``"
+
+#: ../../source/getting_started/installation/local-mode.rst:182
+msgid "Envoy admin and diagnostics."
+msgstr "Envoy 管理与诊断。"
+
+#: ../../source/getting_started/installation/local-mode.rst:183
+msgid "Gateway plugin metrics"
+msgstr "网关插件指标"
+
+#: ../../source/getting_started/installation/local-mode.rst:184
+msgid "``localhost:8080/metrics``"
+msgstr "``localhost:8080/metrics``"
+
+#: ../../source/getting_started/installation/local-mode.rst:185
+msgid "Gateway plugin metrics endpoint."
+msgstr "网关插件指标端点。"
+
+#: ../../source/getting_started/installation/local-mode.rst:186
+msgid "Health check"
+msgstr "健康检查"
+
+#: ../../source/getting_started/installation/local-mode.rst:187
+msgid "``localhost:10080/healthz``"
+msgstr "``localhost:10080/healthz``"
+
+#: ../../source/getting_started/installation/local-mode.rst:188
+msgid "Local gateway health check."
+msgstr "本地网关健康检查。"
+
+#: ../../source/getting_started/installation/local-mode.rst:190
+msgid "The helper script writes logs under ``deployment/local/logs``:"
+msgstr "辅助脚本将日志写到 ``deployment/local/logs`` ："
+
+#: ../../source/getting_started/installation/local-mode.rst:192
+msgid "``gateway-plugin.log``"
+msgstr "``gateway-plugin.log``"
+
+#: ../../source/getting_started/installation/local-mode.rst:193
+msgid "``envoy.log``"
+msgstr "``envoy.log``"
+
+#: ../../source/getting_started/installation/local-mode.rst:196
+msgid "Troubleshooting"
+msgstr "故障排查"
+
+#: ../../source/getting_started/installation/local-mode.rst:198
+msgid ""
+"``no healthy upstream``: confirm the backend model server is running and "
+"the host and port in ``endpoints.yaml`` are correct."
+msgstr "``no healthy upstream`` ：确认后端模型服务正在运行，且 ``endpoints.yaml`` 中的主机和端口正确。"
+
+#: ../../source/getting_started/installation/local-mode.rst:200
+msgid ""
+"``model not found``: confirm the request ``model`` value exactly matches "
+"the configured model name."
+msgstr "``model not found`` ：确认请求中的 ``model`` 值与配置的模型名称完全一致。"
+
+#: ../../source/getting_started/installation/local-mode.rst:202
+msgid ""
+"Envoy cannot bind a port: stop the previous local mode process or change "
+"the listener ports in the Envoy config."
+msgstr ""
+"Envoy 无法绑定端口：停止之前的本地模式进程，或更改 Envoy 配置中的监听端口。"
+
+#: ../../source/getting_started/installation/local-mode.rst:204
+msgid ""
+"External processing errors: check ``gateway-plugin.log`` first, then "
+"verify Envoy is using ``deployment/local/configs/envoy.yaml``."
+msgstr ""
+"外部处理错误：先查看 ``gateway-plugin.log`` ，再确认 Envoy 使用的是 ``deployment/local/configs/envoy.yaml`` "
+"。"
+
+#: ../../source/getting_started/installation/local-mode.rst:206
+msgid ""
+"Prefix-cache or prefill/decode routing does not behave as expected: "
+"confirm the selected ``ROUTING_ALGORITHM`` and the endpoint or roleset "
+"shape in ``endpoints.yaml``."
+msgstr ""
+"前缀缓存或 prefill/decode 路由行为不符合预期：确认所选 ``ROUTING_ALGORITHM`` ，以及 ``endpoints.yaml`` "
+"中的端点或 roleset 形态。"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/mac-for-desktop.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/mac-for-desktop.po
@@ -1,0 +1,90 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:5
+msgid "Mac for Desktop"
+msgstr "Mac 桌面环境"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:7
+msgid ""
+"This guide provides a minimal setup for deploying AIBrix locally on a Mac"
+" desktop for development and testing purposes."
+msgstr "本指南提供在 Mac 桌面本地部署 AIBrix 的最小配置，用于开发和测试。"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:10
+msgid "Why Mac Desktop?"
+msgstr "为什么用 Mac 桌面？"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:12
+msgid ""
+"Mac desktops are ideal for quick testing of AIBrix control plane "
+"components in your local laptop. It is highly recommended for AIBrix "
+"development and for testing lightweight vLLM CPU images."
+msgstr ""
+"Mac 桌面适合在本地笔记本上快速测试 AIBrix 控制面组件。非常适合 AIBrix 开发，"
+"以及测试轻量级 vLLM CPU 镜像。"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:16
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:18
+msgid "Install Docker Desktop (with Kubernetes enabled)"
+msgstr "安装 Docker Desktop（并启用 Kubernetes）"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:19
+msgid "Install kubectl and Helm"
+msgstr "安装 kubectl 和 Helm"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:22
+msgid "Install AIBrix"
+msgstr "安装 AIBrix"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:24
+msgid "Clone the AIBrix repository:"
+msgstr "克隆 AIBrix 仓库："
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:31
+msgid "Install dependencies and core components:"
+msgstr "安装依赖和核心组件："
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:40
+msgid "Expose Gateway"
+msgstr "暴露网关"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:42
+msgid ""
+"Since LoadBalancer is not available by default, use port-forward to "
+"access the gateway:"
+msgstr "默认没有 LoadBalancer，请使用 port-forward 访问网关："
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:48
+msgid "You can now access the gateway at `http://localhost:8888`."
+msgstr "现在可通过 `http://localhost:8888` 访问网关。"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:51
+msgid "Conclusion"
+msgstr "小结"
+
+#: ../../source/getting_started/installation/mac-for-desktop.rst:53
+msgid ""
+"This setup provides a lightweight way to develop and test AIBrix on Mac "
+"without special configuration. Happy developing!"
+msgstr "这套配置可在 Mac 上以轻量方式开发和测试 AIBrix，无需额外特殊配置。祝开发顺利！"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/vke.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/installation/vke.po
@@ -1,0 +1,83 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/installation/vke.rst:5
+msgid "Volcano Engine"
+msgstr "火山引擎"
+
+#: ../../source/getting_started/installation/vke.rst:8
+msgid "Introduction"
+msgstr "简介"
+
+#: ../../source/getting_started/installation/vke.rst:10
+msgid "This doc deploys AIBrix in Volcano Engine Kubernetes Engine."
+msgstr "本文说明如何在火山引擎 Kubernetes 引擎（VKE）上部署 AIBrix。"
+
+#: ../../source/getting_started/installation/vke.rst:13
+msgid "Steps"
+msgstr "步骤"
+
+#: ../../source/getting_started/installation/vke.rst:16
+msgid "AIBrix Installation"
+msgstr "安装 AIBrix"
+
+#: ../../source/getting_started/installation/vke.rst:18
+msgid "Assume you already have VKE cluster up and running"
+msgstr "假定 VKE 集群已经就绪"
+
+#: ../../source/getting_started/installation/vke.rst:19
+msgid "Install AIBrix on VKE"
+msgstr "在 VKE 上安装 AIBrix"
+
+#: ../../source/getting_started/installation/vke.rst:27
+msgid "Wait for components to complete running."
+msgstr "等待组件运行完成。"
+
+#: ../../source/getting_started/installation/vke.rst:30
+msgid "Download Model in TOS"
+msgstr "在 TOS 中下载模型"
+
+#: ../../source/getting_started/installation/vke.rst:32
+msgid "Download models in TOS and create the credential in the cluster."
+msgstr "在 TOS 中下载模型，并在集群中创建凭据。"
+
+#: ../../source/getting_started/installation/vke.rst:40
+msgid "Deploy base model"
+msgstr "部署基座模型"
+
+#: ../../source/getting_started/installation/vke.rst:42
+msgid "Save yaml as `model.yaml` and run `kubectl apply -f model.yaml`."
+msgstr "将 yaml 保存为 `model.yaml` ，然后运行 `kubectl apply -f model.yaml` 。"
+
+#: ../../source/getting_started/installation/vke.rst:48
+msgid "Deploy Prefill-Decode (PD) Disaggregation Model"
+msgstr "部署 Prefill-Decode（PD）分离模型"
+
+#: ../../source/getting_started/installation/vke.rst:50
+msgid "Save yaml as `pd-model.yaml` and run `kubectl apply -f pd-model.yaml`."
+msgstr "将 yaml 保存为 `pd-model.yaml` ，然后运行 `kubectl apply -f pd-model.yaml` 。"
+
+#: ../../source/getting_started/installation/vke.rst:57
+msgid "Inference"
+msgstr "推理"
+
+#: ../../source/getting_started/installation/vke.rst:59
+msgid "Once the model is ready and running, you can test it by running:"
+msgstr "模型就绪并运行后，可运行以下命令进行测试："

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/overview.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/overview.po
@@ -1,0 +1,413 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/overview.rst:5
+msgid "Overview & Concepts"
+msgstr "概述与概念"
+
+#: ../../source/getting_started/overview.rst:7
+msgid ""
+"This page explains what AIBrix is, the vocabulary you need to read the "
+"rest of the documentation, and which feature solves which problem. Read "
+"it before the :doc:`quickstart` if you have not worked with AIBrix "
+"before."
+msgstr ""
+"本页说明 AIBrix 是什么、阅读后续文档所需的术语，以及各功能分别解决什么问题。如果此前未使用过 AIBrix，请先阅读本页，再进入 :doc:`quickstart` "
+"。"
+
+#: ../../source/getting_started/overview.rst:12
+msgid "What AIBrix is"
+msgstr "AIBrix 是什么"
+
+#: ../../source/getting_started/overview.rst:14
+msgid ""
+"AIBrix is a **control plane for LLM inference on Kubernetes**. It is not "
+"an inference engine. You bring the engine, such as vLLM or SGLang, and "
+"AIBrix provides the infrastructure around it: request routing, "
+"autoscaling, KV cache management, model and adapter lifecycle, and the "
+"observability to run all of it in production."
+msgstr ""
+"AIBrix 是 **Kubernetes 上的 LLM 推理控制面** 。它不是推理引擎。你自行提供引擎（如 vLLM 或 SGLang），AIBrix "
+"提供其外围基础设施：请求路由、自动扩缩容、KV cache 管理、模型与 adapter 生命周期，以及在生产环境中运行这一切所需的可观测性。"
+
+#: ../../source/getting_started/overview.rst:19
+msgid "Concretely, AIBrix gives you:"
+msgstr "具体而言，AIBrix 提供："
+
+#: ../../source/getting_started/overview.rst:21
+msgid ""
+"**LLM-aware routing.** A gateway that picks a target pod from live engine"
+" state, such as KV cache occupancy, queue depth and prefix cache hits, "
+"rather than round-robin."
+msgstr ""
+"**感知 LLM 的路由。** 网关根据引擎实时状态（如 KV cache 占用、队列深度和前缀缓存命中）"
+"选择目标 pod，而不是轮询。"
+
+#: ../../source/getting_started/overview.rst:23
+msgid ""
+"**Inference-shaped autoscaling.** Scaling on engine metrics instead of "
+"CPU, which is a poor proxy for GPU inference load."
+msgstr ""
+"**面向推理形态的自动扩缩容。** 基于引擎指标扩缩容，而不是 CPU——"
+"CPU 很难反映 GPU 推理负载。"
+
+#: ../../source/getting_started/overview.rst:25
+msgid ""
+"**Model and adapter lifecycle.** Declarative deployment of base models "
+"and high-density LoRA adapters through Kubernetes custom resources."
+msgstr ""
+"**模型与 adapter 生命周期。** 通过 Kubernetes 自定义资源声明式部署基座模型和"
+"高密度 LoRA adapter。"
+
+#: ../../source/getting_started/overview.rst:27
+msgid ""
+"**Distributed KV cache.** Cross-engine KV reuse to cut redundant prefill "
+"work."
+msgstr ""
+"**分布式 KV cache。** 跨引擎复用 KV，减少重复 prefill 计算。"
+
+#: ../../source/getting_started/overview.rst:29
+msgid ""
+"If you are running a single replica of a single model, you do not need "
+"AIBrix. It earns its place when you have many models, many replicas, "
+"heterogeneous GPUs, or cost and latency targets to hold."
+msgstr ""
+"如果只运行单个模型的单个副本，并不需要 AIBrix。当你有多个模型、多个副本、"
+"异构 GPU，或需要守住成本和延迟目标时，它才真正有价值。"
+
+#: ../../source/getting_started/overview.rst:34
+msgid "How the pieces fit together"
+msgstr "各组件如何配合"
+
+#: ../../source/getting_started/overview.rst:36
+msgid ""
+"AIBrix splits into a **control plane** and a **data plane**. Most "
+"confusion when reading the rest of these docs comes from not knowing "
+"which plane a component belongs to."
+msgstr "AIBrix 分为 **控制面** 和 **数据面** 。阅读后续文档时，多数困惑来自不清楚某个组件属于哪一面。"
+
+#: ../../source/getting_started/overview.rst:55
+msgid ""
+"**Control plane**: the components that decide what *should* exist, such "
+"as how many replicas, which adapters are loaded where, and which pods "
+"form a distributed inference group. These are the Kubernetes controllers "
+"that reconcile the custom resources listed below, and also the **AI "
+"Runtime**, a sidecar in each engine pod that downloads model weights, "
+"loads and unloads LoRA adapters, and normalizes engine metrics into a "
+"consistent shape. See :doc:`../designs/architecture` and "
+":doc:`../features/runtime`."
+msgstr ""
+"**控制面** ：决定*应当*存在什么的组件，例如副本数量、adapter 加载到哪些位置，以及哪些 pod 组成分布式推理组。这些是调和下文所列自定义资源的 "
+"Kubernetes 控制器，以及 **AI Runtime** ：每个引擎 pod 中的 sidecar，负责下载模型权重、加载和卸载 LoRA "
+"adapter，并将引擎指标规范化为统一形态。参见 :doc:`../designs/architecture` 和 :doc:`../features/runtime` "
+"。"
+
+#: ../../source/getting_started/overview.rst:62
+msgid ""
+"**Data plane**: the request path. Envoy terminates the connection and "
+"AIBrix runs as an Envoy ``ext_proc`` extension: for each request it "
+"resolves the model, selects a pod, and returns a ``target-pod`` header. "
+"Envoy forwards the request to that pod, so traffic never flows through "
+"the AIBrix plugin. Routing is decided per request, not per deployment. "
+"See :doc:`../features/gateway-plugins`."
+msgstr ""
+"**数据面** ：请求路径。Envoy 终止连接，AIBrix 作为 Envoy ``ext_proc`` 扩展运行：对每个请求解析模型、选择 "
+"pod，并返回 ``target-pod`` 请求头。Envoy 将请求转发到该 pod，流量不会经过 AIBrix 插件。路由按请求决定，而不是按 "
+"Deployment。参见 :doc:`../features/gateway-plugins` 。"
+
+#: ../../source/getting_started/overview.rst:69
+msgid "Core concepts"
+msgstr "核心概念"
+
+#: ../../source/getting_started/overview.rst:71
+msgid ""
+"AIBrix extends Kubernetes with custom resources. These are the nouns used"
+" throughout the documentation."
+msgstr ""
+"AIBrix 通过自定义资源扩展 Kubernetes。以下是文档中贯穿使用的名词。"
+
+#: ../../source/getting_started/overview.rst:78
+msgid "Resource"
+msgstr "资源"
+
+#: ../../source/getting_started/overview.rst:79
+msgid "API group"
+msgstr "API 组"
+
+#: ../../source/getting_started/overview.rst:80
+msgid "What it does"
+msgstr "作用"
+
+#: ../../source/getting_started/overview.rst:81
+msgid "``PodAutoscaler``"
+msgstr "``PodAutoscaler``"
+
+#: ../../source/getting_started/overview.rst:82
+msgid "``autoscaling.aibrix.ai``"
+msgstr "``autoscaling.aibrix.ai``"
+
+#: ../../source/getting_started/overview.rst:83
+msgid ""
+"Scales a workload on inference metrics. Supports HPA, KPA, and APA "
+"strategies. See :doc:`../features/autoscaling/autoscaling`."
+msgstr ""
+"基于推理指标扩缩容工作负载。支持 HPA、KPA 和 APA 策略。参见 :doc:`../features/autoscaling/autoscaling` "
+"。"
+
+#: ../../source/getting_started/overview.rst:85
+msgid "``ModelAdapter``"
+msgstr "``ModelAdapter``"
+
+#: ../../source/getting_started/overview.rst:86
+#: ../../source/getting_started/overview.rst:90
+msgid "``model.aibrix.ai``"
+msgstr "``model.aibrix.ai``"
+
+#: ../../source/getting_started/overview.rst:87
+msgid ""
+"Registers a LoRA adapter and manages loading it onto matching pods. See "
+":doc:`../features/lora-dynamic-loading`."
+msgstr "注册 LoRA adapter，并管理将其加载到匹配的 pod。参见 :doc:`../features/lora-dynamic-loading` 。"
+
+#: ../../source/getting_started/overview.rst:89
+msgid "``ModelClaim``"
+msgstr "``ModelClaim``"
+
+#: ../../source/getting_started/overview.rst:91
+msgid ""
+"*(experimental)* Lets several independently managed model engines share a"
+" warm GPU runtime pod, instead of one Deployment per model. See "
+":doc:`../features/modelclaim`."
+msgstr ""
+"（实验性）让多个独立管理的模型引擎共享一个已预热的 GPU runtime pod，而不是每个模型一个 Deployment。参见 :doc:`../features/modelclaim` "
+"。"
+
+#: ../../source/getting_started/overview.rst:93
+msgid "``KVCache``"
+msgstr "``KVCache``"
+
+#: ../../source/getting_started/overview.rst:94
+#: ../../source/getting_started/overview.rst:98
+#: ../../source/getting_started/overview.rst:102
+#: ../../source/getting_started/overview.rst:106
+#: ../../source/getting_started/overview.rst:110
+msgid "``orchestration.aibrix.ai``"
+msgstr "``orchestration.aibrix.ai``"
+
+#: ../../source/getting_started/overview.rst:95
+msgid ""
+"Provisions a distributed KV cache backend for offloading and cross-engine"
+" reuse. See :doc:`../features/kvcache-offloading`."
+msgstr "为卸载和跨引擎复用准备分布式 KV cache 后端。参见 :doc:`../features/kvcache-offloading` 。"
+
+#: ../../source/getting_started/overview.rst:97
+msgid "``StormService``"
+msgstr "``StormService``"
+
+#: ../../source/getting_started/overview.rst:99
+msgid ""
+"Orchestrates multi-role serving topologies, including prefill/decode "
+"disaggregation. See :doc:`../designs/aibrix-stormservice`."
+msgstr "编排多角色服务拓扑，包括 prefill/decode 分离。参见 :doc:`../designs/aibrix-stormservice` 。"
+
+#: ../../source/getting_started/overview.rst:101
+msgid "``RoleSet``"
+msgstr "``RoleSet``"
+
+#: ../../source/getting_started/overview.rst:103
+msgid ""
+"A collection of roles, each serving a specific function such as prefill "
+"or decode. ``StormService`` manages ``RoleSet`` replicas."
+msgstr ""
+"一组角色的集合，每个角色承担特定功能，例如 prefill 或 decode。"
+"``StormService`` 管理 ``RoleSet`` 副本。"
+
+#: ../../source/getting_started/overview.rst:105
+msgid "``PodSet``"
+msgstr "``PodSet``"
+
+#: ../../source/getting_started/overview.rst:107
+msgid ""
+"Internal API used by the ``RoleSet`` controller to group pods that must "
+"be scheduled together. Not addressed directly by users."
+msgstr ""
+"``RoleSet`` 控制器使用的内部 API，用于将必须一起调度的 pod 分组。用户无需直接操作。"
+
+#: ../../source/getting_started/overview.rst:109
+msgid "``RayClusterFleet``"
+msgstr "``RayClusterFleet``"
+
+#: ../../source/getting_started/overview.rst:111
+msgid ""
+"Manages multi-node inference on Ray for models too large for one node. "
+"See :doc:`../features/multi-node-inference`."
+msgstr "在 Ray 上管理多节点推理，用于单节点放不下的模型。参见 :doc:`../features/multi-node-inference` 。"
+
+#: ../../source/getting_started/overview.rst:114
+msgid "Two more terms appear constantly:"
+msgstr "还有两个频繁出现的术语："
+
+#: ../../source/getting_started/overview.rst:116
+msgid ""
+"**Routing strategy**: the algorithm the gateway uses to pick a pod "
+"(``least-request``, ``prefix-cache``, ``pd``, and others). It is resolved"
+" per request from a header, a config profile, or an environment default."
+msgstr ""
+"**路由策略** ：网关用来选择 pod 的算法（``least-request`` 、``prefix-cache`` 、``pd`` 等）。按请求从请求头、配置 "
+"profile 或环境默认值解析。"
+
+#: ../../source/getting_started/overview.rst:120
+msgid ""
+"**Prefill / decode disaggregation**: splitting the two phases of "
+"inference across separate pod pools so each can be sized and scaled "
+"independently. See :doc:`../features/pd-disaggregation`."
+msgstr ""
+"**Prefill / decode 分离** ：将推理的两个阶段拆到独立的 pod 池，以便各自独立定容和扩缩容。参见 :doc:`../features/pd-disaggregation` "
+"。"
+
+#: ../../source/getting_started/overview.rst:125
+msgid "Which feature solves which problem"
+msgstr "哪个功能解决哪个问题"
+
+#: ../../source/getting_started/overview.rst:127
+msgid "If you arrived with a specific problem, start here."
+msgstr "如果带着具体问题而来，从这里开始。"
+
+#: ../../source/getting_started/overview.rst:133
+msgid "Your problem"
+msgstr "你的问题"
+
+#: ../../source/getting_started/overview.rst:134
+msgid "Start with"
+msgstr "从这里开始"
+
+#: ../../source/getting_started/overview.rst:135
+msgid "\"Requests pile up on some replicas while others idle\""
+msgstr "“请求堆积在部分副本上，其他副本空闲”"
+
+#: ../../source/getting_started/overview.rst:136
+msgid ":doc:`../features/gateway-plugins`: load-aware routing strategies"
+msgstr ":doc:`../features/gateway-plugins` ：感知负载的路由策略"
+
+#: ../../source/getting_started/overview.rst:137
+msgid "\"Repeated prompt prefixes are re-computed every request\""
+msgstr "“重复的 prompt 前缀每次请求都重新计算”"
+
+#: ../../source/getting_started/overview.rst:138
+msgid ""
+":doc:`../features/kvcache-offloading` and prefix-cache routing in "
+":doc:`../features/gateway-plugins`"
+msgstr ""
+":doc:`../features/kvcache-offloading` 以及 :doc:`../features/gateway-plugins` "
+"中的前缀缓存路由"
+
+#: ../../source/getting_started/overview.rst:140
+msgid "\"I serve many fine-tunes of one base model and GPUs are idle\""
+msgstr "“同一基座模型有很多微调版本，GPU 却在空闲”"
+
+#: ../../source/getting_started/overview.rst:141
+msgid ":doc:`../features/lora-dynamic-loading`: many adapters per pod"
+msgstr ":doc:`../features/lora-dynamic-loading` ：每个 pod 加载多个 adapter"
+
+#: ../../source/getting_started/overview.rst:142
+msgid "\"Replica count does not track real load\""
+msgstr "“副本数量跟不上真实负载”"
+
+#: ../../source/getting_started/overview.rst:143
+msgid ":doc:`../features/autoscaling/autoscaling`: KPA/APA on engine metrics"
+msgstr ":doc:`../features/autoscaling/autoscaling` ：基于引擎指标的 KPA/APA"
+
+#: ../../source/getting_started/overview.rst:144
+msgid "\"Time to first token is too high under load\""
+msgstr "“负载下首 token 延迟过高”"
+
+#: ../../source/getting_started/overview.rst:145
+msgid ":doc:`../features/pd-disaggregation`: separate prefill from decode"
+msgstr ":doc:`../features/pd-disaggregation` ：将 prefill 与 decode 分离"
+
+#: ../../source/getting_started/overview.rst:146
+msgid "\"The model does not fit on one node\""
+msgstr "“模型单节点放不下”"
+
+#: ../../source/getting_started/overview.rst:147
+msgid ":doc:`../features/multi-node-inference`"
+msgstr ":doc:`../features/multi-node-inference`"
+
+#: ../../source/getting_started/overview.rst:148
+msgid "\"I have a mix of GPU types and want to control cost\""
+msgstr "“有多种 GPU 类型，希望控制成本”"
+
+#: ../../source/getting_started/overview.rst:149
+msgid ":doc:`../features/heterogeneous-gpu` *(experimental)*"
+msgstr ":doc:`../features/heterogeneous-gpu` （实验性）"
+
+#: ../../source/getting_started/overview.rst:150
+msgid "\"I need to run large offline jobs, not live traffic\""
+msgstr "“需要跑大规模离线任务，而不是在线流量”"
+
+#: ../../source/getting_started/overview.rst:151
+msgid ":doc:`../features/batch-api`"
+msgstr ":doc:`../features/batch-api`"
+
+#: ../../source/getting_started/overview.rst:152
+msgid "\"I cannot see what the system is doing\""
+msgstr "“看不清系统在做什么”"
+
+#: ../../source/getting_started/overview.rst:153
+msgid ":doc:`../production/observability`"
+msgstr ":doc:`../production/observability`"
+
+#: ../../source/getting_started/overview.rst:154
+msgid "\"I need to measure whether any of this helped\""
+msgstr "“需要衡量这些改动是否有效”"
+
+#: ../../source/getting_started/overview.rst:155
+msgid ""
+":doc:`../features/benchmark-and-generator` and "
+":doc:`../features/brixbench`"
+msgstr ""
+":doc:`../features/benchmark-and-generator` 和 "
+":doc:`../features/brixbench`"
+
+#: ../../source/getting_started/overview.rst:159
+msgid ":doc:`../designs/architecture`"
+msgstr ":doc:`../designs/architecture`"
+
+#: ../../source/getting_started/overview.rst:160
+msgid ""
+"Component-level architecture, with the control plane and data plane "
+"broken out."
+msgstr "组件级架构，分别展开控制面和数据面。"
+
+#: ../../source/getting_started/overview.rst:162
+msgid "What's next?"
+msgstr "下一步"
+
+#: ../../source/getting_started/overview.rst:165
+msgid ":doc:`quickstart`: install AIBrix and serve your first model"
+msgstr ":doc:`quickstart` ：安装 AIBrix 并部署第一个模型"
+
+#: ../../source/getting_started/overview.rst:166
+msgid ":doc:`installation/installation`: production installation, per platform"
+msgstr ":doc:`installation/installation` ：按平台进行生产安装"
+
+#: ../../source/getting_started/overview.rst:167
+msgid ":doc:`../designs/architecture`: how the components fit together in depth"
+msgstr ":doc:`../designs/architecture` ：各组件如何深入配合"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/quickstart.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/getting_started/quickstart.po
@@ -1,0 +1,164 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 19:00+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/getting_started/quickstart.rst:5
+msgid "Quickstart"
+msgstr "快速开始"
+
+#: ../../source/getting_started/quickstart.rst:8
+msgid "Installing AIBrix in your Kubernetes Cluster"
+msgstr "在 Kubernetes 集群中安装 AIBrix"
+
+#: ../../source/getting_started/quickstart.rst:11
+msgid "Install AIBrix Components"
+msgstr "安装 AIBrix 组件"
+
+#: ../../source/getting_started/quickstart.rst:13
+msgid ""
+"Get your kubernetes cluster ready, run following commands to install "
+"aibrix components in your cluster."
+msgstr ""
+"准备好 Kubernetes 集群后，运行以下命令在集群中安装 aibrix 组件。"
+
+#: ../../source/getting_started/quickstart.rst:16
+msgid ""
+"If you just want to install specific components or specific version, "
+"please check installation guidance for more installation options. AIBrix "
+"also provides the helm chart way, check installation guidance for more "
+"details."
+msgstr ""
+"如果只想安装特定组件或特定版本，请查看安装指南了解更多安装选项。"
+"AIBrix 也提供 Helm chart 安装方式，详情见安装指南。"
+
+#: ../../source/getting_started/quickstart.rst:25
+msgid ""
+"Wait for few minutes and run `kubectl get pods -n aibrix-system` to check"
+" pod status util they are ready."
+msgstr ""
+"等待几分钟，然后运行 `kubectl get pods -n aibrix-system` 检查 pod 状态，直到就绪。"
+
+#: ../../source/getting_started/quickstart.rst:39
+msgid "Deploy base model"
+msgstr "部署基座模型"
+
+#: ../../source/getting_started/quickstart.rst:41
+msgid "Save yaml as `model.yaml` and run `kubectl apply -f model.yaml`."
+msgstr "将 yaml 保存为 `model.yaml` ，然后运行 `kubectl apply -f model.yaml` 。"
+
+#: ../../source/getting_started/quickstart.rst:46
+msgid "Ensure that:"
+msgstr "请确保："
+
+#: ../../source/getting_started/quickstart.rst:48
+msgid ""
+"The `Service` name matches the `model.aibrix.ai/name` label value in the "
+"`Deployment`."
+msgstr ""
+"`Service` 名称与 `Deployment` 中的 `model.aibrix.ai/name` 标签值一致。"
+
+#: ../../source/getting_started/quickstart.rst:49
+msgid ""
+"The `--served-model-name` argument value in the `Deployment` command is "
+"also consistent with the `Service` name and `model.aibrix.ai/name` label."
+msgstr ""
+"`Deployment` 命令中的 `--served-model-name` 参数值也要与 `Service` 名称和 "
+"`model.aibrix.ai/name` 标签一致。"
+
+#: ../../source/getting_started/quickstart.rst:52
+msgid "Deploy Prefill-Decode (PD) Disaggregation Model"
+msgstr "部署 Prefill-Decode（PD）分离模型"
+
+#: ../../source/getting_started/quickstart.rst:54
+msgid "Save yaml as `pd-model.yaml` and run `kubectl apply -f pd-model.yaml`."
+msgstr "将 yaml 保存为 `pd-model.yaml` ，然后运行 `kubectl apply -f pd-model.yaml` 。"
+
+#: ../../source/getting_started/quickstart.rst:61
+msgid ""
+"We use an AIBrix-enhanced vLLM image with KVCache and NIXL support for "
+"disaggregated inference. For detailed information about available images,"
+" compatibility, and build instructions, see :ref:`container-images`."
+msgstr ""
+"我们使用带有 KVCache 和 NIXL 支持的 AIBrix 增强版 vLLM 镜像来做分离式推理。关于可用镜像、兼容性和构建说明，参见 :ref:`container-images` "
+"。"
+
+#: ../../source/getting_started/quickstart.rst:64
+msgid "Invoke the model endpoint using gateway API"
+msgstr "通过网关 API 调用模型端点"
+
+#: ../../source/getting_started/quickstart.rst:66
+msgid ""
+"Depending on where you deployed the AIBrix, you can use either of the "
+"following options to query the gateway."
+msgstr ""
+"根据 AIBrix 的部署位置，可以使用以下任一方式查询网关。"
+
+#: ../../source/getting_started/quickstart.rst:80
+msgid ""
+"Some cloud provider like AWS EKS expose the endpoint at hostname field, "
+"if that case, you should use ``.status.loadBalancer.ingress[0].hostname``"
+" instead."
+msgstr ""
+"部分云厂商（如 AWS EKS）在 hostname 字段暴露端点。若是这种情况，应改用 ``.status.loadBalancer.ingress[0].hostname`` "
+"。"
+
+#: ../../source/getting_started/quickstart.rst:112
+msgid ""
+"To test PD disaggregation, add the ``routing-strategy`` header to ``pd``."
+" For example:"
+msgstr "要测试 PD 分离，将 ``routing-strategy`` 请求头设为 ``pd`` 。例如："
+
+#: ../../source/getting_started/quickstart.rst:185
+msgid ""
+"If you meet problems exposing external IPs, feel free to debug with "
+"following commands. `101.18.0.4` is the ip of the gateway service."
+msgstr ""
+"如果暴露外部 IP 遇到问题，可用以下命令调试。`101.18.0.4` 是网关服务的 IP。"
+
+#: ../../source/getting_started/quickstart.rst:194
+msgid ""
+"For advanced development usage, please refer to the :ref:`development` "
+"section."
+msgstr "高级开发用法请参见 :ref:`development` 一节。"
+
+#: ../../source/getting_started/quickstart.rst:196
+msgid "What's next?"
+msgstr "下一步"
+
+#: ../../source/getting_started/quickstart.rst:199
+msgid ""
+":doc:`installation/installation`: production installation for your "
+"platform"
+msgstr ":doc:`installation/installation` ：面向你所用平台的生产安装"
+
+#: ../../source/getting_started/quickstart.rst:200
+msgid ""
+":doc:`../features/gateway-plugins`: choose a routing strategy for your "
+"workload"
+msgstr ":doc:`../features/gateway-plugins` ：为工作负载选择路由策略"
+
+#: ../../source/getting_started/quickstart.rst:201
+msgid ""
+":doc:`../features/autoscaling/autoscaling`: scale replicas on inference "
+"metrics"
+msgstr ":doc:`../features/autoscaling/autoscaling` ：基于推理指标扩缩副本"
+
+#: ../../source/getting_started/quickstart.rst:202
+msgid ":doc:`../production/observability`: see what the system is doing"
+msgstr ":doc:`../production/observability` ：了解系统正在做什么"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/index.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/index.po
@@ -1,0 +1,217 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/index.rst:63
+msgid "Getting Started"
+msgstr "快速开始"
+
+#: ../../source/index.rst:74
+msgid "Architecture"
+msgstr "架构"
+
+#: ../../source/index.rst:85
+msgid "Gateway & Routing"
+msgstr "网关与路由"
+
+#: ../../source/index.rst:94
+msgid "Model Serving"
+msgstr "模型服务"
+
+#: ../../source/index.rst:105
+msgid "Scaling & Performance"
+msgstr "扩缩容与性能"
+
+#: ../../source/index.rst:113
+msgid "Batch Inference"
+msgstr "批量推理"
+
+#: ../../source/index.rst:121
+msgid "Benchmark"
+msgstr "基准测试"
+
+#: ../../source/index.rst:128
+msgid "Development"
+msgstr "开发"
+
+#: ../../source/index.rst:135
+msgid "Production Readiness"
+msgstr "生产就绪"
+
+#: ../../source/index.rst:144
+msgid "Community"
+msgstr "社区"
+
+#: ../../source/index.rst:2
+msgid "Welcome to AIBrix"
+msgstr "欢迎使用 AIBrix"
+
+#: ../../source/index.rst:4
+msgid "AIBrix"
+msgstr "AIBrix"
+
+#: ../../source/index.rst:9
+msgid ""
+"AIBrix is an open-source initiative designed to provide essential "
+"building blocks to construct scalable GenAI inference infrastructure. "
+"AIBrix delivers a cloud-native solution optimized for deploying, "
+"managing, and scaling large language model (LLM) inference, tailored "
+"specifically to enterprise needs."
+msgstr ""
+"AIBrix 是一个开源项目，旨在提供构建可扩展 GenAI 推理基础设施所需的核心组件。"
+"它提供面向企业场景的云原生方案，用于部署、管理和扩缩容大语言模型（LLM）推理。"
+
+#: ../../source/index.rst:12
+msgid "Key features:"
+msgstr "主要特性："
+
+#: ../../source/index.rst:14
+msgid ""
+"**LLM Gateway and Routing**: Efficiently manage and direct traffic across"
+" multiple models and replicas."
+msgstr "**LLM 网关与路由** ：在多个模型和副本之间高效管理并转发流量。"
+
+#: ../../source/index.rst:15
+msgid ""
+"**High-Density LoRA Management**: Streamlined support for lightweight, "
+"low-rank adaptations of models."
+msgstr "**高密度 LoRA 管理** ：简化对轻量低秩模型适配（LoRA）的支持。"
+
+#: ../../source/index.rst:16
+msgid ""
+"**Distributed Inference**: Scalable architecture to handle large "
+"workloads across multiple nodes."
+msgstr "**分布式推理** ：可扩展架构，支持跨多节点处理大规模负载。"
+
+#: ../../source/index.rst:17
+msgid ""
+"**LLM App-Tailored Autoscaler**: Dynamically scale inference resources "
+"based on real-time demand."
+msgstr "**面向 LLM 应用的自动扩缩容** ：根据实时需求动态调整推理资源。"
+
+#: ../../source/index.rst:18
+msgid ""
+"**Unified AI Runtime**: A versatile sidecar enabling metric "
+"standardization, model downloading, and management."
+msgstr "**统一 AI Runtime** ：多用途 sidecar，用于指标标准化、模型下载与管理。"
+
+#: ../../source/index.rst:19
+msgid ""
+"**Heterogeneous-GPU Inference**: Cost-effective SLO-driven LLM inference "
+"using heterogeneous GPUs."
+msgstr "**异构 GPU 推理** ：在异构 GPU 上以 SLO 为导向进行高性价比 LLM 推理。"
+
+#: ../../source/index.rst:20
+msgid ""
+"**GPU Hardware Failure Detection**: Proactive detection of GPU hardware "
+"issues."
+msgstr "**GPU 硬件故障检测** ：主动发现 GPU 硬件问题。"
+
+#: ../../source/index.rst:21
+msgid ""
+"**KVCache Offloading and Cross-Engine KV Reuse**: High-Performance "
+"KVCache offloading framework supporting both naive KV offloading and "
+"cross-engine KV reuse."
+msgstr "**KVCache 卸载与跨引擎 KV 复用** ：高性能 KVCache 卸载框架，同时支持基础 KV 卸载和跨引擎 KV 复用。"
+
+#: ../../source/index.rst:22
+msgid ""
+"**Benchmark Tool**: A tool for measuring inference performance and "
+"resource efficiency."
+msgstr "**基准测试工具** ：用于衡量推理性能和资源效率。"
+
+#: ../../source/index.rst:25
+msgid "Where to start"
+msgstr "从哪里开始"
+
+#: ../../source/index.rst:30
+msgid "Beginner"
+msgstr "入门"
+
+#: ../../source/index.rst:33
+msgid "New to AIBrix. Get one model serving."
+msgstr "刚接触 AIBrix。先跑起来一个模型服务。"
+
+#: ../../source/index.rst:35
+msgid ":doc:`getting_started/overview`"
+msgstr ":doc:`getting_started/overview`"
+
+#: ../../source/index.rst:36
+msgid ":doc:`getting_started/quickstart`"
+msgstr ":doc:`getting_started/quickstart`"
+
+#: ../../source/index.rst:37
+msgid ":doc:`getting_started/installation/installation`"
+msgstr ":doc:`getting_started/installation/installation`"
+
+#: ../../source/index.rst:38
+msgid ":doc:`features/gateway-plugins`"
+msgstr ":doc:`features/gateway-plugins`"
+
+#: ../../source/index.rst:40
+msgid "Intermediate"
+msgstr "进阶"
+
+#: ../../source/index.rst:43
+msgid "Serving works. Make it efficient."
+msgstr "服务已经跑起来。接下来把它做得更高效。"
+
+#: ../../source/index.rst:45
+msgid ":doc:`features/autoscaling/autoscaling`"
+msgstr ":doc:`features/autoscaling/autoscaling`"
+
+#: ../../source/index.rst:46
+msgid ":doc:`features/lora-dynamic-loading`"
+msgstr ":doc:`features/lora-dynamic-loading`"
+
+#: ../../source/index.rst:47
+msgid ":doc:`features/kvcache-offloading`"
+msgstr ":doc:`features/kvcache-offloading`"
+
+#: ../../source/index.rst:48
+msgid ":doc:`production/observability`"
+msgstr ":doc:`production/observability`"
+
+#: ../../source/index.rst:50
+msgid "Advanced"
+msgstr "高级"
+
+#: ../../source/index.rst:53
+msgid "Scale, cost, and latency targets."
+msgstr "规模、成本与延迟目标。"
+
+#: ../../source/index.rst:55
+msgid ":doc:`features/pd-disaggregation`"
+msgstr ":doc:`features/pd-disaggregation`"
+
+#: ../../source/index.rst:56
+msgid ":doc:`features/multi-node-inference`"
+msgstr ":doc:`features/multi-node-inference`"
+
+#: ../../source/index.rst:57
+msgid ":doc:`features/heterogeneous-gpu`"
+msgstr ":doc:`features/heterogeneous-gpu`"
+
+#: ../../source/index.rst:58
+msgid ":doc:`production/model-deployment`"
+msgstr ":doc:`production/model-deployment`"
+
+#: ../../source/index.rst:61
+msgid "Documentation"
+msgstr "文档"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/production/console.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/production/console.po
@@ -1,0 +1,520 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/production/console.rst:5
+msgid "AIBrix Console"
+msgstr "AIBrix Console"
+
+#: ../../source/production/console.rst:7
+msgid ""
+"AIBrix Console is an optional web control plane for AIBrix. It provides a"
+" UI for model deployment workflows, OpenAI-compatible batch jobs, and "
+"playground traffic against an AIBrix gateway. The same workflows remain "
+"available through Kubernetes resources and APIs, so the Console can be "
+"introduced independently."
+msgstr ""
+"AIBrix Console 是 AIBrix 的可选 Web 控制面。它为模型部署工作流、兼容 OpenAI 的批处理任务，"
+"以及面向 AIBrix 网关的 playground 流量提供 UI。相同工作流仍可通过 Kubernetes 资源和 API 使用，"
+"因此可以独立引入 Console。"
+
+#: ../../source/production/console.rst:12
+msgid "The Console is made of three parts:"
+msgstr "Console 由三部分组成："
+
+#: ../../source/production/console.rst:14
+msgid "a React frontend in ``apps/console/web``"
+msgstr "位于 ``apps/console/web`` 的 React 前端"
+
+#: ../../source/production/console.rst:15
+msgid "a Go backend in ``cmd/console`` and ``apps/console/api``"
+msgstr "位于 ``cmd/console`` 和 ``apps/console/api`` 的 Go 后端"
+
+#: ../../source/production/console.rst:16
+msgid ""
+"integrations with the Metadata Service (MDS), the AIBrix gateway, and a "
+"persistent Console store"
+msgstr "与 Metadata Service（MDS）、AIBrix 网关以及持久化 Console 存储的集成"
+
+#: ../../source/production/console.rst:20
+msgid "Run locally"
+msgstr "本地运行"
+
+#: ../../source/production/console.rst:22
+msgid "Build the backend from the repository root:"
+msgstr "在仓库根目录构建后端："
+
+#: ../../source/production/console.rst:28
+msgid "Start the backend in development auth mode:"
+msgstr "以开发认证模式启动后端："
+
+#: ../../source/production/console.rst:39
+msgid "Start the frontend development server:"
+msgstr "启动前端开发服务器："
+
+#: ../../source/production/console.rst:47
+msgid ""
+"The frontend development server listens on ``http://localhost:3000``. The"
+" backend REST API listens on ``http://localhost:8080`` by default."
+msgstr ""
+"前端开发服务器监听 ``http://localhost:3000`` 。后端 REST API 默认监听 ``http://localhost:8080`` "
+"。"
+
+#: ../../source/production/console.rst:51
+msgid "Serve a production frontend build"
+msgstr "提供生产前端构建"
+
+#: ../../source/production/console.rst:53
+msgid "Build the frontend assets and serve them from the Go backend:"
+msgstr "构建前端资源并由 Go 后端提供服务："
+
+#: ../../source/production/console.rst:72
+msgid ""
+"Use a stable ``STORE_URI``, ``SESSION_SECRET``, and "
+"``SECRETS_ENCRYPTION_KEY`` for any environment where user sessions, "
+"credentials, or job history must survive process restarts."
+msgstr ""
+"在用户会话、凭据或任务历史需要在进程重启后保留的环境中，请使用稳定的 ``STORE_URI`` 、``SESSION_SECRET`` 和 ``SECRETS_ENCRYPTION_KEY`` "
+"。"
+
+#: ../../source/production/console.rst:77
+msgid "Storage"
+msgstr "存储"
+
+#: ../../source/production/console.rst:79
+msgid ""
+"The Console backend stores users, sessions, templates, job metadata, and "
+"secrets in the configured store. Set the store with ``STORE_URI``:"
+msgstr ""
+"Console 后端将用户、会话、模板、任务元数据和密钥存储在所配置的 store 中。使用 ``STORE_URI`` 设置存储："
+
+#: ../../source/production/console.rst:85
+msgid "Store"
+msgstr "存储"
+
+#: ../../source/production/console.rst:86
+msgid "URI example"
+msgstr "URI 示例"
+
+#: ../../source/production/console.rst:87
+msgid "Use case"
+msgstr "适用场景"
+
+#: ../../source/production/console.rst:88
+msgid "SQLite"
+msgstr "SQLite"
+
+#: ../../source/production/console.rst:89
+msgid "``sqlite:/var/lib/aibrix/console.db``"
+msgstr "``sqlite:/var/lib/aibrix/console.db``"
+
+#: ../../source/production/console.rst:90
+msgid "Single-instance deployments and local testing"
+msgstr "单实例部署与本地测试"
+
+#: ../../source/production/console.rst:91
+msgid "In-memory"
+msgstr "内存"
+
+#: ../../source/production/console.rst:92
+msgid "``memory://`` or ``sqlite::memory:``"
+msgstr "``memory://`` 或 ``sqlite::memory:``"
+
+#: ../../source/production/console.rst:93
+msgid "Short-lived development only"
+msgstr "仅适用于短期开发"
+
+#: ../../source/production/console.rst:94
+msgid "MySQL"
+msgstr "MySQL"
+
+#: ../../source/production/console.rst:95
+msgid "``mysql://user:pass@host:3306/aibrix``"
+msgstr "``mysql://user:pass@host:3306/aibrix``"
+
+#: ../../source/production/console.rst:96
+msgid "Shared or production deployments"
+msgstr "共享或生产部署"
+
+#: ../../source/production/console.rst:98
+msgid ""
+"SQLite paths under ``/tmp`` are convenient for local testing but are not "
+"appropriate for durable environments."
+msgstr "``/tmp`` 下的 SQLite 路径便于本地测试，但不适合需要持久化的环境。"
+
+#: ../../source/production/console.rst:102
+msgid "Authentication"
+msgstr "认证"
+
+#: ../../source/production/console.rst:104
+msgid "Set ``AUTH_MODE`` to choose how users sign in."
+msgstr "设置 ``AUTH_MODE`` 以选择用户登录方式。"
+
+#: ../../source/production/console.rst:109
+msgid "Mode"
+msgstr "模式"
+
+#: ../../source/production/console.rst:110
+msgid "Required settings"
+msgstr "必需配置"
+
+#: ../../source/production/console.rst:111
+msgid "Notes"
+msgstr "说明"
+
+#: ../../source/production/console.rst:112
+msgid "``dev``"
+msgstr "``dev``"
+
+#: ../../source/production/console.rst:113
+msgid "none"
+msgstr "无"
+
+#: ../../source/production/console.rst:114
+msgid "Uses ``DEV_USER_NAME`` and ``DEV_USER_EMAIL``. Intended for local use."
+msgstr "使用 ``DEV_USER_NAME`` 和 ``DEV_USER_EMAIL`` 。仅用于本地。"
+
+#: ../../source/production/console.rst:115
+msgid "``basic``"
+msgstr "``basic``"
+
+#: ../../source/production/console.rst:116
+msgid ""
+"``BASIC_USERNAME``, ``BASIC_PASSWORD``, ``SESSION_SECRET``, "
+"``SECRETS_ENCRYPTION_KEY``"
+msgstr ""
+"``BASIC_USERNAME``, ``BASIC_PASSWORD``, ``SESSION_SECRET``, "
+"``SECRETS_ENCRYPTION_KEY``"
+
+#: ../../source/production/console.rst:118
+msgid "Simple password login for restricted environments."
+msgstr "适用于受限环境的简单密码登录。"
+
+#: ../../source/production/console.rst:119
+msgid "``oidc``"
+msgstr "``oidc``"
+
+#: ../../source/production/console.rst:120
+msgid ""
+"``OIDC_ISSUER_URL``, ``OIDC_CLIENT_ID``, ``OIDC_REDIRECT_URL``, "
+"``SESSION_SECRET``, ``SECRETS_ENCRYPTION_KEY``"
+msgstr ""
+"``OIDC_ISSUER_URL``, ``OIDC_CLIENT_ID``, ``OIDC_REDIRECT_URL``, "
+"``SESSION_SECRET``, ``SECRETS_ENCRYPTION_KEY``"
+
+#: ../../source/production/console.rst:122
+msgid ""
+"Use an external identity provider. ``OIDC_CLIENT_SECRET`` is required "
+"when the provider or signing algorithm requires it."
+msgstr "使用外部身份提供方。当提供方或签名算法需要时，必须设置 ``OIDC_CLIENT_SECRET`` 。"
+
+#: ../../source/production/console.rst:125
+msgid "Example OIDC configuration:"
+msgstr "OIDC 配置示例："
+
+#: ../../source/production/console.rst:138
+msgid ""
+"Register the redirect URL with the identity provider. For production, "
+"serve the Console over HTTPS and keep ``SESSION_SECRET`` and "
+"``SECRETS_ENCRYPTION_KEY`` stable across restarts."
+msgstr ""
+"在身份提供方处注册重定向 URL。生产环境请通过 HTTPS 提供 Console，并在重启后保持 "
+"``SESSION_SECRET`` 和 ``SECRETS_ENCRYPTION_KEY`` 稳定不变。"
+
+#: ../../source/production/console.rst:142
+msgid "OIDC authorization can be restricted with these settings:"
+msgstr "可通过以下设置限制 OIDC 授权："
+
+#: ../../source/production/console.rst:144
+msgid ""
+"``OIDC_GROUPS_CLAIM``: JWT claim used to read groups. Defaults to "
+"``groups``."
+msgstr "``OIDC_GROUPS_CLAIM`` ：用于读取组的 JWT claim。默认为 ``groups`` 。"
+
+#: ../../source/production/console.rst:146
+msgid "``OIDC_ADMIN_GROUPS``: comma-separated groups that receive admin access."
+msgstr "``OIDC_ADMIN_GROUPS`` ：获得管理员权限的组，逗号分隔。"
+
+#: ../../source/production/console.rst:147
+msgid ""
+"``OIDC_ADMIN_EMAILS``: comma-separated email addresses that receive admin"
+" access."
+msgstr "``OIDC_ADMIN_EMAILS`` ：获得管理员权限的电子邮件地址，逗号分隔。"
+
+#: ../../source/production/console.rst:149
+msgid "``OIDC_SIGNING_ALG``: token signing algorithm. Defaults to ``RS256``."
+msgstr "``OIDC_SIGNING_ALG`` ：令牌签名算法。默认为 ``RS256`` 。"
+
+#: ../../source/production/console.rst:152
+msgid "Configuration reference"
+msgstr "配置参考"
+
+#: ../../source/production/console.rst:157
+msgid "Setting"
+msgstr "配置项"
+
+#: ../../source/production/console.rst:158
+msgid "Default"
+msgstr "默认值"
+
+#: ../../source/production/console.rst:159
+#: ../../source/production/console.rst:227
+msgid "Purpose"
+msgstr "用途"
+
+#: ../../source/production/console.rst:160
+msgid "``HTTP_ADDR``"
+msgstr "``HTTP_ADDR``"
+
+#: ../../source/production/console.rst:161
+msgid "``:8080``"
+msgstr "``:8080``"
+
+#: ../../source/production/console.rst:162
+msgid "Backend HTTP and REST API address. Also available as ``--http-addr``."
+msgstr "后端 HTTP 与 REST API 地址。也可通过 ``--http-addr`` 设置。"
+
+#: ../../source/production/console.rst:164
+msgid "``GRPC_ADDR``"
+msgstr "``GRPC_ADDR``"
+
+#: ../../source/production/console.rst:165
+msgid "``:50060``"
+msgstr "``:50060``"
+
+#: ../../source/production/console.rst:166
+msgid "Backend gRPC address. Also available as ``--grpc-addr``."
+msgstr "后端 gRPC 地址。也可通过 ``--grpc-addr`` 设置。"
+
+#: ../../source/production/console.rst:167
+msgid "``STORE_URI``"
+msgstr "``STORE_URI``"
+
+#: ../../source/production/console.rst:168
+msgid "``sqlite:/tmp/aibrix-console.db``"
+msgstr "``sqlite:/tmp/aibrix-console.db``"
+
+#: ../../source/production/console.rst:169
+msgid "Console database connection string. Also available as ``--store-uri``."
+msgstr "Console 数据库连接字符串。也可通过 ``--store-uri`` 设置。"
+
+#: ../../source/production/console.rst:171
+msgid "``METADATA_SERVICE_URL``"
+msgstr "``METADATA_SERVICE_URL``"
+
+#: ../../source/production/console.rst:172
+msgid "``http://localhost:8090``"
+msgstr "``http://localhost:8090``"
+
+#: ../../source/production/console.rst:173
+msgid "MDS endpoint used for files and OpenAI-compatible batch APIs."
+msgstr "用于文件和兼容 OpenAI 的批处理 API 的 MDS 端点。"
+
+#: ../../source/production/console.rst:174
+msgid "``GATEWAY_ENDPOINT``"
+msgstr "``GATEWAY_ENDPOINT``"
+
+#: ../../source/production/console.rst:175
+msgid "``http://localhost:8888``"
+msgstr "``http://localhost:8888``"
+
+#: ../../source/production/console.rst:176
+msgid ""
+"AIBrix gateway endpoint used by the playground and inference flows. Also "
+"available as ``--gateway-endpoint``."
+msgstr "playground 与推理流程使用的 AIBrix 网关端点。也可通过 ``--gateway-endpoint`` 设置。"
+
+#: ../../source/production/console.rst:178
+msgid "``DEFAULT_BATCH_MODEL_DEPLOYMENT_TEMPLATE``"
+msgstr "``DEFAULT_BATCH_MODEL_DEPLOYMENT_TEMPLATE``"
+
+#: ../../source/production/console.rst:179
+#: ../../source/production/console.rst:192
+#: ../../source/production/console.rst:195
+msgid "empty"
+msgstr "空"
+
+#: ../../source/production/console.rst:180
+msgid "Default model deployment template name for Console-created batch jobs."
+msgstr "Console 创建的批处理任务所用的默认模型部署模板名称。"
+
+#: ../../source/production/console.rst:181
+msgid "``PROVISIONER``"
+msgstr "``PROVISIONER``"
+
+#: ../../source/production/console.rst:182
+msgid "``kubernetes``"
+msgstr "``kubernetes``"
+
+#: ../../source/production/console.rst:183
+msgid ""
+"Batch resource provisioner. Supported values include ``kubernetes``, "
+"``runpod``, and ``lambdaCloud``. See :ref:`batch_resource_manager`."
+msgstr ""
+"批处理资源供给器。支持的值包括 ``kubernetes`` 、``runpod`` 和 ``lambdaCloud`` 。参见 :ref:`batch_resource_manager` "
+"。"
+
+#: ../../source/production/console.rst:185
+msgid "``PLANNING_POLICY``"
+msgstr "``PLANNING_POLICY``"
+
+#: ../../source/production/console.rst:186
+msgid "``simple``"
+msgstr "``simple``"
+
+#: ../../source/production/console.rst:187
+msgid "Planning policy used by the batch resource manager."
+msgstr "批处理资源管理器使用的规划策略。"
+
+#: ../../source/production/console.rst:188
+msgid "``PLANNER_WORKER_COUNT``"
+msgstr "``PLANNER_WORKER_COUNT``"
+
+#: ../../source/production/console.rst:189
+msgid "``10``"
+msgstr "``10``"
+
+#: ../../source/production/console.rst:190
+msgid "Number of planner workers for batch scheduling."
+msgstr "用于批处理调度的 planner worker 数量。"
+
+#: ../../source/production/console.rst:191
+msgid "``STATIC_FILES_DIR``"
+msgstr "``STATIC_FILES_DIR``"
+
+#: ../../source/production/console.rst:193
+msgid "Directory that contains the built Console frontend assets."
+msgstr "包含已构建 Console 前端资源的目录。"
+
+#: ../../source/production/console.rst:194
+msgid "``ALLOWED_ORIGINS``"
+msgstr "``ALLOWED_ORIGINS``"
+
+#: ../../source/production/console.rst:196
+msgid "Comma-separated CORS origins for browser clients."
+msgstr "浏览器客户端的 CORS 来源，逗号分隔。"
+
+#: ../../source/production/console.rst:197
+msgid "``DEV_MODE``"
+msgstr "``DEV_MODE``"
+
+#: ../../source/production/console.rst:198
+msgid "``false``"
+msgstr "``false``"
+
+#: ../../source/production/console.rst:199
+msgid ""
+"Enables development-oriented backend behavior and logging. Also available"
+" as ``--dev-mode``."
+msgstr "启用面向开发的后端行为与日志。也可通过 ``--dev-mode`` 设置。"
+
+#: ../../source/production/console.rst:203
+msgid "Batch workflow"
+msgstr "批处理工作流"
+
+#: ../../source/production/console.rst:205
+msgid ""
+"The Console batch workflow uses the same backend concepts as the Batch "
+"API and Batch Resource Manager:"
+msgstr "Console 批处理工作流使用与 Batch API 和 Batch Resource Manager 相同的后端概念："
+
+#: ../../source/production/console.rst:208
+msgid "Create or select a model deployment template."
+msgstr "创建或选择模型部署模板。"
+
+#: ../../source/production/console.rst:209
+msgid "Upload or select an input JSONL file through MDS."
+msgstr "通过 MDS 上传或选择输入 JSONL 文件。"
+
+#: ../../source/production/console.rst:210
+msgid "Create a batch job from the Console."
+msgstr "从 Console 创建批处理任务。"
+
+#: ../../source/production/console.rst:211
+msgid "The Console stores the job metadata and submits the batch request to MDS."
+msgstr "Console 存储任务元数据，并向 MDS 提交批处理请求。"
+
+#: ../../source/production/console.rst:212
+msgid "The planner and resource manager provision resources when configured."
+msgstr "在已配置时，planner 和资源管理器会供给资源。"
+
+#: ../../source/production/console.rst:213
+msgid "Monitor job status and download output or error files after completion."
+msgstr "监控任务状态，完成后下载输出或错误文件。"
+
+#: ../../source/production/console.rst:215
+msgid ""
+"For the underlying API and resource planning behavior, see "
+":ref:`batch_api`, :ref:`batch_model_deployment_templates`, and "
+":ref:`batch_resource_manager`."
+msgstr ""
+"底层 API 与资源规划行为参见 :ref:`batch_api` 、:ref:`batch_model_deployment_templates` "
+"和 :ref:`batch_resource_manager` 。"
+
+#: ../../source/production/console.rst:219
+msgid "Feature flags"
+msgstr "功能开关"
+
+#: ../../source/production/console.rst:221
+msgid "The web frontend uses build-time feature flags:"
+msgstr "Web 前端使用构建时功能开关："
+
+#: ../../source/production/console.rst:226
+msgid "Flag"
+msgstr "Flag"
+
+#: ../../source/production/console.rst:228
+msgid "``VITE_ENABLE_DEPLOYMENTS``"
+msgstr "``VITE_ENABLE_DEPLOYMENTS``"
+
+#: ../../source/production/console.rst:229
+msgid "Enables deployment management UI."
+msgstr "启用部署管理 UI。"
+
+#: ../../source/production/console.rst:230
+msgid "``VITE_ENABLE_PLAYGROUND``"
+msgstr "``VITE_ENABLE_PLAYGROUND``"
+
+#: ../../source/production/console.rst:231
+msgid "Enables the playground UI."
+msgstr "启用 playground UI。"
+
+#: ../../source/production/console.rst:233
+msgid ""
+"Both flags are enabled by default when running the frontend development "
+"server. Production builds should set them explicitly so the generated "
+"assets match the intended Console surface:"
+msgstr ""
+"运行前端开发服务器时，这两个开关默认启用。生产构建应显式设置它们，使生成的资源与预期的 Console 界面一致："
+
+#: ../../source/production/console.rst:241
+msgid "What's next?"
+msgstr "下一步？"
+
+#: ../../source/production/console.rst:244
+msgid ":doc:`observability`: metrics and dashboards behind the Console views"
+msgstr ":doc:`observability` ：控制台视图背后的指标与仪表盘"
+
+#: ../../source/production/console.rst:245
+msgid ":doc:`model-deployment`: deploy the models the Console manages"
+msgstr ":doc:`model-deployment` ：部署 Console 所管理的模型"
+
+#: ../../source/production/console.rst:246
+msgid ":doc:`../features/batch-api`: submit and track offline batch jobs"
+msgstr ":doc:`../features/batch-api` ：提交并跟踪离线批处理任务"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/production/gateway.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/production/gateway.po
@@ -1,0 +1,454 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/production/gateway.rst:5
+msgid "Deploying Gateway"
+msgstr "部署网关"
+
+#: ../../source/production/gateway.rst:7
+msgid ""
+"This guide covers production deployment configuration for the AIBrix "
+"gateway components."
+msgstr "本指南介绍 AIBrix 网关组件的生产部署配置。"
+
+#: ../../source/production/gateway.rst:10
+msgid "Configuring Resources and Replica Count"
+msgstr "配置资源与副本数"
+
+#: ../../source/production/gateway.rst:12
+msgid ""
+"For production deployments, we recommend tuning replica counts and "
+"resource allocations for both the **Gateway Plugin** and the **Envoy "
+"Proxy** data plane."
+msgstr ""
+"生产部署中，建议同时调整 **Gateway Plugin** 和 **Envoy "
+"Proxy** 数据面的副本数与资源分配。"
+
+#: ../../source/production/gateway.rst:16
+msgid "Gateway Plugin"
+msgstr "Gateway Plugin"
+
+#: ../../source/production/gateway.rst:18
+msgid ""
+"The gateway plugin (``gatewayPlugin``) handles request routing logic and "
+"external processing. Set ``replicaCount`` and container resources in your"
+" ``values.yaml`` override:"
+msgstr ""
+"网关插件（``gatewayPlugin`` ）负责请求路由逻辑和外部处理。在 ``values.yaml`` 覆盖文件中设置 ``replicaCount`` "
+"和容器资源："
+
+#: ../../source/production/gateway.rst:35
+msgid "Envoy Proxy"
+msgstr "Envoy Proxy"
+
+#: ../../source/production/gateway.rst:37
+msgid ""
+"The Envoy proxy (``gateway.envoyProxy``) is the data-plane component "
+"managed by Envoy Gateway. Set ``replicas`` and per-container resources as"
+" follows:"
+msgstr ""
+"Envoy 代理（``gateway.envoyProxy`` ）是由 Envoy Gateway 管理的数据面组件。按如下方式设置 ``replicas`` "
+"和每个容器的资源："
+
+#: ../../source/production/gateway.rst:56
+msgid "Enabling Redis for Multi-Replica Deployments"
+msgstr "为多副本部署启用 Redis"
+
+#: ../../source/production/gateway.rst:58
+msgid ""
+"When running more than one gateway plugin replica, shared state is "
+"required so that all instances agree on routing decisions (e.g. prefix-"
+"cache block assignments, rate-limit counters). Two settings must both be "
+"configured:"
+msgstr ""
+"运行多个网关插件副本时，需要共享状态，以使所有实例对路由决策达成一致（例如 prefix-cache 块分配、限流计数器）。"
+"必须同时配置以下两项："
+
+#: ../../source/production/gateway.rst:62
+msgid ""
+"**Connect to Redis** — the gateway plugin reads the ``REDIS_HOST`` "
+"environment variable at startup. If the variable is unset or Redis is "
+"unreachable, each replica operates with in-process state only, which "
+"causes inconsistent routing across pods."
+msgstr ""
+"**连接 Redis** — 网关插件在启动时读取 ``REDIS_HOST`` "
+"环境变量。如果未设置该变量或 Redis 不可达，每个副本仅使用进程内状态，会导致各 Pod 之间路由不一致。"
+
+#: ../../source/production/gateway.rst:66
+msgid ""
+"**Enable cross-replica state sync** — setting "
+"``AIBRIX_STATESYNC_ENABLED=true`` activates the Redis-backed delta-sync "
+"mechanism that propagates prefix-cache state across replicas. Without "
+"this flag, the gateway connects to Redis for other purposes (e.g. rate "
+"limiting) but **does not** synchronize prefix-cache routing state between"
+" pods, so multi-replica ``prefix-cache`` routing will still produce "
+"inconsistent decisions."
+msgstr ""
+"**启用跨副本状态同步** — 设置 "
+"``AIBRIX_STATESYNC_ENABLED=true`` 会启用基于 Redis 的增量同步机制，在副本间传播 prefix-cache 状态。"
+"没有该标志时，网关仍会为其他用途（例如限流）连接 Redis，但 **不会** 在 Pod 之间同步 prefix-cache 路由状态，"
+"因此多副本 ``prefix-cache`` 路由仍会产生不一致的决策。"
+
+#: ../../source/production/gateway.rst:72
+msgid "Enable both by updating your ``values.yaml`` override:"
+msgstr "通过更新 ``values.yaml`` 覆盖文件同时启用这两项："
+
+#: ../../source/production/gateway.rst:85
+msgid ""
+"The Helm chart sets ``REDIS_HOST`` automatically from "
+"``gatewayPlugin.dependencies.redis.host``, defaulting to ``<release-name"
+">-redis-master`` when the field is empty. For an external Redis cluster, "
+"set ``host`` to the service hostname or IP of your Redis endpoint."
+msgstr ""
+"Helm chart 会根据 ``gatewayPlugin.dependencies.redis.host`` 自动设置 ``REDIS_HOST`` "
+"，该字段为空时默认为 ``<release-name>-redis-master`` 。对于外部 Redis 集群，将 ``host`` 设置为 "
+"Redis 端点的服务主机名或 IP。"
+
+#: ../../source/production/gateway.rst:90
+msgid ""
+"``AIBRIX_STATESYNC_ENABLED`` defaults to ``false``. It must be explicitly"
+" set to ``true`` for cross-replica state sync to activate. Omitting this "
+"flag is the most common cause of inconsistent ``prefix-cache`` routing "
+"when scaling the gateway plugin beyond one replica."
+msgstr ""
+"``AIBRIX_STATESYNC_ENABLED`` 默认为 ``false`` 。必须显式设置为 ``true`` 才会启用跨副本状态同步。将网关插件扩展到多个副本时，漏设该标志是 "
+"``prefix-cache`` 路由不一致最常见的原因。"
+
+#: ../../source/production/gateway.rst:95
+msgid "Sizing Redis"
+msgstr "为 Redis 规划容量"
+
+#: ../../source/production/gateway.rst:97
+msgid ""
+"The bundled Redis instance is deployed under ``metadata.redis``. For "
+"production workloads with multiple gateway plugin replicas, increase its "
+"CPU, memory, and (if using persistence) storage from the defaults:"
+msgstr ""
+"内置 Redis 实例部署在 ``metadata.redis`` 下。对于使用多个网关插件副本的生产负载，"
+"请在默认值基础上提高其 CPU、内存，以及（若使用持久化）存储："
+
+#: ../../source/production/gateway.rst:115
+msgid ""
+"The right sizing depends on request throughput and the number of distinct"
+" prefix-cache keys in flight. As a starting point, allocate roughly **1 "
+"GiB of memory per 1 000 concurrent requests** and increase CPU if Redis "
+"becomes a latency bottleneck (monitor "
+"``redis_commands_duration_seconds``)."
+msgstr ""
+"合适的容量取决于请求吞吐量和进行中的不同 prefix-cache key 数量。作为起点，大约按 **每 1 000 个并发请求 1 GiB "
+"内存** 分配；如果 Redis 成为延迟瓶颈，再增加 CPU（监控 ``redis_commands_duration_seconds`` ）。"
+
+#: ../../source/production/gateway.rst:120
+msgid ""
+"If you are using an externally managed Redis (e.g. AWS ElastiCache, "
+"Google Memorystore), set ``gatewayPlugin.dependencies.redis.host`` to the"
+" external endpoint and remove the ``metadata.redis`` block from your "
+"override — the chart will not deploy its own Redis when a custom host is "
+"provided."
+msgstr ""
+"如果使用外部托管 Redis（例如 AWS ElastiCache、Google Memorystore），将 "
+"``gatewayPlugin.dependencies.redis.host`` 设置为外部端点，并从覆盖文件中删除 ``metadata.redis`` "
+"块 — 提供自定义 host 时，chart 不会部署自带 Redis。"
+
+#: ../../source/production/gateway.rst:126
+msgid "Configuring Buffer Limits, Connections, and QPS"
+msgstr "配置缓冲区限制、连接与 QPS"
+
+#: ../../source/production/gateway.rst:128
+msgid ""
+"AIBrix exposes three policy knobs under ``gateway`` to control how "
+"traffic flows between clients, the Envoy proxy, and backend pods."
+msgstr ""
+"AIBrix 在 ``gateway`` 下提供三个策略开关，用于控制客户端、Envoy 代理与后端 Pod 之间的流量。"
+
+#: ../../source/production/gateway.rst:132
+msgid "Client Traffic Policy"
+msgstr "客户端流量策略"
+
+#: ../../source/production/gateway.rst:134
+msgid ""
+"``clientTrafficPolicy`` governs connections and request sizes arriving "
+"from external clients:"
+msgstr "``clientTrafficPolicy`` 控制来自外部客户端的连接和请求大小："
+
+#: ../../source/production/gateway.rst:136
+msgid ""
+"**bufferLimit** — maximum bytes buffered per request/response body "
+"(input/output size). The default ``4194304`` is 4 MiB. Increase this if "
+"your workloads send large prompts or receive large completions."
+msgstr ""
+"**bufferLimit** — 每个请求/响应体缓冲的最大字节数（输入/输出大小）。默认 ``4194304`` 为 4 MiB。"
+"如果工作负载发送较大 prompt 或接收较大 completion，请增大该值。"
+
+#: ../../source/production/gateway.rst:139
+msgid ""
+"**connectionLimit** — maximum simultaneous TCP connections accepted by "
+"the proxy."
+msgstr "**connectionLimit** — 代理接受的最大同时 TCP 连接数。"
+
+#: ../../source/production/gateway.rst:140
+msgid ""
+"**http2.maxConcurrentStreams** — maximum concurrent HTTP/2 streams per "
+"connection from a client."
+msgstr "**http2.maxConcurrentStreams** — 每个来自客户端的连接上的最大并发 HTTP/2 流数。"
+
+#: ../../source/production/gateway.rst:154
+msgid "Backend Traffic Policy"
+msgstr "后端流量策略"
+
+#: ../../source/production/gateway.rst:156
+msgid ""
+"``backendTrafficPolicy`` controls how Envoy distributes load across "
+"backend pods and limits the blast radius of a single slow or failing pod:"
+msgstr ""
+"``backendTrafficPolicy`` 控制 Envoy 如何在后端 Pod 之间分配负载，并限制单个缓慢或故障 Pod 的影响范围："
+
+#: ../../source/production/gateway.rst:159
+msgid ""
+"**circuitBreaker.maxConnections** — maximum TCP connections to a single "
+"backend pod."
+msgstr "**circuitBreaker.maxConnections** — 到单个后端 Pod 的最大 TCP 连接数。"
+
+#: ../../source/production/gateway.rst:160
+msgid ""
+"**circuitBreaker.maxParallelRequests** — maximum in-flight requests to a "
+"single backend pod (effective QPS cap when combined with latency)."
+msgstr ""
+"**circuitBreaker.maxParallelRequests** — 到单个后端 Pod 的最大进行中请求数（结合延迟时相当于有效 QPS 上限）。"
+
+#: ../../source/production/gateway.rst:161
+msgid ""
+"**circuitBreaker.maxPendingRequests** — maximum requests queued waiting "
+"for a connection to a backend pod."
+msgstr "**circuitBreaker.maxPendingRequests** — 等待连接到后端 Pod 的最大排队请求数。"
+
+#: ../../source/production/gateway.rst:162
+msgid ""
+"**circuitBreaker.maxParallelRetries** — maximum concurrent retries to a "
+"backend pod."
+msgstr "**circuitBreaker.maxParallelRetries** — 到后端 Pod 的最大并发重试数。"
+
+#: ../../source/production/gateway.rst:163
+msgid ""
+"**circuitBreaker.maxRequestsPerConnection** — maximum requests served on "
+"a single connection before it is recycled."
+msgstr "**circuitBreaker.maxRequestsPerConnection** — 单条连接在回收前可服务的最大请求数。"
+
+#: ../../source/production/gateway.rst:164
+msgid ""
+"**http2.maxConcurrentStreams** — maximum concurrent HTTP/2 streams per "
+"connection to a backend pod."
+msgstr "**http2.maxConcurrentStreams** — 到后端 Pod 的每个连接上的最大并发 HTTP/2 流数。"
+
+#: ../../source/production/gateway.rst:180
+msgid "Envoy Patch Policy"
+msgstr "Envoy Patch Policy"
+
+#: ../../source/production/gateway.rst:182
+msgid ""
+"``envoyPatchPolicy`` provides lower-level overrides applied directly to "
+"the Envoy xDS configuration, covering route timeouts and the limits for "
+"the original-destination cluster:"
+msgstr ""
+"``envoyPatchPolicy`` 提供直接作用于 Envoy xDS 配置的更底层覆盖，涵盖路由超时和 original-destination "
+"集群的限制："
+
+#: ../../source/production/gateway.rst:185
+msgid ""
+"**route.timeout** — maximum duration Envoy waits for a backend response. "
+"Increase this for long-running inference requests."
+msgstr "**route.timeout** — Envoy 等待后端响应的最长时间。对长时间推理请求请增大该值。"
+
+#: ../../source/production/gateway.rst:187
+msgid ""
+"**route.connectTimeout** — maximum time to establish a TCP connection to "
+"a backend pod."
+msgstr "**route.connectTimeout** — 与后端 Pod 建立 TCP 连接的最长时间。"
+
+#: ../../source/production/gateway.rst:188
+msgid ""
+"**circuitBreakers.maxConnections / maxRequests / maxPendingRequests** — "
+"same semantics as the backend traffic policy above but applied at the "
+"Envoy cluster level."
+msgstr ""
+"**circuitBreakers.maxConnections / maxRequests / maxPendingRequests** — "
+"语义与上述后端流量策略相同，但作用于 Envoy 集群级别。"
+
+#: ../../source/production/gateway.rst:204
+msgid "Choosing a Routing Strategy"
+msgstr "选择路由策略"
+
+#: ../../source/production/gateway.rst:206
+msgid ""
+"If no ``routing-strategy`` header is provided, the gateway defaults to "
+"``random`` routing."
+msgstr "如果未提供 ``routing-strategy`` 头，网关默认使用 ``random`` 路由。"
+
+#: ../../source/production/gateway.rst:219
+msgid ""
+"For production workloads we recommend selecting a strategy based on your "
+"traffic pattern:"
+msgstr "对于生产负载，建议根据流量模式选择策略："
+
+#: ../../source/production/gateway.rst:221
+msgid ""
+"**Multi-turn conversations or workloads with prompt prefix overlap — "
+"use** ``prefix-cache``"
+msgstr "**多轮对话或 prompt 前缀重叠的负载 — 使用** ``prefix-cache``"
+
+#: ../../source/production/gateway.rst:223
+msgid ""
+"When requests share a common prompt prefix (e.g. a system prompt, few-"
+"shot examples, or conversation history), ``prefix-cache`` routes each "
+"request to the pod that already holds the matching KV-cache blocks in GPU"
+" memory, reducing redundant computation and improving latency. See "
+"`prefix cache routing details "
+"<../../../pkg/plugins/gateway/algorithms/prefix_cache_readme.md>`_ for "
+"algorithm internals and configuration options."
+msgstr ""
+"当请求共享相同 prompt 前缀（例如 system prompt、few-shot 示例或对话历史）时，``prefix-cache`` 会将每个请求路由到 "
+"GPU 内存中已持有匹配 KV-cache 块的 Pod，减少重复计算并改善延迟。算法内部与配置选项见 `prefix cache routing "
+"details <../../../pkg/plugins/gateway/algorithms/prefix_cache_readme.md>`_ "
+"。"
+
+#: ../../source/production/gateway.rst:243
+msgid "**Independent requests with no prefix overlap — use** ``least-request``"
+msgstr "**无前缀重叠的独立请求 — 使用** ``least-request``"
+
+#: ../../source/production/gateway.rst:245
+msgid ""
+"When each request has a unique prompt and there is no KV-cache reuse "
+"benefit, ``least-request`` distributes load evenly by always routing to "
+"the pod with the fewest in-flight requests."
+msgstr ""
+"当每个请求的 prompt 都不同且无法从 KV-cache 复用中获益时，``least-request`` "
+"始终路由到进行中请求最少的 Pod，从而均匀分配负载。"
+
+#: ../../source/production/gateway.rst:259
+msgid "**High-throughput workloads requiring compute separation — use** ``pd``"
+msgstr "**需要计算分离的高吞吐负载 — 使用** ``pd``"
+
+#: ../../source/production/gateway.rst:261
+msgid ""
+"Prefill-Decode (PD) disaggregation splits the two phases of LLM inference"
+" across dedicated pods: prefill pods process the prompt and decode pods "
+"generate tokens. This allows each pod type to be sized and scaled "
+"independently, improving GPU utilization at high request volumes."
+msgstr ""
+"Prefill-Decode（PD）分离将 LLM 推理的两个阶段拆分到专用 Pod：prefill Pod 处理 prompt，decode Pod "
+"生成 token。这样可以对每种 Pod 独立规划容量和扩缩容，在高请求量下提升 GPU 利用率。"
+
+#: ../../source/production/gateway.rst:276
+msgid ""
+"See `prefill-decode disaggregation details "
+"<../../../pkg/plugins/gateway/algorithms/pd_readme.md>`_ for deployment "
+"requirements and configuration options."
+msgstr ""
+"部署要求与配置选项见 `prefill-decode disaggregation details <../../../pkg/plugins/gateway/algorithms/pd_readme.md>`_ "
+"。"
+
+#: ../../source/production/gateway.rst:280
+msgid ""
+"``random`` is suitable for testing and low-traffic scenarios where "
+"routing quality is not critical. For any production deployment, "
+"explicitly set ``routing-strategy`` to avoid relying on the default."
+msgstr "``random`` 适用于测试和低流量、对路由质量要求不高的场景。任何生产部署都应显式设置 ``routing-strategy`` ，避免依赖默认值。"
+
+#: ../../source/production/gateway.rst:285
+msgid "Draining Pods"
+msgstr "排空 Pod"
+
+#: ../../source/production/gateway.rst:287
+msgid ""
+"The gateway excludes Pods annotated with ``aibrix.ai/draining=true`` from"
+" its ready-pod routing candidates. RoleSet and PodSet controllers set "
+"this annotation before deleting serving Pods when a role configures "
+"``drain.timeoutSeconds > 0``. This gives the gateway time to stop "
+"assigning new requests before the controller removes the Pod."
+msgstr ""
+"网关会将带有 ``aibrix.ai/draining=true`` 注解的 Pod 排除出就绪 Pod 路由候选。"
+"当某个 role 配置了 ``drain.timeoutSeconds > 0`` 时，RoleSet 和 PodSet 控制器会在删除服务 Pod 之前设置该注解。"
+"这给网关时间停止分配新请求，然后再由控制器移除该 Pod。"
+
+#: ../../source/production/gateway.rst:293
+msgid "The gateway treats the drain annotation as a routing signal only:"
+msgstr "网关仅将排空注解视为路由信号："
+
+#: ../../source/production/gateway.rst:311
+msgid ""
+"The controller owns the timeout and deletion decision. The gateway does "
+"not parse ``drain-start-time`` and does not emit drain lifecycle events."
+msgstr "超时与删除决策由控制器负责。网关不解析 ``drain-start-time`` ，也不发出排空生命周期事件。"
+
+#: ../../source/production/gateway.rst:315
+msgid "Per-Model Routing Configuration"
+msgstr "按模型配置路由"
+
+#: ../../source/production/gateway.rst:317
+msgid ""
+"When a single gateway deployment serves multiple models, you may need "
+"different routing strategies per model — for example, ``prefix-cache`` "
+"for a chat model and ``pd`` for a batch-inference model. AIBrix supports "
+"this through **Model Config Profiles**, which let you attach a routing "
+"configuration directly to each model's pods via an annotation and select "
+"a profile at request time using the ``config-profile`` header."
+msgstr ""
+"当单个网关部署服务多个模型时，可能需要按模型使用不同路由策略 — 例如聊天模型用 ``prefix-cache`` ，批处理推理模型用 ``pd`` "
+"。AIBrix 通过 **Model Config Profiles** 支持这一点：可用注解将路由配置直接附加到每个模型的 Pod，并在请求时通过 "
+"``config-profile`` 头选择 profile。"
+
+#: ../../source/production/gateway.rst:335
+msgid ""
+"If the ``config-profile`` header is omitted, the model's "
+"``defaultProfile`` is used. This allows the same gateway to enforce "
+"different routing strategies, prompt-length bucketing, and PD modes per "
+"model without deploying separate gateway instances."
+msgstr ""
+"如果省略 ``config-profile`` 头，则使用该模型的 ``defaultProfile`` 。这样同一网关可按模型实施不同的路由策略、prompt "
+"长度分桶和 PD 模式，而无需部署单独的网关实例。"
+
+#: ../../source/production/gateway.rst:339
+msgid ""
+"For config profile setup and the full annotation schema see "
+":ref:`config_profiles` in the Gateway Routing guide. For production "
+"guidance including RPS limiting see :ref:`model_deployment_production`."
+msgstr ""
+"配置 profile 的设置和完整注解 schema 见网关路由指南中的 :ref:`config_profiles` 。包含 RPS 限制在内的生产指导见 "
+":ref:`model_deployment_production` 。"
+
+#: ../../source/production/gateway.rst:341
+msgid "What's next?"
+msgstr "下一步？"
+
+#: ../../source/production/gateway.rst:344
+msgid ":doc:`model-deployment`: deploy models behind this gateway"
+msgstr ":doc:`model-deployment` ：在该网关后部署模型"
+
+#: ../../source/production/gateway.rst:345
+msgid ":doc:`observability`: gateway metrics and dashboards"
+msgstr ":doc:`observability` ：网关指标与仪表盘"
+
+#: ../../source/production/gateway.rst:346
+msgid ":doc:`../features/pd-disaggregation`: split prefill from decode"
+msgstr ":doc:`../features/pd-disaggregation` ：将 prefill 与 decode 分离"
+
+#: ../../source/production/gateway.rst:347
+msgid ":doc:`../designs/aibrix-router`: how routing decisions are made"
+msgstr ":doc:`../designs/aibrix-router` ：路由决策如何产生"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/production/model-deployment.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/production/model-deployment.po
@@ -1,0 +1,410 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/production/model-deployment.rst:5
+msgid "Production Model Deployments"
+msgstr "生产模型部署"
+
+#: ../../source/production/model-deployment.rst:7
+msgid ""
+"This guide covers what to check before a model deployment goes to "
+"production: required labels, choosing a routing strategy, capping model-"
+"level throughput, configuring readiness, and sizing replicas."
+msgstr ""
+"本指南说明模型部署进入生产前需要检查的内容：必需标签、选择路由策略、限制模型级吞吐、配置就绪探针，以及规划副本规模。"
+
+#: ../../source/production/model-deployment.rst:12
+msgid "On this page"
+msgstr "本页内容"
+
+#: ../../source/production/model-deployment.rst:15
+msgid "Required Labels and Annotations"
+msgstr "必需标签与注解"
+
+#: ../../source/production/model-deployment.rst:17
+msgid ""
+"Every pod template that AIBrix manages needs at minimum two labels. "
+"Without them the gateway cannot route traffic to the pod."
+msgstr "AIBrix 管理的每个 Pod 模板至少需要两个标签。缺少它们时，网关无法将流量路由到该 Pod。"
+
+#: ../../source/production/model-deployment.rst:23
+msgid "Label"
+msgstr "标签"
+
+#: ../../source/production/model-deployment.rst:24
+msgid "Description"
+msgstr "说明"
+
+#: ../../source/production/model-deployment.rst:25
+msgid "``model.aibrix.ai/name: <model-name>``"
+msgstr "``model.aibrix.ai/name: <model-name>``"
+
+#: ../../source/production/model-deployment.rst:26
+msgid ""
+"The model identifier clients send in the ``model`` field of their "
+"requests. Must be unique per model."
+msgstr "客户端在请求 ``model`` 字段中发送的模型标识符。每个模型必须唯一。"
+
+#: ../../source/production/model-deployment.rst:27
+msgid "``model.aibrix.ai/port: \"<port>\"``"
+msgstr "``model.aibrix.ai/port: \"<port>\"``"
+
+#: ../../source/production/model-deployment.rst:28
+msgid "The container port the inference server listens on (e.g. ``\"8000\"``)."
+msgstr "推理服务器监听的容器端口（例如 ``\"8000\"`` ）。"
+
+#: ../../source/production/model-deployment.rst:31
+msgid "Choosing a Routing Strategy"
+msgstr "选择路由策略"
+
+#: ../../source/production/model-deployment.rst:33
+msgid ""
+"Set the default routing strategy for a model via the config annotation "
+"rather than relying on the global env default. This makes the intent "
+"explicit and allows different models to use different strategies."
+msgstr ""
+"通过配置注解为模型设置默认路由策略，而不要依赖全局环境变量默认值。这样意图更明确，并允许不同模型使用不同策略。"
+
+#: ../../source/production/model-deployment.rst:45
+msgid "A practical starting point for common workload types:"
+msgstr "常见负载类型的实用起点："
+
+#: ../../source/production/model-deployment.rst:51
+msgid "Workload"
+msgstr "负载"
+
+#: ../../source/production/model-deployment.rst:52
+msgid "Recommended strategy"
+msgstr "推荐策略"
+
+#: ../../source/production/model-deployment.rst:53
+msgid "Multi-turn chat (shared system prompts)"
+msgstr "多轮对话（共享 system prompt）"
+
+#: ../../source/production/model-deployment.rst:54
+msgid ""
+"``prefix-cache`` — routes repeat prefixes to pods that already hold the "
+"KV cache."
+msgstr "``prefix-cache`` — 将重复前缀路由到已持有 KV cache 的 Pod。"
+
+#: ../../source/production/model-deployment.rst:55
+msgid "Independent requests (batch, summarization)"
+msgstr "独立请求（批处理、摘要）"
+
+#: ../../source/production/model-deployment.rst:56
+msgid "``least-request`` — evenly distributes load across pods."
+msgstr "``least-request`` — 在 Pod 之间均匀分配负载。"
+
+#: ../../source/production/model-deployment.rst:57
+msgid "Latency-sensitive interactive"
+msgstr "对延迟敏感的交互式负载"
+
+#: ../../source/production/model-deployment.rst:58
+msgid "``least-latency`` — routes to the pod with the lowest recent latency."
+msgstr "``least-latency`` — 路由到近期延迟最低的 Pod。"
+
+#: ../../source/production/model-deployment.rst:59
+msgid "High-throughput inference"
+msgstr "高吞吐推理"
+
+#: ../../source/production/model-deployment.rst:60
+msgid "``pd`` — separates prefill and decode for maximum GPU utilization."
+msgstr "``pd`` — 分离 prefill 与 decode，以最大化 GPU 利用率。"
+
+#: ../../source/production/model-deployment.rst:61
+msgid "Multi-user SLO enforcement"
+msgstr "多用户 SLO 保障"
+
+#: ../../source/production/model-deployment.rst:62
+msgid "``vtc-basic`` — balances fairness across users while keeping pods loaded."
+msgstr "``vtc-basic`` — 在保持 Pod 负载的同时平衡用户间公平性。"
+
+#: ../../source/production/model-deployment.rst:64
+msgid ""
+"See the `Deploying Gateway <gateway.html>`_ guide for the full strategy "
+"list."
+msgstr "完整策略列表见 `Deploying Gateway <gateway.html>`_ 指南。"
+
+#: ../../source/production/model-deployment.rst:68
+msgid "Config Profiles for Production"
+msgstr "生产环境的 Config Profile"
+
+#: ../../source/production/model-deployment.rst:70
+msgid ""
+"Config profiles let a single model deployment serve multiple traffic "
+"classes without separate deployments. A common pattern for production is "
+"to define a profile per client type:"
+msgstr ""
+"Config profile 使单个模型部署可以服务多种流量类别，而无需单独部署。生产环境的常见做法是按客户端类型定义 profile："
+
+#: ../../source/production/model-deployment.rst:91
+msgid "Clients select a profile with the ``config-profile`` request header:"
+msgstr "客户端通过 ``config-profile`` 请求头选择 profile："
+
+#: ../../source/production/model-deployment.rst:100
+msgid "If no header is set, the ``defaultProfile`` is used."
+msgstr "如果未设置该头，则使用 ``defaultProfile`` 。"
+
+#: ../../source/production/model-deployment.rst:104
+msgid "Capping Model Throughput (RPS Limiting)"
+msgstr "限制模型吞吐（RPS 限制）"
+
+#: ../../source/production/model-deployment.rst:107
+msgid "What it is"
+msgstr "它是什么"
+
+#: ../../source/production/model-deployment.rst:109
+msgid ""
+"``requestsPerSecond`` sets a hard cap on how many requests per second the"
+" gateway will forward to a given model. Requests that exceed the limit "
+"are rejected immediately with HTTP ``429 Too Many Requests`` before any "
+"routing or inference work is done."
+msgstr ""
+"``requestsPerSecond`` 为网关向指定模型转发的每秒请求数设置硬上限。超出限制的请求会立即以 HTTP "
+"``429 Too Many Requests`` 拒绝，不会进行任何路由或推理。"
+
+#: ../../source/production/model-deployment.rst:111
+msgid ""
+"This is a **model-level** cap (all users combined), distinct from the "
+"per-user RPM/TPM limits. Use it to:"
+msgstr "这是 **模型级** 上限（所有用户合计），不同于按用户的 RPM/TPM 限制。可用于："
+
+#: ../../source/production/model-deployment.rst:113
+msgid "Protect a model from accidental traffic spikes."
+msgstr "保护模型免受意外流量尖峰影响。"
+
+#: ../../source/production/model-deployment.rst:114
+msgid "Enforce a cost budget (GPU-hours) for a model in a shared cluster."
+msgstr "在共享集群中为模型执行成本预算（GPU 小时）。"
+
+#: ../../source/production/model-deployment.rst:115
+msgid "Guarantee headroom for higher-priority models on the same gateway."
+msgstr "为同一网关上更高优先级的模型预留余量。"
+
+#: ../../source/production/model-deployment.rst:118
+msgid "How to configure it"
+msgstr "如何配置"
+
+#: ../../source/production/model-deployment.rst:120
+msgid ""
+"Add ``requestsPerSecond`` to the relevant profile in the model's config "
+"annotation:"
+msgstr "在模型配置注解的相应 profile 中添加 ``requestsPerSecond`` ："
+
+#: ../../source/production/model-deployment.rst:135
+msgid "To apply different limits per traffic class, set it per profile:"
+msgstr "要按流量类别应用不同限制，请按 profile 分别设置："
+
+#: ../../source/production/model-deployment.rst:155
+msgid ""
+"Here, interactive traffic (``default`` profile) is capped at 100 RPS "
+"while batch traffic is limited to 20 RPS."
+msgstr "此处，交互流量（``default`` profile）上限为 100 RPS，批处理流量限制为 20 RPS。"
+
+#: ../../source/production/model-deployment.rst:158
+msgid "What clients see when the limit is hit"
+msgstr "达到限制时客户端看到的内容"
+
+#: ../../source/production/model-deployment.rst:160
+msgid "The gateway returns:"
+msgstr "网关返回："
+
+#: ../../source/production/model-deployment.rst:170
+msgid "How it works internally"
+msgstr "内部工作方式"
+
+#: ../../source/production/model-deployment.rst:172
+msgid ""
+"The counter is stored in Redis and incremented atomically on each "
+"request. The 1-second window resets automatically. If routing fails after"
+" the counter is incremented (e.g. no ready pods), the increment is rolled"
+" back so failed requests do not consume quota."
+msgstr ""
+"计数器存储在 Redis 中，并在每次请求时原子递增。1 秒窗口会自动重置。如果计数器递增后路由失败（例如没有就绪 Pod），"
+"该增量会回滚，因此失败请求不会消耗配额。"
+
+#: ../../source/production/model-deployment.rst:175
+msgid ""
+"``requestsPerSecond`` requires Redis to be enabled on the gateway plugin."
+" Without Redis, the counter is in-process and is not shared across "
+"gateway replicas. See the `Deploying Gateway <gateway.html>`_ guide — "
+"Enabling Redis for Multi-Replica Deployments."
+msgstr ""
+"``requestsPerSecond`` 要求在网关插件上启用 Redis。"
+"没有 Redis 时，计数器位于进程内，不会在网关副本之间共享。参见 `Deploying Gateway <gateway.html>`_ 指南 — "
+"为多副本部署启用 Redis。"
+
+#: ../../source/production/model-deployment.rst:177
+msgid "Omit ``requestsPerSecond`` or set it to ``0`` to disable the limit."
+msgstr "省略 ``requestsPerSecond`` 或将其设为 ``0`` 可禁用该限制。"
+
+#: ../../source/production/model-deployment.rst:181
+msgid "Readiness and Health"
+msgstr "就绪与健康"
+
+#: ../../source/production/model-deployment.rst:183
+msgid ""
+"The gateway only routes to pods that Kubernetes considers **Ready**. "
+"Ensure your pod's readiness probe waits for the inference server to fully"
+" load the model before marking the pod ready. For large models this can "
+"take several minutes."
+msgstr ""
+"网关只路由到 Kubernetes 视为 **Ready** 的 Pod。"
+"请确保 Pod 的就绪探针在将 Pod 标记为就绪之前，等待推理服务器完成模型加载。大型模型可能需要数分钟。"
+
+#: ../../source/production/model-deployment.rst:185
+msgid "A practical readiness probe for vLLM:"
+msgstr "适用于 vLLM 的实用就绪探针："
+
+#: ../../source/production/model-deployment.rst:197
+msgid ""
+"If a pod fails its readiness probe after previously being ready (e.g. due"
+" to OOM), the gateway stops routing to it immediately without dropping "
+"in-flight requests."
+msgstr ""
+"如果 Pod 曾经就绪后就绪探针失败（例如因 OOM），网关会立即停止向其路由，但不会丢弃进行中的请求。"
+
+#: ../../source/production/model-deployment.rst:201
+msgid "Replica Sizing"
+msgstr "副本规模规划"
+
+#: ../../source/production/model-deployment.rst:203
+msgid "There is no universal formula, but a useful starting point:"
+msgstr "没有通用公式，但以下起点较为实用："
+
+#: ../../source/production/model-deployment.rst:205
+msgid ""
+"**Measure single-replica capacity** — run a short load test at increasing"
+" QPS until latency or error rate degrades. Note the sustainable QPS."
+msgstr "**测量单副本容量** — 以递增 QPS 运行短期负载测试，直到延迟或错误率劣化。记录可持续 QPS。"
+
+#: ../../source/production/model-deployment.rst:206
+msgid ""
+"**Apply a safety margin** — target 60–70% of the measured peak to leave "
+"room for spikes."
+msgstr "**预留安全余量** — 以测得峰值的 60–70% 为目标，为尖峰留出空间。"
+
+#: ../../source/production/model-deployment.rst:207
+msgid ""
+"**Add replicas** — ``replicas = ceil(target_QPS / "
+"sustainable_QPS_per_replica)``."
+msgstr "**增加副本** — ``replicas = ceil(target_QPS / sustainable_QPS_per_replica)`` 。"
+
+#: ../../source/production/model-deployment.rst:209
+msgid ""
+"For PD deployments, size prefill and decode pods separately: prefill pods"
+" are compute-bound (add more for high-input-token workloads), decode pods"
+" are memory-bandwidth-bound (add more for long-output workloads)."
+msgstr ""
+"对于 PD 部署，请分别规划 prefill 和 decode Pod 规模：prefill Pod 受计算限制（高输入 token 负载需增加更多），"
+"decode Pod 受内存带宽限制（长输出负载需增加更多）。"
+
+#: ../../source/production/model-deployment.rst:213
+msgid "Rolling Updates"
+msgstr "滚动更新"
+
+#: ../../source/production/model-deployment.rst:215
+msgid ""
+"LLM pods take a long time to start. Configure ``maxUnavailable: 0`` and "
+"``maxSurge: 1`` (or higher) to ensure capacity is not lost during "
+"rollouts:"
+msgstr "LLM Pod 启动较慢。配置 ``maxUnavailable: 0`` 和 ``maxSurge: 1`` （或更高），以确保滚动发布期间不损失容量："
+
+#: ../../source/production/model-deployment.rst:226
+msgid ""
+"With ``maxUnavailable: 0``, Kubernetes only terminates an old pod after "
+"the new pod passes its readiness probe. This prevents the gateway from "
+"routing to a pod that has not finished loading the model."
+msgstr ""
+"设置 ``maxUnavailable: 0`` 时，Kubernetes 仅在新 Pod 通过就绪探针后才会终止旧 Pod。"
+"这可防止网关将流量路由到尚未完成模型加载的 Pod。"
+
+#: ../../source/production/model-deployment.rst:228
+msgid ""
+"For PD deployments, update prefill and decode pods in separate rollouts —"
+" updating both simultaneously can temporarily leave some rolesets "
+"incomplete, causing the gateway to skip them."
+msgstr ""
+"对于 PD 部署，请分别滚动更新 prefill 和 decode Pod —"
+" 同时更新两者可能暂时导致部分 RoleSet 不完整，从而使网关跳过它们。"
+
+#: ../../source/production/model-deployment.rst:232
+msgid "Observability Checklist"
+msgstr "可观测性检查清单"
+
+#: ../../source/production/model-deployment.rst:234
+msgid "Before shipping to production, ensure you have visibility into:"
+msgstr "上线生产前，请确保能够观察到："
+
+#: ../../source/production/model-deployment.rst:236
+msgid ""
+"**Request rate per model** — ``aibrix_gateway_requests_total`` counter, "
+"broken down by ``model`` label."
+msgstr "**每个模型的请求速率** — ``aibrix_gateway_requests_total`` 计数器，按 ``model`` 标签分解。"
+
+#: ../../source/production/model-deployment.rst:237
+msgid "**Routing latency** — time between request arrival and pod selection."
+msgstr "**路由延迟** — 从请求到达至选定 Pod 的时间。"
+
+#: ../../source/production/model-deployment.rst:238
+msgid ""
+"**RPS limit rejections** — watch for ``x-error-model-rps-exceeded`` "
+"response headers or the corresponding metric."
+msgstr "**RPS 限制拒绝** — 关注 ``x-error-model-rps-exceeded`` 响应头或对应指标。"
+
+#: ../../source/production/model-deployment.rst:239
+msgid ""
+"**Pod readiness churn** — alerts on pods that flip between Ready and "
+"NotReady indicate OOM or instability."
+msgstr "**Pod 就绪抖动** — 对在 Ready 与 NotReady 之间切换的 Pod 告警，通常表示 OOM 或不稳定。"
+
+#: ../../source/production/model-deployment.rst:240
+msgid ""
+"**Prefill timeout rate** (PD only) — ``pd-prefill-request-error`` log "
+"entries; a high rate suggests prefill pods are overloaded."
+msgstr ""
+"**Prefill 超时率** （仅 PD） — ``pd-prefill-request-error`` 日志条目；比率偏高表明 prefill "
+"Pod 过载。"
+
+#: ../../source/production/model-deployment.rst:242
+msgid ""
+"See the `Observability <observability.html>`_ guide for the full metrics "
+"reference."
+msgstr "完整指标参考见 `Observability <observability.html>`_ 指南。"
+
+#: ../../source/production/model-deployment.rst:244
+msgid "What's next?"
+msgstr "下一步？"
+
+#: ../../source/production/model-deployment.rst:247
+msgid ":doc:`gateway`: production gateway configuration"
+msgstr ":doc:`gateway` ：生产网关配置"
+
+#: ../../source/production/model-deployment.rst:248
+msgid ":doc:`observability`: full metrics reference"
+msgstr ":doc:`observability` ：完整指标参考"
+
+#: ../../source/production/model-deployment.rst:249
+msgid ":doc:`../features/autoscaling/autoscaling`: autoscale the deployment"
+msgstr ":doc:`../features/autoscaling/autoscaling` ：对部署进行自动扩缩容"
+
+#: ../../source/production/model-deployment.rst:250
+msgid ":doc:`../features/kvcache-offloading`: reduce prefill cost with KV reuse"
+msgstr ":doc:`../features/kvcache-offloading` ：通过 KV 复用降低 prefill 成本"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/production/observability.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/production/observability.po
@@ -1,0 +1,226 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, AIBrix Team
+# This file is distributed under the same license as the AIBrix package.
+# AIBrix Team, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AIBrix\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-10 18:51+0800\n"
+"PO-Revision-Date: 2026-09-10 18:55+0800\n"
+"Last-Translator: AIBrix Team\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../source/production/observability.rst:5
+msgid "Observability"
+msgstr "可观测性"
+
+#: ../../source/production/observability.rst:7
+msgid ""
+"To enable observability for your AIBrix deployment, we provide **Built-in"
+" Grafana Dashboards** that cover the key system components:"
+msgstr "要为 AIBrix 部署启用可观测性，我们提供覆盖关键系统组件的 **内置 Grafana 仪表盘** ："
+
+#: ../../source/production/observability.rst:9
+msgid "**Control Plane Runtime Dashboard**"
+msgstr "**Control Plane Runtime Dashboard**"
+
+#: ../../source/production/observability.rst:10
+msgid ""
+"Monitors controller runtime performance, reconciliation behavior, and "
+"health status of the control plane."
+msgstr "监控控制器运行时性能、调和行为以及控制面健康状态。"
+
+#: ../../source/production/observability.rst:12
+msgid "**Envoy Gateway Dashboard**"
+msgstr "**Envoy Gateway Dashboard**"
+
+#: ../../source/production/observability.rst:13
+msgid ""
+"Visualizes traffic metrics including request counts, latencies, and "
+"external processing statistics."
+msgstr "可视化流量指标，包括请求数、延迟和外部处理统计。"
+
+#: ../../source/production/observability.rst:15
+msgid "**Model Service Dashboard**"
+msgstr "**Model Service Dashboard**"
+
+#: ../../source/production/observability.rst:16
+msgid ""
+"Tracks per-model service metrics such as request QPS, prompt and output "
+"length, TTFT/TPOT, and stop reasons etc."
+msgstr "跟踪每个模型的服务指标，例如请求 QPS、prompt 与输出长度、TTFT/TPOT 以及停止原因等。"
+
+#: ../../source/production/observability.rst:18
+msgid "**ModelClaim Runtime Dashboard**"
+msgstr "**ModelClaim Runtime Dashboard**"
+
+#: ../../source/production/observability.rst:19
+msgid ""
+"Tracks ModelClaim desired/ready/activating lifecycle, warm-pool resident "
+"density, kvcached KV use/capacity, and HBM peak per co-resident model."
+msgstr ""
+"跟踪 ModelClaim 的 desired/ready/activating 生命周期、warm-pool 驻留密度、"
+"kvcached 的 KV 使用量/容量，以及每个共驻模型的 HBM 峰值。"
+
+#: ../../source/production/observability.rst:22
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: ../../source/production/observability.rst:24
+msgid ""
+"Before enabling metrics and dashboards, make sure the `kube-prometheus-"
+"stack <https://github.com/prometheus-community/helm-"
+"charts/blob/main/charts/kube-prometheus-stack/README.md>`_ is installed "
+"in your cluster. This provides Prometheus, Grafana, and CRDs like "
+"`ServiceMonitor` required for scraping metrics."
+msgstr ""
+"启用指标和仪表盘之前，请确保集群中已安装 `kube-prometheus-stack <https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/README.md>`_ "
+"。它提供 Prometheus、Grafana，以及抓取指标所需的 `ServiceMonitor` 等 CRD。"
+
+#: ../../source/production/observability.rst:33
+msgid "Metric Enablement Steps"
+msgstr "启用指标的步骤"
+
+#: ../../source/production/observability.rst:35
+msgid "To activate metric collection for each component:"
+msgstr "要为各组件启用指标采集："
+
+#: ../../source/production/observability.rst:37
+msgid ""
+"**Control Plane Runtime** - The default controller manager installation "
+"already expose the metrics."
+msgstr "**Control Plane Runtime** - 默认的 controller manager 安装已暴露指标。"
+
+#: ../../source/production/observability.rst:43
+msgid ""
+"**Envoy Gateway** - In addition to a `ServiceMonitor`, you must deploy an"
+" **auxiliary metrics service** that exposes Envoy's admin interface "
+"metrics (e.g., `/stats/prometheus`) to Prometheus."
+msgstr ""
+"**Envoy Gateway** - 除 `ServiceMonitor` 外，还必须部署一个 **辅助指标服务** ，将 Envoy 管理接口指标（例如 "
+"`/stats/prometheus` ）暴露给 Prometheus。"
+
+#: ../../source/production/observability.rst:53
+msgid ""
+"**Model Service** - We provides a sample `ServiceMonitor` as a reference,"
+" you can change the definition based on your model setups."
+msgstr "**Model Service** - 我们提供示例 `ServiceMonitor` 作为参考，可根据模型配置修改其定义。"
+
+#: ../../source/production/observability.rst:59
+msgid ""
+"**ModelClaim Runtime** - Scrapes the warm-pool `aibrix-runtime` sidecar "
+"`/metrics` endpoint. Services must be labeled ``aibrix.ai/metrics: "
+"modelclaim-runtime`` (see ``samples/modelclaim/warm-runtime-pool.yaml``)."
+" The monitor attaches a bounded ``pool`` label from "
+"``pool.aibrix.ai/name``."
+msgstr ""
+"**ModelClaim Runtime** - 抓取 warm-pool `aibrix-runtime` sidecar 的 `/metrics` "
+"端点。Service 必须带有标签 ``aibrix.ai/metrics: modelclaim-runtime`` （参见 ``samples/modelclaim/warm-runtime-pool.yaml`` "
+"）。该 monitor 会从 ``pool.aibrix.ai/name`` 附加有界的 ``pool`` 标签。"
+
+#: ../../source/production/observability.rst:66
+msgid "Import Grafana Dashboard"
+msgstr "导入 Grafana 仪表盘"
+
+#: ../../source/production/observability.rst:68
+msgid ""
+"For production monitoring, we provide pre-built Grafana dashboards to "
+"visualize metrics from the control plane, Envoy Gateway, model services, "
+"and ModelClaim warm pools. These dashboards offer insights into system "
+"performance, request patterns, error rates, and more. You can import them"
+" into your Grafana instance by uploading the corresponding JSON files. "
+"Ensure your Prometheus data source is correctly configured before "
+"importing. Once imported, the dashboards will begin displaying live "
+"metrics as long as `ServiceMonitor` resources are properly set up and the"
+" kube-prometheus stack is actively scraping data."
+msgstr ""
+"对于生产监控，我们提供预构建的 Grafana 仪表盘，用于可视化控制面、Envoy Gateway、模型服务以及 ModelClaim "
+"warm pool 的指标。这些仪表盘可洞察系统性能、请求模式、错误率等。可通过上传对应 JSON 文件导入到 Grafana 实例。"
+"导入前请确保 Prometheus 数据源配置正确。导入后，只要 `ServiceMonitor` 资源配置正确，且 kube-prometheus "
+"stack 正在抓取数据，仪表盘就会开始显示实时指标。"
+
+#: ../../source/production/observability.rst:73
+msgid ""
+"See ``observability/grafana/README.md`` for the ModelClaim metric "
+"contract and import notes."
+msgstr "ModelClaim 指标约定与导入说明见 ``observability/grafana/README.md`` 。"
+
+#: ../../source/production/observability.rst:75
+msgid ""
+"`AIBrix Control Plane Runtime Dashboard "
+"<https://raw.githubusercontent.com/vllm-"
+"project/aibrix/main/observability/grafana/AIBrix_Control_Plane_Runtime_Dashboard.json>`_"
+msgstr ""
+"`AIBrix Control Plane Runtime Dashboard "
+"<https://raw.githubusercontent.com/vllm-"
+"project/aibrix/main/observability/grafana/AIBrix_Control_Plane_Runtime_Dashboard.json>`_"
+
+#: ../../source/production/observability.rst:76
+msgid ""
+"`AIBrix Envoy Gateway Dashboard <https://raw.githubusercontent.com/vllm-"
+"project/aibrix/main/observability/grafana/AIBrix_Envoy_Gateway_Dashboard.json>`_"
+msgstr ""
+"`AIBrix Envoy Gateway Dashboard <https://raw.githubusercontent.com/vllm-"
+"project/aibrix/main/observability/grafana/AIBrix_Envoy_Gateway_Dashboard.json>`_"
+
+#: ../../source/production/observability.rst:77
+msgid ""
+"`AIBrix vLLM Engine Dashboard <https://raw.githubusercontent.com/vllm-"
+"project/aibrix/main/observability/grafana/AIBrix_vLLM_Engine_Dashboard.json>`_"
+msgstr ""
+"`AIBrix vLLM Engine Dashboard <https://raw.githubusercontent.com/vllm-"
+"project/aibrix/main/observability/grafana/AIBrix_vLLM_Engine_Dashboard.json>`_"
+
+#: ../../source/production/observability.rst:78
+msgid ""
+"`AIBrix ModelClaim Runtime Dashboard <https://raw.githubusercontent.com"
+"/vllm-"
+"project/aibrix/main/observability/grafana/AIBrix_ModelClaim_Runtime_Dashboard.json>`_"
+msgstr ""
+"`AIBrix ModelClaim Runtime Dashboard <https://raw.githubusercontent.com"
+"/vllm-"
+"project/aibrix/main/observability/grafana/AIBrix_ModelClaim_Runtime_Dashboard.json>`_"
+
+#: ../../source/production/observability.rst:81
+msgid "Production Monitoring"
+msgstr "生产监控"
+
+#: ../../source/production/observability.rst:83
+msgid ""
+"TODO: Screenshots and visual examples will be added soon to illustrate "
+"key views and usage patterns."
+msgstr "TODO：将很快补充截图和可视化示例，以说明关键视图和使用方式。"
+
+#: ../../source/production/observability.rst:86
+msgid "OpenTelemetry"
+msgstr "OpenTelemetry"
+
+#: ../../source/production/observability.rst:88
+msgid ""
+"To enable the telemetry components, please refer to "
+":ref:`observability_telemetry` for details."
+msgstr "要启用遥测组件，请参见 :ref:`observability_telemetry` 。"
+
+#: ../../source/production/observability.rst:90
+msgid "What's next?"
+msgstr "下一步？"
+
+#: ../../source/production/observability.rst:93
+msgid ":doc:`gateway`: gateway configuration that produces these metrics"
+msgstr ":doc:`gateway` ：产生这些指标的网关配置"
+
+#: ../../source/production/observability.rst:94
+msgid ":doc:`model-deployment`: the signals worth alerting on"
+msgstr ":doc:`model-deployment` ：值得告警的信号"
+
+#: ../../source/production/observability.rst:95
+msgid ":doc:`../features/benchmark-and-generator`: generate load to exercise them"
+msgstr ":doc:`../features/benchmark-and-generator` ：生成负载以验证这些指标"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Pull Request Description
Publish-ready follow-up to https://github.com/vllm-project/aibrix/pull/2700 (thanks @FAUST-BENCHOU).

Adds Sphinx gettext catalogs for Simplified Chinese and a navbar language switcher so the docs site can be read in Chinese while keeping the English RST as the source of truth. This branch is rebased onto current `main` and includes review hardening that could not be force-pushed back to the fork (GitHub App `workflows` permission on the contributor fork).

- Enable Sphinx i18n in `docs/source/conf.py` and ignore compiled `.mo` files.
- Translate existing docs into `docs/source/locale/zh_CN`.
- Add an English / 中文 switcher in the header (local `/html/` vs `/zh-cn/`, Read the Docs `/en/` vs `/zh-cn/`).
- Harden switcher URL rewriting (prefer RTD / `/build/<lang>/` segments; preserve `file://`).
- Preserve non-English / non-Chinese Sphinx languages in `conf.py`.
- Gate the Chinese navbar option on Read the Docs English builds until `AIBRIX_DOCS_SHOW_ZH=1` is set after the translation project is linked.
- Document local workflow and RTD follow-up in `docs/README.md`.

## Related Issues
Resolves: #2698

Supersedes: #2700

## Test plan
- [x] `sphinx-build -b html -W --keep-going docs/source docs/build/html` builds English HTML
- [x] `cd docs && make html-zh` builds Chinese HTML
- [x] Language switcher jumps between English and Chinese on local HTTP preview
- [x] Path rewrite / `file://` / RTD gating unit checks
- [ ] Maintainer: import a Read the Docs Chinese project, attach it as a translation, then set `AIBRIX_DOCS_SHOW_ZH=1` on the main project

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08c7f-11f0-7d74-b1b5-f73e3b9eb19a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08c7f-11f0-7d74-b1b5-f73e3b9eb19a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

