### PR TITLE
[Misc] Make AIBrix Bot PR validation advisory

### DIFF
--- a/.github/scripts/aibrix-bot.py
+++ b/.github/scripts/aibrix-bot.py
@@ -285,16 +285,19 @@ def handle_pull_request(event: dict, github: GitHub):
     labels = [TRIAGE_LABEL] if errors else []
     lines = [f"## AIBrix bot: PR #{pull_request['number']}"]
     if errors:
-        lines.append("PR checks: failed")
+        lines.append("PR checks: findings (advisory)")
         lines.extend(f"- {error}" for error in errors)
+        for error in errors:
+            print(f"::warning::{error}")
     else:
         lines.append("PR checks: passed")
     _summary(lines)
     try:
         github.sync_labels(pull_request["number"], labels, PR_MANAGED_LABELS)
     except RuntimeError as error:
-        print(f"::warning::Unable to update PR labels: {error}")
-        _summary(["Label update: warning (the validation result is advisory)"])
+        print(f"Unable to update PR labels: {error}", file=sys.stderr)
+        print("::warning::Unable to update PR labels")
+        _summary(["Label update: warning (label mutation failed; validation remains advisory)"])
     # PR title and description checks are advisory and must not block CI.
     return False
 

--- a/.github/scripts/aibrix-bot.py
+++ b/.github/scripts/aibrix-bot.py
@@ -283,7 +283,6 @@ def handle_pull_request(event: dict, github: GitHub):
     pull_request = event["pull_request"]
     errors = validate_pr(pull_request.get("title", ""), pull_request.get("body") or "")
     labels = [TRIAGE_LABEL] if errors else []
-    github.sync_labels(pull_request["number"], labels, PR_MANAGED_LABELS)
     lines = [f"## AIBrix bot: PR #{pull_request['number']}"]
     if errors:
         lines.append("PR checks: failed")
@@ -291,7 +290,13 @@ def handle_pull_request(event: dict, github: GitHub):
     else:
         lines.append("PR checks: passed")
     _summary(lines)
-    return bool(errors)
+    try:
+        github.sync_labels(pull_request["number"], labels, PR_MANAGED_LABELS)
+    except RuntimeError as error:
+        print(f"::warning::Unable to update PR labels: {error}")
+        _summary(["Label update: warning (the validation result is advisory)"])
+    # PR title and description checks are advisory and must not block CI.
+    return False
 
 
 def self_test() -> None:

--- a/.github/workflows/aibrix-bot.yaml
+++ b/.github/workflows/aibrix-bot.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Run AIBrix bot
+      - name: Run AIBrix bot (advisory PR validation)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/aibrix-bot.yaml
+++ b/.github/workflows/aibrix-bot.yaml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   triage:
@@ -27,7 +28,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Run AIBrix bot (advisory PR validation)
+      - name: Run AIBrix bot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Pull Request Description

Make AIBrix Bot pull request title and description validation advisory instead of blocking CI. Preserve clear validation reasons in the workflow summary, tolerate fork PR label permission failures, and keep title prefix matching case-insensitive.

## Related Issues

N/A
