### PR TITLE
[Misc] Add path-based PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -66,4 +66,4 @@ kind/documentation:
   - changed-files:
       - any-glob-to-any-file:
           - "docs/**"
-          - "*.md"
+          - "**/*.md"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,69 @@
+# PR labels are derived from changed paths. Keep these rules broad enough to
+# cover new files in an existing component while limiting each label to a
+# repository area that already exists.
+area/gateway:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "pkg/plugins/gateway/**"
+          - "config/gateway/**"
+          - "test/e2e/gateway/**"
+
+area/orchestration:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "api/**"
+          - "pkg/controller/**"
+          - "config/rbac/controller-manager/**"
+          - "test/e2e/controller/**"
+          - "test/integration/controller/**"
+
+area/runtime:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "python/aibrix/**"
+          - "python/aibrix_kvcache/**"
+          - "build/container/Dockerfile.python"
+
+area/kv-cache:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*kvcache*"
+          - "**/*kv-cache*"
+          - "**/*nixl*"
+          - "**/*shfs*"
+
+area/batch:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*batch*"
+          - "python/aibrix/aibrix/batch/**"
+
+area/website:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "apps/console/**"
+
+area/cicd:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "hack/**"
+          - "Makefile"
+
+area/installation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "dist/chart/**"
+          - "samples/**"
+
+area/testing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "test/**"
+
+kind/documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "*.md"

--- a/.github/workflows/aibrix-bot.yaml
+++ b/.github/workflows/aibrix-bot.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Apply PR labels from changed paths
         if: github.event_name == 'pull_request_target'
+        continue-on-error: true
         uses: actions/labeler@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/aibrix-bot.yaml
+++ b/.github/workflows/aibrix-bot.yaml
@@ -23,6 +23,14 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
 
+      - name: Apply PR labels from changed paths
+        if: github.event_name == 'pull_request_target'
+        uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Pull Request Description

Add repository-local path-based PR labeling through the official GitHub Labeler action. PR area labels are derived from changed files, while the existing Python bot remains responsible for Issue classification and PR advisory validation.

## Related Issues

N/A

## Test Plan

- Parse and validate `.github/labeler.yml`.
- Verify all configured labels already exist in the repository.
- Verify `pull-requests: write` and `actions/labeler@v6` are configured.
- Run `git diff --check`.
