### PR TITLE
[Misc] Add PD failure E2E coverage

### DIFF
--- a/development/app/app.py
+++ b/development/app/app.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from mock_recorder import RequestRecorder
 from pd_contracts import add_prompt_token_ids, parse_fault_headers, validate_or_build
+from sglang_handoff import InMemorySGLangHandoffStore, KubernetesSGLangHandoffStore
 
 
 def _load_metrics_overrides():
@@ -576,6 +577,10 @@ app = Flask(__name__)
 disable_endpoint_logs()
 
 request_recorder = RequestRecorder()
+sglang_handoff_store = (
+    InMemorySGLangHandoffStore() if STANDALONE_MODE else None
+)
+_sglang_store_lock = threading.Lock()
 
 
 def _mock_pd_config():
@@ -593,6 +598,44 @@ def _mock_pd_config():
             else "vllm"
         )
     return contract, role, engine
+
+
+def _get_sglang_handoff_store():
+    global sglang_handoff_store
+    if sglang_handoff_store is None:
+        with _sglang_store_lock:
+            if sglang_handoff_store is None:
+                sglang_handoff_store = KubernetesSGLangHandoffStore(
+                    client.CoreV1Api(), NAMESPACE
+                )
+    return sglang_handoff_store
+
+
+def _mark_sglang_prefill_failure(request_id, payload, error):
+    if not request_id or not isinstance(payload, dict):
+        return False
+    room = payload.get("bootstrap_room")
+    if room is None:
+        return False
+    try:
+        _get_sglang_handoff_store().mark_failure(request_id, room, error)
+        return True
+    except Exception:
+        logger.warning("Unable to persist SGLang prefill failure", exc_info=True)
+        return False
+
+
+def _find_sglang_prefill_failure(request_id, payload):
+    if not request_id or not isinstance(payload, dict):
+        return None
+    room = payload.get("bootstrap_room")
+    if room is None:
+        return None
+    try:
+        return _get_sglang_handoff_store().get_failure(request_id, room)
+    except Exception:
+        logger.warning("Unable to read SGLang prefill failure", exc_info=True)
+        return None
 
 
 def _json_response_body(response):
@@ -765,6 +808,12 @@ def _recorded_completion(path):
 
                 if fault.injected_status_code is not None:
                     message = f"mock failure injected for role {role}"
+                    if contract == "sglang-http" and role == "prefill":
+                        _mark_sglang_prefill_failure(
+                            request_id,
+                            payload,
+                            f"prefill handoff failed: {message}",
+                        )
                     return make_response(
                         create_error_response(
                             message,
@@ -772,6 +821,32 @@ def _recorded_completion(path):
                             status_code=fault.injected_status_code,
                         )
                     )
+
+                if contract == "sglang-http" and role == "decode":
+                    prefill_failure = None
+                    if request.headers.get("X-Aibrix-Mock-Fail") == "prefill":
+                        room = payload.get("bootstrap_room") if isinstance(payload, dict) else None
+                        if not request_id or room is None:
+                            prefill_failure = "prefill handoff state unavailable"
+                        else:
+                            deadline = time.monotonic() + 5.0
+                            while time.monotonic() < deadline:
+                                prefill_failure = _find_sglang_prefill_failure(
+                                    request_id, payload
+                                )
+                                if prefill_failure:
+                                    break
+                                time.sleep(0.25)
+                            if not prefill_failure:
+                                prefill_failure = "prefill handoff state unavailable"
+                    if prefill_failure:
+                        return make_response(
+                            create_error_response(
+                                prefill_failure,
+                                error_type="api_error",
+                                status_code=500,
+                            )
+                        )
 
                 contract_result = None
                 if contract:

--- a/development/app/config/mock/components.yaml
+++ b/development/app/config/mock/components.yaml
@@ -36,6 +36,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/development/app/requirements.txt
+++ b/development/app/requirements.txt
@@ -3,6 +3,4 @@ flask
 Flask-HTTPAuth==4.8.1
 PyYAML==6.0.2
 tiktoken
-
-# Optional: only needed when running in Kubernetes
-# kubernetes
+kubernetes

--- a/development/app/sglang_handoff.py
+++ b/development/app/sglang_handoff.py
@@ -1,0 +1,98 @@
+"""Shared state for the mock SGLang bootstrap handoff."""
+
+from hashlib import sha256
+import threading
+import time
+
+
+def handoff_key(request_id, bootstrap_room):
+    if not request_id or bootstrap_room is None:
+        raise ValueError("request_id and bootstrap_room are required")
+    identity = f"{request_id}:{bootstrap_room}".encode("utf-8")
+    return sha256(identity).hexdigest()
+
+
+class InMemorySGLangHandoffStore:
+    """Thread-safe store used by standalone mock tests and local processes."""
+
+    def __init__(self):
+        self._failures = {}
+        self._lock = threading.Lock()
+
+    def mark_failure(self, request_id, bootstrap_room, error):
+        key = handoff_key(request_id, bootstrap_room)
+        if not error:
+            raise ValueError("error is required")
+        with self._lock:
+            self._failures[key] = str(error)
+
+    def get_failure(self, request_id, bootstrap_room):
+        key = handoff_key(request_id, bootstrap_room)
+        with self._lock:
+            return self._failures.get(key)
+
+
+class KubernetesSGLangHandoffStore:
+    """ConfigMap-backed store shared by mock pods in one namespace."""
+
+    def __init__(self, api, namespace):
+        self._api = api
+        self._namespace = namespace
+
+    @staticmethod
+    def _name(key):
+        return f"aibrix-sglang-handoff-{key[:32]}"
+
+    def mark_failure(self, request_id, bootstrap_room, error):
+        key = handoff_key(request_id, bootstrap_room)
+        if not error:
+            raise ValueError("error is required")
+        name = self._name(key)
+        body = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": name,
+                "labels": {"app.kubernetes.io/managed-by": "aibrix-vllm-mock"},
+            },
+            "data": {"status": "failed", "error": str(error)},
+        }
+        for attempt in range(3):
+            try:
+                self._api.create_namespaced_config_map(self._namespace, body)
+                return
+            except Exception as exc:
+                if getattr(exc, "status", None) == 409:
+                    try:
+                        self._api.patch_namespaced_config_map(
+                            name,
+                            self._namespace,
+                            {"data": body["data"]},
+                        )
+                        return
+                    except Exception:
+                        if attempt == 2:
+                            raise
+                elif attempt == 2:
+                    raise
+            time.sleep(0.05 * (attempt + 1))
+
+    def get_failure(self, request_id, bootstrap_room):
+        key = handoff_key(request_id, bootstrap_room)
+        name = self._name(key)
+        try:
+            config_map = self._api.read_namespaced_config_map(
+                name, self._namespace
+            )
+        except Exception as exc:
+            if getattr(exc, "status", None) == 404:
+                return None
+            raise
+        data = getattr(config_map, "data", None) or {}
+        if data.get("status") != "failed":
+            return None
+        try:
+            self._api.delete_namespaced_config_map(name, self._namespace)
+        except Exception:
+            pass
+        return data.get("error") or "prefill handoff failed"

--- a/development/app/test_mock_endpoints.py
+++ b/development/app/test_mock_endpoints.py
@@ -49,6 +49,44 @@ def query_records(client, request_id):
     return response.get_json()
 
 
+def test_sglang_prefill_failure_is_observed_by_decode(monkeypatch):
+    module = load_mock_module(monkeypatch, contract="sglang-http", role="prefill")
+    client = module.app.test_client()
+    payload = {
+        "model": "m",
+        "messages": [{"role": "user", "content": "hello"}],
+        "bootstrap_host": "10.0.0.1",
+        "bootstrap_port": 8998,
+        "bootstrap_room": 123,
+    }
+    request_id = "sglang-failure"
+
+    prefill_response = post_json(
+        client,
+        "/v1/chat/completions",
+        payload,
+        request_id=request_id,
+        **{"x-aibrix-mock-fail": "prefill"},
+    )
+    assert prefill_response.status_code == 500
+    assert query_records(client, request_id)[0]["outcome"] == "failed"
+
+    monkeypatch.setenv("MOCK_PD_ROLE", "decode")
+    decode_response = post_json(
+        client,
+        "/v1/chat/completions",
+        payload,
+        request_id=request_id,
+        **{"x-aibrix-mock-fail": "prefill"},
+    )
+
+    assert decode_response.status_code == 500
+    assert "prefill handoff failed" in decode_response.get_json()["error"]["message"]
+    records = query_records(client, request_id)
+    assert records[-1]["role"] == "decode"
+    assert records[-1]["outcome"] == "failed"
+
+
 def test_legacy_completion_records_exact_raw_body_and_debug_endpoint_is_public(monkeypatch):
     module = load_mock_module(monkeypatch, api_key="secret")
     client = module.app.test_client()

--- a/development/app/test_sglang_handoff.py
+++ b/development/app/test_sglang_handoff.py
@@ -1,0 +1,96 @@
+import pytest
+
+from sglang_handoff import InMemorySGLangHandoffStore, handoff_key
+from sglang_handoff import KubernetesSGLangHandoffStore
+
+
+class FakeKubernetesError(Exception):
+    def __init__(self, status):
+        self.status = status
+
+
+class FakeConfigMap:
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeConfigMapAPI:
+    def __init__(self, *, exists=False, create_error=None):
+        self.exists = exists
+        self.create_error = create_error
+        self.data = None
+        self.patched = False
+        self.deleted = False
+
+    def create_namespaced_config_map(self, namespace, body):
+        if self.create_error is not None:
+            raise self.create_error
+        if self.exists:
+            raise FakeKubernetesError(409)
+        self.exists = True
+        self.data = body["data"]
+
+    def patch_namespaced_config_map(self, name, namespace, body):
+        self.patched = True
+        self.data = body["data"]
+
+    def read_namespaced_config_map(self, name, namespace):
+        if not self.exists:
+            raise FakeKubernetesError(404)
+        return FakeConfigMap(self.data)
+
+    def delete_namespaced_config_map(self, name, namespace):
+        self.deleted = True
+        self.exists = False
+
+
+def test_handoff_key_is_stable_for_request_and_bootstrap_room():
+    assert handoff_key("request-1", 123) == handoff_key("request-1", 123)
+    assert handoff_key("request-1", 123) != handoff_key("request-2", 123)
+    assert handoff_key("request-1", 123) != handoff_key("request-1", 124)
+
+
+def test_in_memory_store_records_and_reads_prefill_failure():
+    store = InMemorySGLangHandoffStore()
+
+    assert store.get_failure("request-1", 123) is None
+
+    store.mark_failure("request-1", 123, "prefill handoff failed")
+
+    assert store.get_failure("request-1", 123) == "prefill handoff failed"
+
+
+def test_in_memory_store_rejects_empty_handoff_identity():
+    store = InMemorySGLangHandoffStore()
+
+    with pytest.raises(ValueError):
+        store.mark_failure("", 123, "prefill handoff failed")
+    with pytest.raises(ValueError):
+        store.get_failure("request-1", None)
+
+
+def test_kubernetes_store_creates_reads_and_deletes_failure_config_map():
+    api = FakeConfigMapAPI()
+    store = KubernetesSGLangHandoffStore(api, "default")
+
+    store.mark_failure("request-1", 123, "prefill handoff failed")
+
+    assert store.get_failure("request-1", 123) == "prefill handoff failed"
+    assert api.deleted
+
+
+def test_kubernetes_store_patches_existing_failure_config_map():
+    api = FakeConfigMapAPI(exists=True)
+    store = KubernetesSGLangHandoffStore(api, "default")
+
+    store.mark_failure("request-1", 123, "prefill handoff failed")
+
+    assert api.patched
+
+
+def test_kubernetes_store_propagates_create_errors():
+    api = FakeConfigMapAPI(create_error=RuntimeError("API unavailable"))
+    store = KubernetesSGLangHandoffStore(api, "default")
+
+    with pytest.raises(RuntimeError, match="API unavailable"):
+        store.mark_failure("request-1", 123, "prefill handoff failed")

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -161,11 +161,12 @@ func (s *Server) HandleRequestBody(ctx context.Context, routingCtx *types.Routin
 		if targetPodIP == "" || err != nil {
 			var invalidReqErr *engine.InvalidRequestError
 			if errors.As(err, &invalidReqErr) {
-				return buildErrorResponse(envoyTypePb.StatusCode_BadRequest,
+				return buildRoutingErrorResponse(routingCtx, requestID, envoyTypePb.StatusCode_BadRequest,
 					invalidReqErr.Error(), "", "", HeaderErrorRouting, "true"), model, stream, term
 			}
 			klog.ErrorS(err, "failed to select target pod", "requestID", requestID, "routingStrategy", routingAlgorithm, "model", model, "routingDuration", routingCtx.GetRoutingDelay())
-			return buildErrorResponse(envoyTypePb.StatusCode_ServiceUnavailable, "error on selecting target pod", ErrorCodeServiceUnavailable, "", HeaderErrorRouting, "true"), model, stream, term
+			return buildRoutingErrorResponse(routingCtx, requestID, envoyTypePb.StatusCode_ServiceUnavailable,
+				"error on selecting target pod", ErrorCodeServiceUnavailable, "", HeaderErrorRouting, "true"), model, stream, term
 		}
 		headers = buildEnvoyProxyHeaders(headers,
 			HeaderRoutingStrategy, string(routingAlgorithm),
@@ -221,6 +222,25 @@ func (s *Server) HandleRequestBody(ctx context.Context, routingCtx *types.Routin
 			},
 		},
 	}, model, stream, term
+}
+
+func buildRoutingErrorResponse(
+	routingCtx *types.RoutingContext,
+	requestID string,
+	statusCode envoyTypePb.StatusCode,
+	errBody, errorCode, param string,
+	headers ...string,
+) *extProcPb.ProcessingResponse {
+	response := buildErrorResponse(statusCode, errBody, errorCode, param, headers...)
+	setHeaders := response.GetImmediateResponse().GetHeaders().GetSetHeaders()
+	setHeaders = buildEnvoyProxyHeaders(setHeaders, HeaderRequestID, requestID)
+	if routingCtx != nil {
+		for key, value := range routingCtx.RespHeaders {
+			setHeaders = buildEnvoyProxyHeaders(setHeaders, key, value)
+		}
+	}
+	response.GetImmediateResponse().GetHeaders().SetHeaders = setHeaders
+	return response
 }
 
 // getEngineBasedPathRewrite returns the rewritten path for image/video generation endpoints

--- a/pkg/plugins/gateway/gateway_req_headers.go
+++ b/pkg/plugins/gateway/gateway_req_headers.go
@@ -78,8 +78,8 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, requestID string, roo
 			reqConfigProfile = strings.TrimSpace(string(n.RawValue))
 		case constants.HeaderSessionID:
 			reqHeaders[constants.HeaderSessionID] = string(n.RawValue)
-		case constants.HeaderSessionKey:
-			reqHeaders[constants.HeaderSessionKey] = string(n.RawValue)
+		case constants.HeaderSessionKey, HeaderMockPDFailure:
+			reqHeaders[strings.ToLower(n.Key)] = string(n.RawValue)
 		case HeaderTraceParent: // Preserve the trace context for requests initiated by the gateway plugin. like PD
 			reqHeaders[HeaderTraceParent] = string(n.RawValue)
 			if !rootSpan.SpanContext().HasTraceID() { // prefers rootSpan traceID over traceparent

--- a/pkg/plugins/gateway/gateway_req_headers_test.go
+++ b/pkg/plugins/gateway/gateway_req_headers_test.go
@@ -551,3 +551,23 @@ func TestHandleRequestHeadersBearerTokenAuth(t *testing.T) {
 		assert.Contains(t, resp.GetImmediateResponse().GetBody(), `"param":"api_key"`)
 	})
 }
+
+func TestHandleRequestHeadersPreservesMockPDFailureHeader(t *testing.T) {
+	server := &Server{}
+	req := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extProcPb.HttpHeaders{
+				Headers: &configPb.HeaderMap{Headers: []*configPb.HeaderValue{
+					{Key: pathKey, RawValue: []byte(PathCompletions)},
+					{Key: HeaderMockPDFailure, RawValue: []byte("prefill")},
+				}},
+			},
+		},
+	}
+
+	_, _, _, routingCtx, _ := server.HandleRequestHeaders(
+		context.Background(), "request-id", trace.SpanFromContext(context.Background()), req,
+	)
+
+	assert.Equal(t, "prefill", routingCtx.ReqHeaders[HeaderMockPDFailure])
+}

--- a/pkg/plugins/gateway/types.go
+++ b/pkg/plugins/gateway/types.go
@@ -64,6 +64,8 @@ const (
 	// HeaderSessionKey aliases the shared opaque session-key header.
 	HeaderSessionKey  = constants.HeaderSessionKey
 	HeaderTraceParent = "traceparent"
+	// HeaderMockPDFailure is a test-only header forwarded to mock PD backends.
+	HeaderMockPDFailure = "x-aibrix-mock-fail"
 
 	// RPM & TPM Update Errors
 	HeaderUpdateTPM        = "x-update-tpm"

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -71,6 +71,18 @@ func SendPDRequest(
 	routingStrategy, requestID string,
 	body []byte,
 ) (PDRequestResult, error) {
+	return SendPDRequestWithHeaders(ctx, config, routingStrategy, requestID, body, nil)
+}
+
+// SendPDRequestWithHeaders sends an already-serialized JSON request with
+// additional request-scoped headers used by mock PD contract tests.
+func SendPDRequestWithHeaders(
+	ctx context.Context,
+	config Config,
+	routingStrategy, requestID string,
+	body []byte,
+	extraHeaders http.Header,
+) (PDRequestResult, error) {
 	result := PDRequestResult{RequestID: requestID}
 	url := strings.TrimRight(config.GatewayURL, "/") + "/v1/chat/completions"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
@@ -81,6 +93,11 @@ func SendPDRequest(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("routing-strategy", routingStrategy)
 	req.Header.Set("x-request-id", requestID)
+	for key, values := range extraHeaders {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
 
 	resp, err := (&http.Client{Timeout: pdRequestTimeout}).Do(req)
 	if err != nil {

--- a/test/e2e/framework/client_test.go
+++ b/test/e2e/framework/client_test.go
@@ -115,3 +115,26 @@ func TestSendPDRequestReturnsResponseDetailsOnHTTPError(t *testing.T) {
 	require.Equal(t, "request-2", result.RequestID)
 	require.Equal(t, "prefill rejected\n", string(result.Body))
 }
+
+func TestSendPDRequestWithHeadersPreservesFailureInjectionHeaders(t *testing.T) {
+	seen := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- r.Header.Get("x-aibrix-mock-fail")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"prefill handoff failed"}}`))
+	}))
+	defer server.Close()
+
+	result, err := SendPDRequestWithHeaders(
+		context.Background(),
+		Config{GatewayURL: server.URL, APIKey: "test-key"},
+		"pd",
+		"request-3",
+		[]byte(`{"model":"m"}`),
+		http.Header{"x-aibrix-mock-fail": []string{"prefill"}},
+	)
+
+	require.Error(t, err)
+	require.Equal(t, "prefill", <-seen)
+	require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+}

--- a/test/e2e/framework/recorder.go
+++ b/test/e2e/framework/recorder.go
@@ -157,6 +157,134 @@ func classifyPDRecords(records []MockRequestRecord, requestID, engine, role stri
 	return true, nil
 }
 
+func findPDLegOutcome(
+	records []MockRequestRecord,
+	requestID, engine, role, expectedOutcome string,
+) (MockRequestRecord, bool, error) {
+	var matches []MockRequestRecord
+	for _, record := range records {
+		if record.RequestID != requestID || record.Engine != engine || record.Role != role {
+			continue
+		}
+		if record.Outcome == "" {
+			continue
+		}
+		if record.Outcome != expectedOutcome {
+			return MockRequestRecord{}, false, fmt.Errorf(
+				"mock recorder observed unexpected outcome on pod %q role %q: got %q status code %d: %s",
+				record.Pod,
+				record.Role,
+				record.Outcome,
+				record.StatusCode,
+				record.Error,
+			)
+		}
+		matches = append(matches, record)
+	}
+	if len(matches) == 0 {
+		return MockRequestRecord{}, false, nil
+	}
+	if len(matches) != 1 {
+		return MockRequestRecord{}, false, fmt.Errorf(
+			"expected exactly one %s recorder entry for pod role %q, got %d",
+			expectedOutcome,
+			role,
+			len(matches),
+		)
+	}
+	return matches[0], true, nil
+}
+
+// WaitForPDLegOutcome waits for one recorder entry with the requested outcome.
+func WaitForPDLegOutcome(
+	t *testing.T,
+	client kubernetes.Interface,
+	namespace, podName, requestID, engine, role, expectedOutcome string,
+) MockRequestRecord {
+	t.Helper()
+	var lastRecords []byte
+	var matched MockRequestRecord
+	var ready bool
+	err := wait.PollUntilContextTimeout(
+		context.Background(),
+		time.Second,
+		2*time.Minute,
+		true,
+		func(ctx context.Context) (bool, error) {
+			records, err := QueryMockRequests(ctx, client, namespace, podName, requestID)
+			if err != nil {
+				t.Logf("recorder query for pod %q failed; retrying: %v", podName, err)
+				return false, nil
+			}
+			lastRecords, _ = json.Marshal(records)
+			matched, ready, err = findPDLegOutcome(
+				records, requestID, engine, role, expectedOutcome,
+			)
+			return ready, err
+		},
+	)
+	if err != nil {
+		t.Fatalf(
+			"wait for %s PD leg on pod %q for request ID %q: %v; last recorder JSON: %s",
+			expectedOutcome,
+			podName,
+			requestID,
+			err,
+			lastRecords,
+		)
+	}
+	return matched
+}
+
+// WaitForPDLegOutcomeOnPods waits for an outcome across a set of candidate
+// pods. This is used when a gateway returns an error before exposing routing
+// headers for the selected pods.
+func WaitForPDLegOutcomeOnPods(
+	t *testing.T,
+	client kubernetes.Interface,
+	namespace string,
+	podNames []string,
+	requestID, engine, role, expectedOutcome string,
+) MockRequestRecord {
+	t.Helper()
+	var lastRecords []byte
+	var matched MockRequestRecord
+	var ready bool
+	err := wait.PollUntilContextTimeout(
+		context.Background(),
+		time.Second,
+		2*time.Minute,
+		true,
+		func(ctx context.Context) (bool, error) {
+			for _, podName := range podNames {
+				records, err := QueryMockRequests(ctx, client, namespace, podName, requestID)
+				if err != nil {
+					continue
+				}
+				lastRecords, _ = json.Marshal(records)
+				matched, ready, err = findPDLegOutcome(
+					records, requestID, engine, role, expectedOutcome,
+				)
+				if err != nil || ready {
+					return ready, err
+				}
+			}
+			return false, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf(
+			"wait for %s PD leg role %q for request ID %q: %v; last recorder JSON: %s",
+			expectedOutcome,
+			role,
+			requestID,
+			err,
+			lastRecords,
+		)
+	}
+	return matched
+}
+
 // WaitForSuccessfulPDLegs waits for one successful HTTP-200 recorder entry per PD role.
 func WaitForSuccessfulPDLegs(
 	t *testing.T,

--- a/test/e2e/framework/recorder_test.go
+++ b/test/e2e/framework/recorder_test.go
@@ -111,6 +111,42 @@ func TestClassifyPDRecordsReportsRejectedRecordDetails(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid SHFS handoff")
 }
 
+func TestFindPDLegOutcomeReturnsFailedRecord(t *testing.T) {
+	record := MockRequestRecord{
+		RequestID:  "request-1",
+		Pod:        "prefill-pod",
+		Engine:     "vllm",
+		Role:       "prefill",
+		Outcome:    "failed",
+		StatusCode: http.StatusInternalServerError,
+		Error:      "mock failure injected for role prefill",
+	}
+
+	found, ready, err := findPDLegOutcome(
+		[]MockRequestRecord{record}, "request-1", "vllm", "prefill", "failed",
+	)
+
+	require.True(t, ready)
+	require.NoError(t, err)
+	require.Equal(t, record, found)
+}
+
+func TestFindPDLegOutcomeKeepsPendingRecordPending(t *testing.T) {
+	record := MockRequestRecord{
+		RequestID: "request-1",
+		Pod:       "prefill-pod",
+		Engine:    "vllm",
+		Role:      "prefill",
+	}
+
+	_, ready, err := findPDLegOutcome(
+		[]MockRequestRecord{record}, "request-1", "vllm", "prefill", "failed",
+	)
+
+	require.False(t, ready)
+	require.NoError(t, err)
+}
+
 func TestQueryMockRequestsUsesPodProxy(t *testing.T) {
 	handlerErr := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/test/e2e/gateway/pd/helpers_test.go
+++ b/test/e2e/gateway/pd/helpers_test.go
@@ -34,7 +34,11 @@ var (
 	pollPDChatCompletion                  = framework.PollPDChatCompletion
 	newRequestID                          = framework.NewRequestID
 	sendPDRequest                         = framework.SendPDRequest
+	sendPDRequestWithHeaders              = framework.SendPDRequestWithHeaders
 	waitForSuccessfulPDLegs               = framework.WaitForSuccessfulPDLegs
+	waitForPDLegOutcome                   = framework.WaitForPDLegOutcome
+	waitForPDLegOutcomeOnPods             = framework.WaitForPDLegOutcomeOnPods
+	queryMockRequests                     = framework.QueryMockRequests
 )
 
 type MockRequestRecord = framework.MockRequestRecord

--- a/test/e2e/gateway/pd/pd_failure_test.go
+++ b/test/e2e/gateway/pd/pd_failure_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const mockPrefillFailureHeader = "x-aibrix-mock-fail"
+
+func requirePDGatewayFailure(t *testing.T, result PDRequestResult) {
+	t.Helper()
+	require.GreaterOrEqual(t, result.StatusCode, http.StatusInternalServerError)
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(result.Body, &response))
+	errorBody := requireNestedMap(t, response, "error")
+	require.NotEmpty(t, errorBody["message"])
+}
+
+func requireNoSuccessfulPDLeg(t *testing.T, records []MockRequestRecord, role string) {
+	t.Helper()
+	for _, record := range records {
+		if record.Role == role && record.Outcome == "success" && record.StatusCode == http.StatusOK {
+			t.Fatalf("unexpected successful %s leg for request %q on pod %q", role, record.RequestID, record.Pod)
+		}
+	}
+}
+
+func modelRolePods(t *testing.T, client kubernetes.Interface, modelName, role string) []string {
+	t.Helper()
+	pods, err := client.CoreV1().Pods(e2eConfig.Namespace).List(
+		context.Background(),
+		v1.ListOptions{LabelSelector: "role-name=" + role + ",model.aibrix.ai/name=" + modelName},
+	)
+	require.NoError(t, err)
+	result := make([]string, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		result = append(result, pod.Name)
+	}
+	require.NotEmpty(t, result, "expected %s pods for model %s", role, modelName)
+	return result
+}
+
+func requireNoSuccessfulPDLegOnPods(
+	t *testing.T,
+	client kubernetes.Interface,
+	podNames []string,
+	requestID, role string,
+) {
+	t.Helper()
+	for _, podName := range podNames {
+		records, err := queryMockRequests(
+			context.Background(), client, e2eConfig.Namespace, podName, requestID,
+		)
+		require.NoError(t, err)
+		requireNoSuccessfulPDLeg(t, records, role)
+	}
+}
+
+func runSynchronousPrefillFailure(
+	t *testing.T,
+	modelName, engine, requestPrefix string,
+	body []byte,
+) {
+	t.Helper()
+	waitForPDDisaggregationRouting(t, modelName)
+	requestID := newRequestID(requestPrefix)
+	result, err := sendPDRequestWithHeaders(
+		context.Background(), e2eConfig, "pd", requestID, body,
+		http.Header{mockPrefillFailureHeader: []string{"prefill"}},
+	)
+	require.Error(t, err)
+	requirePDGatewayFailure(t, result)
+	gatewayRequestID := requireGatewayRequestID(t, result)
+
+	k8sClient := initializeKubernetesClient(t)
+	prefill := waitForPDLegOutcomeOnPods(
+		t, k8sClient, e2eConfig.Namespace,
+		modelRolePods(t, k8sClient, modelName, "prefill"),
+		gatewayRequestID, engine, "prefill", "failed",
+	)
+	require.Equal(t, http.StatusInternalServerError, prefill.StatusCode)
+	require.Contains(t, prefill.Error, "mock failure injected for role prefill")
+	requireNoSuccessfulPDLegOnPods(
+		t, k8sClient, modelRolePods(t, k8sClient, modelName, "decode"), gatewayRequestID, "decode",
+	)
+}
+
+func TestPDFailureVLLMSynchronousPrefill(t *testing.T) {
+	runSynchronousPrefillFailure(t, modelNameVLLM, "vllm", "vllm-prefill-failure", []byte(`{
+		"model":"llama2-7b-vllm",
+		"messages":[{"role":"user","content":"trigger vLLM prefill failure"}],
+		"max_tokens":8,
+		"stream":false
+	}`))
+}
+
+func TestPDFailureTRTLLMSynchronousPrefill(t *testing.T) {
+	runSynchronousPrefillFailure(t, modelNameTRTLLM, "trtllm", "trtllm-prefill-failure", []byte(`{
+		"model":"llama2-7b-trtllm",
+		"messages":[{"role":"user","content":"trigger TRT-LLM prefill failure"}],
+		"max_tokens":8,
+		"stream":false
+	}`))
+}
+
+func TestPDFailureSGLangAsyncPrefillHandoff(t *testing.T) {
+	waitForPDDisaggregationRouting(t, modelNameSGLang)
+	requestID := newRequestID("sglang-prefill-failure")
+	result, err := sendPDRequestWithHeaders(
+		context.Background(), e2eConfig, "pd", requestID, []byte(`{
+			"model":"llama2-7b-sglang",
+			"messages":[{"role":"user","content":"trigger SGLang prefill failure"}],
+			"max_tokens":8,
+			"stream":false
+		}`),
+		http.Header{mockPrefillFailureHeader: []string{"prefill"}},
+	)
+	require.Error(t, err)
+	requirePDGatewayFailure(t, result)
+	gatewayRequestID := requireGatewayRequestID(t, result)
+
+	k8sClient := initializeKubernetesClient(t)
+	prefill := waitForPDLegOutcomeOnPods(
+		t, k8sClient, e2eConfig.Namespace,
+		modelRolePods(t, k8sClient, modelNameSGLang, "prefill"),
+		gatewayRequestID, "sglang", "prefill", "failed",
+	)
+	decode := waitForPDLegOutcomeOnPods(
+		t, k8sClient, e2eConfig.Namespace,
+		modelRolePods(t, k8sClient, modelNameSGLang, "decode"),
+		gatewayRequestID, "sglang", "decode", "failed",
+	)
+	require.Equal(t, http.StatusInternalServerError, prefill.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, decode.StatusCode)
+	require.Contains(t, prefill.Error, "mock failure injected for role prefill")
+	require.Contains(t, decode.Error, "prefill handoff")
+}

--- a/test/e2e/gateway/pd/pd_test.go
+++ b/test/e2e/gateway/pd/pd_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // assertPDDisaggregation sends a single PD-routed chat completion for the given model and
@@ -132,10 +133,7 @@ func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, modelName, 
 		t.Logf("%s pod %s has been recreated and cluster is back to %d pods", roleLabel, podToDelete, initialCount)
 	})
 
-	// Give the gateway time to detect the pod is gone and re-converge on the
-	// remaining roleset before asserting on individual requests below.
-	time.Sleep(3 * time.Second)
-	waitForPDDisaggregationRouting(t, modelName)
+	waitForPDDisaggregationExcludingPod(t, modelName, roleLabel, podToDelete, prompt)
 
 	var dst *http.Response
 	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
@@ -162,6 +160,49 @@ func assertPDDisaggregationAfterPodDeletion(t *testing.T, roleLabel, modelName, 
 		}
 		t.Logf("request %d — prefill: %s, decode: %s", i, prefillPod, decodePod)
 	}
+}
+
+// waitForPDDisaggregationExcludingPod waits until successful PD requests no longer
+// select the pod removed by the test. A generic routing-readiness check can pass
+// while a stale gateway-plugin replica still has the deleted pod in its cache.
+func waitForPDDisaggregationExcludingPod(t *testing.T, modelName, roleLabel, podToDelete, prompt string) {
+	t.Helper()
+	var dst *http.Response
+	client := createOpenAIClientWithRoutingStrategy(gatewayURL, apiKey, "pd", option.WithResponseInto(&dst))
+	consecutive := 0
+	err := wait.PollUntilContextTimeout(context.Background(), time.Second, 2*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					openai.UserMessage(prompt),
+				},
+				Model: modelName,
+			})
+			if err != nil {
+				consecutive = 0
+				t.Logf("waiting for PD routing to exclude pod %s: %v", podToDelete, err)
+				return false, nil
+			}
+
+			prefillPod := dst.Header.Get("prefill-target-pod")
+			decodePod := dst.Header.Get("target-pod")
+			if prefillPod == "" || decodePod == "" || prefillPod == decodePod {
+				consecutive = 0
+				return false, nil
+			}
+			selectedPod := decodePod
+			if roleLabel == "prefill" {
+				selectedPod = prefillPod
+			}
+			if selectedPod == podToDelete {
+				consecutive = 0
+				return false, nil
+			}
+			consecutive++
+			t.Logf("PD routing excluded pod %s (%d/3 consecutive)", podToDelete, consecutive)
+			return consecutive >= 3, nil
+		})
+	require.NoError(t, err, "timeout waiting for PD routing to exclude pod %s", podToDelete)
 }
 
 // TestPDDisaggregationVLLMMultipleRequests sends several requests to verify that the


### PR DESCRIPTION
## Pull Request Description

This PR completes PR4 for issue #2675:

- Adds `gateway-pd` failure E2E coverage for vLLM synchronous prefill failure.
- Adds `gateway-pd` failure E2E coverage for TRT-LLM synchronous prefill failure.
- Adds SGLang async prefill handoff failure propagation with recorder evidence.
- Uses ConfigMap-backed shared state between independent SGLang prefill/decode Pods.
- Replaces the fixed PD pod-deletion sleep with bounded routing-convergence polling, fixing the failure observed in Installation E2E job 103480873980.

## Related Issues

Resolves: #2675

## Testing

- `python -m pytest development/app/test_sglang_handoff.py development/app/test_pd_contracts.py development/app/test_mock_endpoints.py -q` — 120 passed
- `go test ./test/e2e/framework/... ./test/e2e/gateway/pd -run '^$' -count=1` — compile check passed
- `git diff --check` — passed
- Full Kind E2E was not run locally; the CI failure was diagnosed from the job logs and the affected test now waits for explicit routing convergence.

## Submission Checklist

- [x] PR title includes an appropriate prefix
- [x] Changes are clearly explained in the PR description
- [x] New and existing focused tests pass successfully
- [x] Code follows project style and best practices
- [x] Documentation changes are not required for this test-only change
- [x] DCO `Signed-off-by` is present on the commit