### PR TITLE
[Docs] Fix chat tokenizer examples for JSON message content

### DIFF
--- a/pkg/utils/tokenizer/README.md
+++ b/pkg/utils/tokenizer/README.md
@@ -147,6 +147,11 @@ if remote, ok := tok.(interface {
 
 ### Chat Tokenization
 
+Import `encoding/json` for the chat examples. `ChatMessage.Content` is a
+`json.RawMessage`: text must be encoded as a JSON string, including its surrounding
+quotes. For text from a variable, use `json.Marshal` to handle escaping. Content-part
+arrays can also be passed as JSON for multimodal messages.
+
 ```go
 // Chat tokenization requires type assertion to access advanced features
 if extended, ok := tok.(interface {
@@ -157,8 +162,8 @@ if extended, ok := tok.(interface {
     chatInput := tokenizer.TokenizeInput{
         Type: tokenizer.ChatInput,
         Messages: []tokenizer.ChatMessage{
-            {Role: "system", Content: "You are a helpful assistant."},
-            {Role: "user", Content: "What is the weather today?"},
+            {Role: "system", Content: json.RawMessage(`"You are a helpful assistant."`)},
+            {Role: "user", Content: json.RawMessage(`"What is the weather today?"`)},
         },
         AddGenerationPrompt: true,
     }
@@ -167,6 +172,7 @@ if extended, ok := tok.(interface {
     if err != nil {
         log.Fatal(err)
     }
+    fmt.Printf("Token count: %d\n", result.Count)
 }
 ```
 
@@ -327,8 +333,8 @@ type TokenizeResult struct {
 #### ChatMessage
 ```go
 type ChatMessage struct {
-    Role    string // "system", "user", "assistant"
-    Content string // Message content
+    Role    string          // "system", "user", "assistant"
+    Content json.RawMessage // JSON string or content-part array
 }
 ```
 


### PR DESCRIPTION
## Pull Request Description

The tokenizer README still declares `ChatMessage.Content` as `string` and assigns plain strings in its chat example. The implementation uses `json.RawMessage`, so the example fails to compile. Its `result` variable is also unused.

Update the example and type reference to match the current API, explain JSON string/content-part encoding, and print the returned token count.

Validation against `dcc8aa9aaa5cd8aee657c50a11b5aa4393d648e1`:

- Extracted the chat code block into a temporary Go program with imports and tokenizer setup supplied. The original block fails with two `string`-to-`json.RawMessage` errors and an unused `result` error.
- Ran the corrected block against a local `httptest` server through `NewRemoteTokenizer`. The server verified both message texts decoded correctly, and the example printed `Token count: 3`.
- `go test ./pkg/utils/tokenizer -count=1` and `go vet ./pkg/utils/tokenizer` pass.
- `git diff --check` passes.

No live inference service or model was needed. AI-assisted with OpenAI GPT-6 (Codex); the checks above were executed locally.

## Related Issues

No existing issue; identified by checking the README against `pkg/utils/tokenizer/types.go` and compiling its example.

## Submission Checklist

- [x] PR title includes the `[Docs]` prefix.
- [x] Changes and validation are explained above.
- [x] The affected package's existing tests pass.
- [x] The documentation matches the current API and example behavior.
- [x] The change is limited to the tokenizer README.
