### PR TITLE
[TEST] Add Gateway Plugin integration regression coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ GINKGO_VERSION ?= $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2
 INTEGRATION_ROOT ?= ./test/integration
 INTEGRATION_WEBHOOK_TARGET ?= $(INTEGRATION_ROOT)/webhook/...
 INTEGRATION_CONTROLLER_TARGET ?= $(INTEGRATION_ROOT)/controller/...
+INTEGRATION_GATEWAY_TARGET ?= $(INTEGRATION_ROOT)/gateway/...
 INTEGRATION_TARGET ?= $(INTEGRATION_ROOT)/...
 
 GINKGO = $(shell pwd)/bin/ginkgo
@@ -149,7 +150,7 @@ test-code-coverage: test
 test-race-condition: manifests generate fmt vet envtest ## Run tests with race detection enabled.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race $$(go list ./... | grep -v '/e2e\|/integration')
 
-.PHONY: test-integration test-integration-webhook test-integration-controller
+.PHONY: test-integration test-integration-webhook test-integration-controller test-integration-gateway
 test-integration: manifests fmt vet envtest ginkgo
 	@echo "Running all integration tests..."
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
@@ -164,6 +165,11 @@ test-integration-controller: manifests fmt vet envtest ginkgo
 	@echo "Running controller integration tests only..."
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	$(GINKGO) --junit-report=junit.controller.xml --output-dir=$(ARTIFACTS) -v $(INTEGRATION_CONTROLLER_TARGET)
+
+test-integration-gateway: manifests fmt vet envtest ginkgo
+	@echo "Running gateway integration tests only..."
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	$(GINKGO) --junit-report=junit.gateway.xml --output-dir=$(ARTIFACTS) -v $(INTEGRATION_GATEWAY_TARGET)
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.

--- a/pkg/plugins/gateway/algorithms/least_kv_cache.go
+++ b/pkg/plugins/gateway/algorithms/least_kv_cache.go
@@ -43,6 +43,11 @@ func NewLeastKvCacheRouter() (types.Router, error) {
 	return newLeastKvCacheRouter(c), nil
 }
 
+// NewLeastKvCacheRouterWithCache constructs least-kv-cache with an explicit cache.
+func NewLeastKvCacheRouterWithCache(c cache.Cache) (types.Router, error) {
+	return newLeastKvCacheRouter(c), nil
+}
+
 // newLeastKvCacheRouter builds a leastKvCacheRouter around an existing cache handle, for
 // callers that already hold one (e.g. load_balance.go reusing it purely as a types.PodScorer
 // tie-breaker) rather than fetching their own via cache.Get(). Keeping construction here means

--- a/pkg/plugins/gateway/algorithms/least_latency.go
+++ b/pkg/plugins/gateway/algorithms/least_latency.go
@@ -43,6 +43,11 @@ func NewLeastExpectedLatencyRouter() (types.Router, error) {
 	}, nil
 }
 
+// NewLeastLatencyRouterWithCache constructs least-latency with an explicit cache.
+func NewLeastLatencyRouterWithCache(c cache.Cache) (types.Router, error) {
+	return leastExpectedLatencyRouter{cache: c}, nil
+}
+
 // Polarity returns the polarity for least-latency strategy
 func (r leastExpectedLatencyRouter) Polarity() types.Polarity {
 	return types.PolarityLeast // The lower the expected latency, the better

--- a/pkg/plugins/gateway/algorithms/least_request.go
+++ b/pkg/plugins/gateway/algorithms/least_request.go
@@ -53,6 +53,11 @@ func NewLeastRequestRouter() (types.Router, error) {
 	}, nil
 }
 
+// NewLeastRequestRouterWithCache constructs least-request with an explicit cache.
+func NewLeastRequestRouterWithCache(c cache.Cache) (types.Router, error) {
+	return &leastRequestRouter{cache: c}, nil
+}
+
 // Polarity returns the polarity for least-request strategy
 func (r *leastRequestRouter) Polarity() types.Polarity {
 	return types.PolarityLeast // The fewer requests, the better

--- a/pkg/plugins/gateway/algorithms/load_balance.go
+++ b/pkg/plugins/gateway/algorithms/load_balance.go
@@ -105,6 +105,11 @@ func NewLoadBalanceRouter() (types.Router, error) {
 	return &loadBalanceRouter{cache: c}, nil
 }
 
+// NewLoadBalanceRouterWithCache constructs load-balance with an explicit cache.
+func NewLoadBalanceRouterWithCache(c cache.Cache) (types.Router, error) {
+	return &loadBalanceRouter{cache: c}, nil
+}
+
 // ScoreAll returns pending_time = request_count / capacity for each pod.
 // Lower pending_time means the pod has more headroom to accept this request.
 func (r *loadBalanceRouter) ScoreAll(ctx *types.RoutingContext, readyPodList types.PodList) ([]float64, []bool, error) {

--- a/pkg/plugins/gateway/algorithms/prefix_cache.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache.go
@@ -247,6 +247,22 @@ func loadTokenizerPoolConfigFromEnv() TokenizerPoolConfig {
 }
 
 func NewPrefixCacheRouter() (types.Router, error) {
+	c, err := cache.Get()
+	if err != nil {
+		return nil, err
+	}
+	return NewPrefixCacheRouterWithCache(c)
+}
+
+// NewPrefixCacheRouterWithCache constructs the prefix-cache router with an
+// explicit cache while preserving tokenizer and indexer behavior.
+func NewPrefixCacheRouterWithCache(c cache.Cache) (types.Router, error) {
+	return NewPrefixCacheRouterWithOptions(c, nil)
+}
+
+// NewPrefixCacheRouterWithOptions constructs a prefix-cache router with
+// explicit cache and optional per-instance prefix table dependencies.
+func NewPrefixCacheRouterWithOptions(c cache.Cache, indexer *prefixcacheindexer.PrefixHashTable) (types.Router, error) {
 	// Initialize prefix cache metrics if enabled
 	if err := initializePrefixCacheMetrics(); err != nil {
 		klog.Errorf("Failed to initialize prefix cache metrics: %v", err)
@@ -275,13 +291,6 @@ func NewPrefixCacheRouter() (types.Router, error) {
 		klog.Warning("KV event sync requires remote tokenizer. " +
 			"Remote tokenizer will be automatically enabled.")
 		useRemoteTokenizer = true
-	}
-
-	// Get cache instance (this is existing code)
-	c, err := cache.Get()
-	if err != nil {
-		klog.Error("fail to get cache store in prefix cache router")
-		return nil, err
 	}
 
 	// Configure TokenizerPool if remote tokenizer is needed
@@ -315,10 +324,13 @@ func NewPrefixCacheRouter() (types.Router, error) {
 		"matched_pods_running_requests_standard_deviation_factor", standardDeviationFactor)
 
 	// Create main router with local indexer
+	if indexer == nil {
+		indexer = prefixcacheindexer.GetSharedPrefixHashTable()
+	}
 	router := prefixCacheRouter{
 		cache:              c,
 		tokenizer:          tokenizerObj,
-		prefixCacheIndexer: prefixcacheindexer.GetSharedPrefixHashTable(),
+		prefixCacheIndexer: indexer,
 		// Only assign tokenizerPool if it's not nil to avoid interface nil issues
 	}
 

--- a/pkg/plugins/gateway/algorithms/prefix_cache.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache.go
@@ -251,7 +251,7 @@ func NewPrefixCacheRouter() (types.Router, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewPrefixCacheRouterWithCache(c)
+	return NewPrefixCacheRouterWithOptions(c, prefixcacheindexer.GetSharedPrefixHashTable())
 }
 
 // NewPrefixCacheRouterWithCache constructs the prefix-cache router with an
@@ -260,8 +260,10 @@ func NewPrefixCacheRouterWithCache(c cache.Cache) (types.Router, error) {
 	return NewPrefixCacheRouterWithOptions(c, nil)
 }
 
-// NewPrefixCacheRouterWithOptions constructs a prefix-cache router with
-// explicit cache and optional per-instance prefix table dependencies.
+// NewPrefixCacheRouterWithOptions constructs a prefix-cache router with an
+// explicit cache and optional per-instance prefix table. A nil indexer creates
+// a new private table; the production constructor passes the shared table
+// explicitly.
 func NewPrefixCacheRouterWithOptions(c cache.Cache, indexer *prefixcacheindexer.PrefixHashTable) (types.Router, error) {
 	// Initialize prefix cache metrics if enabled
 	if err := initializePrefixCacheMetrics(); err != nil {
@@ -325,7 +327,7 @@ func NewPrefixCacheRouterWithOptions(c cache.Cache, indexer *prefixcacheindexer.
 
 	// Create main router with local indexer
 	if indexer == nil {
-		indexer = prefixcacheindexer.GetSharedPrefixHashTable()
+		indexer = prefixcacheindexer.NewPrefixHashTable()
 	}
 	router := prefixCacheRouter{
 		cache:              c,

--- a/pkg/plugins/gateway/algorithms/prefix_cache_constructor_test.go
+++ b/pkg/plugins/gateway/algorithms/prefix_cache_constructor_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routingalgorithms
+
+import (
+	"testing"
+
+	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
+)
+
+func TestNewPrefixCacheRouterWithCache(t *testing.T) {
+	router, err := NewPrefixCacheRouterWithCache(cache.NewForTest())
+	if err != nil || router == nil {
+		t.Fatalf("NewPrefixCacheRouterWithCache() = (%v, %v)", router, err)
+	}
+}
+
+func TestNewPrefixCacheRouterWithOptionsUsesInjectedIndexer(t *testing.T) {
+	indexer := prefixcacheindexer.NewPrefixHashTable()
+	router, err := NewPrefixCacheRouterWithOptions(cache.NewForTest(), indexer)
+	if err != nil {
+		t.Fatalf("NewPrefixCacheRouterWithOptions() error = %v", err)
+	}
+	prefixRouter, ok := router.(prefixCacheRouter)
+	if !ok {
+		t.Fatalf("NewPrefixCacheRouterWithOptions() returned %T, want prefixCacheRouter", router)
+	}
+	if prefixRouter.prefixCacheIndexer != indexer {
+		t.Fatal("NewPrefixCacheRouterWithOptions() did not retain injected indexer")
+	}
+}

--- a/pkg/plugins/gateway/algorithms/router.go
+++ b/pkg/plugins/gateway/algorithms/router.go
@@ -654,13 +654,19 @@ func NewRouterManager() *RouterManager {
 // Gateway routing constructors. Unlike Init, it does not mutate the process
 // global manager.
 func NewRouterManagerWithDefaults() *RouterManager {
+	return newIsolatedRouterManager()
+}
+
+func newIsolatedRouterManager() *RouterManager {
 	rm := NewRouterManager()
-	rm.RegisterProvider(RouterRandom, RandomRouterProviderFunc)
-	rm.Register(RouterLeastRequest, NewLeastRequestRouter)
-	rm.Register(RouterLeastKvCache, NewLeastKvCacheRouter)
-	rm.Register(RouterLeastLatency, NewLeastExpectedLatencyRouter)
-	rm.Register(RouterLoadBalance, NewLoadBalanceRouter)
-	rm.Register(RouterPrefixCache, NewPrefixCacheRouter)
+	defaultRM.routerMu.RLock()
+	defer defaultRM.routerMu.RUnlock()
+	for algorithm, constructor := range defaultRM.routerConstructor {
+		rm.routerConstructor[algorithm] = constructor
+	}
+	for algorithm, provider := range defaultRM.routerFactory {
+		rm.routerFactory[algorithm] = provider
+	}
 	return rm
 }
 
@@ -678,7 +684,10 @@ func NewRouterManagerWithCacheAndPrefixIndexer(c cache.Cache, indexer *prefixcac
 	if indexer == nil {
 		indexer = prefixcacheindexer.NewPrefixHashTable()
 	}
-	rm := NewRouterManager()
+	rm := newIsolatedRouterManager()
+	// The six cache-backed strategies capture c. All other registrations are
+	// copied from the production manager and retain their original dependencies
+	// (for example, SLO providers still resolve their configured cache).
 	rm.RegisterProvider(RouterRandom, RandomRouterProviderFunc)
 	rm.Register(RouterLeastRequest, func() (types.Router, error) { return NewLeastRequestRouterWithCache(c) })
 	rm.Register(RouterLeastKvCache, func() (types.Router, error) { return NewLeastKvCacheRouterWithCache(c) })

--- a/pkg/plugins/gateway/algorithms/router.go
+++ b/pkg/plugins/gateway/algorithms/router.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vllm-project/aibrix/pkg/metrics"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils"
+	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -45,6 +46,9 @@ var (
 	ErrFallbackNotRegistered = errors.New("fallback router not registered")
 	defaultRM                = NewRouterManager()
 )
+
+// DefaultRouterManager returns the production process-wide router manager.
+func DefaultRouterManager() *RouterManager { return defaultRM }
 
 // RouterItem represents a single routing algorithm and its weight coefficient for multi-router config.
 type RouterItem struct {
@@ -643,6 +647,46 @@ func NewRouterManager() *RouterManager {
 	rm.routerConstructor = make(map[types.RoutingAlgorithm]types.RouterProviderRegistrationFunc)
 	rm.multiRouterCache = make(map[string]*multiStrategyRouter)
 	rm.unblendableLogged = make(map[string]struct{})
+	return rm
+}
+
+// NewRouterManagerWithDefaults creates an isolated manager with the standard
+// Gateway routing constructors. Unlike Init, it does not mutate the process
+// global manager.
+func NewRouterManagerWithDefaults() *RouterManager {
+	rm := NewRouterManager()
+	rm.RegisterProvider(RouterRandom, RandomRouterProviderFunc)
+	rm.Register(RouterLeastRequest, NewLeastRequestRouter)
+	rm.Register(RouterLeastKvCache, NewLeastKvCacheRouter)
+	rm.Register(RouterLeastLatency, NewLeastExpectedLatencyRouter)
+	rm.Register(RouterLoadBalance, NewLoadBalanceRouter)
+	rm.Register(RouterPrefixCache, NewPrefixCacheRouter)
+	return rm
+}
+
+// NewRouterManagerWithCache creates an isolated manager whose cache-backed
+// constructors capture c instead of consulting the process-global cache.
+func NewRouterManagerWithCache(c cache.Cache) *RouterManager {
+	return NewRouterManagerWithCacheAndPrefixIndexer(c, nil)
+}
+
+// NewRouterManagerWithCacheAndPrefixIndexer creates an isolated manager whose
+// cache-backed constructors capture c and whose prefix-cache constructor uses
+// indexer when it is non-nil. A nil indexer preserves the default per-manager
+// prefix table behavior.
+func NewRouterManagerWithCacheAndPrefixIndexer(c cache.Cache, indexer *prefixcacheindexer.PrefixHashTable) *RouterManager {
+	if indexer == nil {
+		indexer = prefixcacheindexer.NewPrefixHashTable()
+	}
+	rm := NewRouterManager()
+	rm.RegisterProvider(RouterRandom, RandomRouterProviderFunc)
+	rm.Register(RouterLeastRequest, func() (types.Router, error) { return NewLeastRequestRouterWithCache(c) })
+	rm.Register(RouterLeastKvCache, func() (types.Router, error) { return NewLeastKvCacheRouterWithCache(c) })
+	rm.Register(RouterLeastLatency, func() (types.Router, error) { return NewLeastLatencyRouterWithCache(c) })
+	rm.Register(RouterLoadBalance, func() (types.Router, error) { return NewLoadBalanceRouterWithCache(c) })
+	rm.Register(RouterPrefixCache, func() (types.Router, error) {
+		return NewPrefixCacheRouterWithOptions(c, indexer)
+	})
 	return rm
 }
 

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -257,11 +257,10 @@ func NewServerWithOptions(redisClient *redis.Client, client kubernetes.Interface
 			routerManager = routing.NewRouterManagerWithCache(c)
 		} else {
 			routing.Init()
+			routerManager = routing.DefaultRouterManager()
 		}
 	}
-	if routerManager != nil {
-		routerManager.Init()
-	}
+	routerManager.Init()
 
 	shutdown := make(chan struct{})
 	s := &Server{
@@ -282,13 +281,6 @@ func NewServerWithOptions(redisClient *redis.Client, client kubernetes.Interface
 	}
 	s.startVideoJobCacheSync(shutdown)
 	return s
-}
-
-func (s *Server) routers() *routing.RouterManager {
-	if s.routerManager != nil {
-		return s.routerManager
-	}
-	return routing.DefaultRouterManager()
 }
 
 func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
@@ -492,9 +484,6 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 		s.finishRequestCount(st)
 	}
 	klog.ErrorS(err, "error receiving stream from Envoy extproc (non-gRPC)", "requestID", st.requestID)
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return err
-	}
 	return status.Errorf(codes.Unknown, "recv stream error: %v", err)
 }
 
@@ -665,7 +654,11 @@ func (s *Server) selectTargetPod(ctx context.Context, routeCtx *types.RoutingCon
 		readyPods = routing.ApplyLoadImbalanceGate(routeCtx, s.cache, readyPods)
 	}
 
-	router, err := s.routers().Select(routeCtx)
+	if s.routerManager == nil {
+		// Preserve compatibility for legacy tests that build Server literals.
+		s.routerManager = routing.DefaultRouterManager()
+	}
+	router, err := s.routerManager.Select(routeCtx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/plugins/gateway/gateway.go
+++ b/pkg/plugins/gateway/gateway.go
@@ -80,6 +80,8 @@ type Server struct {
 	gatewayClient       gatewayapi.Interface
 	requestCountTracker map[string]int
 	cache               cache.Cache
+	routerManager       *routing.RouterManager
+	inFlightObserver    func(int)
 	wakeRequester       modelWakeRequester
 	httpServer          *http.Server
 	httprouteCache      sync.Map
@@ -94,6 +96,16 @@ type Server struct {
 	shutdownCh   <-chan struct{}
 	shutdown     chan struct{}
 	shutdownOnce sync.Once
+}
+
+// HasRequestBuffers is a test-observation API: it reports whether an in-flight
+// request retains body state in either production buffer. sync.Map makes the
+// point-in-time lookup safe concurrently with Process cleanup; callers should
+// invoke it after Process returns when asserting terminal cleanup.
+func HasRequestBuffers(requestID string) bool {
+	_, requestPresent := requestBuffers.Load(requestID)
+	_, streamPresent := streamBuffers.Load(requestID)
+	return requestPresent || streamPresent
 }
 
 type processState struct {
@@ -203,10 +215,31 @@ func httpRouteCacheTTL() time.Duration {
 	return defaultHTTPRouteCacheTTL
 }
 
+// ServerOptions configures optional dependencies for a Server.
+type ServerOptions struct {
+	Cache         cache.Cache
+	RouterManager *routing.RouterManager
+	// InFlightObserver receives test/diagnostic lifecycle deltas (+1/-1). The
+	// callback must be non-blocking and non-panicking because it runs on the
+	// request processing path and is not recovered by Gateway.
+	InFlightObserver func(int)
+}
+
 func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayClient gatewayapi.Interface) *Server {
-	c, err := cache.Get()
-	if err != nil {
-		panic(err)
+	return NewServerWithOptions(redisClient, client, gatewayClient, ServerOptions{})
+}
+
+// NewServerWithOptions constructs a Gateway server with optional dependencies.
+// A supplied Cache without a RouterManager creates an isolated cache-aware
+// manager; with no options, production global cache and routing behavior apply.
+func NewServerWithOptions(redisClient *redis.Client, client kubernetes.Interface, gatewayClient gatewayapi.Interface, options ServerOptions) *Server {
+	c := options.Cache
+	if c == nil {
+		var err error
+		c, err = cache.Get()
+		if err != nil {
+			panic(err)
+		}
 	}
 	var r ratelimiter.RateLimiter
 	var mr ratelimiter.RateLimiter
@@ -218,8 +251,17 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 		mr = ratelimiter.NewNoopRateLimiter()
 	}
 
-	// Initialize the routers
-	routing.Init()
+	routerManager := options.RouterManager
+	if routerManager == nil {
+		if options.Cache != nil {
+			routerManager = routing.NewRouterManagerWithCache(c)
+		} else {
+			routing.Init()
+		}
+	}
+	if routerManager != nil {
+		routerManager.Init()
+	}
 
 	shutdown := make(chan struct{})
 	s := &Server{
@@ -231,6 +273,8 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 		gatewayClient:       gatewayClient,
 		requestCountTracker: map[string]int{},
 		cache:               c,
+		routerManager:       routerManager,
+		inFlightObserver:    options.InFlightObserver,
 		wakeRequester:       newRuntimeModelWakeRequester(nil, defaultModelClaimRuntimePort),
 		httprouteCacheTTL:   httpRouteCacheTTL(),
 		shutdownCh:          shutdown,
@@ -238,6 +282,13 @@ func NewServer(redisClient *redis.Client, client kubernetes.Interface, gatewayCl
 	}
 	s.startVideoJobCacheSync(shutdown)
 	return s
+}
+
+func (s *Server) routers() *routing.RouterManager {
+	if s.routerManager != nil {
+		return s.routerManager
+	}
+	return routing.DefaultRouterManager()
 }
 
 func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
@@ -254,6 +305,9 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 	}
 
 	metrics.IncGaugeMetric(metrics.GatewayInFlight, metrics.GetMetricHelp(metrics.GatewayInFlight), []string{"gateway_pod"}, podName)
+	if s.inFlightObserver != nil {
+		s.inFlightObserver(1)
+	}
 	defer func() {
 		// This is a fallback for any terminal path that did not explicitly finish
 		// bookkeeping. A non-empty model and routing context mean request-body
@@ -271,6 +325,9 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		}
 		st.releaseModelInFlight()
 		metrics.DecGaugeMetric(metrics.GatewayInFlight, metrics.GetMetricHelp(metrics.GatewayInFlight), []string{"gateway_pod"}, podName)
+		if s.inFlightObserver != nil {
+			s.inFlightObserver(-1)
+		}
 		// routerCtx must remain valid until every completion path above has
 		// returned. Returning it to the pool earlier lets another request reset
 		// the same object while this Process still holds the pointer.
@@ -435,6 +492,9 @@ func (s *Server) handleRecvError(st *processState, err error) error {
 		s.finishRequestCount(st)
 	}
 	klog.ErrorS(err, "error receiving stream from Envoy extproc (non-gRPC)", "requestID", st.requestID)
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
 	return status.Errorf(codes.Unknown, "recv stream error: %v", err)
 }
 
@@ -605,7 +665,7 @@ func (s *Server) selectTargetPod(ctx context.Context, routeCtx *types.RoutingCon
 		readyPods = routing.ApplyLoadImbalanceGate(routeCtx, s.cache, readyPods)
 	}
 
-	router, err := routing.Select(routeCtx)
+	router, err := s.routers().Select(routeCtx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/plugins/gateway/gateway_options_test.go
+++ b/pkg/plugins/gateway/gateway_options_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import "testing"
+
+func TestNewServerWithOptionsUsesInjectedCache(t *testing.T) {
+	injected := &MockCache{}
+
+	server := NewServerWithOptions(nil, nil, nil, ServerOptions{Cache: injected})
+	if server.cache != injected {
+		t.Fatalf("NewServerWithOptions() cache = %p, want injected cache %p", server.cache, injected)
+	}
+	if server.routerManager == nil {
+		t.Fatal("NewServerWithOptions() with Cache-only options must create a local router manager")
+	}
+}

--- a/pkg/plugins/gateway/gateway_options_test.go
+++ b/pkg/plugins/gateway/gateway_options_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package gateway
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/vllm-project/aibrix/pkg/cache"
+)
 
 func TestNewServerWithOptionsUsesInjectedCache(t *testing.T) {
 	injected := &MockCache{}
@@ -27,5 +31,29 @@ func TestNewServerWithOptionsUsesInjectedCache(t *testing.T) {
 	}
 	if server.routerManager == nil {
 		t.Fatal("NewServerWithOptions() with Cache-only options must create a local router manager")
+	}
+	assertProductionStrategiesRegistered(t, server)
+}
+
+func TestNewServerInitializesGlobalRouterManager(t *testing.T) {
+	cache.InitForTest()
+	server := NewServer(nil, nil, nil)
+	if server.routerManager == nil {
+		t.Fatal("NewServer() must retain the initialized global router manager")
+	}
+	assertProductionStrategiesRegistered(t, server)
+}
+
+func assertProductionStrategiesRegistered(t *testing.T, server *Server) {
+	t.Helper()
+	strategies := []string{
+		"pd", "slo-pack-load", "slo-least-load", "vtc-basic", "throughput",
+		"session-affinity", "least-busy-time", "least-gpu-cache", "least-utilization",
+		"least-request", "least-kv-cache", "least-latency", "load-balance", "prefix-cache",
+	}
+	for _, strategy := range strategies {
+		if _, ok := server.routerManager.Validate(strategy); !ok {
+			t.Fatalf("router manager does not validate production strategy %q", strategy)
+		}
 	}
 }

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -108,7 +108,7 @@ func (s *Server) HandleRequestBody(ctx context.Context, routingCtx *types.Routin
 	// Derive and validate routing strategy (headers -> profile -> env); return 400 on invalid
 	if strategy, enabled := deriveRoutingStrategyFromContext(routingCtx); enabled {
 		var ok bool
-		if routingAlgorithm, ok = routing.Validate(strategy); !ok {
+		if routingAlgorithm, ok = s.routers().Validate(strategy); !ok {
 			klog.ErrorS(nil, "incorrect routing strategy", "requestID", requestID, "routing-strategy", strategy)
 			return buildErrorResponse(envoyTypePb.StatusCode_BadRequest, fmt.Sprintf("incorrect routing strategy %s", strategy), "", "", HeaderErrorRouting, "true"), model, stream, term
 		}

--- a/pkg/plugins/gateway/gateway_req_body.go
+++ b/pkg/plugins/gateway/gateway_req_body.go
@@ -108,7 +108,13 @@ func (s *Server) HandleRequestBody(ctx context.Context, routingCtx *types.Routin
 	// Derive and validate routing strategy (headers -> profile -> env); return 400 on invalid
 	if strategy, enabled := deriveRoutingStrategyFromContext(routingCtx); enabled {
 		var ok bool
-		if routingAlgorithm, ok = s.routers().Validate(strategy); !ok {
+		// Some legacy unit tests construct Server literals directly instead of
+		// using NewServerWithOptions. Keep those callers compatible while all
+		// production-constructed servers still receive a manager at construction.
+		if s.routerManager == nil {
+			s.routerManager = routing.DefaultRouterManager()
+		}
+		if routingAlgorithm, ok = s.routerManager.Validate(strategy); !ok {
 			klog.ErrorS(nil, "incorrect routing strategy", "requestID", requestID, "routing-strategy", strategy)
 			return buildErrorResponse(envoyTypePb.StatusCode_BadRequest, fmt.Sprintf("incorrect routing strategy %s", strategy), "", "", HeaderErrorRouting, "true"), model, stream, term
 		}

--- a/test/integration/gateway/config_profile_test.go
+++ b/test/integration/gateway/config_profile_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Gateway config profile integration", Label("gateway", "integration"), func() {
+	It("uses the profile routing strategy when the request omits one", func() {
+		pods := twoReadyPods()
+		pod := pods[0]
+		profileConfig := `{"defaultProfile":"default","profiles":` +
+			`{"default":{"routingStrategy":"least-request:1,load-balance:0"}}}`
+		pod.Annotations = map[string]string{
+			"model.aibrix.ai/config": profileConfig,
+		}
+		fixture := newGatewayFixtureWithRequest(pods, "", "default", "")
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		response := findRequestBodyResponse(fixture.stream.responses())
+		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "routing-strategy", "least-request:1,load-balance:0")
+		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.2:8000")
+		Expect(fixture.cache.finalizationCount(fixture.requestID)).To(Equal(1), fixture.diagnostics())
+		expectSuccessfulLifecycle(fixture)
+	})
+})

--- a/test/integration/gateway/fixture.go
+++ b/test/integration/gateway/fixture.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+
+	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/vllm-project/aibrix/pkg/cache"
+	"github.com/vllm-project/aibrix/pkg/metrics"
+	gatewayplugin "github.com/vllm-project/aibrix/pkg/plugins/gateway"
+	routingalgorithms "github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms"
+	"github.com/vllm-project/aibrix/pkg/types"
+	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type requestEvent struct {
+	Kind, RequestID, Model string
+	TraceTerm              int64
+}
+
+// fakeCache is stateful because Gateway routing and lifecycle assertions read
+// metrics/events at different points in one request. Each fixture owns a fresh
+// instance so request counts, trace terms, and terminal events cannot leak
+// between cases.
+type fakeCache struct {
+	mu             sync.Mutex
+	models         map[string]bool
+	podsByModel    map[string][]*corev1.Pod
+	events         []requestEvent
+	nextTraceTerm  int64
+	metricValues   map[string]metrics.MetricValue
+	inFlightEvents []int
+}
+
+var _ cache.Cache = (*fakeCache)(nil)
+var _ extProcPb.ExternalProcessor_ProcessServer = (*fakeProcessStream)(nil)
+
+func newFakeCache(pods []*corev1.Pod) *fakeCache {
+	values := map[string]metrics.MetricValue{}
+	for i, pod := range pods {
+		base := 10.0
+		if i == 0 {
+			base = 1
+		}
+		values[pod.Name+"/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: base}
+		values[pod.Name+"/"+metrics.KVCacheUsagePerc] = &metrics.SimpleMetricValue{Value: base}
+		values[pod.Name+"/"+metrics.RealtimeRunningRequestsDrainRate1m] = &metrics.SimpleMetricValue{Value: 1 / base}
+		values[pod.Name+"/"+metrics.RequestQueueTimeSeconds] = &metrics.SimpleMetricValue{Value: base}
+		values[pod.Name+"/"+metrics.AvgPromptToksPerReq] = &metrics.SimpleMetricValue{Value: 10}
+		values[pod.Name+"/"+metrics.AvgGenerationToksPerReq] = &metrics.SimpleMetricValue{Value: 10}
+		values[pod.Name+"/"+metrics.RequestPrefillTimeSeconds] = &metrics.HistogramMetricValue{Sum: base, Count: 1}
+		values[pod.Name+"/"+metrics.RequestDecodeTimeSeconds] = &metrics.HistogramMetricValue{Sum: base, Count: 1}
+	}
+	return &fakeCache{
+		models:        map[string]bool{"llama2-7b": true},
+		podsByModel:   map[string][]*corev1.Pod{"llama2-7b": append([]*corev1.Pod(nil), pods...)},
+		nextTraceTerm: 1,
+		metricValues:  values,
+	}
+}
+func (c *fakeCache) HasModel(model string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.models[model]
+}
+func (c *fakeCache) ListModels() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0, len(c.models))
+	for m := range c.models {
+		out = append(out, m)
+	}
+	return out
+}
+func (c *fakeCache) ListModelsByPod(_, _ string) ([]string, error) { return []string{}, nil }
+func (c *fakeCache) ListPodsByModel(model string) (types.PodList, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return &podList{pods: append([]*corev1.Pod(nil), c.podsByModel[model]...)}, nil
+}
+func (c *fakeCache) GetPod(podName, podNamespace string) (*corev1.Pod, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, pods := range c.podsByModel {
+		for _, pod := range pods {
+			if pod.Namespace == podNamespace && pod.Name == podName {
+				return pod.DeepCopy(), nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("pod %s/%s not found", podNamespace, podName)
+}
+func (c *fakeCache) ModelBaseModel(string) (string, bool) { return "", false }
+func (c *fakeCache) GetMetricValueByPod(pod, _, metric string) (metrics.MetricValue, error) {
+	return c.metricValue(pod, metric), nil
+}
+func (c *fakeCache) GetMetricValueByPodModel(pod, _, _, metric string) (metrics.MetricValue, error) {
+	return c.metricValue(pod, metric), nil
+}
+func (c *fakeCache) metricValue(pod, metric string) metrics.MetricValue {
+	if v, ok := c.metricValues[pod+"/"+metric]; ok {
+		return v
+	}
+	return &metrics.SimpleMetricValue{}
+}
+func (c *fakeCache) AddSubscriber(metrics.MetricSubscriber)      {}
+func (c *fakeCache) RegisterRequestTracker(cache.RequestTracker) {}
+func (c *fakeCache) GetModelProfileByPod(*corev1.Pod, string) (*cache.ModelGPUProfile, error) {
+	return nil, nil
+}
+func (c *fakeCache) GetModelProfileByDeploymentName(string, string) (*cache.ModelGPUProfile, error) {
+	return nil, nil
+}
+func (c *fakeCache) GetOutputPredictor(string) (types.OutputPredictor, error) {
+	return fakeOutputPredictor{}, nil
+}
+func (c *fakeCache) GetRouter(*types.RoutingContext) (types.Router, error) { return nil, nil }
+func (c *fakeCache) AddRequestCount(_ *types.RoutingContext, requestID, model string) int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	term := c.nextTraceTerm
+	c.nextTraceTerm++
+	c.events = append(c.events, requestEvent{"add", requestID, model, term})
+	return term
+}
+func (c *fakeCache) DoneRequestCount(_ *types.RoutingContext, requestID, model string, term int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, requestEvent{"done", requestID, model, term})
+}
+func (c *fakeCache) DoneRequestTrace(_ *types.RoutingContext, requestID, model string, _, _, term int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, requestEvent{"done-trace", requestID, model, term})
+}
+func (c *fakeCache) eventsSnapshot() []requestEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]requestEvent(nil), c.events...)
+}
+func (c *fakeCache) finalizationCount(requestID string) int {
+	n := 0
+	for _, e := range c.eventsSnapshot() {
+		if e.RequestID == requestID && (e.Kind == "done" || e.Kind == "done-trace") {
+			n++
+		}
+	}
+	return n
+}
+func (c *fakeCache) inFlightSnapshot() []int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]int(nil), c.inFlightEvents...)
+}
+
+func (c *fakeCache) inFlightValue() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	value := 0
+	for _, delta := range c.inFlightEvents {
+		value += delta
+	}
+	return value
+}
+
+type podList struct{ pods []*corev1.Pod }
+
+func (p *podList) Len() int             { return len(p.pods) }
+func (p *podList) At(i int) *corev1.Pod { return p.pods[i] }
+
+func (p *podList) All() []*corev1.Pod                { return append([]*corev1.Pod(nil), p.pods...) }
+func (p *podList) Indexes() []string                 { return nil }
+func (p *podList) ListByIndex(string) []*corev1.Pod  { return nil }
+func (p *podList) ListPortsForPod() map[string][]int { return nil }
+
+type fakeOutputPredictor struct{}
+
+func (fakeOutputPredictor) AddTrace(int, int, int32) {}
+func (fakeOutputPredictor) Predict(n int) int        { return n }
+
+type fakeProcessStream struct {
+	ctx               context.Context
+	inputs            []*extProcPb.ProcessingRequest
+	outputs           []*extProcPb.ProcessingResponse
+	inputPos          int
+	mu                sync.Mutex
+	blockOnExhaustion bool
+	recvStarted       chan struct{}
+	recvOnce          sync.Once
+}
+
+// fakeProcessStream drives the ordered ext_proc callback sequence consumed by
+// Gateway.Process. Response-body callbacks are protocol boundaries only: Envoy
+// owns forwarding the upstream body bytes.
+func newFakeProcessStream(ctx context.Context, inputs ...*extProcPb.ProcessingRequest) *fakeProcessStream {
+	return &fakeProcessStream{ctx: ctx, inputs: inputs}
+}
+func (s *fakeProcessStream) Recv() (*extProcPb.ProcessingRequest, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.inputPos >= len(s.inputs) {
+		if s.blockOnExhaustion {
+			s.recvOnce.Do(func() {
+				if s.recvStarted != nil {
+					close(s.recvStarted)
+				}
+			})
+			<-s.ctx.Done()
+			return nil, s.ctx.Err()
+		}
+		return nil, io.EOF
+	}
+	req := s.inputs[s.inputPos]
+	s.inputPos++
+	return req, nil
+}
+func (s *fakeProcessStream) Send(resp *extProcPb.ProcessingResponse) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.outputs = append(s.outputs, proto.Clone(resp).(*extProcPb.ProcessingResponse))
+	return nil
+}
+func (s *fakeProcessStream) Context() context.Context { return s.ctx }
+func (s *fakeProcessStream) SetHeader(metadata.MD) error {
+	return fmt.Errorf("fake ext_proc stream does not support SetHeader")
+}
+func (s *fakeProcessStream) SendHeader(metadata.MD) error {
+	return fmt.Errorf("fake ext_proc stream does not support SendHeader")
+}
+
+// SetTrailer is required by grpc.ServerStream but is outside this fake's
+// supported Recv/Send/Context surface; Process never calls it.
+func (s *fakeProcessStream) SetTrailer(metadata.MD) {}
+func (s *fakeProcessStream) SendMsg(any) error {
+	return fmt.Errorf("fake ext_proc stream does not support SendMsg")
+}
+func (s *fakeProcessStream) RecvMsg(any) error {
+	return fmt.Errorf("fake ext_proc stream does not support RecvMsg")
+}
+func (s *fakeProcessStream) responses() []*extProcPb.ProcessingResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*extProcPb.ProcessingResponse(nil), s.outputs...)
+}
+
+type gatewayFixture struct {
+	server        *gatewayplugin.Server
+	cache         *fakeCache
+	prefixIndexer *prefixcacheindexer.PrefixHashTable
+	stream        *fakeProcessStream
+	requestID     string
+}
+
+var fixtureSequence atomic.Uint64
+
+func newGatewayFixture(pods []*corev1.Pod) *gatewayFixture {
+	return newGatewayFixtureWithRequest(pods, "random", "", "")
+}
+
+func newGatewayFixtureWithRequest(pods []*corev1.Pod, strategy, profile, externalFilter string) *gatewayFixture {
+	c := newFakeCache(pods)
+	requestID := fmt.Sprintf("%032x", fixtureSequence.Add(1))
+	prefixIndexer := prefixcacheindexer.NewPrefixHashTable()
+	f := &gatewayFixture{cache: c, prefixIndexer: prefixIndexer, requestID: requestID}
+	// Both dependencies stay local so cases cannot observe process-global
+	// routing/cache registries or shared prefix state.
+	routerManager := routingalgorithms.NewRouterManagerWithCacheAndPrefixIndexer(c, prefixIndexer)
+	f.server = gatewayplugin.NewServerWithOptions(
+		nil, nil, nil,
+		gatewayplugin.ServerOptions{
+			Cache:         c,
+			RouterManager: routerManager,
+			InFlightObserver: func(delta int) {
+				c.mu.Lock()
+				defer c.mu.Unlock()
+				c.inFlightEvents = append(c.inFlightEvents, delta)
+			},
+		},
+	)
+	inputs := []*extProcPb.ProcessingRequest{
+		requestHeadersRequest(requestID, strategy, profile, externalFilter),
+		requestBodyRequest(),
+	}
+	_, valid := routerManager.Validate(strategy)
+	if hasReadyPod(pods) && (valid || profile != "") {
+		inputs = append(inputs, responseHeadersRequest(), responseBodyRequest())
+	}
+	f.stream = newFakeProcessStream(context.Background(), inputs...)
+	return f
+}
+
+func (f *gatewayFixture) run() error { return f.server.Process(f.stream) }
+func (f *gatewayFixture) diagnostics() string {
+	inputs := make([]string, 0, len(f.stream.inputs))
+	for _, input := range f.stream.inputs {
+		inputs = append(inputs, fmt.Sprintf("%T", input.Request))
+	}
+	outputs := make([]string, 0, len(f.stream.responses()))
+	for _, output := range f.stream.responses() {
+		status := ""
+		target := ""
+		strategy := ""
+		if immediate := output.GetImmediateResponse(); immediate != nil {
+			status = fmt.Sprintf("immediate:%d %s", immediate.GetStatus().GetCode(), immediate.GetBody())
+		}
+		if body := output.GetRequestBody(); body != nil && body.GetResponse() != nil {
+			for _, h := range body.GetResponse().GetHeaderMutation().GetSetHeaders() {
+				if h.GetHeader().GetKey() == "target-pod" {
+					target = string(h.GetHeader().GetRawValue())
+				}
+				if h.GetHeader().GetKey() == "routing-strategy" {
+					strategy = string(h.GetHeader().GetRawValue())
+				}
+			}
+		}
+		outputs = append(outputs, fmt.Sprintf(
+			"%T status=%s target=%s strategy=%s",
+			output.Response, status, target, strategy,
+		))
+	}
+	return fmt.Sprintf(
+		"request_id=%s inputs=%v outputs=%v events=%v",
+		f.requestID, inputs, outputs, f.cache.eventsSnapshot(),
+	)
+}
+func requestHeadersRequest(requestID, strategy, profile, externalFilter string) *extProcPb.ProcessingRequest {
+	headers := []*configPb.HeaderValue{
+		{Key: ":method", RawValue: []byte("POST")},
+		{Key: ":path", RawValue: []byte("/v1/chat/completions")},
+		{Key: "content-type", RawValue: []byte("application/json")},
+		{Key: "routing-strategy", RawValue: []byte(strategy)},
+		{Key: "traceparent", RawValue: []byte("00-" + requestID + "-00f067aa0ba902b7-01")},
+	}
+	if profile != "" {
+		headers = append(headers, &configPb.HeaderValue{Key: "config-profile", RawValue: []byte(profile)})
+	}
+	if externalFilter != "" {
+		headers = append(headers, &configPb.HeaderValue{Key: "external-filter", RawValue: []byte(externalFilter)})
+	}
+	return &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extProcPb.HttpHeaders{
+				Headers: &configPb.HeaderMap{Headers: headers},
+			},
+		},
+	}
+}
+func requestBodyRequest() *extProcPb.ProcessingRequest {
+	return &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestBody{
+			RequestBody: &extProcPb.HttpBody{
+				Body:        []byte(`{"model":"llama2-7b","messages":[{"role":"user","content":"hello"}],"stream":false}`),
+				EndOfStream: true,
+			},
+		},
+	}
+}
+func responseHeadersRequest() *extProcPb.ProcessingRequest {
+	return &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseHeaders{
+			ResponseHeaders: &extProcPb.HttpHeaders{
+				Headers: &configPb.HeaderMap{
+					Headers: []*configPb.HeaderValue{{
+						Key: ":status", RawValue: []byte("200"),
+					}},
+				},
+			},
+		},
+	}
+}
+func responseBodyRequest() *extProcPb.ProcessingRequest {
+	return &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body: []byte(
+					`{"model":"llama2-7b","choices":[],"usage":` +
+						`{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+				),
+				EndOfStream: true,
+			},
+		},
+	}
+}
+
+func hasReadyPod(pods []*corev1.Pod) bool {
+	for _, pod := range pods {
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/test/integration/gateway/fixture.go
+++ b/test/integration/gateway/fixture.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -31,7 +32,9 @@ import (
 	routingalgorithms "github.com/vllm-project/aibrix/pkg/plugins/gateway/algorithms"
 	"github.com/vllm-project/aibrix/pkg/types"
 	"github.com/vllm-project/aibrix/pkg/utils/prefixcacheindexer"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -52,6 +55,7 @@ type fakeCache struct {
 	events         []requestEvent
 	nextTraceTerm  int64
 	metricValues   map[string]metrics.MetricValue
+	metricReads    map[string]int
 	inFlightEvents []int
 }
 
@@ -79,6 +83,7 @@ func newFakeCache(pods []*corev1.Pod) *fakeCache {
 		podsByModel:   map[string][]*corev1.Pod{"llama2-7b": append([]*corev1.Pod(nil), pods...)},
 		nextTraceTerm: 1,
 		metricValues:  values,
+		metricReads:   make(map[string]int),
 	}
 }
 func (c *fakeCache) HasModel(model string) bool {
@@ -121,10 +126,25 @@ func (c *fakeCache) GetMetricValueByPodModel(pod, _, _, metric string) (metrics.
 	return c.metricValue(pod, metric), nil
 }
 func (c *fakeCache) metricValue(pod, metric string) metrics.MetricValue {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.metricReads[pod+"/"+metric]++
 	if v, ok := c.metricValues[pod+"/"+metric]; ok {
 		return v
 	}
 	return &metrics.SimpleMetricValue{}
+}
+
+func (c *fakeCache) metricReadCount(metric string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	count := 0
+	for key, reads := range c.metricReads {
+		if strings.HasSuffix(key, "/"+metric) {
+			count += reads
+		}
+	}
+	return count
 }
 func (c *fakeCache) AddSubscriber(metrics.MetricSubscriber)      {}
 func (c *fakeCache) RegisterRequestTracker(cache.RequestTracker) {}
@@ -220,7 +240,6 @@ func newFakeProcessStream(ctx context.Context, inputs ...*extProcPb.ProcessingRe
 }
 func (s *fakeProcessStream) Recv() (*extProcPb.ProcessingRequest, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.inputPos >= len(s.inputs) {
 		if s.blockOnExhaustion {
 			s.recvOnce.Do(func() {
@@ -228,13 +247,19 @@ func (s *fakeProcessStream) Recv() (*extProcPb.ProcessingRequest, error) {
 					close(s.recvStarted)
 				}
 			})
+			s.mu.Unlock()
 			<-s.ctx.Done()
-			return nil, s.ctx.Err()
+			if s.ctx.Err() == context.DeadlineExceeded {
+				return nil, status.Error(codes.DeadlineExceeded, "context deadline exceeded")
+			}
+			return nil, status.Error(codes.Canceled, "context canceled")
 		}
+		s.mu.Unlock()
 		return nil, io.EOF
 	}
 	req := s.inputs[s.inputPos]
 	s.inputPos++
+	s.mu.Unlock()
 	return req, nil
 }
 func (s *fakeProcessStream) Send(resp *extProcPb.ProcessingResponse) error {

--- a/test/integration/gateway/metrics_test.go
+++ b/test/integration/gateway/metrics_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package gateway
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gatewayplugin "github.com/vllm-project/aibrix/pkg/plugins/gateway"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Gateway lifecycle metrics boundary", Label("gateway", "integration"), func() {
+	It("finalizes exactly once and returns to idle state", func() {
+		// InFlightObserver is a test observation hook: each request must emit
+		// +1/-1 once and leave the fixture idle after finalization.
+		fixture := newGatewayFixture([]*corev1.Pod{readyPod("target", "10.0.0.2", nil)})
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		Expect(fixture.cache.finalizationCount(fixture.requestID)).To(Equal(1), fixture.diagnostics())
+		Expect(fixture.cache.inFlightSnapshot()).To(Equal([]int{1, -1}), fixture.diagnostics())
+		Expect(fixture.cache.inFlightValue()).To(Equal(0), fixture.diagnostics())
+		Expect(gatewayplugin.HasRequestBuffers(fixture.requestID)).To(BeFalse(), fixture.diagnostics())
+	})
+})

--- a/test/integration/gateway/request_pipeline_test.go
+++ b/test/integration/gateway/request_pipeline_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gatewayplugin "github.com/vllm-project/aibrix/pkg/plugins/gateway"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Gateway ext_proc integration", Label("gateway", "integration"), func() {
+	It("routes a valid request to a ready Pod and finalizes once", func() {
+		fixture := newGatewayFixture([]*corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llama2-7b-0",
+				Namespace: "default",
+				Labels:    map[string]string{"aibrix.ai/model-name": "llama2-7b"},
+			},
+			Status: corev1.PodStatus{
+				PodIP:      "10.0.0.2",
+				Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+			},
+		}})
+
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		pod, err := fixture.cache.GetPod("llama2-7b-0", "default")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pod.Name).To(Equal("llama2-7b-0"))
+		bodyResponse := findRequestBodyResponse(fixture.stream.responses())
+		expectHeader(bodyResponse.GetHeaderMutation().GetSetHeaders(), "routing-strategy", "random")
+		expectHeader(bodyResponse.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.2:8000")
+		Expect(fixture.cache.finalizationCount(fixture.requestID)).To(Equal(1), fixture.diagnostics())
+		events := fixture.cache.eventsSnapshot()
+		Expect(events).To(HaveLen(2), fixture.diagnostics())
+		Expect(findEvent(events, "add")).NotTo(BeNil(), fixture.diagnostics())
+		Expect(findEvent(events, "done-trace")).NotTo(BeNil(), fixture.diagnostics())
+		Expect(findEvent(events, "done")).To(BeNil(), fixture.diagnostics())
+		for _, event := range events {
+			Expect(event.RequestID).To(Equal(fixture.requestID))
+			Expect(event.Model).To(Equal("llama2-7b"))
+			Expect(event.TraceTerm).To(BeNumerically(">", 0))
+		}
+		Expect(gatewayplugin.HasRequestBuffers(fixture.requestID)).To(BeFalse(), fixture.diagnostics())
+		Expect(findResponseWithImmediate(fixture.stream.responses())).To(BeNil(), fixture.diagnostics())
+	})
+
+	It("returns a gateway error when no ready Pod exists", func() {
+		fixture := newGatewayFixture([]*corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "llama2-7b-0", Namespace: "default"},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},
+			},
+		}})
+
+		err := fixture.run()
+		Expect(err).To(HaveOccurred(), fixture.diagnostics())
+		Expect(errors.Is(err, io.EOF)).To(BeTrue(), fixture.diagnostics())
+		immediate := findResponseWithImmediate(fixture.stream.responses()).GetImmediateResponse()
+		Expect(immediate).NotTo(BeNil(), fixture.diagnostics())
+		Expect(immediate.GetStatus().GetCode()).To(Equal(envoyTypePb.StatusCode_ServiceUnavailable), fixture.diagnostics())
+		Expect(immediate.GetBody()).To(ContainSubstring("error on getting pods for model llama2-7b"), fixture.diagnostics())
+		Expect(fixture.cache.finalizationCount(fixture.requestID)).To(Equal(1), fixture.diagnostics())
+		events := fixture.cache.eventsSnapshot()
+		Expect(events).To(HaveLen(1), fixture.diagnostics())
+		Expect(findEvent(events, "done")).NotTo(BeNil(), fixture.diagnostics())
+		Expect(findEvent(events, "done-trace")).To(BeNil(), fixture.diagnostics())
+		for _, event := range events {
+			Expect(event.RequestID).To(Equal(fixture.requestID))
+			Expect(event.Model).To(Equal("llama2-7b"))
+		}
+		Expect(gatewayplugin.HasRequestBuffers(fixture.requestID)).To(BeFalse(), fixture.diagnostics())
+		Expect(fixture.stream.responses()).NotTo(BeEmpty(), fixture.diagnostics())
+	})
+})
+
+func findRequestBodyResponse(responses []*extProcPb.ProcessingResponse) *extProcPb.CommonResponse {
+	for _, response := range responses {
+		if body := response.GetRequestBody(); body != nil && body.GetResponse() != nil {
+			return body.GetResponse()
+		}
+	}
+	Fail("missing request-body response")
+	return nil
+}
+
+func findResponseWithImmediate(responses []*extProcPb.ProcessingResponse) *extProcPb.ProcessingResponse {
+	for _, response := range responses {
+		if response.GetImmediateResponse() != nil {
+			return response
+		}
+	}
+	return nil
+}
+
+func findEvent(events []requestEvent, kind string) *requestEvent {
+	for i := range events {
+		if events[i].Kind == kind {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+func expectHeader(headers []*configPb.HeaderValueOption, key, value string) {
+	for _, header := range headers {
+		if header.GetHeader().GetKey() == key {
+			Expect(string(header.GetHeader().GetRawValue())).To(Equal(value))
+			return
+		}
+	}
+	Fail(fmt.Sprintf("missing header %q", key))
+}

--- a/test/integration/gateway/request_response_test.go
+++ b/test/integration/gateway/request_response_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Gateway request and response boundary", Label("gateway", "integration"), func() {
+	// These assertions inspect Gateway ext_proc mutations and its error envelope.
+	// Backend HTTP transport is outside this integration package's boundary.
+	It("preserves the request body and applies gateway headers", func() {
+		fixture := newGatewayFixture([]*corev1.Pod{readyPod("target", "10.0.0.2", nil)})
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		response := findRequestBodyResponse(fixture.stream.responses())
+		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.2:8000")
+		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "routing-strategy", "random")
+		Expect(response.GetBodyMutation().GetBody()).To(Equal(fixture.stream.inputs[1].GetRequestBody().GetBody()))
+	})
+
+	It("does not forward the user header in request mutations", func() {
+		fixture := newGatewayFixture([]*corev1.Pod{readyPod("target", "10.0.0.2", nil)})
+		fixture.stream.inputs[0].GetRequestHeaders().Headers.Headers = append(
+			fixture.stream.inputs[0].GetRequestHeaders().Headers.Headers,
+			&configPb.HeaderValue{Key: "user", RawValue: []byte("alice")},
+		)
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		response := findRequestBodyResponse(fixture.stream.responses())
+		for _, header := range response.GetHeaderMutation().GetSetHeaders() {
+			Expect(strings.ToLower(header.GetHeader().GetKey())).NotTo(Equal("user"))
+		}
+		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.2:8000")
+	})
+
+	It("passes through an OpenAI-compatible upstream error without double wrapping", func() {
+		fixture := newGatewayFixture([]*corev1.Pod{readyPod("target", "10.0.0.2", nil)})
+		fixture.stream = newFakeProcessStream(
+			context.Background(),
+			requestHeadersRequest(fixture.requestID, "random", "", ""),
+			requestBodyRequest(), responseErrorHeadersRequest(), responseErrorBodyRequest(),
+		)
+		err := fixture.run()
+		Expect(err).To(Succeed(), fixture.diagnostics())
+		lastImmediate := findLastResponseWithImmediate(fixture.stream.responses())
+		Expect(lastImmediate).NotTo(BeNil(), fixture.diagnostics())
+		immediate := lastImmediate.GetImmediateResponse()
+		Expect(immediate.GetStatus().GetCode()).To(Equal(envoyTypePb.StatusCode_InternalServerError))
+		var envelope map[string]any
+		Expect(json.Unmarshal([]byte(immediate.GetBody()), &envelope)).To(Succeed())
+		Expect(envelope["error"]).NotTo(BeNil())
+		errorObject := envelope["error"].(map[string]any)
+		Expect(errorObject["message"]).To(Equal("upstream failed"))
+		Expect(errorObject["type"]).To(Equal("server_error"))
+		Expect(errorObject["error"]).To(BeNil())
+	})
+})
+
+func responseErrorHeadersRequest() *extProcPb.ProcessingRequest {
+	return &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseHeaders{
+			ResponseHeaders: &extProcPb.HttpHeaders{
+				Headers: &configPb.HeaderMap{Headers: []*configPb.HeaderValue{{
+					Key: ":status", RawValue: []byte("200"),
+				}}},
+			},
+		},
+	}
+}
+
+func responseErrorBodyRequest() *extProcPb.ProcessingRequest {
+	return &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body:        []byte(`{"error":{"message":"upstream failed","type":"server_error"}}`),
+				EndOfStream: true,
+			},
+		},
+	}
+}
+
+func findLastResponseWithImmediate(responses []*extProcPb.ProcessingResponse) *extProcPb.ProcessingResponse {
+	for i := len(responses) - 1; i >= 0; i-- {
+		if responses[i].GetImmediateResponse() != nil {
+			return responses[i]
+		}
+	}
+	return nil
+}

--- a/test/integration/gateway/resilience_test.go
+++ b/test/integration/gateway/resilience_test.go
@@ -17,12 +17,13 @@ package gateway
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gatewayplugin "github.com/vllm-project/aibrix/pkg/plugins/gateway"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -49,7 +50,7 @@ var _ = Describe("Gateway resilience boundary", Label("gateway", "integration"),
 		case <-time.After(2 * time.Second):
 			Fail("Process did not return after context cancellation")
 		}
-		Expect(errors.Is(err, context.Canceled)).To(BeTrue(), fixture.diagnostics())
+		Expect(status.Code(err)).To(Equal(codes.Canceled), fixture.diagnostics())
 		Expect(fixture.cache.finalizationCount(fixture.requestID)).To(Equal(1), fixture.diagnostics())
 		Expect(gatewayplugin.HasRequestBuffers(fixture.requestID)).To(BeFalse(), fixture.diagnostics())
 		Expect(fixture.cache.inFlightSnapshot()).To(Equal([]int{1, -1}), fixture.diagnostics())
@@ -78,7 +79,7 @@ var _ = Describe("Gateway resilience boundary", Label("gateway", "integration"),
 		case <-time.After(2 * time.Second):
 			Fail("Process did not return after request deadline")
 		}
-		Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue(), fixture.diagnostics())
+		Expect(status.Code(err)).To(Equal(codes.DeadlineExceeded), fixture.diagnostics())
 		Expect(fixture.cache.finalizationCount(fixture.requestID)).To(Equal(1), fixture.diagnostics())
 		Expect(gatewayplugin.HasRequestBuffers(fixture.requestID)).To(BeFalse(), fixture.diagnostics())
 		Expect(fixture.cache.inFlightSnapshot()).To(Equal([]int{1, -1}), fixture.diagnostics())

--- a/test/integration/gateway/resilience_test.go
+++ b/test/integration/gateway/resilience_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package gateway
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gatewayplugin "github.com/vllm-project/aibrix/pkg/plugins/gateway"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Gateway resilience boundary", Label("gateway", "integration"), func() {
+	It("cleans up on context cancellation", func() {
+		// Process headers/body first, then block Recv so cancellation is observed
+		// during processing rather than being an input-construction shortcut.
+		ctx, cancel := context.WithCancel(context.Background())
+		fixture := newGatewayFixture([]*corev1.Pod{readyPod("target", "10.0.0.2", nil)})
+		fixture.stream = newFakeProcessStream(
+			ctx,
+			requestHeadersRequest(fixture.requestID, "random", "", ""),
+			requestBodyRequest(),
+		)
+		fixture.stream.blockOnExhaustion = true
+		fixture.stream.recvStarted = make(chan struct{})
+		result := make(chan error, 1)
+		go func() { result <- fixture.run() }()
+		Eventually(fixture.stream.recvStarted).Should(BeClosed())
+		cancel()
+		var err error
+		select {
+		case err = <-result:
+		case <-time.After(2 * time.Second):
+			Fail("Process did not return after context cancellation")
+		}
+		Expect(errors.Is(err, context.Canceled)).To(BeTrue(), fixture.diagnostics())
+		Expect(fixture.cache.finalizationCount(fixture.requestID)).To(Equal(1), fixture.diagnostics())
+		Expect(gatewayplugin.HasRequestBuffers(fixture.requestID)).To(BeFalse(), fixture.diagnostics())
+		Expect(fixture.cache.inFlightSnapshot()).To(Equal([]int{1, -1}), fixture.diagnostics())
+	})
+
+	It("cleans up when the request deadline expires while receiving", func() {
+		// The result select has a safety timeout so a regression becomes a failure,
+		// not a deadlocked test process.
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		fixture := newGatewayFixture([]*corev1.Pod{readyPod("target", "10.0.0.2", nil)})
+		fixture.stream = newFakeProcessStream(
+			ctx,
+			requestHeadersRequest(fixture.requestID, "random", "", ""),
+			requestBodyRequest(),
+		)
+		fixture.stream.blockOnExhaustion = true
+		fixture.stream.recvStarted = make(chan struct{})
+		result := make(chan error, 1)
+		go func() { result <- fixture.run() }()
+		Eventually(fixture.stream.recvStarted).Should(BeClosed())
+
+		var err error
+		select {
+		case err = <-result:
+		case <-time.After(2 * time.Second):
+			Fail("Process did not return after request deadline")
+		}
+		Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue(), fixture.diagnostics())
+		Expect(fixture.cache.finalizationCount(fixture.requestID)).To(Equal(1), fixture.diagnostics())
+		Expect(gatewayplugin.HasRequestBuffers(fixture.requestID)).To(BeFalse(), fixture.diagnostics())
+		Expect(fixture.cache.inFlightSnapshot()).To(Equal([]int{1, -1}), fixture.diagnostics())
+	})
+})

--- a/test/integration/gateway/routing_regression_test.go
+++ b/test/integration/gateway/routing_regression_test.go
@@ -132,6 +132,9 @@ var _ = Describe("routing configuration regressions", Label("gateway", "integrat
 			"routing-strategy", "least-request:0,least-kv-cache:1,load-balance:0",
 		)
 		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.3:8000")
+		// Balanced running counts make least-request prefer target while the
+		// enabled KV scorer prefers other; KV reads prove scorer participation.
+		Expect(fixture.cache.metricReadCount(metrics.KVCacheUsagePerc)).To(BeNumerically(">=", 2), fixture.diagnostics())
 		expectSuccessfulLifecycle(fixture)
 
 		// Full scorer-exclusion A/B coverage is a follow-up: the gateway's
@@ -286,8 +289,8 @@ func configureStrategyMetrics(c *fakeCache, strategy string) {
 }
 
 func configureZeroWeightMetrics(c *fakeCache) {
-	c.metricValues["target/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 10}
-	c.metricValues["other/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 1}
+	c.metricValues["target/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 1}
+	c.metricValues["other/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 3}
 	c.metricValues["target/"+metrics.KVCacheUsagePerc] = &metrics.SimpleMetricValue{Value: .9}
 	c.metricValues["target/"+metrics.CPUCacheUsagePerc] = &metrics.SimpleMetricValue{Value: .9}
 	c.metricValues["other/"+metrics.KVCacheUsagePerc] = &metrics.SimpleMetricValue{Value: .1}

--- a/test/integration/gateway/routing_regression_test.go
+++ b/test/integration/gateway/routing_regression_test.go
@@ -1,0 +1,316 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vllm-project/aibrix/pkg/metrics"
+	gatewayplugin "github.com/vllm-project/aibrix/pkg/plugins/gateway"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = DescribeTable("routing strategy regressions", Label("gateway", "integration"),
+	func(strategy string) {
+		// Every entry exercises the common contract: real Server.Process,
+		// strategy-specific state, effective routing output, and cleanup.
+		fixture := newGatewayFixtureWithRequest(twoReadyPods(), strategy, "", "")
+		configureStrategyMetrics(fixture.cache, strategy)
+		if strategy == "prefix-cache" {
+			// Keep both candidates through the gateway load gate, then seed the
+			// fixture-local table so the real prefix scorer can select other.
+			fixture.cache.metricValues["target/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 4}
+			fixture.cache.metricValues["other/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 4}
+			fixture.prefixIndexer.AddPrefix(fixture.prefixIndexer.GetPrefixHashes([]byte("hello")), "llama2-7b", "other")
+		}
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		response := findRequestBodyResponse(fixture.stream.responses())
+		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "routing-strategy", strategy)
+		switch strategy {
+		case "random":
+			// Random has no stable target contract; only its ready candidate set is stable.
+			expectHeaderOneOf(response.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.2:8000", "10.0.0.3:8000")
+		case "prefix-cache":
+			expectHeader(response.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.3:8000")
+		default:
+			expectHeader(response.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.2:8000")
+		}
+		expectSuccessfulLifecycle(fixture)
+	},
+	Entry("random", "random"),
+	Entry("least-request", "least-request"),
+	Entry("least-kv-cache", "least-kv-cache"),
+	Entry("least-latency", "least-latency"),
+	Entry("load-balance", "load-balance"),
+	Entry("prefix-cache", "prefix-cache"),
+)
+
+// The base prefix case covers fallback; the configuration regression below
+// reuses one fixture/server/local table to prove miss-to-hit without shared state.
+
+var _ = Describe("routing configuration regressions", Label("gateway", "integration"), func() {
+	It("retains a prefix mapping across requests in the fixture-local indexer", func() {
+		strategy := "prefix-cache:1,least-request:0,load-balance:0"
+		fixture := newGatewayFixtureWithRequest(twoReadyPods(), strategy, "", "")
+		// Keep both pods through the gateway imbalance gate (gap < 8), while
+		// making the real prefix router's miss fallback choose other.
+		fixture.cache.metricValues["target/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 8}
+		fixture.cache.metricValues["other/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 1}
+
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		first := findRequestBodyResponse(fixture.stream.responses())
+		expectHeader(first.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.3:8000")
+		firstMatch, _ := fixture.prefixIndexer.MatchPrefix(
+			[]byte("hello"), "llama2-7b",
+			map[string]struct{}{"target": {}, "other": {}},
+		)
+		Expect(firstMatch["other"]).To(BeNumerically(">", 0), fixture.diagnostics())
+		expectSuccessfulLifecycle(fixture)
+
+		secondID := fmt.Sprintf("%032x", fixtureSequence.Add(1))
+		fixture.requestID = secondID
+		fixture.stream = newFakeProcessStream(
+			context.Background(),
+			requestHeadersRequest(secondID, strategy, "", ""),
+			requestBodyRequest(), responseHeadersRequest(), responseBodyRequest(),
+		)
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		second := findRequestBodyResponse(fixture.stream.responses())
+		expectHeader(second.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.3:8000")
+		secondMatch, _ := fixture.prefixIndexer.MatchPrefix(
+			[]byte("hello"), "llama2-7b",
+			map[string]struct{}{"target": {}, "other": {}},
+		)
+		Expect(secondMatch["other"]).To(BeNumerically(">", 0), fixture.diagnostics())
+		expectSuccessfulLifecycle(fixture)
+	})
+
+	It("rejects an invalid strategy", func() {
+		fixture := newGatewayFixtureWithRequest([]*corev1.Pod{readyPod("target", "10.0.0.2", nil)}, "not-a-strategy", "", "")
+		err := fixture.run()
+		Expect(err).To(HaveOccurred(), fixture.diagnostics())
+		Expect(errors.Is(err, io.EOF)).To(BeTrue(), fixture.diagnostics())
+		immediateResponse := findResponseWithImmediate(fixture.stream.responses())
+		Expect(immediateResponse).NotTo(BeNil(), fixture.diagnostics())
+		immediate := immediateResponse.GetImmediateResponse()
+		Expect(immediate.GetStatus().GetCode()).To(Equal(envoyTypePb.StatusCode_BadRequest), fixture.diagnostics())
+		Expect(immediate.GetBody()).To(ContainSubstring("incorrect routing strategy"), fixture.diagnostics())
+		expectErrorLifecycle(fixture)
+	})
+
+	It("ignores a zero-weight strategy", func() {
+		// This is a representative configuration case, not a complete scorer-
+		// exclusion matrix, which belongs in broader routing coverage.
+		fixture := newGatewayFixtureWithRequest(twoReadyPods(), "least-request:0,least-kv-cache:1,load-balance:0", "", "")
+		configureZeroWeightMetrics(fixture.cache)
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		response := findRequestBodyResponse(fixture.stream.responses())
+		expectHeader(
+			response.GetHeaderMutation().GetSetHeaders(),
+			"routing-strategy", "least-request:0,least-kv-cache:1,load-balance:0",
+		)
+		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.3:8000")
+		expectSuccessfulLifecycle(fixture)
+
+		// Full scorer-exclusion A/B coverage is a follow-up: the gateway's
+		// load-imbalance gate and auto-blend can observe disabled metrics.
+	})
+
+	It("uses the multi-strategy routing configuration", func() {
+		// Keep one representative real composition here; exhaustive weight causality
+		// is intentionally outside this focused integration suite.
+		fixture := newGatewayFixtureWithRequest(twoReadyPods(), "least-request:3,least-latency:1", "", "")
+		configureMultiStrategyMetrics(fixture.cache)
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		response := findRequestBodyResponse(fixture.stream.responses())
+		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "routing-strategy", "least-request:3,least-latency:1")
+		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.2:8000")
+		// A complete weight-by-weight causal matrix is a follow-up; this case
+		// verifies the real combined router path and effective target.
+		expectSuccessfulLifecycle(fixture)
+	})
+
+	It("filters candidates by readiness", func() {
+		fixture := newGatewayFixtureWithRequest(
+			[]*corev1.Pod{
+				readyPod("target", "10.0.0.2", nil),
+				notReadyPod("offline", "10.0.0.3"),
+			}, "random", "", "",
+		)
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		expectHeader(
+			findRequestBodyResponse(fixture.stream.responses()).GetHeaderMutation().GetSetHeaders(),
+			"target-pod", "10.0.0.2:8000",
+		)
+		expectSuccessfulLifecycle(fixture)
+	})
+
+	It("applies the external label filter before routing", func() {
+		fixture := newGatewayFixtureWithRequest(
+			[]*corev1.Pod{
+				readyPod("target", "10.0.0.2", map[string]string{"gpu": "true"}),
+				readyPod("other", "10.0.0.3", map[string]string{"gpu": "false"}),
+			}, "random", "", "gpu=true",
+		)
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		expectHeader(
+			findRequestBodyResponse(fixture.stream.responses()).GetHeaderMutation().GetSetHeaders(),
+			"target-pod", "10.0.0.2:8000",
+		)
+		expectSuccessfulLifecycle(fixture)
+	})
+
+	It("lets a request routing header override the selected profile", func() {
+		pods := twoReadyPods()
+		profileConfig := `{"defaultProfile":"default","profiles":` +
+			`{"default":{"routingStrategy":"least-kv-cache:1,load-balance:0"}}}`
+		for _, pod := range pods {
+			pod.Annotations = map[string]string{
+				"model.aibrix.ai/config": profileConfig,
+			}
+		}
+		fixture := newGatewayFixtureWithRequest(pods, "least-request:1,load-balance:0", "default", "")
+		fixture.cache.metricValues["target/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 10}
+		fixture.cache.metricValues["other/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 1}
+		fixture.cache.metricValues["target/"+metrics.KVCacheUsagePerc] = &metrics.SimpleMetricValue{Value: 0.1}
+		fixture.cache.metricValues["other/"+metrics.KVCacheUsagePerc] = &metrics.SimpleMetricValue{Value: 0.9}
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		response := findRequestBodyResponse(fixture.stream.responses())
+		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "routing-strategy", "least-request:1,load-balance:0")
+		expectHeader(response.GetHeaderMutation().GetSetHeaders(), "target-pod", "10.0.0.3:8000")
+		expectSuccessfulLifecycle(fixture)
+	})
+})
+
+func readyPod(name, ip string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Labels: labels},
+		Status: corev1.PodStatus{
+			PodIP:      ip,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+}
+
+func notReadyPod(name, ip string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status: corev1.PodStatus{
+			PodIP:      ip,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},
+		},
+	}
+}
+
+func twoReadyPods() []*corev1.Pod {
+	return []*corev1.Pod{readyPod("target", "10.0.0.2", nil), readyPod("other", "10.0.0.3", nil)}
+}
+
+func expectSuccessfulLifecycle(fixture *gatewayFixture) {
+	events := fixture.cache.eventsSnapshotForRequest(fixture.requestID)
+	Expect(events).To(HaveLen(2), fixture.diagnostics())
+	Expect(findEvent(events, "add")).NotTo(BeNil(), fixture.diagnostics())
+	Expect(findEvent(events, "done-trace")).NotTo(BeNil(), fixture.diagnostics())
+	Expect(findEvent(events, "done")).To(BeNil(), fixture.diagnostics())
+	Expect(gatewayplugin.HasRequestBuffers(fixture.requestID)).To(BeFalse(), fixture.diagnostics())
+}
+
+func (c *fakeCache) eventsSnapshotForRequest(requestID string) []requestEvent {
+	events := c.eventsSnapshot()
+	filtered := make([]requestEvent, 0, len(events))
+	for _, event := range events {
+		if event.RequestID == requestID {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered
+}
+
+func expectErrorLifecycle(fixture *gatewayFixture) {
+	events := fixture.cache.eventsSnapshot()
+	Expect(events).To(HaveLen(1), fixture.diagnostics())
+	Expect(findEvent(events, "done")).NotTo(BeNil(), fixture.diagnostics())
+	Expect(findEvent(events, "done-trace")).To(BeNil(), fixture.diagnostics())
+	Expect(gatewayplugin.HasRequestBuffers(fixture.requestID)).To(BeFalse(), fixture.diagnostics())
+}
+
+func configureStrategyMetrics(c *fakeCache, strategy string) {
+	set := func(pod, metric string, value metrics.MetricValue) { c.metricValues[pod+"/"+metric] = value }
+	switch strategy {
+	case "least-request":
+		set("target", metrics.RealtimeNumRequestsRunning, &metrics.SimpleMetricValue{Value: 2})
+		set("other", metrics.RealtimeNumRequestsRunning, &metrics.SimpleMetricValue{Value: 17})
+	case "least-kv-cache":
+		set("target", metrics.KVCacheUsagePerc, &metrics.SimpleMetricValue{Value: .15})
+		set("target", metrics.CPUCacheUsagePerc, &metrics.SimpleMetricValue{Value: .05})
+		set("other", metrics.KVCacheUsagePerc, &metrics.SimpleMetricValue{Value: .85})
+		set("other", metrics.CPUCacheUsagePerc, &metrics.SimpleMetricValue{Value: .75})
+	case "least-latency":
+		set("target", metrics.RequestQueueTimeSeconds, &metrics.SimpleMetricValue{Value: .02})
+		set("other", metrics.RequestQueueTimeSeconds, &metrics.SimpleMetricValue{Value: .9})
+		set("target", metrics.RequestPrefillTimeSeconds, &metrics.HistogramMetricValue{Sum: .1, Count: 1})
+		set("target", metrics.RequestDecodeTimeSeconds, &metrics.HistogramMetricValue{Sum: .1, Count: 1})
+		set("other", metrics.RequestPrefillTimeSeconds, &metrics.HistogramMetricValue{Sum: 4, Count: 1})
+		set("other", metrics.RequestDecodeTimeSeconds, &metrics.HistogramMetricValue{Sum: 4, Count: 1})
+	case "load-balance":
+		set("target", metrics.RealtimeNumRequestsRunning, &metrics.SimpleMetricValue{Value: 3})
+		set("target", metrics.RealtimeRunningRequestsDrainRate1m, &metrics.SimpleMetricValue{Value: 3})
+		set("other", metrics.RealtimeNumRequestsRunning, &metrics.SimpleMetricValue{Value: 12})
+		set("other", metrics.RealtimeRunningRequestsDrainRate1m, &metrics.SimpleMetricValue{Value: 1})
+	case "prefix-cache":
+		set("target", metrics.RealtimeNumRequestsRunning, &metrics.SimpleMetricValue{Value: 4})
+		set("other", metrics.RealtimeNumRequestsRunning, &metrics.SimpleMetricValue{Value: 15})
+	}
+}
+
+func configureZeroWeightMetrics(c *fakeCache) {
+	c.metricValues["target/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 10}
+	c.metricValues["other/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 1}
+	c.metricValues["target/"+metrics.KVCacheUsagePerc] = &metrics.SimpleMetricValue{Value: .9}
+	c.metricValues["target/"+metrics.CPUCacheUsagePerc] = &metrics.SimpleMetricValue{Value: .9}
+	c.metricValues["other/"+metrics.KVCacheUsagePerc] = &metrics.SimpleMetricValue{Value: .1}
+	c.metricValues["other/"+metrics.CPUCacheUsagePerc] = &metrics.SimpleMetricValue{Value: .1}
+}
+
+func configureMultiStrategyMetrics(c *fakeCache) {
+	c.metricValues["target/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 1}
+	c.metricValues["other/"+metrics.RealtimeNumRequestsRunning] = &metrics.SimpleMetricValue{Value: 10}
+	c.metricValues["target/"+metrics.RequestQueueTimeSeconds] = &metrics.SimpleMetricValue{Value: 10}
+	c.metricValues["other/"+metrics.RequestQueueTimeSeconds] = &metrics.SimpleMetricValue{Value: 1}
+	c.metricValues["target/"+metrics.RequestPrefillTimeSeconds] = &metrics.HistogramMetricValue{Sum: 10, Count: 1}
+	c.metricValues["target/"+metrics.RequestDecodeTimeSeconds] = &metrics.HistogramMetricValue{Sum: 10, Count: 1}
+	c.metricValues["other/"+metrics.RequestPrefillTimeSeconds] = &metrics.HistogramMetricValue{Sum: 1, Count: 1}
+	c.metricValues["other/"+metrics.RequestDecodeTimeSeconds] = &metrics.HistogramMetricValue{Sum: 1, Count: 1}
+}
+
+func expectHeaderOneOf(headers []*configPb.HeaderValueOption, key string, values ...string) {
+	for _, header := range headers {
+		if header.GetHeader().GetKey() == key {
+			Expect(values).To(ContainElement(string(header.GetHeader().GetRawValue())))
+			return
+		}
+	}
+	Fail(fmt.Sprintf("missing header %q", key))
+}

--- a/test/integration/gateway/streaming_test.go
+++ b/test/integration/gateway/streaming_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package gateway
+
+import (
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gatewayplugin "github.com/vllm-project/aibrix/pkg/plugins/gateway"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Gateway response streaming boundary", Label("gateway", "integration"), func() {
+	It("processes split JSON and DONE", func() {
+		// Use real split JSON and DONE callbacks. Gateway does not rewrite SSE
+		// bytes here; this proves callback preservation and lifecycle only. Full
+		// parser matrices remain unit/follow-up coverage.
+		fixture := newGatewayFixture([]*corev1.Pod{readyPod("target", "10.0.0.2", nil)})
+		fixture.stream = newFakeProcessStream(
+			fixture.stream.ctx,
+			requestHeadersRequest(fixture.requestID, "random", "", ""),
+			streamingBodyRequest(), responseHeadersRequest(),
+			responseChunk("data: {\"id\":", false),
+			responseChunk("\"x\",\"choices\":[]}\n\n", false),
+			responseChunk("data: [DONE]\n\n", true),
+		)
+		Expect(fixture.run()).To(Succeed(), fixture.diagnostics())
+		Expect(fixture.cache.finalizationCount(fixture.requestID)).To(Equal(1), fixture.diagnostics())
+		// Gateway returns CommonResponse for streaming callbacks; Envoy owns
+		// forwarding the original SSE bytes. This verifies callback boundaries,
+		// not Gateway SSE parsing; parser behavior remains unit/follow-up coverage.
+		Expect(fixture.stream.inputs[3].GetResponseBody().GetBody()).To(Equal([]byte("data: {\"id\":")))
+		Expect(fixture.stream.inputs[4].GetResponseBody().GetBody()).To(Equal([]byte("\"x\",\"choices\":[]}\n\n")))
+		Expect(fixture.stream.inputs[5].GetResponseBody().GetBody()).To(Equal([]byte("data: [DONE]\n\n")))
+		Expect(fixture.stream.inputs[3].GetResponseBody().GetEndOfStream()).To(BeFalse())
+		Expect(fixture.stream.inputs[4].GetResponseBody().GetEndOfStream()).To(BeFalse())
+		Expect(fixture.stream.inputs[5].GetResponseBody().GetEndOfStream()).To(BeTrue())
+		Expect(responseBodyResponseCount(fixture.stream.responses())).To(Equal(3), fixture.diagnostics())
+		for _, response := range fixture.stream.responses() {
+			if response.GetResponseBody() == nil {
+				continue
+			}
+			Expect(response.GetResponseBody()).NotTo(BeNil(), fixture.diagnostics())
+			Expect(response.GetImmediateResponse()).To(BeNil(), fixture.diagnostics())
+			Expect(response.GetResponseBody().GetResponse()).NotTo(BeNil(), fixture.diagnostics())
+			Expect(response.GetResponseBody().GetResponse().GetBodyMutation()).To(BeNil(), fixture.diagnostics())
+		}
+		Expect(gatewayplugin.HasRequestBuffers(fixture.requestID)).To(BeFalse(), fixture.diagnostics())
+	})
+})
+
+func streamingBodyRequest() *extProcPb.ProcessingRequest {
+	return &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestBody{
+			RequestBody: &extProcPb.HttpBody{
+				Body:        []byte(`{"model":"llama2-7b","messages":[{"role":"user","content":"hello"}],"stream":true}`),
+				EndOfStream: true,
+			},
+		},
+	}
+}
+
+func responseBodyResponseCount(responses []*extProcPb.ProcessingResponse) int {
+	count := 0
+	for _, response := range responses {
+		if response.GetResponseBody() != nil {
+			count++
+		}
+	}
+	return count
+}
+func responseChunk(body string, end bool) *extProcPb.ProcessingRequest {
+	return &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{Body: []byte(body), EndOfStream: end},
+		},
+	}
+}

--- a/test/integration/gateway/suite_test.go
+++ b/test/integration/gateway/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 The Aibrix Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGatewayIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gateway Integration Suite")
+}


### PR DESCRIPTION
## Summary

- Add a dedicated `test/integration/gateway` suite driven through the real ext_proc `Server.Process` boundary.
- Cover representative routing, readiness/filtering, configuration precedence, request/response, SSE callback, timeout/cancellation, prefix-cache, lifecycle, and in-flight metric behavior.
- Add cache/router-manager dependency injection so integration fixtures use isolated state without changing the default production path.

## Scope

This PR implements the high-value PR1 foundation plus selected PR2/PR3 regression cases from #2708. Envoy/backend HTTP retry, exhaustive routing-weight matrices, full SSE parser/error matrices, and broader multi-port/data-parallel coverage remain follow-up work. PD HTTP handoff contracts remain owned by #2675.

## Validation

- `go test ./test/integration/gateway -count=1` (23 specs)
- `go test ./pkg/cache ./pkg/plugins/gateway/algorithms ./pkg/plugins/gateway -count=1`
- `go test -race ./test/integration/gateway ./pkg/plugins/gateway -count=1`
- `go vet ./pkg/cache ./pkg/plugins/gateway/algorithms ./pkg/plugins/gateway ./test/integration/gateway`
- `make licensecheck`
- `git diff --check`

Related to #2708; follows the E2E ownership boundary in #2675.