### PR TITLE
[Bug] Fix Helm chart drift: missing modelclaims CRD, stale RBAC, and broken vedeployment webhook

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -5,8 +5,29 @@ on:
   pull_request:
     paths:
       - 'dist/chart/**'
+      - 'config/crd/**'
+      - 'hack/verify-crd-sync.sh'
+      - '.github/workflows/chart-ci.yml'
 
 jobs:
+  verify-crd-sync:
+    name: Verify Helm CRD Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.22'
+
+      - name: Generate CRDs
+        run: make manifests
+
+      - name: Verify CRD synchronization (modules + Helm chart)
+        run: bash ${GITHUB_WORKSPACE}/hack/verify-crd-sync.sh
+
   build-images:
     name: Build image (${{ matrix.image }})
     runs-on: ubuntu-latest

--- a/dist/chart/crds/model.aibrix.ai_modelclaims.yaml
+++ b/dist/chart/crds/model.aibrix.ai_modelclaims.yaml
@@ -1,0 +1,171 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: modelclaims.model.aibrix.ai
+spec:
+  group: model.aibrix.ai
+  names:
+    kind: ModelClaim
+    listKind: ModelClaimList
+    plural: modelclaims
+    shortNames:
+    - mc
+    singular: modelclaim
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.desiredReplicas
+      name: Desired
+      type: integer
+    - jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - jsonPath: .spec.engine
+      name: Engine
+      type: string
+    - jsonPath: .spec.artifactURL
+      name: Artifact
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              artifactURL:
+                type: string
+              engine:
+                default: vllm
+                enum:
+                - vllm
+                - sglang
+                type: string
+              engineConfig:
+                properties:
+                  args:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              modelName:
+                type: string
+              podSelector:
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
+            required:
+            - artifactURL
+            - podSelector
+            type: object
+          status:
+            properties:
+              candidates:
+                format: int32
+                type: integer
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              desiredReplicas:
+                format: int32
+                type: integer
+              instances:
+                items:
+                  properties:
+                    phase:
+                      type: string
+                    pod:
+                      type: string
+                    port:
+                      format: int32
+                      type: integer
+                  required:
+                  - pod
+                  type: object
+                type: array
+              phase:
+                type: string
+              readyReplicas:
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dist/chart/templates/controller-manager/rbac.yaml
+++ b/dist/chart/templates/controller-manager/rbac.yaml
@@ -191,6 +191,7 @@ rules:
   - model.aibrix.ai
   resources:
   - modeladapters
+  - modelclaims
   verbs:
   - create
   - delete
@@ -203,12 +204,14 @@ rules:
   - model.aibrix.ai
   resources:
   - modeladapters/finalizers
+  - modelclaims/finalizers
   verbs:
   - update
 - apiGroups:
   - model.aibrix.ai
   resources:
   - modeladapters/status
+  - modelclaims/status
   verbs:
   - get
   - patch

--- a/dist/chart/templates/controller-manager/rbac.yaml
+++ b/dist/chart/templates/controller-manager/rbac.yaml
@@ -72,6 +72,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers
@@ -83,6 +91,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - external.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
 - apiGroups:
   - autoscaling.aibrix.ai
   resources:
@@ -305,16 +320,31 @@ rules:
   - update
   - watch
 - apiGroups:
-    - leaderworkerset.x-k8s.io
+  - scheduling.godel.kubewharf.io
   resources:
-    - leaderworkersets
+  - podgroups
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - update
-    - watch
+  - '*'
+- apiGroups:
+  - scheduling.x-k8s.io
+  resources:
+  - podgroups
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.volcano.sh
+  resources:
+  - podgroups
+  verbs:
+  - '*'
+- apiGroups:
+  - leaderworkerset.x-k8s.io
+  resources:
+  - leaderworkersets
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/dist/chart/templates/webhook/webhooks.yaml
+++ b/dist/chart/templates/webhook/webhooks.yaml
@@ -206,8 +206,8 @@ webhooks:
     - v1
   clientConfig:
     service:
-      name: webhook-service
-      namespace: system
+      name: aibrix-webhook-service
+      namespace: {{ .Release.Namespace }}
       path: /validate-apps-v1-deployment
   failurePolicy: Ignore
   name: vedeployment.aibrix.ai

--- a/hack/verify-crd-sync.sh
+++ b/hack/verify-crd-sync.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Verify that CRD files (only) in module directories are synchronized with bases/.
-# Ignores kustomization.yaml and other non-CRD files.
+# Verify that CRD files (only) in module directories and the Helm chart are
+# synchronized with bases/. Ignores kustomization.yaml and other non-CRD files.
+#
+# CI runs `make manifests` before this script so config/crd/bases/ exists.
 
 set -o errexit
 set -o nounset
@@ -28,6 +30,7 @@ BASES_DIR="${SCRIPT_ROOT}/config/crd/bases"
 ORCHESTRATION_DIR="${SCRIPT_ROOT}/config/crd/orchestration"
 AUTOSCALING_DIR="${SCRIPT_ROOT}/config/crd/autoscaling"
 MODEL_DIR="${SCRIPT_ROOT}/config/crd/model"
+HELM_CRDS_DIR="${SCRIPT_ROOT}/dist/chart/crds"
 
 # Temporary directory for diff
 TMP_DIFFROOT="$(mktemp -d -t verify-crd-sync.XXXXXX)"
@@ -38,7 +41,7 @@ trap cleanup EXIT
 
 echo "Verifying CRD synchronization between 'bases' and module directories..."
 
-# Function to compare only CRD files
+# Function to compare only CRD files for a single API module.
 verify_crd_sync() {
   local src_dir=$1
   local dst_dir=$2
@@ -89,6 +92,66 @@ verify_crd_sync() {
     return 1
   fi
 }
+
+# Verify every CRD in bases/ is present and byte-identical under dist/chart/crds/.
+# Also flag any extra chart CRDs that are not generated into bases/.
+verify_helm_crd_sync() {
+  local src_dir=$1
+  local dst_dir=$2
+  local all_ok=true
+
+  if [[ ! -d "${src_dir}" ]]; then
+    echo "ERROR: Source directory does not exist: ${src_dir}" >&2
+    exit 1
+  fi
+
+  if [[ ! -d "${dst_dir}" ]]; then
+    echo "❌ Helm CRD directory does not exist: ${dst_dir}" >&2
+    echo "   Please run 'make sync-crds-to-helm' to populate it." >&2
+    return 1
+  fi
+
+  echo "Verifying CRD synchronization between 'bases' and Helm chart (dist/chart/crds/)..."
+
+  while IFS= read -r src_file; do
+    local filename
+    filename=$(basename "$src_file")
+    local dst_file="${dst_dir}/${filename}"
+
+    if [[ ! -f "$dst_file" ]]; then
+      echo "❌ CRD file missing in Helm chart: ${dst_file}" >&2
+      echo "   Please run 'make sync-crds-to-helm' to update it." >&2
+      all_ok=false
+      continue
+    fi
+
+    if ! diff -Naupr "$src_file" "$dst_file" >/dev/null 2>&1; then
+      echo "❌ CRD file '${filename}' in '${dst_dir}' differs from 'bases/'." >&2
+      echo "   Please run 'make sync-crds-to-helm' to update it." >&2
+      all_ok=false
+    fi
+  done < <(find "${src_dir}" -maxdepth 1 -name "*.yaml" -type f | sort)
+
+  while IFS= read -r dst_file; do
+    local filename
+    filename=$(basename "$dst_file")
+    local src_file="${src_dir}/${filename}"
+
+    if [[ ! -f "$src_file" ]]; then
+      echo "❌ Extra CRD in Helm chart not present in bases/: ${dst_file}" >&2
+      echo "   Remove it or regenerate bases with 'make manifests'." >&2
+      all_ok=false
+    fi
+  done < <(find "${dst_dir}" -maxdepth 1 -name "*.yaml" -type f | sort)
+
+  if [[ "${all_ok}" == "true" ]]; then
+    echo "✅ Helm chart CRDs are synchronized with bases/."
+    return 0
+  else
+    return 1
+  fi
+}
+
 # Run verification for each module
 all_ok=true
 
@@ -104,8 +167,12 @@ for module in "${!modules[@]}"; do
   fi
 done
 
+if ! verify_helm_crd_sync "${BASES_DIR}" "${HELM_CRDS_DIR}"; then
+  all_ok=false
+fi
+
 if [[ "${all_ok}" == "true" ]]; then
-  echo "🎉 All CRD modules are synchronized with bases/."
+  echo "🎉 All CRD modules and the Helm chart are synchronized with bases/."
   exit 0
 else
   echo "❌ CRD synchronization verification failed."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Pull Request Description

Supersedes / completes https://github.com/vllm-project/aibrix/pull/2701 (fork head cannot receive workflow updates from the GitHub App, and could not be rebased onto latest `main` for the same reason).

The Helm chart under `dist/chart` had drifted from the authoritative manifests under `config/`, which are the source of truth used by the kustomize install path (`config/default`). Three independent defects caused a Helm-based install to behave differently from a kustomize-based install, and in one case silently skip validation entirely.

Chart alignment changes are confined to `dist/chart`. A CI guardrail is added so this class of drift fails before merge.

### Fixes

1. **Missing `ModelClaim` CRD** — Package `model.aibrix.ai_modelclaims.yaml` in `dist/chart/crds/` and grant controller-manager RBAC for `modelclaims` (resources, finalizers, status) to match `config/rbac/controller-manager/role.yaml`.

2. **Stale controller-manager RBAC** — Align chart ClusterRole rules with `config/rbac/controller-manager/role.yaml`:
   - add `apps/replicasets` get/list/watch
   - add `external.metrics.k8s.io/*` get/list
   - add PodGroup permissions for Godel, x-k8s, and Volcano scheduling APIs
   - narrow `leaderworkerset.x-k8s.io/leaderworkersets` to get/list/watch

3. **Broken `vedeployment.aibrix.ai` webhook** — Replace leftover kustomize placeholders (`webhook-service` / `system`) with `aibrix-webhook-service` / `{{ .Release.Namespace }}`. With `failurePolicy: Ignore`, the misconfiguration previously disabled Deployment validation silently under Helm.

4. **CI guardrail** (addresses review on #2701 from @googs1025):
   - Extend `hack/verify-crd-sync.sh` to compare `dist/chart/crds/` with generated `config/crd/bases/`
   - Add a `Verify Helm CRD Sync` job to `.github/workflows/chart-ci.yml` and expand path filters so chart/CRD/script changes trigger it

### Verification

- Chart ClusterRole rules match `config/rbac/controller-manager/role.yaml` (34/34).
- All 9 Helm CRDs are byte-identical to the corresponding files under `config/crd/`.
- `hack/verify-crd-sync.sh` passes after `make manifests` (and fails if `modelclaims` is removed from the chart).
- Helm Chart Install Test passed on #2701 head `e4b80d7b` after the verify-script commit.

## Related Issues

N/A — bug fix for Helm vs kustomize install drift.

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[x] PR title includes appropriate prefix(es)</li>
    <li>[x] Changes are clearly explained in the PR description</li>
    <li>[x] New and existing tests pass successfully</li>
    <li>[x] Code adheres to project style and best practices</li>
    <li>[x] Documentation updated to reflect changes (if applicable)</li>
    <li>[x] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08c7d-2409-7654-9b39-d0637de53db0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08c7d-2409-7654-9b39-d0637de53db0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

