### PR TITLE
[Bug] Fix running-request count drift from concurrent pod delete/re-add races

### DIFF
--- a/pkg/cache/cache_init.go
+++ b/pkg/cache/cache_init.go
@@ -94,6 +94,23 @@ type Store struct {
 	// Pod related storage
 	metaPods utils.SyncMap[string, *Pod] // pod_namespace/pod_name -> *Pod
 
+	// recentlyDeletedPods holds realtime-counter snapshots for pods just removed
+	// from metaPods, keyed the same way, so a fast re-add of the same pod key
+	// (see deletedPodSnapshot in informers.go) can resume its request-tracking
+	// counters instead of restarting at zero.
+	recentlyDeletedPods utils.SyncMap[string, *deletedPodSnapshot]
+	// nextStatsGeneration issues statsGeneration values for freshly added
+	// cache pods (not resumes). Never reused for the process lifetime so a
+	// stale completion cannot match a later generation of the same pod key.
+	nextStatsGeneration atomic.Int64
+
+	// podStatsMu stripes per-pod-key locks (see podStatsLockFor in cache_trace.go),
+	// synchronizing running-request counter mutations (addPodStats/donePodStats) against
+	// the pod delete/re-add resume cycle (deletePodLocked/addPodLocked in informers.go)
+	// for the same pod identity. A fixed-size stripe -- rather than a lock per pod key --
+	// avoids unbounded growth as distinct pod keys accumulate over the process lifetime.
+	podStatsMu [podStatsLockStripes]sync.Mutex
+
 	// Model related storage
 	metaModels utils.SyncMap[string, *Model] // model_name -> *Model
 	// ModelClaim advertisements include non-routable port-0 states and are kept

--- a/pkg/cache/cache_request_tracker_test.go
+++ b/pkg/cache/cache_request_tracker_test.go
@@ -18,6 +18,8 @@ package cache
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -235,6 +237,176 @@ func TestDoneRequestCountAfterSameNamePodRecreationDoesNotDecrementNewPod(t *tes
 	assert.Equal(t, int32(0), atomic.LoadInt32(&newMetaPod.runningRequests))
 }
 
+// TestAddPodAfterFlakyDeleteWithSameIPPreservesRunningRequests covers the
+// opposite scenario from the recreation test above: the pod key is deleted
+// and re-added at the *same* IP, e.g. a transient health-check flap on a pod
+// that never actually stopped serving. The re-added pod should resume its
+// running-request count instead of restarting at zero, and a request that
+// was already in flight before the flap must still correctly decrement it on
+// completion rather than the decrement silently landing on the orphaned
+// pre-flap object.
+func TestAddPodAfterFlakyDeleteWithSameIPPreservesRunningRequests(t *testing.T) {
+	const (
+		modelName = "test-model"
+		namespace = "default"
+		podName   = "decode-0"
+		requestID = "request-across-flap"
+		podIP     = "10.0.0.1"
+	)
+
+	cache := NewForTest()
+	oldPod := requestTrackerTestPod(podName, namespace, modelName, podIP)
+	cache.addPod(oldPod)
+	oldMetaPod, ok := cache.metaPods.Load(namespace + "/" + podName)
+	assert.True(t, ok)
+
+	routingCtx := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+	routingCtx.SetTargetPod(oldPod)
+
+	traceTerm := cache.AddRequestCount(routingCtx, requestID, modelName)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&oldMetaPod.runningRequests))
+
+	// The pod is briefly dropped from the cache and re-added moments later
+	// at the same IP -- the in-flight request above is still running on the
+	// real engine the whole time; only the gateway's bookkeeping blipped.
+	cache.deletePod(oldPod)
+	cache.addPod(requestTrackerTestPod(podName, namespace, modelName, podIP))
+
+	newMetaPod, ok := cache.metaPods.Load(namespace + "/" + podName)
+	assert.True(t, ok)
+	assert.NotSame(t, oldMetaPod, newMetaPod)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&newMetaPod.runningRequests),
+		"re-adding the same pod (same IP) after a flaky delete should preserve its running-request count instead of resetting to zero")
+
+	cache.DoneRequestCount(routingCtx, requestID, modelName, traceTerm)
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&newMetaPod.runningRequests),
+		"a request in flight across the flap must decrement the current pod entry, not vanish into the orphaned pre-flap object")
+	// The pre-flap object is orphaned (no longer reachable via metaPods) and
+	// is never touched again -- the decrement above redirected to newMetaPod
+	// instead, so this stays at whatever it was when the flap happened.
+	assert.Equal(t, int32(1), atomic.LoadInt32(&oldMetaPod.runningRequests))
+}
+
+// gapTestLoadProvider is a CappedLoadProvider that returns a fixed consumption
+// so tests can seed pending-load without a GPU profile.
+type gapTestLoadProvider struct {
+	load float64
+}
+
+func (p gapTestLoadProvider) GetUtilization(*types.RoutingContext, *v1.Pod) (float64, error) {
+	return 0, nil
+}
+
+func (p gapTestLoadProvider) GetConsumption(*types.RoutingContext, *v1.Pod) (float64, error) {
+	return p.load, nil
+}
+
+func (p gapTestLoadProvider) Cap() float64 { return 1 }
+
+// TestDoneRequestCountDuringDeleteAddGapDecrementsPendingSnapshot covers a
+// request that completes *inside* the delete/re-add gap itself -- the pod
+// key is deleted but hasn't been re-added yet when DoneRequestCount runs.
+// This is the realistic flap timing, not just the happy-path ordering in
+// TestAddPodAfterFlakyDeleteWithSameIPPreservesRunningRequests (which only
+// exercises completion *after* the re-add): a pod flap is exactly a
+// delete/add window, and in-flight requests can finish at any point inside
+// it. Without decrementing the pending snapshot in place, the eventual
+// re-add would resume from a count that still includes this already-finished
+// request, permanently inflating it by one.
+//
+// Also covers the snapshot path's other mutation, which the local
+// running-request assertion alone would not catch: pending-load is
+// decremented on the snapshot and resumed onto the re-added pod.
+func TestDoneRequestCountDuringDeleteAddGapDecrementsPendingSnapshot(t *testing.T) {
+	const (
+		modelName   = "test-model"
+		namespace   = "default"
+		podName     = "decode-0"
+		requestID   = "request-during-gap"
+		podIP       = "10.0.0.1"
+		pendingLoad = 0.25
+	)
+
+	cache := NewForTest()
+	cache.pendingLoadProvider = gapTestLoadProvider{load: pendingLoad}
+
+	oldPod := requestTrackerTestPod(podName, namespace, modelName, podIP)
+	cache.addPod(oldPod)
+
+	routingCtx := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+	routingCtx.SetTargetPod(oldPod)
+	traceTerm := cache.AddRequestCount(routingCtx, requestID, modelName)
+
+	oldMetaPod, ok := cache.metaPods.Load(namespace + "/" + podName)
+	assert.True(t, ok)
+	assert.Equal(t, pendingLoad, oldMetaPod.pendingLoadUtilization.Load())
+
+	// The pod is dropped from the cache (flap) but hasn't reappeared yet --
+	// no addPod call in between.
+	cache.deletePod(oldPod)
+	_, ok = cache.metaPods.Load(namespace + "/" + podName)
+	assert.False(t, ok, "pod should be absent from the cache mid-gap")
+
+	snap, ok := cache.recentlyDeletedPods.Load(namespace + "/" + podName)
+	assert.True(t, ok)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&snap.runningRequests))
+	assert.Equal(t, pendingLoad, snap.pendingLoadUtilization.Load(),
+		"delete should snapshot pending-load so a mid-gap completion can decrement it in place")
+
+	// The in-flight request finishes while the pod is still gone.
+	cache.DoneRequestCount(routingCtx, requestID, modelName, traceTerm)
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&snap.runningRequests),
+		"a completion mid-gap should decrement the pending snapshot in place")
+	assert.Equal(t, 0.0, snap.pendingLoadUtilization.Load(),
+		"a completion mid-gap should decrement snapshot pending-load, not leave it for the re-add to resume")
+
+	// The pod reappears at the same IP.
+	cache.addPod(requestTrackerTestPod(podName, namespace, modelName, podIP))
+	newMetaPod, ok := cache.metaPods.Load(namespace + "/" + podName)
+	assert.True(t, ok)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&newMetaPod.runningRequests),
+		"re-add should resume from the already-decremented count, not the stale count from delete time")
+	assert.Equal(t, 0.0, newMetaPod.pendingLoadUtilization.Load(),
+		"re-add should resume from the already-decremented pending-load, not the stale value from delete time")
+}
+
+// TestAddPodAfterDeleteGracePeriodExpiryDoesNotPreserveRunningRequests
+// verifies the preservation in TestAddPodAfterFlakyDeleteWithSameIPPreservesRunningRequests
+// is bounded: a pod key that stays gone longer than recentlyDeletedPodGracePeriod
+// is presumed genuinely dead, not just slow to answer a health probe, so a
+// later re-add must not resurrect a stale count.
+func TestAddPodAfterDeleteGracePeriodExpiryDoesNotPreserveRunningRequests(t *testing.T) {
+	const (
+		modelName = "test-model"
+		namespace = "default"
+		podName   = "decode-0"
+		podIP     = "10.0.0.1"
+	)
+
+	cache := NewForTest()
+	pod := requestTrackerTestPod(podName, namespace, modelName, podIP)
+	cache.addPod(pod)
+	metaPod, ok := cache.metaPods.Load(namespace + "/" + podName)
+	assert.True(t, ok)
+	atomic.StoreInt32(&metaPod.runningRequests, 5)
+
+	cache.deletePod(pod)
+
+	// Backdate the snapshot past the grace period instead of sleeping.
+	key := namespace + "/" + podName
+	snap, ok := cache.recentlyDeletedPods.Load(key)
+	assert.True(t, ok)
+	snap.deletedAt = snap.deletedAt.Add(-recentlyDeletedPodGracePeriod)
+	cache.recentlyDeletedPods.Store(key, snap)
+
+	cache.addPod(requestTrackerTestPod(podName, namespace, modelName, podIP))
+	newMetaPod, ok := cache.metaPods.Load(key)
+	assert.True(t, ok)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&newMetaPod.runningRequests))
+}
+
 func TestDoneRequestWithNilContextCleansPreviouslyAddedPodStats(t *testing.T) {
 	for _, tt := range []struct {
 		name string
@@ -272,7 +444,8 @@ func TestDoneRequestWithNilContextCleansPreviouslyAddedPodStats(t *testing.T) {
 
 			traceTerm := cache.AddRequestCount(routingCtx, requestID, modelName)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&metaPod.runningRequests))
-			assert.Equal(t, 1, cache.podStats.Len())
+			// Primary attempt key plus nil-ctx requestID alias.
+			assert.Equal(t, 2, cache.podStats.Len())
 
 			tt.done(cache, requestID, modelName, traceTerm)
 
@@ -301,7 +474,8 @@ func TestDoubleCleanupOnlyDecrementsPodStatsOnce(t *testing.T) {
 
 	traceTerm := cache.AddRequestCount(routingCtx, requestID, modelName)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&metaPod.runningRequests))
-	assert.Equal(t, 1, cache.podStats.Len())
+	// Primary attempt key plus nil-ctx requestID alias.
+	assert.Equal(t, 2, cache.podStats.Len())
 
 	cache.DoneRequestTrace(routingCtx, requestID, modelName, 10, 20, traceTerm)
 	assert.Equal(t, int32(0), atomic.LoadInt32(&metaPod.runningRequests))
@@ -312,4 +486,418 @@ func TestDoubleCleanupOnlyDecrementsPodStatsOnce(t *testing.T) {
 	})
 	assert.Equal(t, int32(0), atomic.LoadInt32(&metaPod.runningRequests))
 	assert.Equal(t, 0, cache.podStats.Len())
+}
+
+// TestConcurrentRequestsAndPodFlapDoNotDriftRunningRequests is a regression test for
+// a production incident where a pod's gateway-local running-request counter drifted
+// permanently negative after enough requests completed while the pod was being
+// repeatedly deleted/re-added by the informer's updatePod handler, which runs on
+// every in-place pod update, not just genuine flaps.
+//
+// addPodStats/donePodStats (this file's cache.AddRequestCount/DoneRequestCount) and
+// deletePodLocked/addPodLocked (informers.go) each read-then-act on the same pod key
+// across two separate maps (metaPods and recentlyDeletedPods) without previously
+// sharing a lock, so a delete+re-add could land in the gap and misdirect or lose a
+// completing request's decrement. This race is invisible to `go test -race`: every
+// individual memory access is already atomic (atomic.AddInt32 / sync.Map), so nothing
+// trips the low-level race detector -- only asserting the final, business-logic-level
+// count catches it. Run with -race anyway to make sure the fix's new locking itself
+// introduces no genuine memory race.
+//
+// Every AddRequestCount below is paired with exactly one DoneRequestCount, so a
+// correct implementation must always settle back to exactly zero -- concurrently with
+// a goroutine continuously flapping the same pod key -- regardless of how many
+// requester goroutines and delete/re-add cycles interleave.
+//
+// The final counter value alone cannot catch every regression here: donePodStats
+// decrements through decrementClamped, which floors at 0, so a bug that issues one
+// extra decrement per lost pairing would settle at the same visible 0 as a correctly
+// balanced run -- silently masked by the very floor meant to keep the incident's
+// symptom (a negative count) from reaching production. clampedRunningRequestDecrements
+// is the unmasked signal: it counts every time the floor actually had to fire, which
+// should be exactly zero here since no decrement is ever unpaired.
+func TestConcurrentRequestsAndPodFlapDoNotDriftRunningRequests(t *testing.T) {
+	const (
+		modelName         = "test-model"
+		namespace         = "default"
+		podName           = "decode-0"
+		podIP             = "10.0.0.1"
+		numRequesters     = 20
+		itersPerRequester = 200
+	)
+
+	cache := NewForTest()
+	pod := requestTrackerTestPod(podName, namespace, modelName, podIP)
+	cache.addPod(pod)
+
+	clampedBefore := atomic.LoadInt64(&clampedRunningRequestDecrements)
+
+	stopFlapping := make(chan struct{})
+	var flapWG sync.WaitGroup
+	flapWG.Add(1)
+	go func() {
+		defer flapWG.Done()
+		for {
+			select {
+			case <-stopFlapping:
+				return
+			default:
+				cache.deletePod(requestTrackerTestPod(podName, namespace, modelName, podIP))
+				cache.addPod(requestTrackerTestPod(podName, namespace, modelName, podIP))
+			}
+		}
+	}()
+
+	var reqWG sync.WaitGroup
+	for r := 0; r < numRequesters; r++ {
+		reqWG.Add(1)
+		go func(r int) {
+			defer reqWG.Done()
+			for i := 0; i < itersPerRequester; i++ {
+				requestID := fmt.Sprintf("req-%d-%d", r, i)
+				routingCtx := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+				routingCtx.SetTargetPod(pod)
+				traceTerm := cache.AddRequestCount(routingCtx, requestID, modelName)
+				cache.DoneRequestCount(routingCtx, requestID, modelName, traceTerm)
+			}
+		}(r)
+	}
+	reqWG.Wait()
+	close(stopFlapping)
+	flapWG.Wait()
+
+	// Whatever object (live pod, or a snapshot pending re-add) currently represents
+	// the pod key holds the ground truth.
+	key := namespace + "/" + podName
+	var finalCount int32
+	if metaPod, ok := cache.metaPods.Load(key); ok {
+		finalCount = atomic.LoadInt32(&metaPod.runningRequests)
+	} else if snap, ok := cache.recentlyDeletedPods.Load(key); ok {
+		finalCount = atomic.LoadInt32(&snap.runningRequests)
+	} else {
+		t.Fatal("pod key missing from both metaPods and recentlyDeletedPods after the flap loop stopped")
+	}
+
+	assert.GreaterOrEqual(t, finalCount, int32(0), "running-request count must never go negative")
+	assert.Equal(t, int32(0), finalCount,
+		"every AddRequestCount was matched by a DoneRequestCount, so the running-request "+
+			"count must settle back to exactly zero even under concurrent pod flapping -- a "+
+			"nonzero result means a completion's decrement was lost or misdirected by a race "+
+			"against the concurrent delete/re-add cycle")
+
+	clampedAfter := atomic.LoadInt64(&clampedRunningRequestDecrements)
+	assert.Equal(t, clampedBefore, clampedAfter,
+		"decrementClamped must never hit its floor when every AddRequestCount is matched "+
+			"by exactly one DoneRequestCount -- a nonzero delta means an extra decrement "+
+			"occurred and was silently floored to 0 instead of surfacing as the negative "+
+			"count that finalCount alone can no longer catch once clamping is in place; "+
+			"this is exactly the production incident this test guards against")
+}
+
+// BenchmarkAddDoneRequestCountWithPodFlap is the same shape as
+// TestConcurrentRequestsAndPodFlapDoNotDriftRunningRequests -- concurrent
+// AddRequestCount/DoneRequestCount pairs racing a continuous pod delete/re-add
+// flap -- but driven by the standard go test -bench harness instead of a fixed
+// iteration count, so it can be run at whatever load -benchtime/-cpu ask for
+// to hunt for the race under more (or less) contention than a fixed-size test
+// loop provides.
+//
+// It doubles as a correctness check, not just a timing measurement: ns/op
+// here is secondary (the flap goroutine competes for CPU with the timed loop,
+// so throughput numbers are noisy) and the real signal is whether the
+// benchmark fails at all. After all b.N pairs finish, it asserts the
+// running-request count has settled back to exactly zero and that
+// decrementClamped never had to floor a stray decrement -- see
+// TestConcurrentRequestsAndPodFlapDoNotDriftRunningRequests's doc comment for
+// why both checks are needed (the clamp added by this fix would otherwise
+// mask a regression that reintroduces an extra decrement behind a
+// business-logic-level 0 that looks identical to a correctly balanced run).
+//
+// Run with -race to check the locking itself introduces no data race, and
+// scale -benchtime / -cpu to vary how much pressure the flap puts on the
+// counter:
+//
+//	go test ./pkg/cache/ -run '^$' -bench BenchmarkAddDoneRequestCountWithPodFlap -benchtime=200000x -race
+func BenchmarkAddDoneRequestCountWithPodFlap(b *testing.B) {
+	const (
+		modelName = "test-model"
+		namespace = "default"
+		podName   = "pod-0"
+		podIP     = "10.0.0.1"
+	)
+
+	cache := NewForTest()
+	pod := requestTrackerTestPod(podName, namespace, modelName, podIP)
+	cache.addPod(pod)
+
+	clampedBefore := atomic.LoadInt64(&clampedRunningRequestDecrements)
+
+	stopFlapping := make(chan struct{})
+	var flapWG sync.WaitGroup
+	flapWG.Add(1)
+	go func() {
+		defer flapWG.Done()
+		for {
+			select {
+			case <-stopFlapping:
+				return
+			default:
+				cache.deletePod(requestTrackerTestPod(podName, namespace, modelName, podIP))
+				cache.addPod(requestTrackerTestPod(podName, namespace, modelName, podIP))
+			}
+		}
+	}()
+
+	var counter int64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			id := atomic.AddInt64(&counter, 1)
+			requestID := fmt.Sprintf("bench-req-%d", id)
+			routingCtx := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+			routingCtx.SetTargetPod(pod)
+			traceTerm := cache.AddRequestCount(routingCtx, requestID, modelName)
+			cache.DoneRequestCount(routingCtx, requestID, modelName, traceTerm)
+		}
+	})
+	b.StopTimer()
+
+	close(stopFlapping)
+	flapWG.Wait()
+
+	// Whatever object (live pod, or a snapshot pending re-add) currently
+	// represents the pod key holds the ground truth.
+	key := namespace + "/" + podName
+	var finalCount int32
+	if metaPod, ok := cache.metaPods.Load(key); ok {
+		finalCount = atomic.LoadInt32(&metaPod.runningRequests)
+	} else if snap, ok := cache.recentlyDeletedPods.Load(key); ok {
+		finalCount = atomic.LoadInt32(&snap.runningRequests)
+	} else {
+		b.Fatal("pod key missing from both metaPods and recentlyDeletedPods after the flap loop stopped")
+	}
+
+	if finalCount != 0 {
+		b.Fatalf("running-request count drifted to %d after %d paired Add/Done calls under concurrent "+
+			"pod flapping (want 0) -- a completion's decrement was lost or misdirected by a race against "+
+			"the concurrent delete/re-add cycle", finalCount, b.N)
+	}
+
+	if clampedAfter := atomic.LoadInt64(&clampedRunningRequestDecrements); clampedAfter != clampedBefore {
+		b.Fatalf("decrementClamped floored %d stray decrement(s) during the benchmark -- an extra "+
+			"decrement occurred and was silently clamped to 0 instead of surfacing as a negative count",
+			clampedAfter-clampedBefore)
+	}
+}
+
+// TestRetriedRequestReusingIDDoesNotLeakPodStats covers a retried request that
+// reuses the original requestID while the first attempt is still in flight
+// (e.g. the client retries after its own timeout, or the upstream engine
+// rejects the retry as "already running"). Before podStatsAttemptKey, the
+// second addPodStats call would silently overwrite the first attempt's
+// c.podStats entry, permanently leaking its pod-stats increment once the
+// first attempt eventually completed and found nothing to clean up.
+func TestRetriedRequestReusingIDDoesNotLeakPodStats(t *testing.T) {
+	const (
+		modelName = "test-model"
+		namespace = "default"
+		requestID = "request-retried-same-id"
+	)
+
+	cache := NewForTest()
+	podA := requestTrackerTestPod("decode-a", namespace, modelName, "10.0.0.1")
+	podB := requestTrackerTestPod("decode-b", namespace, modelName, "10.0.0.2")
+	cache.addPod(podA)
+	cache.addPod(podB)
+	metaPodA, ok := cache.metaPods.Load(namespace + "/decode-a")
+	assert.True(t, ok)
+	metaPodB, ok := cache.metaPods.Load(namespace + "/decode-b")
+	assert.True(t, ok)
+
+	// Attempt A routes to podA.
+	ctxA := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+	ctxA.SetTargetPod(podA)
+	traceTermA := cache.AddRequestCount(ctxA, requestID, modelName)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&metaPodA.runningRequests))
+
+	// Attempt B is a retry reusing the same requestID, routed to podB while A
+	// is still in flight.
+	ctxB := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+	ctxB.SetTargetPod(podB)
+	traceTermB := cache.AddRequestCount(ctxB, requestID, modelName)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&metaPodB.runningRequests))
+	// Two attempt keys plus the nil-ctx alias held by A (LoadOrStore first-wins).
+	assert.Equal(t, 3, cache.podStats.Len(), "both attempts should have their own tracked entry")
+
+	// B finishes first (out of order) -- must decrement podB, not podA.
+	cache.DoneRequestTrace(ctxB, requestID, modelName, 10, 20, traceTermB)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&metaPodB.runningRequests))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&metaPodA.runningRequests), "A's entry must survive B's cleanup")
+	assert.Equal(t, 2, cache.podStats.Len())
+
+	// A finishes -- must still find and decrement its own entry, not leak it.
+	cache.DoneRequestTrace(ctxA, requestID, modelName, 10, 20, traceTermA)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&metaPodA.runningRequests))
+	assert.Equal(t, 0, cache.podStats.Len())
+}
+
+// TestAddRequestCountDuringDeleteAddGapIncrementsPendingSnapshot is the
+// counterpart of TestDoneRequestCountDuringDeleteAddGapDecrementsPendingSnapshot:
+// a request that *starts* inside the delete/re-add window must increment the
+// pending snapshot (and store podStats) instead of returning as "can't find
+// routing pod". Otherwise the request is invisible to least-request scoring
+// for its whole lifetime, and the matching Done is a no-op.
+func TestAddRequestCountDuringDeleteAddGapIncrementsPendingSnapshot(t *testing.T) {
+	const (
+		modelName   = "test-model"
+		namespace   = "default"
+		podName     = "decode-0"
+		requestID   = "request-add-during-gap"
+		podIP       = "10.0.0.1"
+		pendingLoad = 0.25
+	)
+
+	cache := NewForTest()
+	cache.pendingLoadProvider = gapTestLoadProvider{load: pendingLoad}
+
+	oldPod := requestTrackerTestPod(podName, namespace, modelName, podIP)
+	cache.addPod(oldPod)
+	key := namespace + "/" + podName
+
+	cache.deletePod(oldPod)
+	_, ok := cache.metaPods.Load(key)
+	assert.False(t, ok, "pod should be absent from the cache mid-gap")
+
+	routingCtx := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+	routingCtx.SetTargetPod(oldPod)
+	traceTerm := cache.AddRequestCount(routingCtx, requestID, modelName)
+
+	snap, ok := cache.recentlyDeletedPods.Load(key)
+	assert.True(t, ok)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&snap.runningRequests),
+		"a request that starts mid-gap should increment the pending snapshot in place")
+	assert.Equal(t, pendingLoad, snap.pendingLoadUtilization.Load(),
+		"a request that starts mid-gap should apply pending-load to the snapshot")
+
+	cache.addPod(requestTrackerTestPod(podName, namespace, modelName, podIP))
+	newMetaPod, ok := cache.metaPods.Load(key)
+	assert.True(t, ok)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&newMetaPod.runningRequests),
+		"re-add should resume the mid-gap increment instead of dropping the request")
+	assert.Equal(t, pendingLoad, newMetaPod.pendingLoadUtilization.Load(),
+		"re-add should resume the mid-gap pending-load")
+
+	cache.DoneRequestCount(routingCtx, requestID, modelName, traceTerm)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&newMetaPod.runningRequests))
+	assert.Equal(t, 0.0, newMetaPod.pendingLoadUtilization.Load())
+	assert.Equal(t, 0, cache.podStats.Len())
+}
+
+// TestDoneRequestCountAfterGracePeriodExpiryDoesNotDecrementNewGeneration
+// extends TestAddPodAfterDeleteGracePeriodExpiryDoesNotPreserveRunningRequests:
+// after the grace period a same-IP re-add is a new statsGeneration, so a
+// stale Done of a pre-delete request must not decrement the new object --
+// including when the new generation already has its own in-flight requests.
+func TestDoneRequestCountAfterGracePeriodExpiryDoesNotDecrementNewGeneration(t *testing.T) {
+	const (
+		modelName = "test-model"
+		namespace = "default"
+		podName   = "decode-0"
+		podIP     = "10.0.0.1"
+	)
+
+	cache := NewForTest()
+	pod := requestTrackerTestPod(podName, namespace, modelName, podIP)
+	cache.addPod(pod)
+	key := namespace + "/" + podName
+	oldMetaPod, ok := cache.metaPods.Load(key)
+	assert.True(t, ok)
+
+	oldCtx := types.NewRoutingContext(context.Background(), "least-request", modelName, "", "request-before-expiry", "")
+	oldCtx.SetTargetPod(pod)
+	oldTerm := cache.AddRequestCount(oldCtx, "request-before-expiry", modelName)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&oldMetaPod.runningRequests))
+
+	cache.deletePod(pod)
+	snap, ok := cache.recentlyDeletedPods.Load(key)
+	assert.True(t, ok)
+	snap.deletedAt = snap.deletedAt.Add(-recentlyDeletedPodGracePeriod)
+	cache.recentlyDeletedPods.Store(key, snap)
+
+	cache.addPod(requestTrackerTestPod(podName, namespace, modelName, podIP))
+	newMetaPod, ok := cache.metaPods.Load(key)
+	assert.True(t, ok)
+	assert.NotSame(t, oldMetaPod, newMetaPod)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&newMetaPod.runningRequests))
+	assert.NotEqual(t, oldMetaPod.statsGeneration, newMetaPod.statsGeneration)
+
+	newCtx := types.NewRoutingContext(context.Background(), "least-request", modelName, "", "request-after-expiry", "")
+	newCtx.SetTargetPod(requestTrackerTestPod(podName, namespace, modelName, podIP))
+	newTerm := cache.AddRequestCount(newCtx, "request-after-expiry", modelName)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&newMetaPod.runningRequests))
+
+	clampedBefore := atomic.LoadInt64(&clampedRunningRequestDecrements)
+	cache.DoneRequestCount(oldCtx, "request-before-expiry", modelName, oldTerm)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&newMetaPod.runningRequests),
+		"a stale completion after grace expiry must not decrement the new generation")
+	assert.Equal(t, clampedBefore, atomic.LoadInt64(&clampedRunningRequestDecrements),
+		"the stale completion must land on the orphaned object, not clamp the new generation")
+
+	cache.DoneRequestCount(newCtx, "request-after-expiry", modelName, newTerm)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&newMetaPod.runningRequests))
+}
+
+// TestConcurrentDoneOfRetriedRequestDoesNotLeakPodStats covers the race
+// TestRetriedRequestReusingIDDoesNotLeakPodStats cannot: both attempts of a
+// reused requestID completing at the same time. The old LoadAndDelete +
+// put-back of the shared requestID key could drop the original's record in
+// that hole and leak its increment.
+func TestConcurrentDoneOfRetriedRequestDoesNotLeakPodStats(t *testing.T) {
+	const (
+		modelName = "test-model"
+		namespace = "default"
+		iters     = 500
+	)
+
+	cache := NewForTest()
+	podA := requestTrackerTestPod("decode-a", namespace, modelName, "10.0.0.1")
+	podB := requestTrackerTestPod("decode-b", namespace, modelName, "10.0.0.2")
+	cache.addPod(podA)
+	cache.addPod(podB)
+	metaPodA, ok := cache.metaPods.Load(namespace + "/decode-a")
+	assert.True(t, ok)
+	metaPodB, ok := cache.metaPods.Load(namespace + "/decode-b")
+	assert.True(t, ok)
+
+	clampedBefore := atomic.LoadInt64(&clampedRunningRequestDecrements)
+
+	for i := 0; i < iters; i++ {
+		requestID := fmt.Sprintf("request-retried-concurrent-%d", i)
+		ctxA := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+		ctxA.SetTargetPod(podA)
+		ctxB := types.NewRoutingContext(context.Background(), "least-request", modelName, "", requestID, "")
+		ctxB.SetTargetPod(podB)
+		termA := cache.AddRequestCount(ctxA, requestID, modelName)
+		termB := cache.AddRequestCount(ctxB, requestID, modelName)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func(ctx *types.RoutingContext, requestID string, term int64) {
+			defer wg.Done()
+			cache.DoneRequestCount(ctx, requestID, modelName, term)
+		}(ctxA, requestID, termA)
+		go func(ctx *types.RoutingContext, requestID string, term int64) {
+			defer wg.Done()
+			cache.DoneRequestCount(ctx, requestID, modelName, term)
+		}(ctxB, requestID, termB)
+		wg.Wait()
+	}
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&metaPodA.runningRequests),
+		"every attempt on podA must have been decremented")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&metaPodB.runningRequests),
+		"every attempt on podB must have been decremented")
+	assert.Equal(t, 0, cache.podStats.Len())
+	assert.Equal(t, clampedBefore, atomic.LoadInt64(&clampedRunningRequestDecrements),
+		"no extra decrement should have been clamped away")
 }

--- a/pkg/cache/cache_trace.go
+++ b/pkg/cache/cache_trace.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -32,16 +33,196 @@ import (
 const (
 	expireWriteRequestTraceIntervalInMins = 10
 	traceLogInterval                      = 1 * time.Second
+
+	// podStatsLockStripes sizes Store.podStatsMu -- see podStatsLockFor.
+	podStatsLockStripes = 256
 )
+
+// podStatsLockFor returns the stripe lock guarding podKey's running-request counter
+// (and its deletedPodSnapshot equivalent) against concurrent mutation. addPodStats and
+// donePodStats hold it while resolving which *Pod object (or deletedPodSnapshot)
+// currently represents podKey and mutating its counter; deletePodLocked and
+// addPodLocked (informers.go) hold it around the delete/re-add snapshot handoff for
+// the same key. Without a shared lock, those two sides can interleave: a completing
+// request can resolve "the live pod is object O1" and then, after a concurrent
+// delete+re-add swaps in O2, apply its decrement to the now-orphaned O1 -- silently
+// losing it (or, symmetrically, applying it to the wrong generation and undercounting
+// O2). A fixed-size stripe (indexed by a hash of podKey) is used instead of a lock per
+// key so the lock set doesn't grow unbounded as distinct pod keys accumulate over the
+// process lifetime; the tradeoff is harmless false-sharing between unrelated pod keys
+// that happen to hash to the same stripe.
+func (c *Store) podStatsLockFor(podKey string) *sync.Mutex {
+	return &c.podStatsMu[fnv32a(podKey)%podStatsLockStripes]
+}
+
+// fnv32a is a small, non-allocating FNV-1a string hash used only to pick a lock
+// stripe in podStatsLockFor -- not for anything requiring collision resistance.
+func fnv32a(s string) uint32 {
+	const offset32 = 2166136261
+	const prime32 = 16777619
+	h := uint32(offset32)
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= prime32
+	}
+	return h
+}
+
+// clampedRunningRequestDecrements counts how many times decrementClamped actually hit
+// its floor -- i.e. an attempted decrement past zero. This is test/observability-only:
+// production code never reads it. It exists because the clamp itself makes the
+// counter's own value an unreliable signal in a test: an extra decrement that gets
+// floored to 0 is indistinguishable from a counter that correctly settled at 0, so
+// asserting "the counter is 0" cannot catch the failure mode the clamp guards
+// against. Tests should instead snapshot this before/after a concurrent run and
+// assert the delta is 0.
+var clampedRunningRequestDecrements int64
+
+// decrementClamped atomically decrements *counter by 1, clamping at 0, and returns the
+// value after the decrement. A defense-in-depth floor: even if some other bug ever
+// slips an extra decrement past podStatsLockFor's mutual exclusion, a real running-
+// request count should never be reported as negative. When the floor actually fires
+// (the counter was already <= 0), a warning is logged with podName/requestID so the
+// extra decrement is visible rather than silent.
+//
+// This is a genuine lock-free floor, not merely a floor under the caller's lock: the
+// old <= 0 case never blindly Stores 0 (observing 0 and unconditionally writing 0 back
+// could stomp a concurrent AddInt32(+1) landing in between the two), it either does
+// nothing (old == 0: already at the floor) or CASes up from a negative old value,
+// which -- like the normal decrement path -- only succeeds if the value hasn't changed
+// since the Load, so a concurrent increment always wins the race rather than being
+// silently overwritten.
+func decrementClamped(counter *int32, podName, requestID string) int32 {
+	for {
+		old := atomic.LoadInt32(counter)
+		if old <= 0 {
+			if old < 0 && !atomic.CompareAndSwapInt32(counter, old, 0) {
+				continue
+			}
+			atomic.AddInt64(&clampedRunningRequestDecrements, 1)
+			klog.Warningf("running-request count would go negative, clamped to 0, pod: %s, requestID: %s, observed: %d",
+				podName, requestID, old)
+			return 0
+		}
+		if atomic.CompareAndSwapInt32(counter, old, old-1) {
+			return old - 1
+		}
+	}
+}
+
+// sameStatsGeneration reports whether two cache-pod generations are the same
+// live identity. 0 is never issued (see nextStatsGeneration) and means
+// uninitialized, so it must not match.
+func sameStatsGeneration(a, b int64) bool {
+	return a != 0 && a == b
+}
+
+// resolvePodOrSnapshotLocked resolves whichever object -- a live *Pod (returned as
+// pod, with snap nil), or a pending deletedPodSnapshot (returned as snap, with pod
+// nil) -- currently represents podKey, given staleMetaPod: a possibly-outdated *Pod
+// reference captured before this lock was (re-)acquired (e.g. before a slow call like
+// pendingLoadProvider.GetConsumption ran unlocked, or before donePodStats re-resolves
+// the object addPodStats originally saw).
+//
+// If podKey currently maps to a *different*, live object with the same
+// statsGeneration, that live object is returned -- the common case: the pod flapped
+// via a delete/re-add cycle (deletePodLocked/addPodLocked in informers.go, which hold
+// the same podStatsLockFor(podKey) lock) and addPodLocked resumed this generation
+// onto a new *Pod. Matching on generation (not IP) is required so a same-IP re-add
+// after recentlyDeletedPodGracePeriod -- which deliberately starts a new generation
+// at zero -- cannot inherit stale Add/Done from the previous one.
+// If generations don't match, or podKey is absent with no matching snapshot either,
+// pod is staleMetaPod itself: the pod was genuinely recreated, or the grace period
+// expired, and stale bookkeeping must not bleed into that new backend's fresh
+// counters. Applying a decrement/delta to that returned stale object is a
+// deliberate, harmless no-op: it's orphaned (unreachable via metaPods), so nothing
+// else ever reads it again.
+//
+// Caller must hold podStatsLockFor(podKey).
+func (c *Store) resolvePodOrSnapshotLocked(podKey string, staleMetaPod *Pod) (pod *Pod, snap *deletedPodSnapshot) {
+	if current, ok := c.metaPods.Load(podKey); ok {
+		if current != staleMetaPod && sameStatsGeneration(current.statsGeneration, staleMetaPod.statsGeneration) {
+			return current, nil
+		}
+		return staleMetaPod, nil
+	}
+	if s, ok := c.recentlyDeletedPods.Load(podKey); ok && sameStatsGeneration(s.statsGeneration, staleMetaPod.statsGeneration) {
+		return nil, s
+	}
+	return staleMetaPod, nil
+}
 
 type podStatsRecord struct {
 	pod         *Pod
 	port        int
 	pendingLoad float64
+	// ctx is this attempt's owner. Used to delete the attempt-scoped primary
+	// key from a nil-ctx donePodStats (which only has the requestID alias).
+	// nil is a valid value and never matches a real ctx.
+	ctx *types.RoutingContext
+	// consumed is CAS'd from 0 to 1 when the record is taken for decrement,
+	// so a concurrent ctx-Done and nil-ctx Done of the same attempt cannot
+	// both apply the increment.
+	consumed int32
 }
 
+func (r *podStatsRecord) take() bool {
+	return atomic.CompareAndSwapInt32(&r.consumed, 0, 1)
+}
+
+// podStatsKey is a nil-ctx alias keyed by (modelName, requestID) alone. The
+// primary record lives at podStatsAttemptKey; this alias lets DoneRequestCount
+// with ctx=nil still find one in-flight attempt for the requestID (the first
+// one that stored). LoadOrStore so a retry cannot clobber the original.
 func podStatsKey(modelName, requestID string) string {
 	return modelName + "\x00" + requestID
+}
+
+// podStatsAttemptKey identifies one specific in-flight routing attempt via its
+// RoutingContext's pointer identity, which is stable for exactly that attempt's
+// lifetime (one RoutingContext per Process() call, returned to the pool only
+// after donePodStats has run for it -- see the ordering in Process()'s
+// deferred cleanup). This is the primary podStats map key whenever ctx != nil.
+func podStatsAttemptKey(ctx *types.RoutingContext, modelName, requestID string) string {
+	return fmt.Sprintf("%s\x00%s\x00%p", modelName, requestID, ctx)
+}
+
+// storePodStats writes the attempt-scoped primary key and, if vacant, the
+// requestID alias used by nil-ctx donePodStats. Both keys point at the same
+// record so CompareAndDelete can drop the alias without stealing another
+// attempt.
+func (c *Store) storePodStats(ctx *types.RoutingContext, modelName, requestID string, podStats *podStatsRecord) {
+	if ctx != nil {
+		c.podStats.Store(podStatsAttemptKey(ctx, modelName, requestID), podStats)
+	}
+	c.podStats.LoadOrStore(podStatsKey(modelName, requestID), podStats)
+}
+
+// takePodStats removes this attempt's podStats record. ctx != nil deletes the
+// attempt key first (no put-back of someone else's entry). ctx == nil deletes
+// the requestID alias and the attempt key of whichever record it held. take()
+// ensures only one of a concurrent ctx-Done and nil-ctx Done actually
+// decrements.
+func (c *Store) takePodStats(ctx *types.RoutingContext, modelName, requestID string) (*podStatsRecord, bool) {
+	var (
+		podStats *podStatsRecord
+		ok       bool
+	)
+	if ctx != nil {
+		podStats, ok = c.podStats.LoadAndDelete(podStatsAttemptKey(ctx, modelName, requestID))
+		if ok {
+			c.podStats.CompareAndDelete(podStatsKey(modelName, requestID), podStats)
+		}
+	} else {
+		podStats, ok = c.podStats.LoadAndDelete(podStatsKey(modelName, requestID))
+		if ok && podStats.ctx != nil {
+			c.podStats.CompareAndDelete(podStatsAttemptKey(podStats.ctx, modelName, requestID), podStats)
+		}
+	}
+	if !ok || !podStats.take() {
+		return nil, false
+	}
+	return podStats, true
 }
 
 func (c *Store) getRequestTrace(modelName string) *RequestTrace {
@@ -61,40 +242,87 @@ func (c *Store) addPodStats(ctx *types.RoutingContext, requestID string, modelNa
 	}
 	pod := ctx.TargetPod()
 	port := ctx.TargetPort()
+	podKey := utils.GeneratePodKey(pod.Namespace, pod.Name)
 
-	metaPod, ok := c.metaPods.Load(utils.GeneratePodKey(pod.Namespace, pod.Name))
+	// See podStatsLockFor: held across resolving metaPod and mutating its running-
+	// request counter so this can't interleave with a concurrent delete/re-add of the
+	// same pod key.
+	mu := c.podStatsLockFor(podKey)
+	mu.Lock()
+	metaPod, ok := c.metaPods.Load(podKey)
+	var snap *deletedPodSnapshot
 	if !ok {
-		klog.Warningf("can't find routing pod: %s, requestID: %s", pod.Name, requestID)
-		return
+		// Symmetric with donePodStats: a request can start inside the
+		// delete/re-add window (updatePod releases the stripe lock between
+		// deletePodLocked and addPodLocked). Increment the matching-IP
+		// snapshot in place so the eventual resume includes this request
+		// rather than dropping it for its whole lifetime.
+		if pod.Status.PodIP != "" {
+			if s, loaded := c.recentlyDeletedPods.Load(podKey); loaded && s.podIP == pod.Status.PodIP && s.pod != nil {
+				snap = s
+				metaPod = s.pod
+				ok = true
+			}
+		}
+		if !ok {
+			mu.Unlock()
+			klog.Warningf("can't find routing pod: %s, requestID: %s", pod.Name, requestID)
+			return
+		}
 	}
-	podStats := &podStatsRecord{pod: metaPod, port: port}
+	podStats := &podStatsRecord{pod: metaPod, port: port, ctx: ctx}
 
 	// Update running requests
-	requests := atomic.AddInt32(&metaPod.runningRequests, 1)
-	metricName := metrics.RealtimeNumRequestsRunning
-	if port > 0 {
-		metricName = metricName + "/" + strconv.Itoa(port)
+	var requests int32
+	if snap != nil {
+		requests = atomic.AddInt32(&snap.runningRequests, 1)
+	} else {
+		requests = atomic.AddInt32(&metaPod.runningRequests, 1)
+		metricName := metrics.RealtimeNumRequestsRunning
+		if port > 0 {
+			metricName = metricName + "/" + strconv.Itoa(port)
+		}
+		if err := c.updatePodRecord(metaPod, "", metricName, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: float64(requests)}); err != nil {
+			klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s, err: %v", metrics.RealtimeNumRequestsRunning, metaPod.Name, requestID, err)
+		}
 	}
-	if err := c.updatePodRecord(metaPod, "", metricName, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: float64(requests)}); err != nil {
-		klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s, err: %v", metrics.RealtimeNumRequestsRunning, metaPod.Name, requestID, err)
-	}
+	mu.Unlock()
 
-	// Update pending load
+	// Update pending load. GetConsumption runs unlocked -- it can be slow (e.g. a GPU
+	// profile lookup) or take other locks, and stripe locks should stay short -- so
+	// only the resulting delta is computed here. The lock is then re-acquired and
+	// resolvePodOrSnapshotLocked re-resolves the current target from scratch rather
+	// than trusting metaPod, which may have gone stale (a delete/re-add, or even a
+	// genuine recreation, could have landed while GetConsumption was running): see
+	// resolvePodOrSnapshotLocked's doc comment for why applying to a captured-before-
+	// unlock pointer would risk landing on an orphaned object.
 	var utilization float64
 	if c.pendingLoadProvider != nil {
 		var err error
 		ctx.PendingLoad, err = c.pendingLoadProvider.GetConsumption(ctx, pod)
 		if err == nil {
 			podStats.pendingLoad = ctx.PendingLoad
-			utilization = metaPod.pendingLoadUtilization.Add(ctx.PendingLoad)
-			if c.updatePodRecord(metaPod, "", metrics.RealtimeNormalizedPendings, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: utilization}) != nil {
-				klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s, err: %v", metrics.RealtimeNormalizedPendings, metaPod.Name, requestID, err)
+			mu.Lock()
+			target, snap := c.resolvePodOrSnapshotLocked(podKey, metaPod)
+			if snap != nil {
+				snap.pendingLoadUtilization.Add(ctx.PendingLoad)
+				mu.Unlock()
+			} else {
+				utilization = target.pendingLoadUtilization.Add(ctx.PendingLoad)
+				mu.Unlock()
+				if c.updatePodRecord(target, "", metrics.RealtimeNormalizedPendings, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: utilization}) != nil {
+					klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s, err: %v", metrics.RealtimeNormalizedPendings, metaPod.Name, requestID, err)
+				}
 			}
 		} else if !IsError(err, ErrorMissingProfile) { // ErrorMissingProfile is not considered as an error here and should be reported where the profile is essential.
-			klog.Errorf("error on track request load consumption: %v", err)
+			klog.V(4).Infof("error on track request load consumption: %v", err)
 		}
 	}
-	c.podStats.Store(podStatsKey(modelName, requestID), podStats)
+	// Always store under the attempt key so two in-flight attempts that share
+	// a requestID cannot clobber each other, and so donePodStats never has to
+	// LoadAndDelete someone else's entry and put it back (a race that leaks
+	// the original increment). The requestID key is only a nil-ctx alias.
+	c.storePodStats(ctx, modelName, requestID, podStats)
 
 	if metaPod.CanLogPodTrace(5) {
 		klog.V(4).InfoS("pod stats updated (addPodStats).", "pod", metaPod.Name, "requestID", ctx.RequestID, "running_requests", requests, "pending_util", utilization, "pending_load", ctx.PendingLoad)
@@ -102,7 +330,7 @@ func (c *Store) addPodStats(ctx *types.RoutingContext, requestID string, modelNa
 }
 
 func (c *Store) donePodStats(ctx *types.RoutingContext, requestID string, modelName string) {
-	podStats, ok := c.podStats.LoadAndDelete(podStatsKey(modelName, requestID))
+	podStats, ok := c.takePodStats(ctx, modelName, requestID)
 	if !ok {
 		if ctx != nil {
 			pod := ctx.TargetPod()
@@ -115,8 +343,58 @@ func (c *Store) donePodStats(ctx *types.RoutingContext, requestID string, modelN
 	metaPod := podStats.pod
 	port := podStats.port
 
-	// Update running requests
-	requests := atomic.AddInt32(&metaPod.runningRequests, -1)
+	// A pod key that was deleted and quickly re-added (a transient health-check
+	// flap -- see deletedPodSnapshot/addPodLocked in informers.go) gets a
+	// brand-new *Pod object with counters seeded from the old one's snapshot.
+	// addPodStats above captured the OLD object's pointer for this request
+	// before that flap happened, so without a redirect, this decrement would
+	// land on the now-orphaned old object and silently vanish -- permanently
+	// inflating the new object's count by one for every request that was in
+	// flight at flap time.
+	//
+	// Two cases, both gated on matching statsGeneration (a same-named pod
+	// genuinely recreated, or re-added after recentlyDeletedPodGracePeriod,
+	// starts a new generation and must not have this stale completion bleed
+	// into it):
+	//
+	//   - The pod key is live again: redirect straight to the current entry.
+	//   - The pod key is still absent (this request is completing *inside*
+	//     the delete/re-add gap itself, before any re-add has happened):
+	//     decrement the pending deletedPodSnapshot in place instead, so the
+	//     eventual re-add resumes from a count that already reflects this
+	//     completion rather than one that still includes it.
+	//
+	// podStatsLockFor(podKey) is held across resolving which object/snapshot is
+	// current AND mutating BOTH its running-request counter and its pending-load
+	// utilization, so a concurrent delete/re-add (deletePodLocked/addPodLocked,
+	// which take the same lock) can't land mid-resolve and misdirect or lose either
+	// -- see podStatsLockFor's and resolvePodOrSnapshotLocked's doc comments.
+	// Nothing in this critical section is slow or reentrant (podStats.pendingLoad
+	// was already computed back in addPodStats; only QueueRouter.Route below might
+	// be either, so that alone stays outside).
+	podKey := utils.GeneratePodKey(metaPod.Namespace, metaPod.Name)
+	mu := c.podStatsLockFor(podKey)
+	mu.Lock()
+	target, snap := c.resolvePodOrSnapshotLocked(podKey, metaPod)
+	if snap != nil {
+		decrementClamped(&snap.runningRequests, metaPod.Name, requestID)
+		atomic.AddInt64(&snap.completedRequests, 1)
+		if podStats.pendingLoad != 0.0 && c.pendingLoadProvider != nil {
+			snap.pendingLoadUtilization.Add(-podStats.pendingLoad)
+		}
+		mu.Unlock()
+		if metaPod.CanLogPodTrace(5) {
+			klog.V(4).InfoS("pod stats updated on a snapshot pending re-add (donePodStats).",
+				"pod", metaPod.Name, "requestID", requestID, "pending_load", podStats.pendingLoad)
+		}
+		return
+	}
+	metaPod = target
+
+	// Update running requests. Clamped at 0 (see decrementClamped) as a
+	// defense-in-depth floor so a real count is never reported negative even if
+	// some other bug slips an extra decrement past the lock above.
+	requests := decrementClamped(&metaPod.runningRequests, metaPod.Name, requestID)
 	atomic.AddInt64(&metaPod.completedRequests, 1)
 	metricName := metrics.RealtimeNumRequestsRunning
 	if port > 0 {
@@ -126,19 +404,26 @@ func (c *Store) donePodStats(ctx *types.RoutingContext, requestID string, modelN
 		klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s", metrics.RealtimeNumRequestsRunning, metaPod.Name, requestID)
 	}
 
-	// Update pending load
+	// Update pending load, still under the same lock as the resolve above (this is
+	// just a cheap atomic float add, unlike GetConsumption in addPodStats, so there's
+	// no cost to keeping it in the critical section).
 	var utilization float64
+	var notifyQueueRouter bool
 	if podStats.pendingLoad != 0.0 && c.pendingLoadProvider != nil {
 		utilization = metaPod.pendingLoadUtilization.Add(-podStats.pendingLoad)
-		if c.updatePodRecord(metaPod, modelName, metrics.RealtimeNormalizedPendings, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: utilization}) != nil {
+		if err := c.updatePodRecord(metaPod, modelName, metrics.RealtimeNormalizedPendings, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: utilization}); err != nil {
 			klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s", metrics.RealtimeNormalizedPendings, metaPod.Name, requestID)
 		}
-		if utilization < c.pendingLoadProvider.Cap() {
-			// Notify queue router to try route with pending requests.
-			if metaModel, ok := c.metaModels.Load(modelName); ok && metaModel.QueueRouter != nil {
-				// nolint: errcheck
-				metaModel.QueueRouter.Route(nil, metaModel.Pods.Array())
-			}
+		notifyQueueRouter = utilization < c.pendingLoadProvider.Cap()
+	}
+	mu.Unlock()
+
+	if notifyQueueRouter {
+		// Notify queue router to try route with pending requests. Kept outside the
+		// lock: Route may be slow or (via the router's own logic) reentrant.
+		if metaModel, ok := c.metaModels.Load(modelName); ok && metaModel.QueueRouter != nil {
+			// nolint: errcheck
+			metaModel.QueueRouter.Route(nil, metaModel.Pods.Array())
 		}
 	}
 

--- a/pkg/cache/cache_trace.go
+++ b/pkg/cache/cache_trace.go
@@ -310,7 +310,7 @@ func (c *Store) addPodStats(ctx *types.RoutingContext, requestID string, modelNa
 			} else {
 				utilization = target.pendingLoadUtilization.Add(ctx.PendingLoad)
 				mu.Unlock()
-				if c.updatePodRecord(target, "", metrics.RealtimeNormalizedPendings, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: utilization}) != nil {
+				if err := c.updatePodRecord(target, "", metrics.RealtimeNormalizedPendings, metrics.PodMetricScope, &metrics.SimpleMetricValue{Value: utilization}); err != nil {
 					klog.Warningf("can't update realtime metric: %s, pod: %s, requestID: %s, err: %v", metrics.RealtimeNormalizedPendings, metaPod.Name, requestID, err)
 				}
 			}

--- a/pkg/cache/informers.go
+++ b/pkg/cache/informers.go
@@ -19,11 +19,13 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	crdinformers "github.com/vllm-project/aibrix/pkg/client/informers/externalversions"
 	"github.com/vllm-project/aibrix/pkg/constants"
 	"github.com/vllm-project/aibrix/pkg/utils"
+	atomic_ext "go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -375,9 +377,57 @@ func (c *Store) addPodLocked(pod *v1.Pod) *Pod {
 	} else {
 		c.bufferPod.Pod = pod
 	}
-	metaPod, loaded := c.metaPods.LoadOrStore(utils.GeneratePodKey(pod.Namespace, pod.Name), c.bufferPod)
+
+	key := utils.GeneratePodKey(pod.Namespace, pod.Name)
+
+	// A pod key that was deleted moments ago (a transient health-check flap on a
+	// busy pod, or the delete+re-add updatePod does for every in-place K8s pod
+	// update -- see deletePodLocked) gets its realtime counters resumed here
+	// instead of restarting at zero. Without this, a pod that never actually
+	// stopped serving would briefly look empty to least-request/load-balance
+	// scoring right as it reappears, and get piled on with new requests on top
+	// of whatever it was already running.
+	//
+	// Gated on the reappearing pod's IP matching the deleted one's: the same
+	// name can legitimately be recreated as a genuinely different backend (e.g.
+	// a StatefulSet pod restarted with a fresh process on a new IP), which must
+	// start at zero rather than inherit a stale, unrelated count -- see
+	// TestDoneRequestCountAfterSameNamePodRecreationDoesNotDecrementNewPod.
+	//
+	// podStatsLockFor(key) is held across the snapshot-resume-and-publish sequence
+	// below so it can't interleave with a concurrent addPodStats/donePodStats for the
+	// same key (which take the same lock around resolving and mutating the counters
+	// this resumes) -- see podStatsLockFor's doc comment in cache_trace.go.
+	mu := c.podStatsLockFor(key)
+	mu.Lock()
+	defer mu.Unlock()
+
+	resumed := false
+	if snap, ok := c.recentlyDeletedPods.LoadAndDelete(key); ok {
+		if time.Since(snap.deletedAt) < recentlyDeletedPodGracePeriod &&
+			snap.podIP != "" && snap.podIP == pod.Status.PodIP {
+			c.bufferPod.runningRequests = atomic.LoadInt32(&snap.runningRequests)
+			c.bufferPod.completedRequests = atomic.LoadInt64(&snap.completedRequests)
+			c.bufferPod.pendingLoadUtilization.Store(snap.pendingLoadUtilization.Load())
+			c.bufferPod.statsGeneration = snap.statsGeneration
+			resumed = true
+		}
+	}
+	if !resumed {
+		c.bufferPod.statsGeneration = c.nextStatsGeneration.Add(1)
+	}
+
+	metaPod, loaded := c.metaPods.LoadOrStore(key, c.bufferPod)
 	if !loaded {
 		c.bufferPod = nil
+	} else {
+		// An entry already existed, so this buffer wasn't consumed and will
+		// be reused for an unrelated pod on some future call -- clear any
+		// counters just seeded onto it so they don't leak into that pod.
+		c.bufferPod.runningRequests = 0
+		c.bufferPod.completedRequests = 0
+		c.bufferPod.pendingLoadUtilization.Store(0)
+		c.bufferPod.statsGeneration = 0
 	}
 	return metaPod
 }
@@ -419,10 +469,69 @@ func (c *Store) addPodAndModelMappingLocked(metaPod *Pod, modelName string) {
 	klog.V(4).InfoS("Pod added to model", "model", modelName, "pod", podKey, "pods", metaModel.Pods.Len())
 }
 
+// deletedPodSnapshot preserves a deleted pod's realtime request-tracking
+// counters so a fast re-add of the same key (see addPodLocked) can resume
+// from where they left off instead of restarting at zero.
+//
+// It is stored and shared by pointer (not by value): a request that started
+// before the delete can still complete while the pod key is absent from
+// metaPods entirely -- mid-flap, before any re-add happens (see
+// donePodStats). Its counters must be mutable in place, atomically, so that
+// completion is reflected in whatever a later re-add resumes from, rather
+// than being silently lost.
+type deletedPodSnapshot struct {
+	pod                    *Pod   // Orphaned cache pod; same statsGeneration. addPodStats mid-gap stores this as podStats.pod so donePodStats can resolve back to this snapshot.
+	podIP                  string // Guards against reuse across a genuine pod recreation; see addPodLocked.
+	statsGeneration        int64  // Copied from pod at delete; resume copies it onto the new *Pod, fresh add does not.
+	runningRequests        int32  // atomic
+	completedRequests      int64  // atomic
+	pendingLoadUtilization atomic_ext.Float64
+	deletedAt              time.Time
+}
+
+// recentlyDeletedPodGracePeriod bounds how long a deletedPodSnapshot survives
+// waiting for a matching re-add before it's dropped as a genuine deletion.
+const recentlyDeletedPodGracePeriod = 60 * time.Second
+
 func (c *Store) deletePodLocked(podName, podNamespace string) *Pod {
 	key := utils.GeneratePodKey(podNamespace, podName)
-	metaPod, _ := c.metaPods.LoadAndDelete(key)
+
+	// See the matching lock in addPodLocked and podStatsLockFor's doc comment
+	// (cache_trace.go): held across the snapshot-take-and-publish sequence below so
+	// it can't interleave with a concurrent addPodStats/donePodStats for this key.
+	mu := c.podStatsLockFor(key)
+	mu.Lock()
+	defer mu.Unlock()
+
+	metaPod, ok := c.metaPods.LoadAndDelete(key)
+	if ok {
+		snap := &deletedPodSnapshot{
+			pod:               metaPod,
+			podIP:             metaPod.Status.PodIP,
+			statsGeneration:   metaPod.statsGeneration,
+			runningRequests:   atomic.LoadInt32(&metaPod.runningRequests),
+			completedRequests: atomic.LoadInt64(&metaPod.completedRequests),
+			deletedAt:         time.Now(),
+		}
+		snap.pendingLoadUtilization.Store(metaPod.pendingLoadUtilization.Load())
+		c.recentlyDeletedPods.Store(key, snap)
+		c.pruneExpiredDeletedPodSnapshotsLocked()
+	}
 	return metaPod
+}
+
+// pruneExpiredDeletedPodSnapshotsLocked drops snapshots whose grace period has
+// elapsed. Run from deletePodLocked (rather than a dedicated ticker) so pods
+// that never come back don't leak an entry here forever, while staying
+// bounded by delete frequency instead of needing its own background goroutine.
+func (c *Store) pruneExpiredDeletedPodSnapshotsLocked() {
+	now := time.Now()
+	c.recentlyDeletedPods.Range(func(key string, snap *deletedPodSnapshot) bool {
+		if now.Sub(snap.deletedAt) >= recentlyDeletedPodGracePeriod {
+			c.recentlyDeletedPods.Delete(key)
+		}
+		return true
+	})
 }
 
 // deletePodAndModelMapping delete mappings between pods and model by specified names.

--- a/pkg/cache/pod.go
+++ b/pkg/cache/pod.go
@@ -36,6 +36,11 @@ type Pod struct {
 	runningRequests        int32 // Realtime running requests counter.
 	completedRequests      int64 // Monotonically increasing count of finished requests (gateway-tracked).
 	pendingLoadUtilization atomic_ext.Float64
+	// statsGeneration identifies this cache object's request-tracking counters.
+	// Copied on a same-IP resume (see addPodLocked) so in-flight Add/Done can
+	// follow the live object across a flap; incremented on a fresh add so a
+	// stale completion cannot bleed into a new generation after grace expiry.
+	statsGeneration int64
 
 	// Log frenquency control
 	lastTraceLogTimestamp int64


### PR DESCRIPTION
## Pull Request Description
Pod delete/re-add cycles (a transient health-check flap, or the informer's
routine delete+add on every in-place pod update) raced against concurrently
completing requests in addPodStats/donePodStats, causing the running-request
counter to drift permanently (observed as low as -16 in production):

- A completing request could resolve "the live pod is object O1" and then,
  after a concurrent delete+re-add swapped in O2, apply its decrement to the
  now-orphaned O1, silently losing it.
- A request starting inside the delete/re-add gap itself found no cached pod
  and was dropped without being tracked, so its later completion became a
  no-op.
- Two in-flight attempts sharing a retried requestID could clobber each
  other's bookkeeping entry, permanently leaking one side's increment.
- A same-IP pod re-added after being gone longer than the resume grace
  period could still receive a stale completion meant for the pod it
  replaced, corrupting a live counter.

Fix:
- Stripe-locked (podStatsLockFor) synchronization between addPodStats/
  donePodStats and the delete/re-add snapshot handoff in informers.go, so
  the two sides can no longer interleave.
- deletedPodSnapshot preserves a deleted pod's counters so a fast re-add
  resumes them instead of restarting at zero, and so a request completing
  mid-gap (before any re-add) can still be applied in place.
- statsGeneration replaces IP-based matching to decide whether a live/
  snapshot object is genuinely the same tracked identity across a flap,
  so a re-add past the grace period starts a fresh generation that can't
  inherit or receive stale Add/Done calls.
- Attempt-scoped podStats keys (podStatsAttemptKey) plus a consumed/take()
  CAS guard eliminate the retry-collision leak without a load-then-put-back
  race.
- decrementClamped floors the counter at 0 as defense-in-depth, with a
  test-only counter to detect a masked regression.

Adds regression tests for flaky same-IP re-add, mid-gap completion, grace-
period expiry, concurrent flap-vs-request races (run with -race), and
retried-requestID collisions, plus a benchmark
(BenchmarkAddDoneRequestCountWithPodFlap) that doubles as a correctness
check under adjustable concurrency/-benchtime.


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to aibrix! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to aibrix's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>